### PR TITLE
Add SQLite database layer, models, and migration runner

### DIFF
--- a/src/atc/state/__init__.py
+++ b/src/atc/state/__init__.py
@@ -1,0 +1,1 @@
+"""Database state layer — connection factory, models, and migrations."""

--- a/src/atc/state/db.py
+++ b/src/atc/state/db.py
@@ -1,1 +1,145 @@
-"""SQLite WAL connection factory — stub."""
+"""SQLite WAL connection factory with retry logic."""
+
+from __future__ import annotations
+
+import itertools
+import logging
+import sqlite3
+from contextlib import contextmanager
+from time import sleep
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from collections.abc import Generator
+    from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+_memory_counter = itertools.count()
+
+# Default retry settings for SQLITE_BUSY
+DEFAULT_MAX_RETRIES = 5
+DEFAULT_RETRY_DELAY = 0.1  # seconds, doubles each retry
+
+
+class ConnectionFactory:
+    """Manages SQLite connections with WAL mode and retry logic.
+
+    All database access should go through this factory — never use
+    bare ``sqlite3.connect()`` elsewhere.
+    """
+
+    def __init__(
+        self,
+        db_path: str | Path,
+        *,
+        wal_mode: bool = True,
+        max_retries: int = DEFAULT_MAX_RETRIES,
+        retry_delay: float = DEFAULT_RETRY_DELAY,
+    ) -> None:
+        raw = str(db_path)
+        # Use shared-cache URI for in-memory databases so multiple connections
+        # see the same data (each plain `:memory:` connection is isolated).
+        if raw == ":memory:":
+            n = next(_memory_counter)
+            self._db_path = f"file:memdb{n}?mode=memory&cache=shared"
+            self._use_uri = True
+        else:
+            self._db_path = raw
+            self._use_uri = False
+        self._wal_mode = wal_mode
+        self._max_retries = max_retries
+        self._retry_delay = retry_delay
+        # For shared-cache in-memory DBs, keep one connection open so the
+        # database survives between connect()/close() cycles.
+        self._keepalive: sqlite3.Connection | None = None
+        if self._use_uri:
+            self._keepalive = sqlite3.connect(self._db_path, uri=True)
+
+    @property
+    def db_path(self) -> str:
+        return self._db_path
+
+    @property
+    def is_memory(self) -> bool:
+        """True when backed by an in-memory database."""
+        return self._use_uri
+
+    def close(self) -> None:
+        """Close the keepalive connection (for in-memory databases)."""
+        if self._keepalive is not None:
+            self._keepalive.close()
+            self._keepalive = None
+
+    def _configure(self, conn: sqlite3.Connection) -> None:
+        """Apply connection-level pragmas."""
+        conn.execute("PRAGMA foreign_keys = ON")
+        # WAL is not meaningful for in-memory databases
+        if self._wal_mode and not self._use_uri:
+            conn.execute("PRAGMA journal_mode = WAL")
+
+    def connect(self) -> sqlite3.Connection:
+        """Open a new connection with WAL mode and foreign keys enabled."""
+        conn = sqlite3.connect(self._db_path, uri=self._use_uri)
+        conn.row_factory = sqlite3.Row
+        self._configure(conn)
+        return conn
+
+    @contextmanager
+    def connection(self) -> Generator[sqlite3.Connection, None, None]:
+        """Context manager that opens, yields, and closes a connection."""
+        conn = self.connect()
+        try:
+            yield conn
+        finally:
+            conn.close()
+
+    @contextmanager
+    def transaction(self) -> Generator[sqlite3.Connection, None, None]:
+        """Context manager that wraps work in a transaction with retry."""
+        conn = self.connect()
+        try:
+            yield conn
+            conn.commit()
+        except Exception:
+            conn.rollback()
+            raise
+        finally:
+            conn.close()
+
+    def with_retry(
+        self,
+        fn: Any,
+        *args: Any,
+        max_retries: int | None = None,
+        retry_delay: float | None = None,
+    ) -> Any:
+        """Execute ``fn(conn, *args)`` with exponential-backoff retry on SQLITE_BUSY.
+
+        Returns whatever ``fn`` returns. The connection is opened/closed per attempt.
+        """
+        retries = max_retries if max_retries is not None else self._max_retries
+        delay = retry_delay if retry_delay is not None else self._retry_delay
+
+        last_err: Exception | None = None
+        for attempt in range(retries + 1):
+            try:
+                with self.transaction() as conn:
+                    return fn(conn, *args)
+            except sqlite3.OperationalError as exc:
+                if "locked" not in str(exc).lower() and "busy" not in str(exc).lower():
+                    raise
+                last_err = exc
+                if attempt < retries:
+                    wait = delay * (2**attempt)
+                    logger.warning(
+                        "DB busy (attempt %d/%d), retrying in %.2fs",
+                        attempt + 1,
+                        retries + 1,
+                        wait,
+                    )
+                    sleep(wait)
+
+        raise sqlite3.OperationalError(
+            f"Database busy after {retries + 1} attempts"
+        ) from last_err

--- a/src/atc/state/migrations/__init__.py
+++ b/src/atc/state/migrations/__init__.py
@@ -1,0 +1,92 @@
+"""Migration runner — applies versioned SQL files in order."""
+
+from __future__ import annotations
+
+import logging
+import re
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from atc.state.db import ConnectionFactory
+
+logger = logging.getLogger(__name__)
+
+VERSIONS_DIR = Path(__file__).parent / "versions"
+
+# Matches files like 001_initial_schema.sql
+_MIGRATION_RE = re.compile(r"^(\d{3})_.*\.sql$")
+
+
+def _ensure_migrations_table(factory: ConnectionFactory) -> None:
+    """Create the ``_migrations`` tracking table if it doesn't exist."""
+    with factory.connection() as conn:
+        conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS _migrations (
+                version  INTEGER PRIMARY KEY,
+                filename TEXT NOT NULL,
+                applied_at TEXT NOT NULL DEFAULT (datetime('now'))
+            )
+            """
+        )
+        conn.commit()
+
+
+def _applied_versions(factory: ConnectionFactory) -> set[int]:
+    """Return the set of already-applied migration version numbers."""
+    with factory.connection() as conn:
+        rows = conn.execute("SELECT version FROM _migrations").fetchall()
+    return {row[0] for row in rows}
+
+
+def _discover_migrations(versions_dir: Path | None = None) -> list[tuple[int, Path]]:
+    """Discover and sort migration files by version number."""
+    search_dir = versions_dir or VERSIONS_DIR
+    migrations: list[tuple[int, Path]] = []
+    if not search_dir.exists():
+        return migrations
+    for path in sorted(search_dir.iterdir()):
+        match = _MIGRATION_RE.match(path.name)
+        if match:
+            version = int(match.group(1))
+            migrations.append((version, path))
+    return migrations
+
+
+def run_migrations(
+    factory: ConnectionFactory,
+    *,
+    versions_dir: Path | None = None,
+) -> list[str]:
+    """Apply all pending migrations in order.
+
+    Returns a list of filenames that were applied.
+    """
+    _ensure_migrations_table(factory)
+    applied = _applied_versions(factory)
+    migrations = _discover_migrations(versions_dir)
+
+    newly_applied: list[str] = []
+    for version, path in migrations:
+        if version in applied:
+            continue
+
+        sql = path.read_text()
+        logger.info("Applying migration %s", path.name)
+        with factory.connection() as conn:
+            conn.executescript(sql)
+            conn.execute(
+                "INSERT INTO _migrations (version, filename) VALUES (?, ?)",
+                (version, path.name),
+            )
+            conn.commit()
+        newly_applied.append(path.name)
+        logger.info("Applied migration %s", path.name)
+
+    if not newly_applied:
+        logger.info("Database is up to date — no migrations to apply")
+    else:
+        logger.info("Applied %d migration(s)", len(newly_applied))
+
+    return newly_applied

--- a/src/atc/state/models.py
+++ b/src/atc/state/models.py
@@ -1,1 +1,163 @@
-"""Dataclass models — stub."""
+"""Dataclass models for all core database entities."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass
+class Project:
+    id: str
+    name: str
+    status: str  # active|paused|archived
+    description: str | None = None
+    repo_path: str | None = None
+    github_repo: str | None = None
+    created_at: str = ""
+    updated_at: str = ""
+
+
+@dataclass
+class Leader:
+    id: str
+    project_id: str
+    status: str  # idle|planning|managing|paused|error
+    session_id: str | None = None
+    context: dict[str, Any] | None = None
+    goal: str | None = None
+    created_at: str = ""
+    updated_at: str = ""
+
+    def context_json(self) -> str | None:
+        """Serialize context dict to JSON for DB storage."""
+        return json.dumps(self.context) if self.context is not None else None
+
+    @staticmethod
+    def context_from_json(raw: str | None) -> dict[str, Any] | None:
+        """Deserialize context JSON from DB."""
+        return json.loads(raw) if raw is not None else None
+
+
+@dataclass
+class Session:
+    id: str
+    project_id: str
+    session_type: str  # ace|manager
+    name: str
+    status: str  # idle|connecting|working|paused|waiting|disconnected|error
+    task_id: str | None = None
+    host: str | None = None
+    tmux_session: str | None = None
+    tmux_pane: str | None = None
+    alternate_on: bool = False
+    auto_accept: bool = False
+    created_at: str = ""
+    updated_at: str = ""
+
+
+@dataclass
+class Task:
+    id: str
+    project_id: str
+    leader_id: str
+    title: str
+    status: str  # pending|assigned|in_progress|blocked|done|cancelled
+    parent_task_id: str | None = None
+    description: str | None = None
+    priority: int = 0
+    assigned_to: str | None = None
+    result: dict[str, Any] | None = None
+    created_at: str = ""
+    updated_at: str = ""
+
+    def result_json(self) -> str | None:
+        """Serialize result dict to JSON for DB storage."""
+        return json.dumps(self.result) if self.result is not None else None
+
+    @staticmethod
+    def result_from_json(raw: str | None) -> dict[str, Any] | None:
+        """Deserialize result JSON from DB."""
+        return json.loads(raw) if raw is not None else None
+
+
+@dataclass
+class ProjectBudget:
+    project_id: str
+    daily_token_limit: int | None = None
+    monthly_cost_limit: float | None = None
+    warn_threshold: float = 0.8
+    current_status: str = "ok"  # ok|warn|exceeded
+    updated_at: str = ""
+
+
+@dataclass
+class UsageEvent:
+    id: str
+    event_type: str  # ai_tokens|ai_cost|cpu|ram|disk|github_api
+    recorded_at: str
+    project_id: str | None = None
+    session_id: str | None = None
+    model: str | None = None
+    input_tokens: int | None = None
+    output_tokens: int | None = None
+    cost_usd: float | None = None
+    cpu_pct: float | None = None
+    ram_mb: float | None = None
+    disk_mb: float | None = None
+    api_calls: int | None = None
+
+
+@dataclass
+class GitHubPR:
+    id: str  # "{owner}/{repo}#{number}"
+    project_id: str | None
+    number: int
+    title: str | None = None
+    status: str | None = None  # open|merged|closed
+    ci_status: str | None = None  # pending|running|success|failure
+    url: str | None = None
+    updated_at: str = ""
+
+
+@dataclass
+class Notification:
+    id: str
+    level: str  # info|warning|error|budget
+    message: str
+    project_id: str | None = None
+    read: bool = False
+    created_at: str = ""
+
+
+@dataclass
+class Config:
+    key: str
+    value: str
+    updated_at: str = ""
+
+
+@dataclass
+class TowerMemory:
+    id: str
+    key: str
+    value: str  # JSON
+    project_id: str | None = None
+    created_at: str = ""
+    updated_at: str = ""
+
+
+@dataclass
+class FailureLog:
+    id: str
+    level: str  # info|warning|error|critical
+    category: str  # creation_failure|runtime_error|budget_exceeded|etc
+    message: str
+    context: str  # JSON
+    project_id: str | None = None
+    entity_type: str | None = None
+    entity_id: str | None = None
+    stack_trace: str | None = None
+    resolved: bool = False
+    created_at: str = ""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,12 +7,22 @@ from fastapi.testclient import TestClient
 
 from atc.api.app import create_app
 from atc.config import Settings
+from atc.state.db import ConnectionFactory
+from atc.state.migrations import run_migrations
 
 
 @pytest.fixture
 def settings() -> Settings:
     """Test settings with in-memory database."""
     return Settings(database={"path": ":memory:"})  # type: ignore[arg-type]
+
+
+@pytest.fixture
+def db_factory() -> ConnectionFactory:
+    """In-memory ConnectionFactory with migrations applied."""
+    factory = ConnectionFactory(":memory:")
+    run_migrations(factory)
+    return factory
 
 
 @pytest.fixture

--- a/tests/unit/test_db.py
+++ b/tests/unit/test_db.py
@@ -1,0 +1,336 @@
+"""Tests for connection factory, retry logic, and migration runner."""
+
+from __future__ import annotations
+
+import sqlite3
+import tempfile
+from typing import TYPE_CHECKING
+
+import pytest
+
+from atc.state.db import ConnectionFactory
+from atc.state.migrations import (
+    _applied_versions,
+    _discover_migrations,
+    _ensure_migrations_table,
+    run_migrations,
+)
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+# ---------------------------------------------------------------------------
+# ConnectionFactory tests
+# ---------------------------------------------------------------------------
+
+
+class TestConnectionFactory:
+    def test_connect_returns_connection(self) -> None:
+        factory = ConnectionFactory(":memory:")
+        conn = factory.connect()
+        assert isinstance(conn, sqlite3.Connection)
+        conn.close()
+
+    def test_wal_mode_enabled(self) -> None:
+        with tempfile.NamedTemporaryFile(suffix=".db", delete=False) as f:
+            db_path = f.name
+        factory = ConnectionFactory(db_path, wal_mode=True)
+        conn = factory.connect()
+        mode = conn.execute("PRAGMA journal_mode").fetchone()[0]
+        conn.close()
+        assert mode == "wal"
+
+    def test_wal_mode_disabled(self) -> None:
+        with tempfile.NamedTemporaryFile(suffix=".db", delete=False) as f:
+            db_path = f.name
+        factory = ConnectionFactory(db_path, wal_mode=False)
+        conn = factory.connect()
+        mode = conn.execute("PRAGMA journal_mode").fetchone()[0]
+        conn.close()
+        # Without WAL enabled, default journal mode is "delete"
+        assert mode != "wal"
+
+    def test_foreign_keys_enabled(self) -> None:
+        factory = ConnectionFactory(":memory:")
+        conn = factory.connect()
+        fk = conn.execute("PRAGMA foreign_keys").fetchone()[0]
+        conn.close()
+        assert fk == 1
+
+    def test_row_factory_is_row(self) -> None:
+        factory = ConnectionFactory(":memory:")
+        conn = factory.connect()
+        assert conn.row_factory is sqlite3.Row
+        conn.close()
+
+    def test_connection_context_manager(self) -> None:
+        factory = ConnectionFactory(":memory:")
+        with factory.connection() as conn:
+            conn.execute("CREATE TABLE t (id TEXT)")
+            conn.commit()
+            rows = conn.execute("SELECT * FROM t").fetchall()
+            assert rows == []
+
+    def test_transaction_commits(self) -> None:
+        with tempfile.NamedTemporaryFile(suffix=".db", delete=False) as f:
+            db_path = f.name
+        factory = ConnectionFactory(db_path)
+        with factory.connection() as conn:
+            conn.execute("CREATE TABLE t (id TEXT)")
+            conn.commit()
+
+        with factory.transaction() as conn:
+            conn.execute("INSERT INTO t VALUES ('a')")
+
+        with factory.connection() as conn:
+            rows = conn.execute("SELECT id FROM t").fetchall()
+            assert len(rows) == 1
+            assert rows[0][0] == "a"
+
+    def test_transaction_rollback_on_error(self) -> None:
+        with tempfile.NamedTemporaryFile(suffix=".db", delete=False) as f:
+            db_path = f.name
+        factory = ConnectionFactory(db_path)
+        with factory.connection() as conn:
+            conn.execute("CREATE TABLE t (id TEXT)")
+            conn.commit()
+
+        with pytest.raises(ValueError, match="boom"), factory.transaction() as conn:
+            conn.execute("INSERT INTO t VALUES ('a')")
+            raise ValueError("boom")
+
+        with factory.connection() as conn:
+            rows = conn.execute("SELECT id FROM t").fetchall()
+            assert len(rows) == 0
+
+    def test_db_path_property(self) -> None:
+        factory = ConnectionFactory("/tmp/test.db")
+        assert factory.db_path == "/tmp/test.db"
+
+    def test_is_memory(self) -> None:
+        mem_factory = ConnectionFactory(":memory:")
+        assert mem_factory.is_memory is True
+        file_factory = ConnectionFactory("/tmp/test.db")
+        assert file_factory.is_memory is False
+
+    def test_close_keepalive(self) -> None:
+        factory = ConnectionFactory(":memory:")
+        assert factory._keepalive is not None
+        factory.close()
+        assert factory._keepalive is None
+        # Closing again is a no-op
+        factory.close()
+
+
+# ---------------------------------------------------------------------------
+# Retry logic tests
+# ---------------------------------------------------------------------------
+
+
+class TestWithRetry:
+    def test_success_no_retry(self) -> None:
+        with tempfile.NamedTemporaryFile(suffix=".db", delete=False) as f:
+            db_path = f.name
+        factory = ConnectionFactory(db_path)
+        with factory.connection() as conn:
+            conn.execute("CREATE TABLE t (val INTEGER)")
+            conn.commit()
+
+        def insert(conn: sqlite3.Connection) -> str:
+            conn.execute("INSERT INTO t VALUES (42)")
+            return "ok"
+
+        result = factory.with_retry(insert)
+        assert result == "ok"
+
+    def test_retry_on_busy(self) -> None:
+        call_count = 0
+
+        def flaky_fn(conn: sqlite3.Connection) -> str:
+            nonlocal call_count
+            call_count += 1
+            if call_count < 3:
+                raise sqlite3.OperationalError("database is locked")
+            return "success"
+
+        factory = ConnectionFactory(":memory:", retry_delay=0.01)
+        result = factory.with_retry(flaky_fn)
+        assert result == "success"
+        assert call_count == 3
+
+    def test_retry_exhausted(self) -> None:
+        def always_busy(conn: sqlite3.Connection) -> None:
+            raise sqlite3.OperationalError("database is locked")
+
+        factory = ConnectionFactory(":memory:", max_retries=2, retry_delay=0.01)
+        with pytest.raises(sqlite3.OperationalError, match="busy after 3 attempts"):
+            factory.with_retry(always_busy)
+
+    def test_non_busy_error_not_retried(self) -> None:
+        call_count = 0
+
+        def bad_sql(conn: sqlite3.Connection) -> None:
+            nonlocal call_count
+            call_count += 1
+            raise sqlite3.OperationalError("no such table: nope")
+
+        factory = ConnectionFactory(":memory:", retry_delay=0.01)
+        with pytest.raises(sqlite3.OperationalError, match="no such table"):
+            factory.with_retry(bad_sql)
+        assert call_count == 1
+
+    def test_custom_retry_params(self) -> None:
+        call_count = 0
+
+        def busy(conn: sqlite3.Connection) -> None:
+            nonlocal call_count
+            call_count += 1
+            raise sqlite3.OperationalError("database is busy")
+
+        factory = ConnectionFactory(":memory:", max_retries=10, retry_delay=1.0)
+        with pytest.raises(sqlite3.OperationalError):
+            factory.with_retry(busy, max_retries=1, retry_delay=0.01)
+        # Should only have tried 2 times (1 + 1 retry)
+        assert call_count == 2
+
+
+# ---------------------------------------------------------------------------
+# Migration runner tests
+# ---------------------------------------------------------------------------
+
+
+class TestMigrationRunner:
+    def test_ensure_migrations_table(self) -> None:
+        factory = ConnectionFactory(":memory:")
+        _ensure_migrations_table(factory)
+        with factory.connection() as conn:
+            rows = conn.execute(
+                "SELECT name FROM sqlite_master WHERE type='table' AND name='_migrations'"
+            ).fetchall()
+        assert len(rows) == 1
+
+    def test_discover_migrations(self, tmp_path: Path) -> None:
+        # Create some migration files
+        versions_dir = tmp_path / "versions"
+        versions_dir.mkdir()
+        (versions_dir / "001_initial.sql").write_text("-- first")
+        (versions_dir / "002_add_stuff.sql").write_text("-- second")
+        (versions_dir / "not_a_migration.txt").write_text("ignore")
+        (versions_dir / "abc_bad.sql").write_text("ignore")
+
+        migrations = _discover_migrations(versions_dir)
+        assert len(migrations) == 2
+        assert migrations[0][0] == 1
+        assert migrations[1][0] == 2
+        assert migrations[0][1].name == "001_initial.sql"
+
+    def test_run_migrations_applies_all(self, tmp_path: Path) -> None:
+        versions_dir = tmp_path / "versions"
+        versions_dir.mkdir()
+        (versions_dir / "001_create.sql").write_text(
+            "CREATE TABLE IF NOT EXISTS t1 (id TEXT PRIMARY KEY);"
+        )
+        (versions_dir / "002_extend.sql").write_text(
+            "CREATE TABLE IF NOT EXISTS t2 (id TEXT PRIMARY KEY);"
+        )
+
+        factory = ConnectionFactory(":memory:")
+        applied = run_migrations(factory, versions_dir=versions_dir)
+        assert applied == ["001_create.sql", "002_extend.sql"]
+
+        # Tables should exist
+        with factory.connection() as conn:
+            tables = {
+                row[0]
+                for row in conn.execute(
+                    "SELECT name FROM sqlite_master WHERE type='table'"
+                ).fetchall()
+            }
+        assert "t1" in tables
+        assert "t2" in tables
+        assert "_migrations" in tables
+
+    def test_run_migrations_skips_applied(self, tmp_path: Path) -> None:
+        versions_dir = tmp_path / "versions"
+        versions_dir.mkdir()
+        (versions_dir / "001_first.sql").write_text(
+            "CREATE TABLE IF NOT EXISTS t1 (id TEXT);"
+        )
+
+        factory = ConnectionFactory(":memory:")
+        first_run = run_migrations(factory, versions_dir=versions_dir)
+        assert len(first_run) == 1
+
+        # Add a second migration
+        (versions_dir / "002_second.sql").write_text(
+            "CREATE TABLE IF NOT EXISTS t2 (id TEXT);"
+        )
+
+        second_run = run_migrations(factory, versions_dir=versions_dir)
+        assert second_run == ["002_second.sql"]
+
+    def test_run_migrations_empty_dir(self, tmp_path: Path) -> None:
+        versions_dir = tmp_path / "versions"
+        versions_dir.mkdir()
+
+        factory = ConnectionFactory(":memory:")
+        applied = run_migrations(factory, versions_dir=versions_dir)
+        assert applied == []
+
+    def test_run_migrations_nonexistent_dir(self, tmp_path: Path) -> None:
+        versions_dir = tmp_path / "nope"
+
+        factory = ConnectionFactory(":memory:")
+        applied = run_migrations(factory, versions_dir=versions_dir)
+        assert applied == []
+
+    def test_applied_versions_tracking(self, tmp_path: Path) -> None:
+        versions_dir = tmp_path / "versions"
+        versions_dir.mkdir()
+        (versions_dir / "001_init.sql").write_text(
+            "CREATE TABLE IF NOT EXISTS x (id TEXT);"
+        )
+
+        factory = ConnectionFactory(":memory:")
+        run_migrations(factory, versions_dir=versions_dir)
+
+        versions = _applied_versions(factory)
+        assert versions == {1}
+
+    def test_initial_migration_applies_cleanly(self) -> None:
+        """Verify the real 001_initial_schema.sql applies without errors."""
+        factory = ConnectionFactory(":memory:")
+        applied = run_migrations(factory)
+        assert "001_initial_schema.sql" in applied
+
+        # Check all expected tables exist
+        expected_tables = {
+            "projects",
+            "leaders",
+            "sessions",
+            "tasks",
+            "project_budgets",
+            "usage_events",
+            "github_prs",
+            "notifications",
+            "config",
+            "tower_memory",
+            "failure_logs",
+            "_migrations",
+        }
+        with factory.connection() as conn:
+            tables = {
+                row[0]
+                for row in conn.execute(
+                    "SELECT name FROM sqlite_master WHERE type='table'"
+                ).fetchall()
+            }
+        assert expected_tables.issubset(tables)
+
+    def test_initial_migration_is_idempotent(self) -> None:
+        """Running migrations twice should not fail."""
+        factory = ConnectionFactory(":memory:")
+        first = run_migrations(factory)
+        second = run_migrations(factory)
+        assert len(first) == 1
+        assert len(second) == 0

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -1,0 +1,206 @@
+"""Tests for dataclass models."""
+
+from __future__ import annotations
+
+from atc.state.models import (
+    Config,
+    FailureLog,
+    GitHubPR,
+    Leader,
+    Notification,
+    Project,
+    ProjectBudget,
+    Session,
+    Task,
+    TowerMemory,
+    UsageEvent,
+)
+
+
+class TestProject:
+    def test_required_fields(self) -> None:
+        p = Project(id="p1", name="Test", status="active")
+        assert p.id == "p1"
+        assert p.name == "Test"
+        assert p.status == "active"
+
+    def test_optional_defaults(self) -> None:
+        p = Project(id="p1", name="Test", status="active")
+        assert p.description is None
+        assert p.repo_path is None
+        assert p.github_repo is None
+        assert p.created_at == ""
+        assert p.updated_at == ""
+
+    def test_all_fields(self) -> None:
+        p = Project(
+            id="p1",
+            name="Test",
+            status="paused",
+            description="A project",
+            repo_path="/tmp/repo",
+            github_repo="owner/repo",
+            created_at="2026-01-01T00:00:00Z",
+            updated_at="2026-01-01T00:00:00Z",
+        )
+        assert p.github_repo == "owner/repo"
+
+
+class TestLeader:
+    def test_context_json_serialization(self) -> None:
+        leader = Leader(
+            id="l1",
+            project_id="p1",
+            status="idle",
+            context={"key": "value", "num": 42},
+        )
+        json_str = leader.context_json()
+        assert json_str is not None
+        assert '"key"' in json_str
+        assert '"num": 42' in json_str
+
+    def test_context_json_none(self) -> None:
+        leader = Leader(id="l1", project_id="p1", status="idle")
+        assert leader.context_json() is None
+
+    def test_context_from_json(self) -> None:
+        result = Leader.context_from_json('{"key": "value"}')
+        assert result == {"key": "value"}
+
+    def test_context_from_json_none(self) -> None:
+        assert Leader.context_from_json(None) is None
+
+    def test_defaults(self) -> None:
+        leader = Leader(id="l1", project_id="p1", status="idle")
+        assert leader.session_id is None
+        assert leader.context is None
+        assert leader.goal is None
+
+
+class TestSession:
+    def test_required_fields(self) -> None:
+        s = Session(
+            id="s1",
+            project_id="p1",
+            session_type="ace",
+            name="ace-1",
+            status="idle",
+        )
+        assert s.session_type == "ace"
+        assert s.alternate_on is False
+        assert s.auto_accept is False
+
+    def test_optional_fields(self) -> None:
+        s = Session(
+            id="s1",
+            project_id="p1",
+            session_type="manager",
+            name="leader-1",
+            status="working",
+            task_id="t1",
+            host="remote",
+            tmux_session="sess",
+            tmux_pane="%1",
+            alternate_on=True,
+            auto_accept=True,
+        )
+        assert s.host == "remote"
+        assert s.alternate_on is True
+
+
+class TestTask:
+    def test_result_json_serialization(self) -> None:
+        task = Task(
+            id="t1",
+            project_id="p1",
+            leader_id="l1",
+            title="Do stuff",
+            status="done",
+            result={"summary": "done", "files": 3},
+        )
+        json_str = task.result_json()
+        assert json_str is not None
+        assert '"summary"' in json_str
+
+    def test_result_json_none(self) -> None:
+        task = Task(
+            id="t1", project_id="p1", leader_id="l1", title="X", status="pending"
+        )
+        assert task.result_json() is None
+
+    def test_result_from_json(self) -> None:
+        result = Task.result_from_json('{"files": 3}')
+        assert result == {"files": 3}
+
+    def test_result_from_json_none(self) -> None:
+        assert Task.result_from_json(None) is None
+
+    def test_defaults(self) -> None:
+        task = Task(
+            id="t1", project_id="p1", leader_id="l1", title="X", status="pending"
+        )
+        assert task.parent_task_id is None
+        assert task.description is None
+        assert task.priority == 0
+        assert task.assigned_to is None
+
+
+class TestProjectBudget:
+    def test_defaults(self) -> None:
+        b = ProjectBudget(project_id="p1")
+        assert b.daily_token_limit is None
+        assert b.monthly_cost_limit is None
+        assert b.warn_threshold == 0.8
+        assert b.current_status == "ok"
+
+
+class TestUsageEvent:
+    def test_required_and_defaults(self) -> None:
+        e = UsageEvent(id="u1", event_type="ai_tokens", recorded_at="2026-01-01")
+        assert e.project_id is None
+        assert e.model is None
+        assert e.cost_usd is None
+
+
+class TestGitHubPR:
+    def test_fields(self) -> None:
+        pr = GitHubPR(id="owner/repo#1", project_id="p1", number=1, title="Fix bug")
+        assert pr.number == 1
+        assert pr.status is None
+        assert pr.ci_status is None
+
+
+class TestNotification:
+    def test_defaults(self) -> None:
+        n = Notification(id="n1", level="info", message="Hello")
+        assert n.project_id is None
+        assert n.read is False
+
+
+class TestConfig:
+    def test_fields(self) -> None:
+        c = Config(key="theme", value="dark")
+        assert c.key == "theme"
+        assert c.updated_at == ""
+
+
+class TestTowerMemory:
+    def test_fields(self) -> None:
+        tm = TowerMemory(id="tm1", key="pattern", value='{"x": 1}')
+        assert tm.project_id is None
+        assert tm.created_at == ""
+
+
+class TestFailureLog:
+    def test_defaults(self) -> None:
+        fl = FailureLog(
+            id="f1",
+            level="error",
+            category="creation_failure",
+            message="Failed",
+            context="{}",
+        )
+        assert fl.project_id is None
+        assert fl.entity_type is None
+        assert fl.stack_trace is None
+        assert fl.resolved is False


### PR DESCRIPTION
## Summary
- **ConnectionFactory** (`src/atc/state/db.py`): SQLite WAL connection factory with foreign keys, shared-cache in-memory support (for testing), and exponential-backoff retry on SQLITE_BUSY
- **Dataclass models** (`src/atc/state/models.py`): All 11 core entities from design doc §7 — Project, Leader, Session, Task, ProjectBudget, UsageEvent, GitHubPR, Notification, Config, TowerMemory, FailureLog
- **Migration runner** (`src/atc/state/migrations/__init__.py`): Discovers `NNN_*.sql` files, tracks applied versions in `_migrations` table, applies pending migrations in order
- Updated `tests/conftest.py` with `db_factory` fixture for in-memory DB with migrations applied

## Testing Done
- 47 unit tests covering all three modules
- **100% code coverage** on `atc.state.db`, `atc.state.models`, and `atc.state.migrations`
- Tests cover: connection factory (WAL, FK, row_factory, context managers, transactions), retry logic (success, busy retry, exhaustion, non-busy errors, custom params), migration runner (table creation, discovery, application, skip-applied, empty/missing dirs, idempotency), real 001_initial_schema.sql validation, and all model fields/defaults/serialization

```
$ pytest tests/unit/test_db.py tests/unit/test_models.py --cov=atc.state.db --cov=atc.state.migrations --cov=atc.state.models --cov-report=term-missing
47 passed
TOTAL    255      0   100%
```

```
$ ruff check src/atc/state/ tests/unit/test_db.py tests/unit/test_models.py
All checks passed!
```