### PR TITLE
Add agent provider abstraction layer (factory pattern)

### DIFF
--- a/src/atc/agents/__init__.py
+++ b/src/atc/agents/__init__.py
@@ -1,0 +1,35 @@
+"""Agent provider abstraction layer.
+
+Public API::
+
+    from atc.agents import create_provider, AgentProvider, SessionStatus
+
+    provider = create_provider("opencode", base_url="http://localhost:4096")
+    info = await provider.spawn_session("worker-1", working_dir="/tmp/repo")
+"""
+
+from atc.agents.base import (
+    AgentProvider,
+    OutputChunk,
+    PromptResult,
+    ProviderError,
+    SessionInfo,
+    SessionStatus,
+)
+from atc.agents.factory import (
+    create_provider,
+    list_providers,
+    register_provider,
+)
+
+__all__ = [
+    "AgentProvider",
+    "OutputChunk",
+    "PromptResult",
+    "ProviderError",
+    "SessionInfo",
+    "SessionStatus",
+    "create_provider",
+    "list_providers",
+    "register_provider",
+]

--- a/src/atc/agents/base.py
+++ b/src/atc/agents/base.py
@@ -1,0 +1,164 @@
+"""Agent provider base protocol — abstract interface for CLI tool backends.
+
+Defines the contract that all agent providers (Claude Code, OpenCode, etc.)
+must implement. The session lifecycle delegates to a provider rather than
+hardcoding tmux commands directly.
+"""
+
+from __future__ import annotations
+
+import enum
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncIterator
+
+
+class SessionStatus(enum.Enum):
+    """Lifecycle status of a provider-managed session."""
+
+    STARTING = "starting"
+    IDLE = "idle"
+    BUSY = "busy"
+    ERROR = "error"
+    STOPPED = "stopped"
+
+
+@dataclass(frozen=True)
+class SessionInfo:
+    """Snapshot of a session's current state as reported by the provider."""
+
+    session_id: str
+    status: SessionStatus
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class PromptResult:
+    """Result of sending a prompt to a session."""
+
+    session_id: str
+    accepted: bool
+    message: str = ""
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class OutputChunk:
+    """A chunk of streaming output from a session."""
+
+    session_id: str
+    content: str
+    is_final: bool = False
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+
+@runtime_checkable
+class AgentProvider(Protocol):
+    """Protocol defining the interface for agent CLI tool backends.
+
+    Each provider encapsulates one way of running an AI coding agent
+    (e.g. Claude Code via tmux+PTY, OpenCode via REST API). The session
+    lifecycle layer uses this interface instead of calling tmux directly.
+    """
+
+    @property
+    def name(self) -> str:
+        """Human-readable provider name (e.g. 'claude_code', 'opencode')."""
+        ...
+
+    async def spawn_session(
+        self,
+        session_id: str,
+        *,
+        working_dir: str | None = None,
+        env: dict[str, str] | None = None,
+    ) -> SessionInfo:
+        """Spawn a new agent session.
+
+        Args:
+            session_id: Unique identifier for this session.
+            working_dir: Working directory for the agent process.
+            env: Extra environment variables to pass.
+
+        Returns:
+            SessionInfo with initial status.
+
+        Raises:
+            ProviderError: If the session cannot be spawned.
+        """
+        ...
+
+    async def send_prompt(self, session_id: str, prompt: str) -> PromptResult:
+        """Send a prompt/instruction to an existing session.
+
+        Args:
+            session_id: Target session identifier.
+            prompt: The text prompt to send.
+
+        Returns:
+            PromptResult indicating acceptance.
+
+        Raises:
+            ProviderError: If the prompt cannot be delivered.
+        """
+        ...
+
+    async def get_status(self, session_id: str) -> SessionInfo:
+        """Get the current status of a session.
+
+        Args:
+            session_id: Target session identifier.
+
+        Returns:
+            SessionInfo with current status.
+
+        Raises:
+            ProviderError: If the session is not found.
+        """
+        ...
+
+    async def stream_output(self, session_id: str) -> AsyncIterator[OutputChunk]:
+        """Stream real-time output from a session.
+
+        Yields OutputChunk objects as the agent produces output.
+        The final chunk has ``is_final=True``.
+
+        Args:
+            session_id: Target session identifier.
+
+        Yields:
+            OutputChunk with content fragments.
+
+        Raises:
+            ProviderError: If the stream cannot be established.
+        """
+        ...
+
+    async def stop_session(self, session_id: str) -> None:
+        """Stop and clean up a session.
+
+        Args:
+            session_id: Target session identifier.
+
+        Raises:
+            ProviderError: If the session cannot be stopped cleanly.
+        """
+        ...
+
+    async def list_sessions(self) -> list[SessionInfo]:
+        """List all sessions managed by this provider.
+
+        Returns:
+            List of SessionInfo for all known sessions.
+        """
+        ...
+
+
+class ProviderError(Exception):
+    """Base exception for agent provider errors."""
+
+    def __init__(self, provider: str, message: str) -> None:
+        self.provider = provider
+        super().__init__(f"[{provider}] {message}")

--- a/src/atc/agents/claude_provider.py
+++ b/src/atc/agents/claude_provider.py
@@ -1,0 +1,270 @@
+"""ClaudeCodeProvider — wraps the existing tmux + PTY approach behind AgentProvider.
+
+Spawns Claude Code sessions in tmux panes, sends prompts via tmux send-keys,
+and monitors output through PTY streaming. This is the original ATC approach
+wrapped behind the provider abstraction.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import shutil
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncIterator
+
+from atc.agents.base import (
+    OutputChunk,
+    PromptResult,
+    ProviderError,
+    SessionInfo,
+    SessionStatus,
+)
+
+logger = logging.getLogger(__name__)
+
+_TMUX_CMD = "tmux"
+
+
+class ClaudeCodeProvider:
+    """Agent provider using Claude Code in tmux panes.
+
+    Sessions are spawned as tmux split-window commands. Prompts are delivered
+    via ``tmux send-keys``. Status is tracked internally (future: via PTY
+    monitor). Output streaming delegates to the terminal/pty_stream module.
+
+    Implements :class:`AgentProvider` protocol.
+    """
+
+    def __init__(
+        self,
+        *,
+        tmux_session: str = "atc",
+        claude_command: str = "claude",
+    ) -> None:
+        self._tmux_session = tmux_session
+        self._claude_command = claude_command
+        self._sessions: dict[str, _TrackedSession] = {}
+
+    @property
+    def name(self) -> str:
+        return "claude_code"
+
+    async def spawn_session(
+        self,
+        session_id: str,
+        *,
+        working_dir: str | None = None,
+        env: dict[str, str] | None = None,
+    ) -> SessionInfo:
+        if session_id in self._sessions:
+            raise ProviderError(self.name, f"Session {session_id} already exists")
+
+        self._check_tmux_available()
+
+        # Build the claude command
+        cmd_parts = [self._claude_command]
+        env_prefix = ""
+        if env:
+            env_parts = [f"{k}={v}" for k, v in env.items()]
+            env_prefix = " ".join(env_parts) + " "
+
+        shell_cmd = f"{env_prefix}{' '.join(cmd_parts)}"
+
+        # Spawn in a new tmux pane
+        tmux_args = [
+            _TMUX_CMD,
+            "split-window",
+            "-h",
+            "-t",
+            self._tmux_session,
+            "-P",  # print pane info
+            "-F",
+            "#{pane_id}",
+        ]
+        if working_dir:
+            tmux_args.extend(["-c", working_dir])
+        tmux_args.append(shell_cmd)
+
+        try:
+            proc = await asyncio.create_subprocess_exec(
+                *tmux_args,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+            )
+            stdout, stderr = await proc.communicate()
+        except OSError as exc:
+            raise ProviderError(self.name, f"Failed to spawn tmux pane: {exc}") from exc
+
+        if proc.returncode != 0:
+            err = stderr.decode().strip()
+            raise ProviderError(self.name, f"tmux split-window failed: {err}")
+
+        pane_id = stdout.decode().strip()
+        tracked = _TrackedSession(
+            session_id=session_id,
+            pane_id=pane_id,
+            status=SessionStatus.IDLE,
+        )
+        self._sessions[session_id] = tracked
+
+        logger.info("Spawned Claude Code session %s in pane %s", session_id, pane_id)
+        return tracked.to_info()
+
+    async def send_prompt(self, session_id: str, prompt: str) -> PromptResult:
+        tracked = self._get_tracked(session_id)
+
+        # Send text + Enter atomically (no await gap per PATTERNS.md)
+        escaped = prompt.replace("'", "'\\''")
+        send_cmd = [
+            _TMUX_CMD,
+            "send-keys",
+            "-t",
+            tracked.pane_id,
+            escaped,
+            "Enter",
+        ]
+
+        try:
+            proc = await asyncio.create_subprocess_exec(
+                *send_cmd,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+            )
+            _, stderr = await proc.communicate()
+        except OSError as exc:
+            raise ProviderError(self.name, f"send-keys failed: {exc}") from exc
+
+        if proc.returncode != 0:
+            err = stderr.decode().strip()
+            return PromptResult(
+                session_id=session_id,
+                accepted=False,
+                message=f"tmux send-keys failed: {err}",
+            )
+
+        tracked.status = SessionStatus.BUSY
+        logger.info("Sent prompt to session %s (pane %s)", session_id, tracked.pane_id)
+        return PromptResult(session_id=session_id, accepted=True)
+
+    async def get_status(self, session_id: str) -> SessionInfo:
+        tracked = self._get_tracked(session_id)
+
+        # Verify the tmux pane still exists
+        check_cmd = [
+            _TMUX_CMD,
+            "has-session",
+            "-t",
+            tracked.pane_id,
+        ]
+        try:
+            proc = await asyncio.create_subprocess_exec(
+                *check_cmd,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+            )
+            await proc.communicate()
+        except OSError:
+            tracked.status = SessionStatus.ERROR
+            return tracked.to_info()
+
+        if proc.returncode != 0:
+            tracked.status = SessionStatus.STOPPED
+        return tracked.to_info()
+
+    async def stream_output(self, session_id: str) -> AsyncIterator[OutputChunk]:
+        """Stream output via PTY pipe-pane.
+
+        NOTE: Full implementation depends on the terminal/pty_stream module
+        (ATC-5). This provides a basic capture-pane fallback.
+        """
+        tracked = self._get_tracked(session_id)
+
+        capture_cmd = [
+            _TMUX_CMD,
+            "capture-pane",
+            "-t",
+            tracked.pane_id,
+            "-p",  # print to stdout
+        ]
+        try:
+            proc = await asyncio.create_subprocess_exec(
+                *capture_cmd,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+            )
+            stdout, _ = await proc.communicate()
+        except OSError as exc:
+            raise ProviderError(self.name, f"capture-pane failed: {exc}") from exc
+
+        content = stdout.decode()
+        yield OutputChunk(
+            session_id=session_id,
+            content=content,
+            is_final=True,
+        )
+
+    async def stop_session(self, session_id: str) -> None:
+        tracked = self._get_tracked(session_id)
+
+        kill_cmd = [
+            _TMUX_CMD,
+            "kill-pane",
+            "-t",
+            tracked.pane_id,
+        ]
+        try:
+            proc = await asyncio.create_subprocess_exec(
+                *kill_cmd,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+            )
+            _, stderr = await proc.communicate()
+        except OSError as exc:
+            raise ProviderError(self.name, f"kill-pane failed: {exc}") from exc
+
+        if proc.returncode != 0:
+            err = stderr.decode().strip()
+            logger.warning("kill-pane for %s returned error: %s", session_id, err)
+
+        tracked.status = SessionStatus.STOPPED
+        del self._sessions[session_id]
+        logger.info("Stopped session %s (pane %s)", session_id, tracked.pane_id)
+
+    async def list_sessions(self) -> list[SessionInfo]:
+        return [t.to_info() for t in self._sessions.values()]
+
+    def _get_tracked(self, session_id: str) -> _TrackedSession:
+        tracked = self._sessions.get(session_id)
+        if tracked is None:
+            raise ProviderError(self.name, f"Session {session_id} not found")
+        return tracked
+
+    def _check_tmux_available(self) -> None:
+        if shutil.which(_TMUX_CMD) is None:
+            raise ProviderError(self.name, "tmux is not installed or not on PATH")
+
+
+class _TrackedSession:
+    """Internal bookkeeping for a Claude Code session."""
+
+    __slots__ = ("session_id", "pane_id", "status")
+
+    def __init__(
+        self,
+        session_id: str,
+        pane_id: str,
+        status: SessionStatus,
+    ) -> None:
+        self.session_id = session_id
+        self.pane_id = pane_id
+        self.status = status
+
+    def to_info(self) -> SessionInfo:
+        return SessionInfo(
+            session_id=self.session_id,
+            status=self.status,
+            metadata={"pane_id": self.pane_id},
+        )

--- a/src/atc/agents/factory.py
+++ b/src/atc/agents/factory.py
@@ -1,0 +1,79 @@
+"""Agent provider factory — creates providers by name from config.
+
+Provides a registry of available provider implementations and a factory
+function for instantiation. Provider selection is driven by project settings.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from atc.agents.base import AgentProvider, ProviderError
+
+logger = logging.getLogger(__name__)
+
+# Type alias for provider constructor callables
+ProviderConstructor = type  # Callable that returns an AgentProvider
+
+# Global registry of known provider types
+_REGISTRY: dict[str, ProviderConstructor] = {}
+
+
+def register_provider(name: str, cls: ProviderConstructor) -> None:
+    """Register a provider class under the given name.
+
+    Args:
+        name: Lookup key (e.g. ``"claude_code"``, ``"opencode"``).
+        cls: The provider class to instantiate when this name is requested.
+    """
+    _REGISTRY[name] = cls
+    logger.debug("Registered agent provider: %s → %s", name, cls.__name__)
+
+
+def create_provider(name: str, **kwargs: Any) -> AgentProvider:
+    """Create an agent provider instance by name.
+
+    Args:
+        name: Registered provider name.
+        **kwargs: Passed to the provider constructor.
+
+    Returns:
+        An AgentProvider instance.
+
+    Raises:
+        ProviderError: If the name is not registered.
+    """
+    cls = _REGISTRY.get(name)
+    if cls is None:
+        available = ", ".join(sorted(_REGISTRY)) or "(none)"
+        raise ProviderError(
+            "factory",
+            f"Unknown provider {name!r}. Available: {available}",
+        )
+    provider: AgentProvider = cls(**kwargs)
+    logger.info("Created agent provider: %s (%s)", name, cls.__name__)
+    return provider
+
+
+def list_providers() -> list[str]:
+    """Return names of all registered providers."""
+    return sorted(_REGISTRY)
+
+
+def get_provider_class(name: str) -> ProviderConstructor | None:
+    """Return the registered class for a provider name, or None."""
+    return _REGISTRY.get(name)
+
+
+def _register_builtins() -> None:
+    """Register the built-in providers (claude_code, opencode)."""
+    from atc.agents.claude_provider import ClaudeCodeProvider
+    from atc.agents.opencode_provider import OpenCodeProvider
+
+    register_provider("claude_code", ClaudeCodeProvider)
+    register_provider("opencode", OpenCodeProvider)
+
+
+# Auto-register builtins on import
+_register_builtins()

--- a/src/atc/agents/opencode_provider.py
+++ b/src/atc/agents/opencode_provider.py
@@ -1,0 +1,353 @@
+"""OpenCodeProvider — agent provider using OpenCode REST API.
+
+Communicates with an OpenCode server (``opencode serve`` on localhost:4096)
+via its REST API. Sessions are spawned in tmux panes running
+``opencode --session-id <id>``, but all control flows through HTTP —
+no terminal scraping needed.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import shutil
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncIterator
+
+from atc.agents.base import (
+    OutputChunk,
+    PromptResult,
+    ProviderError,
+    SessionInfo,
+    SessionStatus,
+)
+
+logger = logging.getLogger(__name__)
+
+_TMUX_CMD = "tmux"
+
+# Mapping from OpenCode API status strings to our canonical enum
+_STATUS_MAP: dict[str, SessionStatus] = {
+    "idle": SessionStatus.IDLE,
+    "busy": SessionStatus.BUSY,
+    "running": SessionStatus.BUSY,
+    "error": SessionStatus.ERROR,
+    "stopped": SessionStatus.STOPPED,
+}
+
+
+class OpenCodeProvider:
+    """Agent provider backed by the OpenCode REST API.
+
+    Requires an OpenCode server running on ``base_url`` (default localhost:4096).
+    Sessions are spawned as ``opencode --session-id <id>`` in tmux panes for
+    human visibility, but all commands flow through HTTP endpoints.
+
+    Implements :class:`AgentProvider` protocol.
+    """
+
+    def __init__(
+        self,
+        *,
+        base_url: str = "http://localhost:4096",
+        tmux_session: str = "atc",
+        auth_username: str | None = None,
+        auth_password: str | None = None,
+    ) -> None:
+        self._base_url = base_url.rstrip("/")
+        self._tmux_session = tmux_session
+        self._auth_username = auth_username
+        self._auth_password = auth_password
+        self._pane_ids: dict[str, str] = {}
+
+    @property
+    def name(self) -> str:
+        return "opencode"
+
+    async def spawn_session(
+        self,
+        session_id: str,
+        *,
+        working_dir: str | None = None,
+        env: dict[str, str] | None = None,
+    ) -> SessionInfo:
+        if session_id in self._pane_ids:
+            raise ProviderError(self.name, f"Session {session_id} already tracked")
+
+        # Create session via REST API
+        body: dict[str, Any] = {"id": session_id}
+        if working_dir:
+            body["working_dir"] = working_dir
+        await self._api_request("POST", "/session", body=body)
+
+        # Also spawn a tmux pane for human observability
+        pane_id = await self._spawn_tmux_pane(session_id, working_dir, env)
+        self._pane_ids[session_id] = pane_id
+
+        logger.info(
+            "Spawned OpenCode session %s (pane %s, server %s)",
+            session_id,
+            pane_id,
+            self._base_url,
+        )
+        return SessionInfo(
+            session_id=session_id,
+            status=SessionStatus.IDLE,
+            metadata={"pane_id": pane_id, "base_url": self._base_url},
+        )
+
+    async def send_prompt(self, session_id: str, prompt: str) -> PromptResult:
+        self._require_tracked(session_id)
+
+        try:
+            resp = await self._api_request(
+                "POST",
+                "/prompt_async",
+                body={"session_id": session_id, "prompt": prompt},
+            )
+        except ProviderError:
+            return PromptResult(
+                session_id=session_id,
+                accepted=False,
+                message="API request failed",
+            )
+
+        logger.info("Sent prompt to OpenCode session %s", session_id)
+        return PromptResult(
+            session_id=session_id,
+            accepted=True,
+            metadata=resp,
+        )
+
+    async def get_status(self, session_id: str) -> SessionInfo:
+        self._require_tracked(session_id)
+
+        try:
+            resp = await self._api_request("GET", f"/session/{session_id}")
+        except ProviderError:
+            return SessionInfo(
+                session_id=session_id,
+                status=SessionStatus.ERROR,
+                metadata={"error": "Failed to reach OpenCode API"},
+            )
+
+        api_status = resp.get("status", "idle")
+        status = _STATUS_MAP.get(api_status, SessionStatus.IDLE)
+        return SessionInfo(
+            session_id=session_id,
+            status=status,
+            metadata=resp,
+        )
+
+    async def stream_output(self, session_id: str) -> AsyncIterator[OutputChunk]:
+        """Stream output via Server-Sent Events from the OpenCode API."""
+        self._require_tracked(session_id)
+
+        url = f"{self._base_url}/session/{session_id}/events"
+        headers = self._auth_headers()
+        headers["Accept"] = "text/event-stream"
+
+        try:
+            proc = await asyncio.create_subprocess_exec(
+                "curl",
+                "-sN",
+                *self._curl_auth_args(),
+                "-H",
+                "Accept: text/event-stream",
+                url,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+            )
+        except OSError as exc:
+            raise ProviderError(self.name, f"Failed to start SSE stream: {exc}") from exc
+
+        assert proc.stdout is not None  # noqa: S101
+        try:
+            async for line_bytes in proc.stdout:
+                line = line_bytes.decode().strip()
+                if not line or line.startswith(":"):
+                    continue
+                if line.startswith("data: "):
+                    data_str = line[6:]
+                    try:
+                        data = json.loads(data_str)
+                    except json.JSONDecodeError:
+                        data = {"raw": data_str}
+
+                    content = data.get("content", data.get("text", data_str))
+                    is_final = data.get("done", False) is True
+
+                    yield OutputChunk(
+                        session_id=session_id,
+                        content=str(content),
+                        is_final=is_final,
+                        metadata=data,
+                    )
+                    if is_final:
+                        break
+        finally:
+            proc.terminate()
+            await proc.wait()
+
+    async def stop_session(self, session_id: str) -> None:
+        self._require_tracked(session_id)
+
+        # Stop via API
+        try:
+            await self._api_request("DELETE", f"/session/{session_id}")
+        except ProviderError:
+            logger.warning("API delete for session %s failed, cleaning up locally", session_id)
+
+        # Kill the tmux pane
+        pane_id = self._pane_ids.get(session_id)
+        if pane_id:
+            try:
+                proc = await asyncio.create_subprocess_exec(
+                    _TMUX_CMD, "kill-pane", "-t", pane_id,
+                    stdout=asyncio.subprocess.PIPE,
+                    stderr=asyncio.subprocess.PIPE,
+                )
+                await proc.communicate()
+            except OSError:
+                pass
+
+        del self._pane_ids[session_id]
+        logger.info("Stopped OpenCode session %s", session_id)
+
+    async def list_sessions(self) -> list[SessionInfo]:
+        try:
+            resp = await self._api_request("GET", "/session")
+        except ProviderError:
+            logger.warning("Failed to list sessions from OpenCode API")
+            return []
+
+        sessions: list[SessionInfo] = []
+        items = resp if isinstance(resp, list) else resp.get("sessions", [])
+        for item in items:
+            sid = item.get("id", "")
+            api_status = item.get("status", "idle")
+            status = _STATUS_MAP.get(api_status, SessionStatus.IDLE)
+            sessions.append(SessionInfo(session_id=sid, status=status, metadata=item))
+        return sessions
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _require_tracked(self, session_id: str) -> None:
+        if session_id not in self._pane_ids:
+            raise ProviderError(self.name, f"Session {session_id} not tracked")
+
+    def _auth_headers(self) -> dict[str, str]:
+        headers: dict[str, str] = {}
+        if self._auth_username and self._auth_password:
+            import base64
+
+            creds = base64.b64encode(
+                f"{self._auth_username}:{self._auth_password}".encode()
+            ).decode()
+            headers["Authorization"] = f"Basic {creds}"
+        return headers
+
+    def _curl_auth_args(self) -> list[str]:
+        if self._auth_username and self._auth_password:
+            return ["-u", f"{self._auth_username}:{self._auth_password}"]
+        return []
+
+    async def _api_request(
+        self,
+        method: str,
+        path: str,
+        *,
+        body: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        """Make an HTTP request to the OpenCode API using curl.
+
+        Uses curl subprocess to avoid adding httpx as a runtime dependency.
+        """
+        url = f"{self._base_url}{path}"
+        cmd: list[str] = ["curl", "-s", "-X", method]
+        cmd.extend(self._curl_auth_args())
+        cmd.extend(["-H", "Content-Type: application/json"])
+
+        if body is not None:
+            cmd.extend(["-d", json.dumps(body)])
+        cmd.append(url)
+
+        try:
+            proc = await asyncio.create_subprocess_exec(
+                *cmd,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+            )
+            stdout, stderr = await proc.communicate()
+        except OSError as exc:
+            raise ProviderError(self.name, f"HTTP {method} {path} failed: {exc}") from exc
+
+        if proc.returncode != 0:
+            err = stderr.decode().strip()
+            raise ProviderError(self.name, f"HTTP {method} {path} error: {err}")
+
+        raw = stdout.decode().strip()
+        if not raw:
+            return {}
+        try:
+            result = json.loads(raw)
+        except json.JSONDecodeError as exc:
+            raise ProviderError(
+                self.name, f"Invalid JSON from {method} {path}: {raw[:200]}"
+            ) from exc
+
+        if isinstance(result, dict):
+            return result
+        return {"data": result}
+
+    async def _spawn_tmux_pane(
+        self,
+        session_id: str,
+        working_dir: str | None,
+        env: dict[str, str] | None,
+    ) -> str:
+        """Spawn an ``opencode --session-id`` process in a tmux pane."""
+        if shutil.which(_TMUX_CMD) is None:
+            raise ProviderError(self.name, "tmux is not installed or not on PATH")
+
+        env_prefix = ""
+        if env:
+            env_parts = [f"{k}={v}" for k, v in env.items()]
+            env_prefix = " ".join(env_parts) + " "
+
+        shell_cmd = f"{env_prefix}opencode --session-id {session_id}"
+
+        tmux_args = [
+            _TMUX_CMD,
+            "split-window",
+            "-h",
+            "-t",
+            self._tmux_session,
+            "-P",
+            "-F",
+            "#{pane_id}",
+        ]
+        if working_dir:
+            tmux_args.extend(["-c", working_dir])
+        tmux_args.append(shell_cmd)
+
+        try:
+            proc = await asyncio.create_subprocess_exec(
+                *tmux_args,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+            )
+            stdout, stderr = await proc.communicate()
+        except OSError as exc:
+            raise ProviderError(self.name, f"tmux spawn failed: {exc}") from exc
+
+        if proc.returncode != 0:
+            err = stderr.decode().strip()
+            raise ProviderError(self.name, f"tmux split-window failed: {err}")
+
+        return stdout.decode().strip()

--- a/src/atc/config.py
+++ b/src/atc/config.py
@@ -47,6 +47,17 @@ class LoggingConfig(BaseModel):
     level: str = "INFO"
 
 
+class AgentProviderConfig(BaseModel):
+    """Configuration for the agent provider abstraction layer."""
+
+    default: str = "claude_code"
+    opencode_url: str = "http://localhost:4096"
+    opencode_username: str | None = None
+    opencode_password: str | None = None
+    tmux_session: str = "atc"
+    claude_command: str = "claude"
+
+
 class Settings(BaseSettings):
     server: ServerConfig = ServerConfig()
     database: DatabaseConfig = DatabaseConfig()
@@ -56,6 +67,7 @@ class Settings(BaseSettings):
     budget: BudgetConfig = BudgetConfig()
     cost_tracker: CostTrackerConfig = CostTrackerConfig()
     logging: LoggingConfig = LoggingConfig()
+    agent_provider: AgentProviderConfig = AgentProviderConfig()
 
 
 def _load_yaml(path: Path) -> dict[str, Any]:

--- a/tests/unit/test_agent_provider.py
+++ b/tests/unit/test_agent_provider.py
@@ -1,0 +1,531 @@
+"""Unit tests for the agent provider abstraction layer."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from atc.agents.base import (
+    AgentProvider,
+    OutputChunk,
+    PromptResult,
+    ProviderError,
+    SessionInfo,
+    SessionStatus,
+)
+from atc.agents.claude_provider import ClaudeCodeProvider
+from atc.agents.factory import (
+    _REGISTRY,
+    create_provider,
+    get_provider_class,
+    list_providers,
+    register_provider,
+)
+from atc.agents.opencode_provider import OpenCodeProvider
+
+# ---------------------------------------------------------------------------
+# Base protocol / data classes
+# ---------------------------------------------------------------------------
+
+
+class TestSessionStatus:
+    def test_all_values_exist(self) -> None:
+        assert SessionStatus.STARTING.value == "starting"
+        assert SessionStatus.IDLE.value == "idle"
+        assert SessionStatus.BUSY.value == "busy"
+        assert SessionStatus.ERROR.value == "error"
+        assert SessionStatus.STOPPED.value == "stopped"
+
+
+class TestSessionInfo:
+    def test_frozen(self) -> None:
+        info = SessionInfo(session_id="s1", status=SessionStatus.IDLE)
+        with pytest.raises(AttributeError):
+            info.session_id = "other"  # type: ignore[misc]
+
+    def test_default_metadata(self) -> None:
+        info = SessionInfo(session_id="s1", status=SessionStatus.IDLE)
+        assert info.metadata == {}
+
+    def test_with_metadata(self) -> None:
+        info = SessionInfo(
+            session_id="s1",
+            status=SessionStatus.BUSY,
+            metadata={"pane_id": "%5"},
+        )
+        assert info.metadata["pane_id"] == "%5"
+
+
+class TestPromptResult:
+    def test_accepted(self) -> None:
+        result = PromptResult(session_id="s1", accepted=True)
+        assert result.accepted is True
+        assert result.message == ""
+
+    def test_rejected_with_message(self) -> None:
+        result = PromptResult(session_id="s1", accepted=False, message="pane dead")
+        assert result.accepted is False
+        assert "pane dead" in result.message
+
+
+class TestOutputChunk:
+    def test_defaults(self) -> None:
+        chunk = OutputChunk(session_id="s1", content="hello")
+        assert chunk.is_final is False
+        assert chunk.metadata == {}
+
+    def test_final(self) -> None:
+        chunk = OutputChunk(session_id="s1", content="done", is_final=True)
+        assert chunk.is_final is True
+
+
+class TestProviderError:
+    def test_message_includes_provider(self) -> None:
+        err = ProviderError("opencode", "connection refused")
+        assert "opencode" in str(err)
+        assert "connection refused" in str(err)
+        assert err.provider == "opencode"
+
+
+# ---------------------------------------------------------------------------
+# Protocol compliance
+# ---------------------------------------------------------------------------
+
+
+class TestProtocolCompliance:
+    def test_claude_code_is_agent_provider(self) -> None:
+        assert isinstance(ClaudeCodeProvider(), AgentProvider)
+
+    def test_opencode_is_agent_provider(self) -> None:
+        assert isinstance(OpenCodeProvider(), AgentProvider)
+
+
+# ---------------------------------------------------------------------------
+# Factory
+# ---------------------------------------------------------------------------
+
+
+class TestFactory:
+    def test_builtin_providers_registered(self) -> None:
+        names = list_providers()
+        assert "claude_code" in names
+        assert "opencode" in names
+
+    def test_create_claude_code(self) -> None:
+        provider = create_provider("claude_code")
+        assert provider.name == "claude_code"
+
+    def test_create_opencode(self) -> None:
+        provider = create_provider("opencode", base_url="http://localhost:9999")
+        assert provider.name == "opencode"
+
+    def test_create_unknown_raises(self) -> None:
+        with pytest.raises(ProviderError, match="Unknown provider"):
+            create_provider("nonexistent")
+
+    def test_register_custom_provider(self) -> None:
+        class CustomProvider:
+            @property
+            def name(self) -> str:
+                return "custom"
+
+        register_provider("custom", CustomProvider)  # type: ignore[arg-type]
+        assert "custom" in list_providers()
+        assert get_provider_class("custom") is CustomProvider
+
+        # Clean up
+        del _REGISTRY["custom"]
+
+    def test_get_provider_class_none_for_unknown(self) -> None:
+        assert get_provider_class("does_not_exist") is None
+
+
+# ---------------------------------------------------------------------------
+# ClaudeCodeProvider
+# ---------------------------------------------------------------------------
+
+
+def _make_process(returncode: int = 0, stdout: bytes = b"", stderr: bytes = b"") -> AsyncMock:
+    """Create a mock asyncio subprocess."""
+    proc = AsyncMock()
+    proc.returncode = returncode
+    proc.communicate = AsyncMock(return_value=(stdout, stderr))
+    return proc
+
+
+class TestClaudeCodeProvider:
+    @pytest.fixture
+    def provider(self) -> ClaudeCodeProvider:
+        return ClaudeCodeProvider(tmux_session="test-atc")
+
+    async def test_name(self, provider: ClaudeCodeProvider) -> None:
+        assert provider.name == "claude_code"
+
+    @patch("shutil.which", return_value="/usr/bin/tmux")
+    @patch("asyncio.create_subprocess_exec")
+    async def test_spawn_session(
+        self,
+        mock_exec: AsyncMock,
+        _mock_which: MagicMock,
+        provider: ClaudeCodeProvider,
+    ) -> None:
+        mock_exec.return_value = _make_process(stdout=b"%42\n")
+
+        info = await provider.spawn_session("worker-1", working_dir="/tmp/repo")
+
+        assert info.session_id == "worker-1"
+        assert info.status == SessionStatus.IDLE
+        assert info.metadata["pane_id"] == "%42"
+
+    @patch("shutil.which", return_value="/usr/bin/tmux")
+    @patch("asyncio.create_subprocess_exec")
+    async def test_spawn_duplicate_raises(
+        self,
+        mock_exec: AsyncMock,
+        _mock_which: MagicMock,
+        provider: ClaudeCodeProvider,
+    ) -> None:
+        mock_exec.return_value = _make_process(stdout=b"%42\n")
+        await provider.spawn_session("s1")
+
+        with pytest.raises(ProviderError, match="already exists"):
+            await provider.spawn_session("s1")
+
+    @patch("shutil.which", return_value=None)
+    async def test_spawn_no_tmux_raises(
+        self,
+        _mock_which: MagicMock,
+        provider: ClaudeCodeProvider,
+    ) -> None:
+        with pytest.raises(ProviderError, match="tmux"):
+            await provider.spawn_session("s1")
+
+    @patch("shutil.which", return_value="/usr/bin/tmux")
+    @patch("asyncio.create_subprocess_exec")
+    async def test_send_prompt(
+        self,
+        mock_exec: AsyncMock,
+        _mock_which: MagicMock,
+        provider: ClaudeCodeProvider,
+    ) -> None:
+        # Spawn first
+        mock_exec.return_value = _make_process(stdout=b"%42\n")
+        await provider.spawn_session("s1")
+
+        # Send prompt
+        mock_exec.return_value = _make_process()
+        result = await provider.send_prompt("s1", "Write hello world")
+
+        assert result.accepted is True
+        assert result.session_id == "s1"
+
+    async def test_send_prompt_unknown_session(self, provider: ClaudeCodeProvider) -> None:
+        with pytest.raises(ProviderError, match="not found"):
+            await provider.send_prompt("unknown", "test")
+
+    @patch("shutil.which", return_value="/usr/bin/tmux")
+    @patch("asyncio.create_subprocess_exec")
+    async def test_get_status(
+        self,
+        mock_exec: AsyncMock,
+        _mock_which: MagicMock,
+        provider: ClaudeCodeProvider,
+    ) -> None:
+        # Spawn
+        mock_exec.return_value = _make_process(stdout=b"%42\n")
+        await provider.spawn_session("s1")
+
+        # Check status (has-session succeeds)
+        mock_exec.return_value = _make_process()
+        info = await provider.get_status("s1")
+        assert info.status == SessionStatus.IDLE
+
+    @patch("shutil.which", return_value="/usr/bin/tmux")
+    @patch("asyncio.create_subprocess_exec")
+    async def test_get_status_pane_dead(
+        self,
+        mock_exec: AsyncMock,
+        _mock_which: MagicMock,
+        provider: ClaudeCodeProvider,
+    ) -> None:
+        mock_exec.return_value = _make_process(stdout=b"%42\n")
+        await provider.spawn_session("s1")
+
+        # has-session returns non-zero
+        mock_exec.return_value = _make_process(returncode=1)
+        info = await provider.get_status("s1")
+        assert info.status == SessionStatus.STOPPED
+
+    @patch("shutil.which", return_value="/usr/bin/tmux")
+    @patch("asyncio.create_subprocess_exec")
+    async def test_stop_session(
+        self,
+        mock_exec: AsyncMock,
+        _mock_which: MagicMock,
+        provider: ClaudeCodeProvider,
+    ) -> None:
+        mock_exec.return_value = _make_process(stdout=b"%42\n")
+        await provider.spawn_session("s1")
+
+        mock_exec.return_value = _make_process()
+        await provider.stop_session("s1")
+
+        sessions = await provider.list_sessions()
+        assert len(sessions) == 0
+
+    @patch("shutil.which", return_value="/usr/bin/tmux")
+    @patch("asyncio.create_subprocess_exec")
+    async def test_list_sessions(
+        self,
+        mock_exec: AsyncMock,
+        _mock_which: MagicMock,
+        provider: ClaudeCodeProvider,
+    ) -> None:
+        mock_exec.return_value = _make_process(stdout=b"%1\n")
+        await provider.spawn_session("s1")
+        mock_exec.return_value = _make_process(stdout=b"%2\n")
+        await provider.spawn_session("s2")
+
+        sessions = await provider.list_sessions()
+        assert len(sessions) == 2
+        ids = {s.session_id for s in sessions}
+        assert ids == {"s1", "s2"}
+
+    @patch("shutil.which", return_value="/usr/bin/tmux")
+    @patch("asyncio.create_subprocess_exec")
+    async def test_stream_output(
+        self,
+        mock_exec: AsyncMock,
+        _mock_which: MagicMock,
+        provider: ClaudeCodeProvider,
+    ) -> None:
+        mock_exec.return_value = _make_process(stdout=b"%42\n")
+        await provider.spawn_session("s1")
+
+        # capture-pane output
+        mock_exec.return_value = _make_process(stdout=b"Hello from Claude\n")
+
+        chunks: list[OutputChunk] = []
+        async for chunk in provider.stream_output("s1"):
+            chunks.append(chunk)
+
+        assert len(chunks) == 1
+        assert "Hello from Claude" in chunks[0].content
+        assert chunks[0].is_final is True
+
+
+# ---------------------------------------------------------------------------
+# OpenCodeProvider
+# ---------------------------------------------------------------------------
+
+
+class TestOpenCodeProvider:
+    @pytest.fixture
+    def provider(self) -> OpenCodeProvider:
+        return OpenCodeProvider(base_url="http://localhost:9999", tmux_session="test-atc")
+
+    async def test_name(self, provider: OpenCodeProvider) -> None:
+        assert provider.name == "opencode"
+
+    @patch("shutil.which", return_value="/usr/bin/tmux")
+    @patch("asyncio.create_subprocess_exec")
+    async def test_spawn_session(
+        self,
+        mock_exec: AsyncMock,
+        _mock_which: MagicMock,
+        provider: OpenCodeProvider,
+    ) -> None:
+        # First call: API request (curl for POST /session)
+        # Second call: tmux split-window
+        api_response = b'{"id": "w1", "status": "idle"}'
+        calls = [
+            _make_process(stdout=api_response),  # curl POST /session
+            _make_process(stdout=b"%50\n"),  # tmux split-window
+        ]
+        mock_exec.side_effect = calls
+
+        info = await provider.spawn_session("w1", working_dir="/tmp/work")
+
+        assert info.session_id == "w1"
+        assert info.status == SessionStatus.IDLE
+
+    @patch("shutil.which", return_value="/usr/bin/tmux")
+    @patch("asyncio.create_subprocess_exec")
+    async def test_spawn_duplicate_raises(
+        self,
+        mock_exec: AsyncMock,
+        _mock_which: MagicMock,
+        provider: OpenCodeProvider,
+    ) -> None:
+        mock_exec.side_effect = [
+            _make_process(stdout=b'{}'),
+            _make_process(stdout=b"%50\n"),
+        ]
+        await provider.spawn_session("w1")
+
+        with pytest.raises(ProviderError, match="already tracked"):
+            await provider.spawn_session("w1")
+
+    @patch("shutil.which", return_value="/usr/bin/tmux")
+    @patch("asyncio.create_subprocess_exec")
+    async def test_send_prompt(
+        self,
+        mock_exec: AsyncMock,
+        _mock_which: MagicMock,
+        provider: OpenCodeProvider,
+    ) -> None:
+        # Spawn
+        mock_exec.side_effect = [
+            _make_process(stdout=b'{}'),
+            _make_process(stdout=b"%50\n"),
+        ]
+        await provider.spawn_session("w1")
+
+        # Reset side_effect so return_value works
+        mock_exec.side_effect = None
+        mock_exec.return_value = _make_process(stdout=b'{"ok": true}')
+        result = await provider.send_prompt("w1", "Write tests")
+
+        assert result.accepted is True
+        assert result.session_id == "w1"
+
+    async def test_send_prompt_unknown_session(self, provider: OpenCodeProvider) -> None:
+        with pytest.raises(ProviderError, match="not tracked"):
+            await provider.send_prompt("ghost", "test")
+
+    @patch("shutil.which", return_value="/usr/bin/tmux")
+    @patch("asyncio.create_subprocess_exec")
+    async def test_get_status(
+        self,
+        mock_exec: AsyncMock,
+        _mock_which: MagicMock,
+        provider: OpenCodeProvider,
+    ) -> None:
+        mock_exec.side_effect = [
+            _make_process(stdout=b'{}'),
+            _make_process(stdout=b"%50\n"),
+        ]
+        await provider.spawn_session("w1")
+
+        # Reset side_effect so return_value works
+        mock_exec.side_effect = None
+        mock_exec.return_value = _make_process(
+            stdout=b'{"id": "w1", "status": "busy"}'
+        )
+        info = await provider.get_status("w1")
+        assert info.status == SessionStatus.BUSY
+
+    @patch("shutil.which", return_value="/usr/bin/tmux")
+    @patch("asyncio.create_subprocess_exec")
+    async def test_get_status_api_down(
+        self,
+        mock_exec: AsyncMock,
+        _mock_which: MagicMock,
+        provider: OpenCodeProvider,
+    ) -> None:
+        mock_exec.side_effect = [
+            _make_process(stdout=b'{}'),
+            _make_process(stdout=b"%50\n"),
+        ]
+        await provider.spawn_session("w1")
+
+        # Reset side_effect so return_value works
+        mock_exec.side_effect = None
+        mock_exec.return_value = _make_process(returncode=1, stderr=b"Connection refused")
+        info = await provider.get_status("w1")
+        assert info.status == SessionStatus.ERROR
+
+    @patch("shutil.which", return_value="/usr/bin/tmux")
+    @patch("asyncio.create_subprocess_exec")
+    async def test_stop_session(
+        self,
+        mock_exec: AsyncMock,
+        _mock_which: MagicMock,
+        provider: OpenCodeProvider,
+    ) -> None:
+        mock_exec.side_effect = [
+            _make_process(stdout=b'{}'),
+            _make_process(stdout=b"%50\n"),
+        ]
+        await provider.spawn_session("w1")
+
+        # DELETE /session/w1 then kill-pane
+        mock_exec.side_effect = [
+            _make_process(stdout=b'{}'),  # API delete
+            _make_process(),  # kill-pane
+        ]
+        await provider.stop_session("w1")
+
+        # After stop, session is removed locally; list_sessions calls API
+        # which will fail (side_effect exhausted), returning empty
+        mock_exec.side_effect = None
+        mock_exec.return_value = _make_process(returncode=1, stderr=b"no mock")
+        sessions = await provider.list_sessions()
+        assert isinstance(sessions, list)
+
+    @patch("shutil.which", return_value="/usr/bin/tmux")
+    @patch("asyncio.create_subprocess_exec")
+    async def test_list_sessions(
+        self,
+        mock_exec: AsyncMock,
+        _mock_which: MagicMock,
+        provider: OpenCodeProvider,
+    ) -> None:
+        mock_exec.side_effect = [
+            _make_process(stdout=b'{}'),
+            _make_process(stdout=b"%50\n"),
+        ]
+        await provider.spawn_session("w1")
+
+        # Reset side_effect so return_value works
+        mock_exec.side_effect = None
+        mock_exec.return_value = _make_process(
+            stdout=b'{"sessions": [{"id": "w1", "status": "idle"}]}'
+        )
+        sessions = await provider.list_sessions()
+        assert len(sessions) == 1
+        assert sessions[0].session_id == "w1"
+
+
+# ---------------------------------------------------------------------------
+# Config integration
+# ---------------------------------------------------------------------------
+
+
+class TestConfigIntegration:
+    def test_agent_provider_config_defaults(self) -> None:
+        from atc.config import AgentProviderConfig
+
+        cfg = AgentProviderConfig()
+        assert cfg.default == "claude_code"
+        assert cfg.opencode_url == "http://localhost:4096"
+        assert cfg.tmux_session == "atc"
+
+    def test_settings_has_agent_provider(self) -> None:
+        from atc.config import Settings
+
+        settings = Settings()
+        assert settings.agent_provider.default == "claude_code"
+
+    def test_create_provider_from_config(self) -> None:
+        from atc.config import AgentProviderConfig
+
+        cfg = AgentProviderConfig(default="opencode", opencode_url="http://localhost:5555")
+        provider = create_provider(
+            cfg.default,
+            base_url=cfg.opencode_url,
+            tmux_session=cfg.tmux_session,
+        )
+        assert provider.name == "opencode"
+
+    def test_create_claude_from_config(self) -> None:
+        from atc.config import AgentProviderConfig
+
+        cfg = AgentProviderConfig(default="claude_code")
+        provider = create_provider(
+            cfg.default,
+            tmux_session=cfg.tmux_session,
+            claude_command=cfg.claude_command,
+        )
+        assert provider.name == "claude_code"


### PR DESCRIPTION
## Summary
- Implements the `AgentProvider` protocol (base class) with methods: `spawn_session()`, `send_prompt()`, `get_status()`, `stream_output()`, `stop_session()`, `list_sessions()`
- `ClaudeCodeProvider` — wraps existing tmux + PTY approach behind the interface
- `OpenCodeProvider` — MVP implementation using OpenCode REST API (localhost:4096) with SSE streaming
- `AgentProviderFactory` — registry pattern for creating providers by name
- `AgentProviderConfig` added to `Settings` for provider selection via config.yaml
- Clean public API: `from atc.agents import create_provider, AgentProvider`

## Architecture
The factory pattern allows session lifecycle code to delegate to a provider instead of hardcoding tmux commands. Providers are registered at import time and instantiated by name from config. The pattern is extensible for future CLI tools.

```
AgentProvider (Protocol)
├── ClaudeCodeProvider  — tmux split-window + send-keys + capture-pane
└── OpenCodeProvider    — REST API + SSE streaming + tmux for observability
```

## Files Changed
| File | Description |
|------|-------------|
| `src/atc/agents/base.py` | AgentProvider protocol, data classes (SessionInfo, PromptResult, OutputChunk), ProviderError |
| `src/atc/agents/claude_provider.py` | ClaudeCodeProvider implementation |
| `src/atc/agents/opencode_provider.py` | OpenCodeProvider implementation |
| `src/atc/agents/factory.py` | Factory with registry, create_provider(), list_providers() |
| `src/atc/agents/__init__.py` | Public API exports |
| `src/atc/config.py` | AgentProviderConfig added to Settings |
| `tests/unit/test_agent_provider.py` | 41 unit tests |

## Testing Done
```
$ python3 -m pytest tests/unit/test_agent_provider.py -v
41 passed in 0.10s

$ python3 -m pytest tests/unit/ -v
113 passed in 0.29s  (no regressions)

$ ruff check src/atc/agents/ tests/unit/test_agent_provider.py
All checks passed!

$ mypy src/atc/agents/ --strict
Success: no issues found in 6 source files
```