### PR TITLE
feat: PTY streaming layer — reader, pool, parser, monitor

### DIFF
--- a/src/atc/core/events.py
+++ b/src/atc/core/events.py
@@ -1,1 +1,54 @@
-"""Core events — stub."""
+"""In-process pub/sub event bus for ATC subsystem communication."""
+
+from __future__ import annotations
+
+import contextlib
+import logging
+from collections import defaultdict
+from collections.abc import Callable, Coroutine
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+# Type alias for event handlers
+EventHandler = Callable[[dict[str, Any]], Coroutine[Any, Any, None]]
+
+
+class EventBus:
+    """Async in-process pub/sub event bus.
+
+    Subsystems publish events by name; registered handlers receive them
+    asynchronously.  Handlers that raise are logged but do not block
+    other subscribers.
+    """
+
+    def __init__(self) -> None:
+        self._handlers: dict[str, list[EventHandler]] = defaultdict(list)
+        self._started = False
+
+    def subscribe(self, event: str, handler: EventHandler) -> None:
+        """Register *handler* to be called whenever *event* is published."""
+        self._handlers[event].append(handler)
+
+    def unsubscribe(self, event: str, handler: EventHandler) -> None:
+        """Remove a previously registered handler."""
+        with contextlib.suppress(ValueError):
+            self._handlers[event].remove(handler)
+
+    async def publish(self, event: str, data: dict[str, Any] | None = None) -> None:
+        """Dispatch *event* with *data* to all registered handlers."""
+        payload = data or {}
+        for handler in list(self._handlers.get(event, [])):
+            try:
+                await handler(payload)
+            except Exception:
+                logger.exception("Event handler failed for %s", event)
+
+    async def start(self) -> None:
+        """Mark the bus as started (future-proofing for queue-based dispatch)."""
+        self._started = True
+
+    async def stop(self) -> None:
+        """Shut down the event bus."""
+        self._started = False
+        self._handlers.clear()

--- a/src/atc/terminal/__init__.py
+++ b/src/atc/terminal/__init__.py
@@ -1,0 +1,15 @@
+"""Terminal subsystem — PTY streaming, output parsing, and session monitoring."""
+
+from atc.terminal.monitor import MonitorPool, SessionMonitor
+from atc.terminal.output_parser import OutputParser, ParseResult, TuiState
+from atc.terminal.pty_stream import PtyStreamPool, PtyStreamReader
+
+__all__ = [
+    "MonitorPool",
+    "OutputParser",
+    "ParseResult",
+    "PtyStreamPool",
+    "PtyStreamReader",
+    "SessionMonitor",
+    "TuiState",
+]

--- a/src/atc/terminal/monitor.py
+++ b/src/atc/terminal/monitor.py
@@ -1,1 +1,196 @@
-"""Terminal monitor — stub."""
+"""Per-session monitor loop — detects status changes and publishes events.
+
+Each monitored session gets an asyncio task that:
+1. Receives PTY output chunks from the PtyStreamReader
+2. Feeds them through the OutputParser
+3. Detects state transitions (idle → working, working → waiting, etc.)
+4. Publishes status-change events on the event bus
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import logging
+from typing import TYPE_CHECKING
+
+from atc.terminal.output_parser import OutputParser, TuiState
+
+if TYPE_CHECKING:
+    from atc.core.events import EventBus
+    from atc.terminal.pty_stream import PtyStreamPool
+
+logger = logging.getLogger(__name__)
+
+# Map TUI states to session status strings used in DB / events
+_STATE_TO_STATUS: dict[TuiState, str] = {
+    TuiState.SHELL_PROMPT: "idle",
+    TuiState.CLAUDE_IDLE: "idle",
+    TuiState.CLAUDE_WORKING: "working",
+    TuiState.CLAUDE_WAITING: "waiting",
+    TuiState.ALTERNATE_SCREEN: "working",  # e.g. vim inside Claude
+}
+
+
+class SessionMonitor:
+    """Monitors a single session's PTY output for status changes."""
+
+    def __init__(
+        self,
+        session_id: str,
+        event_bus: EventBus,
+    ) -> None:
+        self._session_id = session_id
+        self._event_bus = event_bus
+        self._parser = OutputParser()
+        self._current_status: str = "idle"
+        self._queue: asyncio.Queue[bytes] = asyncio.Queue(maxsize=1024)
+        self._task: asyncio.Task[None] | None = None
+        self._running = False
+
+    @property
+    def session_id(self) -> str:
+        return self._session_id
+
+    @property
+    def current_status(self) -> str:
+        return self._current_status
+
+    @property
+    def alternate_on(self) -> bool:
+        return self._parser.alternate_on
+
+    @property
+    def running(self) -> bool:
+        return self._running
+
+    def enqueue(self, session_id: str, data: bytes) -> None:
+        """Callback for PtyStreamReader — enqueue a chunk for processing."""
+        if session_id != self._session_id:
+            return
+        try:
+            self._queue.put_nowait(data)
+        except asyncio.QueueFull:
+            logger.warning("Monitor queue full for %s, dropping chunk", self._session_id)
+
+    async def start(self) -> None:
+        """Start the monitor loop."""
+        if self._running:
+            return
+        self._running = True
+        self._task = asyncio.create_task(
+            self._monitor_loop(), name=f"monitor-{self._session_id}"
+        )
+        logger.info("SessionMonitor started for %s", self._session_id)
+
+    async def stop(self) -> None:
+        """Stop the monitor loop."""
+        self._running = False
+        if self._task and not self._task.done():
+            self._task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await self._task
+            self._task = None
+        logger.info("SessionMonitor stopped for %s", self._session_id)
+
+    async def _monitor_loop(self) -> None:
+        """Process queued PTY chunks and detect status transitions."""
+        while self._running:
+            try:
+                chunk = await asyncio.wait_for(self._queue.get(), timeout=1.0)
+            except TimeoutError:
+                continue
+            except asyncio.CancelledError:
+                raise
+
+            try:
+                result = self._parser.feed(chunk)
+                new_status = _STATE_TO_STATUS.get(result.state)
+
+                if new_status and new_status != self._current_status:
+                    old_status = self._current_status
+                    self._current_status = new_status
+                    await self._event_bus.publish("session_status_changed", {
+                        "session_id": self._session_id,
+                        "old_status": old_status,
+                        "new_status": new_status,
+                        "tui_state": result.state.value,
+                        "alternate_on": result.alternate_on,
+                    })
+
+                # Publish cost events when detected
+                if result.cost_dollars is not None:
+                    await self._event_bus.publish("session_cost_update", {
+                        "session_id": self._session_id,
+                        "cost_dollars": result.cost_dollars,
+                        "tokens_in": result.tokens_in,
+                        "tokens_out": result.tokens_out,
+                    })
+
+                # Publish error events when detected
+                if result.error_text:
+                    await self._event_bus.publish("session_error", {
+                        "session_id": self._session_id,
+                        "error_text": result.error_text,
+                    })
+
+            except Exception:
+                logger.exception("Monitor parse error for %s", self._session_id)
+
+
+class MonitorPool:
+    """Manages SessionMonitor instances for all active sessions.
+
+    Coordinates with PtyStreamPool to register data callbacks
+    and manages the lifecycle of per-session monitors.
+    """
+
+    def __init__(
+        self,
+        event_bus: EventBus,
+        pty_pool: PtyStreamPool,
+    ) -> None:
+        self._event_bus = event_bus
+        self._pty_pool = pty_pool
+        self._monitors: dict[str, SessionMonitor] = {}
+
+    @property
+    def session_ids(self) -> list[str]:
+        return list(self._monitors.keys())
+
+    def get_monitor(self, session_id: str) -> SessionMonitor | None:
+        return self._monitors.get(session_id)
+
+    async def add_session(self, session_id: str) -> SessionMonitor:
+        """Create and start a monitor for the given session.
+
+        The monitor is wired to the session's PtyStreamReader as a data callback.
+        """
+        if session_id in self._monitors:
+            await self.remove_session(session_id)
+
+        monitor = SessionMonitor(
+            session_id=session_id,
+            event_bus=self._event_bus,
+        )
+
+        # Wire up the PTY reader callback
+        reader = self._pty_pool.get_reader(session_id)
+        if reader:
+            reader.on_data(monitor.enqueue)
+
+        await monitor.start()
+        self._monitors[session_id] = monitor
+        return monitor
+
+    async def remove_session(self, session_id: str) -> None:
+        """Stop and remove the monitor for the given session."""
+        monitor = self._monitors.pop(session_id, None)
+        if monitor:
+            await monitor.stop()
+
+    async def stop_all(self) -> None:
+        """Stop all monitors."""
+        for monitor in list(self._monitors.values()):
+            await monitor.stop()
+        self._monitors.clear()

--- a/src/atc/terminal/output_parser.py
+++ b/src/atc/terminal/output_parser.py
@@ -1,1 +1,246 @@
-"""Terminal output_parser — stub."""
+"""Regex-based TUI state detection and prompt parsing for tmux PTY output.
+
+Detects Claude Code TUI states, shell prompts, and status transitions
+from raw terminal output captured via tmux pipe-pane.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from enum import StrEnum
+
+
+class TuiState(StrEnum):
+    """Detected state of the terminal session."""
+
+    SHELL_PROMPT = "shell_prompt"
+    CLAUDE_IDLE = "claude_idle"        # Claude TUI visible, waiting for input
+    CLAUDE_WORKING = "claude_working"  # Claude is generating / using tools
+    CLAUDE_WAITING = "claude_waiting"  # Claude finished, waiting for user
+    ALTERNATE_SCREEN = "alternate_screen"  # Full-screen TUI active (e.g. vim)
+    UNKNOWN = "unknown"
+
+
+@dataclass
+class ParseResult:
+    """Result of parsing a chunk of terminal output."""
+
+    state: TuiState = TuiState.UNKNOWN
+    prompt_detected: bool = False
+    prompt_text: str = ""
+    alternate_on: bool = False
+    cost_dollars: float | None = None
+    tokens_in: int | None = None
+    tokens_out: int | None = None
+    tool_name: str | None = None
+    error_text: str | None = None
+
+
+# --- Pattern constants ---
+
+# Shell prompt patterns (bash/zsh)
+_SHELL_PROMPT_RE = re.compile(
+    r"(?:^|\n)"            # start of line
+    r"(?:\x1b\[[^m]*m)*"   # optional ANSI escapes
+    r"(?:"
+    r"[\w@.\-]+[#$%>]\s*"  # user@host$ or similar
+    r"|"
+    r"\$ \s*"              # bare dollar prompt
+    r")"
+    r"$",                  # at end of chunk
+    re.MULTILINE,
+)
+
+# Claude Code TUI markers
+_CLAUDE_IDLE_RE = re.compile(
+    r"(?:"
+    r"Type a message"       # Claude idle prompt text
+    r"|"
+    r"What would you like"  # alternate idle phrasing
+    r"|"
+    r">\s*$"               # simple > prompt from Claude
+    r")",
+    re.IGNORECASE,
+)
+
+_CLAUDE_WORKING_PATTERNS = [
+    re.compile(r"⠋|⠙|⠹|⠸|⠼|⠴|⠦|⠧|⠇|⠏"),  # spinner characters
+    re.compile(r"Thinking|Working|Reading|Writing|Searching|Running", re.IGNORECASE),
+    re.compile(r"Tool:?\s+\w+", re.IGNORECASE),
+    re.compile(r"━+"),  # progress bar
+]
+
+_CLAUDE_WAITING_RE = re.compile(
+    r"(?:"
+    r"Do you want to proceed"
+    r"|"
+    r"Yes\s*/\s*No"
+    r"|"
+    r"\[Y/n\]"
+    r"|"
+    r"Would you like to (?:proceed|approve|confirm|accept)"
+    r"|"
+    r"Press Enter"
+    r")",
+    re.IGNORECASE,
+)
+
+# Cost line from Claude Code output: e.g. "Cost: $0.12 | Tokens: 1.2k in, 0.8k out"
+_COST_RE = re.compile(
+    r"\$(\d+\.?\d*)"
+    r".*?"
+    r"(\d+(?:\.\d+)?)\s*k?\s*in"
+    r".*?"
+    r"(\d+(?:\.\d+)?)\s*k?\s*out",
+    re.IGNORECASE,
+)
+
+# Tool usage detection
+_TOOL_RE = re.compile(
+    r"(?:Tool|Using|Running):\s*(\w[\w\-]*)",
+    re.IGNORECASE,
+)
+
+# Error patterns
+_ERROR_RE = re.compile(
+    r"(?:Error|ERROR|FATAL|Traceback|panic)[:.\s](.{1,200})",
+)
+
+# Alternate screen control sequences
+_ALT_SCREEN_ON = re.compile(r"\x1b\[\?1049h|\x1b\[\?47h")
+_ALT_SCREEN_OFF = re.compile(r"\x1b\[\?1049l|\x1b\[\?47l")
+
+
+def strip_ansi(text: str) -> str:
+    """Remove ANSI escape sequences from text."""
+    return re.sub(r"\x1b\[[0-9;]*[A-Za-z]|\x1b\][^\x07]*\x07", "", text)
+
+
+class OutputParser:
+    """Stateful parser that tracks TUI state across successive output chunks.
+
+    Feed chunks of raw terminal output via ``feed()`` and inspect the
+    returned ``ParseResult`` to determine the current terminal state.
+    """
+
+    def __init__(self) -> None:
+        self._alternate_on: bool = False
+        self._last_state: TuiState = TuiState.UNKNOWN
+        self._buffer: str = ""
+        self._max_buffer: int = 8192
+
+    @property
+    def alternate_on(self) -> bool:
+        """Whether the terminal is currently in alternate screen mode."""
+        return self._alternate_on
+
+    @property
+    def last_state(self) -> TuiState:
+        """The most recently detected TUI state."""
+        return self._last_state
+
+    def reset(self) -> None:
+        """Reset parser state."""
+        self._alternate_on = False
+        self._last_state = TuiState.UNKNOWN
+        self._buffer = ""
+
+    def feed(self, data: str | bytes) -> ParseResult:
+        """Parse a chunk of terminal output and return detected state.
+
+        Args:
+            data: Raw terminal output (str or bytes).
+
+        Returns:
+            ParseResult with detected state and extracted metadata.
+        """
+        if isinstance(data, bytes):
+            try:
+                text = data.decode("utf-8", errors="replace")
+            except Exception:
+                text = data.decode("latin-1")
+        else:
+            text = data
+
+        result = ParseResult()
+
+        # Track alternate screen transitions
+        if _ALT_SCREEN_ON.search(text):
+            self._alternate_on = True
+        if _ALT_SCREEN_OFF.search(text):
+            self._alternate_on = False
+        result.alternate_on = self._alternate_on
+
+        if self._alternate_on:
+            result.state = TuiState.ALTERNATE_SCREEN
+            self._last_state = result.state
+            return result
+
+        # Work on ANSI-stripped text for pattern matching
+        clean = strip_ansi(text)
+
+        # Append to rolling buffer for multi-chunk detection
+        self._buffer += clean
+        if len(self._buffer) > self._max_buffer:
+            self._buffer = self._buffer[-self._max_buffer:]
+
+        # Extract cost info
+        cost_match = _COST_RE.search(clean)
+        if cost_match:
+            result.cost_dollars = float(cost_match.group(1))
+            raw_in = float(cost_match.group(2))
+            raw_out = float(cost_match.group(3))
+            # Handle "k" suffix — if < 100, assume it was in thousands
+            if "k" in cost_match.group(0).lower():
+                result.tokens_in = int(raw_in * 1000)
+                result.tokens_out = int(raw_out * 1000)
+            else:
+                result.tokens_in = int(raw_in)
+                result.tokens_out = int(raw_out)
+
+        # Extract tool usage
+        tool_match = _TOOL_RE.search(clean)
+        if tool_match:
+            result.tool_name = tool_match.group(1)
+
+        # Extract errors
+        error_match = _ERROR_RE.search(clean)
+        if error_match:
+            result.error_text = error_match.group(1).strip()
+
+        # Determine TUI state (order matters — most specific first)
+        state = self._detect_state(clean)
+        result.state = state
+        self._last_state = state
+
+        # Detect shell prompt
+        if state == TuiState.SHELL_PROMPT:
+            result.prompt_detected = True
+            prompt_match = _SHELL_PROMPT_RE.search(clean)
+            if prompt_match:
+                result.prompt_text = prompt_match.group(0).strip()
+
+        return result
+
+    def _detect_state(self, clean: str) -> TuiState:
+        """Determine TUI state from ANSI-stripped text."""
+        # Check for Claude waiting (user action needed)
+        if _CLAUDE_WAITING_RE.search(clean):
+            return TuiState.CLAUDE_WAITING
+
+        # Check for Claude working (spinner, tool use, etc.)
+        for pattern in _CLAUDE_WORKING_PATTERNS:
+            if pattern.search(clean):
+                return TuiState.CLAUDE_WORKING
+
+        # Check for Claude idle (ready for input)
+        if _CLAUDE_IDLE_RE.search(clean):
+            return TuiState.CLAUDE_IDLE
+
+        # Check for shell prompt
+        if _SHELL_PROMPT_RE.search(clean):
+            return TuiState.SHELL_PROMPT
+
+        # Fall back to last known state if nothing matches
+        return self._last_state if self._last_state != TuiState.UNKNOWN else TuiState.UNKNOWN

--- a/src/atc/terminal/pty_stream.py
+++ b/src/atc/terminal/pty_stream.py
@@ -1,1 +1,309 @@
-"""Terminal pty_stream — stub."""
+"""PTY streaming via tmux pipe-pane → FIFO → asyncio reader.
+
+PtyStreamReader  — reads from a per-session FIFO created by tmux pipe-pane.
+PtyStreamPool    — manages readers for all active sessions, lifecycle hooks.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import logging
+import os
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from atc.core.events import EventBus
+
+logger = logging.getLogger(__name__)
+
+# Default directory for FIFO files
+FIFO_DIR = Path("/tmp/atc/fifos")
+
+# Read buffer size (64 KiB)
+READ_BUFFER = 65536
+
+
+class PtyStreamReader:
+    """Reads raw PTY output from a per-session FIFO.
+
+    tmux pipe-pane writes terminal output into a named pipe (FIFO).
+    This reader opens the FIFO in non-blocking mode and publishes
+    binary chunks to registered callbacks and the WebSocket hub.
+
+    Lifecycle:
+        1. ``start()`` — create FIFO, attach tmux pipe-pane, begin reading.
+        2. Reading loop runs until ``stop()`` is called.
+        3. ``stop()`` — detach pipe-pane, close FIFO, clean up.
+    """
+
+    def __init__(
+        self,
+        session_id: str,
+        tmux_pane: str,
+        event_bus: EventBus,
+        fifo_dir: Path = FIFO_DIR,
+    ) -> None:
+        self._session_id = session_id
+        self._tmux_pane = tmux_pane
+        self._event_bus = event_bus
+        self._fifo_dir = fifo_dir
+        self._fifo_path: Path | None = None
+        self._task: asyncio.Task[None] | None = None
+        self._running = False
+        self._callbacks: list[Any] = []
+
+    @property
+    def session_id(self) -> str:
+        return self._session_id
+
+    @property
+    def fifo_path(self) -> Path | None:
+        return self._fifo_path
+
+    @property
+    def running(self) -> bool:
+        return self._running
+
+    def on_data(self, callback: Any) -> None:
+        """Register a callback invoked with (session_id, bytes) on each chunk."""
+        self._callbacks.append(callback)
+
+    async def start(self) -> None:
+        """Create FIFO, attach tmux pipe-pane, and begin the read loop."""
+        if self._running:
+            return
+
+        self._fifo_dir.mkdir(parents=True, exist_ok=True)
+        fifo = self._fifo_dir / f"{self._session_id}.fifo"
+
+        # Create FIFO if it doesn't exist
+        if fifo.exists():
+            fifo.unlink()
+        os.mkfifo(str(fifo))
+        self._fifo_path = fifo
+
+        # Attach tmux pipe-pane to write output into the FIFO
+        await self._run_tmux(
+            "pipe-pane", "-t", self._tmux_pane, f"cat >> {fifo}"
+        )
+
+        self._running = True
+        self._task = asyncio.create_task(self._read_loop(), name=f"pty-{self._session_id}")
+        logger.info(
+            "PtyStreamReader started for session %s (pane %s)",
+            self._session_id, self._tmux_pane,
+        )
+
+    async def stop(self) -> None:
+        """Detach pipe-pane, cancel reader task, and clean up FIFO."""
+        if not self._running:
+            return
+
+        self._running = False
+
+        # Detach tmux pipe-pane (empty string disables piping)
+        try:
+            await self._run_tmux("pipe-pane", "-t", self._tmux_pane, "")
+        except Exception:
+            logger.warning("Failed to detach pipe-pane for %s", self._session_id)
+
+        # Cancel the read loop
+        if self._task and not self._task.done():
+            self._task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await self._task
+            self._task = None
+
+        # Remove FIFO
+        if self._fifo_path and self._fifo_path.exists():
+            with contextlib.suppress(OSError):
+                self._fifo_path.unlink()
+
+        logger.info("PtyStreamReader stopped for session %s", self._session_id)
+
+    async def _read_loop(self) -> None:
+        """Continuously read from FIFO and dispatch chunks."""
+        while self._running:
+            fd: int | None = None
+            try:
+                # Open FIFO non-blocking — blocks in asyncio until a writer attaches
+                fd = await asyncio.get_event_loop().run_in_executor(
+                    None, lambda: os.open(str(self._fifo_path), os.O_RDONLY | os.O_NONBLOCK)
+                )
+
+                stream_reader = asyncio.StreamReader()
+                protocol = asyncio.StreamReaderProtocol(stream_reader)
+                read_transport, _ = await asyncio.get_event_loop().connect_read_pipe(
+                    lambda _proto=protocol: _proto,
+                    os.fdopen(fd, "rb", closefd=False),
+                )
+
+                try:
+                    while self._running:
+                        chunk = await stream_reader.read(READ_BUFFER)
+                        if not chunk:
+                            # Writer closed — reopen
+                            break
+                        await self._dispatch(chunk)
+                finally:
+                    read_transport.close()
+
+            except asyncio.CancelledError:
+                raise
+            except Exception:
+                if self._running:
+                    logger.exception("Read error for session %s", self._session_id)
+                    await asyncio.sleep(0.5)
+            finally:
+                if fd is not None:
+                    with contextlib.suppress(OSError):
+                        os.close(fd)
+
+    async def _dispatch(self, chunk: bytes) -> None:
+        """Forward a raw PTY chunk to callbacks and the event bus."""
+        for cb in self._callbacks:
+            try:
+                result = cb(self._session_id, chunk)
+                if asyncio.iscoroutine(result):
+                    await result
+            except Exception:
+                logger.exception("Callback error for session %s", self._session_id)
+
+        # Publish on the event bus for WsHub integration
+        await self._event_bus.publish("pty_output", {
+            "session_id": self._session_id,
+            "data": chunk,
+        })
+
+    @staticmethod
+    async def _run_tmux(*args: str) -> str:
+        """Execute a tmux command and return stdout."""
+        proc = await asyncio.create_subprocess_exec(
+            "tmux", *args,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+        stdout, stderr = await proc.communicate()
+        if proc.returncode != 0:
+            msg = stderr.decode(errors="replace").strip()
+            raise RuntimeError(f"tmux {args[0]} failed: {msg}")
+        return stdout.decode(errors="replace").strip()
+
+
+class PtyStreamPool:
+    """Manages PtyStreamReader instances for all active sessions.
+
+    Provides lifecycle management (start/stop readers), lookup by session ID,
+    and integration with the WsHub for binary frame distribution.
+    """
+
+    def __init__(self, event_bus: EventBus, fifo_dir: Path = FIFO_DIR) -> None:
+        self._event_bus = event_bus
+        self._fifo_dir = fifo_dir
+        self._readers: dict[str, PtyStreamReader] = {}
+        self._started = False
+
+    @property
+    def session_ids(self) -> list[str]:
+        """List of session IDs with active readers."""
+        return list(self._readers.keys())
+
+    def get_reader(self, session_id: str) -> PtyStreamReader | None:
+        """Return the reader for *session_id*, or ``None``."""
+        return self._readers.get(session_id)
+
+    async def start(self) -> None:
+        """Start the pool (ensure FIFO directory exists)."""
+        self._fifo_dir.mkdir(parents=True, exist_ok=True)
+        self._started = True
+        logger.info("PtyStreamPool started (fifo_dir=%s)", self._fifo_dir)
+
+    async def stop(self) -> None:
+        """Stop all readers and shut down the pool."""
+        for reader in list(self._readers.values()):
+            await reader.stop()
+        self._readers.clear()
+        self._started = False
+        logger.info("PtyStreamPool stopped")
+
+    async def add_session(
+        self,
+        session_id: str,
+        tmux_pane: str,
+    ) -> PtyStreamReader:
+        """Create and start a reader for the given session.
+
+        If a reader already exists for *session_id*, it is stopped first.
+        """
+        if session_id in self._readers:
+            await self.remove_session(session_id)
+
+        reader = PtyStreamReader(
+            session_id=session_id,
+            tmux_pane=tmux_pane,
+            event_bus=self._event_bus,
+            fifo_dir=self._fifo_dir,
+        )
+        await reader.start()
+        self._readers[session_id] = reader
+        return reader
+
+    async def remove_session(self, session_id: str) -> None:
+        """Stop and remove the reader for *session_id*."""
+        reader = self._readers.pop(session_id, None)
+        if reader:
+            await reader.stop()
+
+    async def send_keys(self, session_id: str, keys: str) -> None:
+        """Send keystrokes to a session's tmux pane via tmux send-keys.
+
+        This is the input path: keystrokes from the frontend WebSocket
+        are forwarded to the tmux pane.
+        """
+        reader = self._readers.get(session_id)
+        if reader is None:
+            raise ValueError(f"No active reader for session {session_id}")
+        await PtyStreamReader._run_tmux("send-keys", "-t", reader._tmux_pane, keys)
+
+    async def send_instruction(self, session_id: str, text: str) -> None:
+        """Send an instruction followed by Enter to a session's tmux pane.
+
+        Implements the atomic instruction pattern from PATTERNS.md:
+        text and Enter are sent back-to-back with no await gap.
+        """
+        reader = self._readers.get(session_id)
+        if reader is None:
+            raise ValueError(f"No active reader for session {session_id}")
+
+        pane = reader._tmux_pane
+        await PtyStreamReader._run_tmux("send-keys", "-t", pane, text)
+        await PtyStreamReader._run_tmux("send-keys", "-t", pane, "Enter")
+
+    async def check_tui_ready(self, session_id: str) -> bool:
+        """Check if the session's TUI is ready for input (not in alternate screen).
+
+        Returns True if the pane is NOT in alternate screen mode.
+        """
+        reader = self._readers.get(session_id)
+        if reader is None:
+            raise ValueError(f"No active reader for session {session_id}")
+
+        try:
+            output = await PtyStreamReader._run_tmux(
+                "display-message", "-t", reader._tmux_pane, "-p", "#{alternate_on}"
+            )
+            return output.strip() == "0"
+        except RuntimeError:
+            return False
+
+    async def capture_pane(self, session_id: str) -> str:
+        """Capture the current visible content of a session's tmux pane."""
+        reader = self._readers.get(session_id)
+        if reader is None:
+            raise ValueError(f"No active reader for session {session_id}")
+
+        return await PtyStreamReader._run_tmux(
+            "capture-pane", "-t", reader._tmux_pane, "-p"
+        )

--- a/tests/unit/test_events.py
+++ b/tests/unit/test_events.py
@@ -1,0 +1,113 @@
+"""Unit tests for the EventBus."""
+
+from __future__ import annotations
+
+import pytest
+
+from atc.core.events import EventBus
+
+
+class TestEventBus:
+    @pytest.fixture
+    def bus(self) -> EventBus:
+        return EventBus()
+
+    async def test_publish_no_subscribers(self, bus: EventBus) -> None:
+        """Publishing with no subscribers should not raise."""
+        await bus.publish("some_event", {"key": "value"})
+
+    async def test_subscribe_and_receive(self, bus: EventBus) -> None:
+        received: list[dict] = []
+
+        async def handler(data: dict) -> None:
+            received.append(data)
+
+        bus.subscribe("test_event", handler)
+        await bus.publish("test_event", {"x": 1})
+
+        assert len(received) == 1
+        assert received[0] == {"x": 1}
+
+    async def test_multiple_subscribers(self, bus: EventBus) -> None:
+        results: list[str] = []
+
+        async def handler_a(data: dict) -> None:
+            results.append("a")
+
+        async def handler_b(data: dict) -> None:
+            results.append("b")
+
+        bus.subscribe("ev", handler_a)
+        bus.subscribe("ev", handler_b)
+        await bus.publish("ev")
+
+        assert sorted(results) == ["a", "b"]
+
+    async def test_unsubscribe(self, bus: EventBus) -> None:
+        received: list[dict] = []
+
+        async def handler(data: dict) -> None:
+            received.append(data)
+
+        bus.subscribe("ev", handler)
+        bus.unsubscribe("ev", handler)
+        await bus.publish("ev", {"x": 1})
+
+        assert len(received) == 0
+
+    async def test_unsubscribe_nonexistent(self, bus: EventBus) -> None:
+        """Unsubscribing a handler that was never registered should not raise."""
+
+        async def handler(data: dict) -> None:
+            pass
+
+        bus.unsubscribe("ev", handler)  # no error
+
+    async def test_handler_error_does_not_block_others(self, bus: EventBus) -> None:
+        results: list[str] = []
+
+        async def bad_handler(data: dict) -> None:
+            raise RuntimeError("boom")
+
+        async def good_handler(data: dict) -> None:
+            results.append("ok")
+
+        bus.subscribe("ev", bad_handler)
+        bus.subscribe("ev", good_handler)
+        await bus.publish("ev")
+
+        assert results == ["ok"]
+
+    async def test_publish_default_data(self, bus: EventBus) -> None:
+        received: list[dict] = []
+
+        async def handler(data: dict) -> None:
+            received.append(data)
+
+        bus.subscribe("ev", handler)
+        await bus.publish("ev")  # no data arg
+
+        assert received == [{}]
+
+    async def test_start_stop(self, bus: EventBus) -> None:
+        await bus.start()
+        await bus.stop()
+        # After stop, handlers are cleared
+        assert len(bus._handlers) == 0
+
+    async def test_events_are_isolated(self, bus: EventBus) -> None:
+        a_results: list[str] = []
+        b_results: list[str] = []
+
+        async def handler_a(data: dict) -> None:
+            a_results.append("a")
+
+        async def handler_b(data: dict) -> None:
+            b_results.append("b")
+
+        bus.subscribe("event_a", handler_a)
+        bus.subscribe("event_b", handler_b)
+
+        await bus.publish("event_a")
+        assert a_results == ["a"]
+        assert b_results == []

--- a/tests/unit/test_monitor.py
+++ b/tests/unit/test_monitor.py
@@ -1,0 +1,236 @@
+"""Unit tests for SessionMonitor and MonitorPool."""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import MagicMock
+
+import pytest
+
+from atc.core.events import EventBus
+from atc.terminal.monitor import MonitorPool, SessionMonitor
+from atc.terminal.pty_stream import PtyStreamPool, PtyStreamReader
+
+
+@pytest.fixture
+def event_bus() -> EventBus:
+    return EventBus()
+
+
+# ---------------------------------------------------------------------------
+# SessionMonitor
+# ---------------------------------------------------------------------------
+
+class TestSessionMonitor:
+    @pytest.fixture
+    def monitor(self, event_bus: EventBus) -> SessionMonitor:
+        return SessionMonitor(session_id="sess-1", event_bus=event_bus)
+
+    def test_properties(self, monitor: SessionMonitor) -> None:
+        assert monitor.session_id == "sess-1"
+        assert monitor.current_status == "idle"
+        assert monitor.alternate_on is False
+        assert monitor.running is False
+
+    async def test_start_stop(self, monitor: SessionMonitor) -> None:
+        await monitor.start()
+        assert monitor.running is True
+        await monitor.stop()
+        assert monitor.running is False
+
+    async def test_start_idempotent(self, monitor: SessionMonitor) -> None:
+        await monitor.start()
+        await monitor.start()  # no-op
+        assert monitor.running is True
+        await monitor.stop()
+
+    def test_enqueue(self, monitor: SessionMonitor) -> None:
+        monitor.enqueue("sess-1", b"hello")
+        assert monitor._queue.qsize() == 1
+
+    def test_enqueue_wrong_session(self, monitor: SessionMonitor) -> None:
+        monitor.enqueue("other-session", b"hello")
+        assert monitor._queue.qsize() == 0
+
+    async def test_detects_working_status(
+        self, monitor: SessionMonitor, event_bus: EventBus
+    ) -> None:
+        events: list[dict] = []
+
+        async def handler(data: dict) -> None:
+            events.append(data)
+
+        event_bus.subscribe("session_status_changed", handler)
+
+        await monitor.start()
+        monitor.enqueue("sess-1", b"\xe2\xa0\x8b Thinking...")  # ⠋ spinner
+        await asyncio.sleep(0.2)
+        await monitor.stop()
+
+        assert len(events) >= 1
+        assert events[0]["session_id"] == "sess-1"
+        assert events[0]["old_status"] == "idle"
+        assert events[0]["new_status"] == "working"
+
+    async def test_detects_waiting_status(
+        self, monitor: SessionMonitor, event_bus: EventBus
+    ) -> None:
+        events: list[dict] = []
+
+        async def handler(data: dict) -> None:
+            events.append(data)
+
+        event_bus.subscribe("session_status_changed", handler)
+
+        await monitor.start()
+        # First make it "working"
+        monitor.enqueue("sess-1", b"Working on task...")
+        await asyncio.sleep(0.1)
+        # Then transition to "waiting"
+        monitor.enqueue("sess-1", b"Do you want to proceed?")
+        await asyncio.sleep(0.2)
+        await monitor.stop()
+
+        statuses = [e["new_status"] for e in events]
+        assert "working" in statuses
+        assert "waiting" in statuses
+
+    async def test_publishes_cost_event(
+        self, monitor: SessionMonitor, event_bus: EventBus
+    ) -> None:
+        costs: list[dict] = []
+
+        async def handler(data: dict) -> None:
+            costs.append(data)
+
+        event_bus.subscribe("session_cost_update", handler)
+
+        await monitor.start()
+        monitor.enqueue("sess-1", b"Cost: $0.15 | Tokens: 2.0k in, 1.5k out")
+        await asyncio.sleep(0.2)
+        await monitor.stop()
+
+        assert len(costs) >= 1
+        assert costs[0]["cost_dollars"] == 0.15
+        assert costs[0]["session_id"] == "sess-1"
+
+    async def test_publishes_error_event(
+        self, monitor: SessionMonitor, event_bus: EventBus
+    ) -> None:
+        errors: list[dict] = []
+
+        async def handler(data: dict) -> None:
+            errors.append(data)
+
+        event_bus.subscribe("session_error", handler)
+
+        await monitor.start()
+        monitor.enqueue("sess-1", b"Error: connection refused")
+        await asyncio.sleep(0.2)
+        await monitor.stop()
+
+        assert len(errors) >= 1
+        assert "connection refused" in errors[0]["error_text"]
+
+    async def test_no_duplicate_status_events(
+        self, monitor: SessionMonitor, event_bus: EventBus
+    ) -> None:
+        """Same status should not trigger duplicate events."""
+        events: list[dict] = []
+
+        async def handler(data: dict) -> None:
+            events.append(data)
+
+        event_bus.subscribe("session_status_changed", handler)
+
+        await monitor.start()
+        monitor.enqueue("sess-1", b"Working on task...")
+        await asyncio.sleep(0.1)
+        monitor.enqueue("sess-1", b"Still working...")  # same state
+        await asyncio.sleep(0.2)
+        await monitor.stop()
+
+        # Should only get one transition to "working"
+        working_events = [e for e in events if e["new_status"] == "working"]
+        assert len(working_events) == 1
+
+    async def test_queue_full_drops(self, monitor: SessionMonitor) -> None:
+        """When queue is full, new chunks should be dropped without error."""
+        for _ in range(1100):
+            monitor.enqueue("sess-1", b"x")
+        # Queue maxsize is 1024, so some were dropped — no error raised
+
+
+# ---------------------------------------------------------------------------
+# MonitorPool
+# ---------------------------------------------------------------------------
+
+class TestMonitorPool:
+    @pytest.fixture
+    def pty_pool(self, event_bus: EventBus, tmp_path: object) -> MagicMock:
+        pool = MagicMock(spec=PtyStreamPool)
+        pool.get_reader.return_value = MagicMock(spec=PtyStreamReader)
+        return pool
+
+    @pytest.fixture
+    def monitor_pool(
+        self, event_bus: EventBus, pty_pool: MagicMock
+    ) -> MonitorPool:
+        return MonitorPool(event_bus=event_bus, pty_pool=pty_pool)
+
+    async def test_add_session(
+        self, monitor_pool: MonitorPool, pty_pool: MagicMock
+    ) -> None:
+        monitor = await monitor_pool.add_session("sess-1")
+        assert monitor.session_id == "sess-1"
+        assert monitor.running is True
+        assert "sess-1" in monitor_pool.session_ids
+        await monitor_pool.stop_all()
+
+    async def test_remove_session(self, monitor_pool: MonitorPool) -> None:
+        await monitor_pool.add_session("sess-1")
+        await monitor_pool.remove_session("sess-1")
+        assert "sess-1" not in monitor_pool.session_ids
+
+    async def test_get_monitor(self, monitor_pool: MonitorPool) -> None:
+        await monitor_pool.add_session("sess-1")
+        m = monitor_pool.get_monitor("sess-1")
+        assert m is not None
+        assert m.session_id == "sess-1"
+        await monitor_pool.stop_all()
+
+    async def test_get_monitor_nonexistent(self, monitor_pool: MonitorPool) -> None:
+        assert monitor_pool.get_monitor("nope") is None
+
+    async def test_add_session_replaces_existing(
+        self, monitor_pool: MonitorPool
+    ) -> None:
+        m1 = await monitor_pool.add_session("sess-1")
+        m2 = await monitor_pool.add_session("sess-1")
+        assert m1 is not m2
+        assert m1.running is False
+        assert m2.running is True
+        await monitor_pool.stop_all()
+
+    async def test_stop_all(self, monitor_pool: MonitorPool) -> None:
+        await monitor_pool.add_session("sess-1")
+        await monitor_pool.add_session("sess-2")
+        await monitor_pool.stop_all()
+        assert monitor_pool.session_ids == []
+
+    async def test_wires_pty_callback(
+        self, monitor_pool: MonitorPool, pty_pool: MagicMock
+    ) -> None:
+        reader = pty_pool.get_reader.return_value
+        await monitor_pool.add_session("sess-1")
+        reader.on_data.assert_called_once()
+        await monitor_pool.stop_all()
+
+    async def test_handles_no_reader(
+        self, monitor_pool: MonitorPool, pty_pool: MagicMock
+    ) -> None:
+        """If PTY reader doesn't exist yet, monitor should still start."""
+        pty_pool.get_reader.return_value = None
+        monitor = await monitor_pool.add_session("sess-1")
+        assert monitor.running is True
+        await monitor_pool.stop_all()

--- a/tests/unit/test_output_parser.py
+++ b/tests/unit/test_output_parser.py
@@ -1,1 +1,313 @@
-"""Unit tests for output parser."""
+"""Unit tests for OutputParser — TUI state detection and prompt parsing."""
+
+from __future__ import annotations
+
+from atc.terminal.output_parser import OutputParser, ParseResult, TuiState, strip_ansi
+
+# ---------------------------------------------------------------------------
+# strip_ansi
+# ---------------------------------------------------------------------------
+
+class TestStripAnsi:
+    def test_plain_text(self) -> None:
+        assert strip_ansi("hello world") == "hello world"
+
+    def test_removes_color_codes(self) -> None:
+        assert strip_ansi("\x1b[32mgreen\x1b[0m") == "green"
+
+    def test_removes_bold(self) -> None:
+        assert strip_ansi("\x1b[1mbold\x1b[0m") == "bold"
+
+    def test_removes_osc_sequences(self) -> None:
+        assert strip_ansi("\x1b]0;title\x07text") == "text"
+
+    def test_empty_string(self) -> None:
+        assert strip_ansi("") == ""
+
+    def test_multiple_sequences(self) -> None:
+        result = strip_ansi("\x1b[31mred\x1b[0m and \x1b[34mblue\x1b[0m")
+        assert result == "red and blue"
+
+
+# ---------------------------------------------------------------------------
+# TuiState enum
+# ---------------------------------------------------------------------------
+
+class TestTuiState:
+    def test_values(self) -> None:
+        assert TuiState.SHELL_PROMPT == "shell_prompt"
+        assert TuiState.CLAUDE_IDLE == "claude_idle"
+        assert TuiState.CLAUDE_WORKING == "claude_working"
+        assert TuiState.CLAUDE_WAITING == "claude_waiting"
+        assert TuiState.ALTERNATE_SCREEN == "alternate_screen"
+        assert TuiState.UNKNOWN == "unknown"
+
+
+# ---------------------------------------------------------------------------
+# OutputParser — basic state detection
+# ---------------------------------------------------------------------------
+
+class TestOutputParserStateDetection:
+    def setup_method(self) -> None:
+        self.parser = OutputParser()
+
+    def test_initial_state_is_unknown(self) -> None:
+        assert self.parser.last_state == TuiState.UNKNOWN
+        assert not self.parser.alternate_on
+
+    def test_shell_prompt_dollar(self) -> None:
+        result = self.parser.feed("user@host$ ")
+        assert result.state == TuiState.SHELL_PROMPT
+        assert result.prompt_detected is True
+
+    def test_shell_prompt_bare_dollar(self) -> None:
+        result = self.parser.feed("$ ")
+        assert result.state == TuiState.SHELL_PROMPT
+        assert result.prompt_detected is True
+
+    def test_shell_prompt_hash(self) -> None:
+        result = self.parser.feed("root@server# ")
+        assert result.state == TuiState.SHELL_PROMPT
+
+    def test_claude_idle_type_message(self) -> None:
+        result = self.parser.feed("Type a message to start chatting")
+        assert result.state == TuiState.CLAUDE_IDLE
+
+    def test_claude_idle_what_would_you_like(self) -> None:
+        result = self.parser.feed("What would you like to do?")
+        assert result.state == TuiState.CLAUDE_IDLE
+
+    def test_claude_working_spinner(self) -> None:
+        result = self.parser.feed("⠋ Thinking...")
+        assert result.state == TuiState.CLAUDE_WORKING
+
+    def test_claude_working_tool(self) -> None:
+        result = self.parser.feed("Tool: Read /path/to/file.py")
+        assert result.state == TuiState.CLAUDE_WORKING
+
+    def test_claude_working_reading(self) -> None:
+        result = self.parser.feed("Reading file contents...")
+        assert result.state == TuiState.CLAUDE_WORKING
+
+    def test_claude_working_writing(self) -> None:
+        result = self.parser.feed("Writing to output.txt")
+        assert result.state == TuiState.CLAUDE_WORKING
+
+    def test_claude_working_progress_bar(self) -> None:
+        result = self.parser.feed("━━━━━━━━━━")
+        assert result.state == TuiState.CLAUDE_WORKING
+
+    def test_claude_waiting_proceed(self) -> None:
+        result = self.parser.feed("Do you want to proceed?")
+        assert result.state == TuiState.CLAUDE_WAITING
+
+    def test_claude_waiting_yes_no(self) -> None:
+        result = self.parser.feed("Apply changes? Yes / No")
+        assert result.state == TuiState.CLAUDE_WAITING
+
+    def test_claude_waiting_yn_bracket(self) -> None:
+        result = self.parser.feed("Continue? [Y/n]")
+        assert result.state == TuiState.CLAUDE_WAITING
+
+    def test_claude_waiting_would_you_like(self) -> None:
+        result = self.parser.feed("Would you like to proceed with this?")
+        assert result.state == TuiState.CLAUDE_WAITING
+
+    def test_claude_waiting_press_enter(self) -> None:
+        result = self.parser.feed("Press Enter to confirm")
+        assert result.state == TuiState.CLAUDE_WAITING
+
+    def test_unknown_for_random_text(self) -> None:
+        result = self.parser.feed("some random output text")
+        assert result.state == TuiState.UNKNOWN
+
+
+# ---------------------------------------------------------------------------
+# OutputParser — alternate screen tracking
+# ---------------------------------------------------------------------------
+
+class TestOutputParserAlternateScreen:
+    def setup_method(self) -> None:
+        self.parser = OutputParser()
+
+    def test_alt_screen_on(self) -> None:
+        result = self.parser.feed("\x1b[?1049h")
+        assert result.state == TuiState.ALTERNATE_SCREEN
+        assert result.alternate_on is True
+        assert self.parser.alternate_on is True
+
+    def test_alt_screen_off(self) -> None:
+        self.parser.feed("\x1b[?1049h")
+        result = self.parser.feed("\x1b[?1049l some prompt $ ")
+        assert result.alternate_on is False
+        assert self.parser.alternate_on is False
+
+    def test_alt_screen_47h(self) -> None:
+        result = self.parser.feed("\x1b[?47h")
+        assert result.alternate_on is True
+
+    def test_alt_screen_47l(self) -> None:
+        self.parser.feed("\x1b[?47h")
+        result = self.parser.feed("\x1b[?47l")
+        assert result.alternate_on is False
+
+    def test_alt_screen_overrides_state_detection(self) -> None:
+        """While in alternate screen, state should be ALTERNATE_SCREEN regardless of content."""
+        self.parser.feed("\x1b[?1049h")
+        result = self.parser.feed("user@host$ ")
+        assert result.state == TuiState.ALTERNATE_SCREEN
+
+
+# ---------------------------------------------------------------------------
+# OutputParser — cost extraction
+# ---------------------------------------------------------------------------
+
+class TestOutputParserCostExtraction:
+    def setup_method(self) -> None:
+        self.parser = OutputParser()
+
+    def test_cost_with_k_tokens(self) -> None:
+        result = self.parser.feed("Cost: $0.12 | Tokens: 1.2k in, 0.8k out")
+        assert result.cost_dollars == 0.12
+        assert result.tokens_in == 1200
+        assert result.tokens_out == 800
+
+    def test_cost_plain_tokens(self) -> None:
+        result = self.parser.feed("$0.05 usage 500 in 300 out")
+        assert result.cost_dollars == 0.05
+        assert result.tokens_in == 500
+        assert result.tokens_out == 300
+
+    def test_no_cost(self) -> None:
+        result = self.parser.feed("just some text without cost")
+        assert result.cost_dollars is None
+        assert result.tokens_in is None
+        assert result.tokens_out is None
+
+
+# ---------------------------------------------------------------------------
+# OutputParser — tool extraction
+# ---------------------------------------------------------------------------
+
+class TestOutputParserToolExtraction:
+    def setup_method(self) -> None:
+        self.parser = OutputParser()
+
+    def test_tool_colon(self) -> None:
+        result = self.parser.feed("Tool: Read")
+        assert result.tool_name == "Read"
+
+    def test_using_tool(self) -> None:
+        result = self.parser.feed("Using: Write")
+        assert result.tool_name == "Write"
+
+    def test_running_tool(self) -> None:
+        result = self.parser.feed("Running: Bash")
+        assert result.tool_name == "Bash"
+
+    def test_no_tool(self) -> None:
+        result = self.parser.feed("hello world")
+        assert result.tool_name is None
+
+
+# ---------------------------------------------------------------------------
+# OutputParser — error extraction
+# ---------------------------------------------------------------------------
+
+class TestOutputParserErrorExtraction:
+    def setup_method(self) -> None:
+        self.parser = OutputParser()
+
+    def test_error_keyword(self) -> None:
+        result = self.parser.feed("Error: connection refused")
+        assert result.error_text is not None
+        assert "connection refused" in result.error_text
+
+    def test_traceback(self) -> None:
+        result = self.parser.feed("Traceback (most recent call last)")
+        assert result.error_text is not None
+
+    def test_fatal(self) -> None:
+        result = self.parser.feed("FATAL: database is corrupted")
+        assert result.error_text is not None
+
+    def test_no_error(self) -> None:
+        result = self.parser.feed("everything is fine")
+        assert result.error_text is None
+
+
+# ---------------------------------------------------------------------------
+# OutputParser — bytes input
+# ---------------------------------------------------------------------------
+
+class TestOutputParserBytesInput:
+    def setup_method(self) -> None:
+        self.parser = OutputParser()
+
+    def test_bytes_utf8(self) -> None:
+        result = self.parser.feed(b"user@host$ ")
+        assert result.state == TuiState.SHELL_PROMPT
+
+    def test_bytes_with_invalid_utf8(self) -> None:
+        """Should handle invalid UTF-8 gracefully without crashing."""
+        result = self.parser.feed(b"\xff\xfe user@host$ ")
+        # Replacement characters may interfere with prompt regex — just ensure no crash
+        assert isinstance(result, ParseResult)
+
+
+# ---------------------------------------------------------------------------
+# OutputParser — stateful behavior
+# ---------------------------------------------------------------------------
+
+class TestOutputParserStateful:
+    def setup_method(self) -> None:
+        self.parser = OutputParser()
+
+    def test_state_persists(self) -> None:
+        """Last known state should persist when new chunk has no clear state."""
+        self.parser.feed("⠋ Thinking...")
+        result = self.parser.feed("some continuation text")
+        assert result.state == TuiState.CLAUDE_WORKING
+
+    def test_state_transitions(self) -> None:
+        """Parser should detect transitions between states."""
+        r1 = self.parser.feed("⠋ Working on it...")
+        assert r1.state == TuiState.CLAUDE_WORKING
+
+        r2 = self.parser.feed("Do you want to proceed?")
+        assert r2.state == TuiState.CLAUDE_WAITING
+
+    def test_reset(self) -> None:
+        self.parser.feed("\x1b[?1049h")
+        assert self.parser.alternate_on is True
+        self.parser.reset()
+        assert self.parser.alternate_on is False
+        assert self.parser.last_state == TuiState.UNKNOWN
+
+    def test_prompt_text_captured(self) -> None:
+        result = self.parser.feed("user@host$ ")
+        assert result.prompt_detected is True
+        assert "user@host$" in result.prompt_text
+
+    def test_ansi_in_prompt(self) -> None:
+        """Shell prompt with ANSI color codes should still be detected."""
+        result = self.parser.feed("\x1b[32muser@host\x1b[0m$ ")
+        assert result.state == TuiState.SHELL_PROMPT
+
+
+# ---------------------------------------------------------------------------
+# ParseResult defaults
+# ---------------------------------------------------------------------------
+
+class TestParseResult:
+    def test_defaults(self) -> None:
+        r = ParseResult()
+        assert r.state == TuiState.UNKNOWN
+        assert r.prompt_detected is False
+        assert r.prompt_text == ""
+        assert r.alternate_on is False
+        assert r.cost_dollars is None
+        assert r.tokens_in is None
+        assert r.tokens_out is None
+        assert r.tool_name is None
+        assert r.error_text is None

--- a/tests/unit/test_pty_stream.py
+++ b/tests/unit/test_pty_stream.py
@@ -1,0 +1,263 @@
+"""Unit tests for PtyStreamReader and PtyStreamPool."""
+
+from __future__ import annotations
+
+from pathlib import Path  # noqa: TC003 — used at runtime by pytest fixtures
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from atc.core.events import EventBus
+from atc.terminal.pty_stream import PtyStreamPool, PtyStreamReader
+
+
+@pytest.fixture
+def event_bus() -> EventBus:
+    return EventBus()
+
+
+@pytest.fixture
+def tmp_fifo_dir(tmp_path: Path) -> Path:
+    d = tmp_path / "fifos"
+    d.mkdir()
+    return d
+
+
+# ---------------------------------------------------------------------------
+# PtyStreamReader
+# ---------------------------------------------------------------------------
+
+class TestPtyStreamReader:
+    @pytest.fixture
+    def reader(self, event_bus: EventBus, tmp_fifo_dir: Path) -> PtyStreamReader:
+        return PtyStreamReader(
+            session_id="sess-1",
+            tmux_pane="%0",
+            event_bus=event_bus,
+            fifo_dir=tmp_fifo_dir,
+        )
+
+    def test_properties(self, reader: PtyStreamReader) -> None:
+        assert reader.session_id == "sess-1"
+        assert reader.fifo_path is None
+        assert reader.running is False
+
+    @patch.object(PtyStreamReader, "_run_tmux", new_callable=AsyncMock)
+    async def test_start_creates_fifo(
+        self, mock_tmux: AsyncMock, reader: PtyStreamReader, tmp_fifo_dir: Path
+    ) -> None:
+        mock_tmux.return_value = ""
+        await reader.start()
+        assert reader.running is True
+        assert reader.fifo_path is not None
+        assert reader.fifo_path.exists()
+        # Verify pipe-pane was called
+        mock_tmux.assert_called_once()
+        args = mock_tmux.call_args[0]
+        assert args[0] == "pipe-pane"
+        await reader.stop()
+
+    @patch.object(PtyStreamReader, "_run_tmux", new_callable=AsyncMock)
+    async def test_start_idempotent(
+        self, mock_tmux: AsyncMock, reader: PtyStreamReader
+    ) -> None:
+        mock_tmux.return_value = ""
+        await reader.start()
+        await reader.start()  # second call should be no-op
+        assert mock_tmux.call_count == 1
+        await reader.stop()
+
+    @patch.object(PtyStreamReader, "_run_tmux", new_callable=AsyncMock)
+    async def test_stop_cleans_up(
+        self, mock_tmux: AsyncMock, reader: PtyStreamReader, tmp_fifo_dir: Path
+    ) -> None:
+        mock_tmux.return_value = ""
+        await reader.start()
+        fifo_path = reader.fifo_path
+        assert fifo_path is not None
+
+        await reader.stop()
+        assert reader.running is False
+        assert not fifo_path.exists()
+
+    async def test_stop_when_not_started(self, reader: PtyStreamReader) -> None:
+        """Stopping a reader that was never started should be a no-op."""
+        await reader.stop()
+        assert reader.running is False
+
+    def test_on_data_registers_callback(self, reader: PtyStreamReader) -> None:
+        cb = MagicMock()
+        reader.on_data(cb)
+        assert cb in reader._callbacks
+
+    @patch.object(PtyStreamReader, "_run_tmux", new_callable=AsyncMock)
+    async def test_dispatch_calls_callbacks(
+        self, mock_tmux: AsyncMock, reader: PtyStreamReader, event_bus: EventBus
+    ) -> None:
+        mock_tmux.return_value = ""
+        received: list[tuple[str, bytes]] = []
+
+        def cb(sid: str, data: bytes) -> None:
+            received.append((sid, data))
+
+        reader.on_data(cb)
+
+        # Directly test _dispatch without full start
+        await reader._dispatch(b"hello")
+        assert len(received) == 1
+        assert received[0] == ("sess-1", b"hello")
+
+    @patch.object(PtyStreamReader, "_run_tmux", new_callable=AsyncMock)
+    async def test_dispatch_publishes_event(
+        self, mock_tmux: AsyncMock, reader: PtyStreamReader, event_bus: EventBus
+    ) -> None:
+        mock_tmux.return_value = ""
+        events: list[dict] = []
+        event_bus.subscribe("pty_output", lambda data: events.append(data))
+
+        await reader._dispatch(b"world")
+        # Event handler is a coroutine in this test, so wrap it
+        assert len(events) == 1
+        assert events[0]["session_id"] == "sess-1"
+        assert events[0]["data"] == b"world"
+
+    @patch.object(PtyStreamReader, "_run_tmux", new_callable=AsyncMock)
+    async def test_dispatch_async_callback(
+        self, mock_tmux: AsyncMock, reader: PtyStreamReader
+    ) -> None:
+        received: list[bytes] = []
+
+        async def async_cb(sid: str, data: bytes) -> None:
+            received.append(data)
+
+        reader.on_data(async_cb)
+        await reader._dispatch(b"async-data")
+        assert received == [b"async-data"]
+
+
+# ---------------------------------------------------------------------------
+# PtyStreamPool
+# ---------------------------------------------------------------------------
+
+class TestPtyStreamPool:
+    @pytest.fixture
+    def pool(self, event_bus: EventBus, tmp_fifo_dir: Path) -> PtyStreamPool:
+        return PtyStreamPool(event_bus=event_bus, fifo_dir=tmp_fifo_dir)
+
+    async def test_start_creates_dir(self, event_bus: EventBus, tmp_path: Path) -> None:
+        new_dir = tmp_path / "new_fifos"
+        pool = PtyStreamPool(event_bus=event_bus, fifo_dir=new_dir)
+        await pool.start()
+        assert new_dir.exists()
+        await pool.stop()
+
+    async def test_session_ids_initially_empty(self, pool: PtyStreamPool) -> None:
+        assert pool.session_ids == []
+
+    @patch.object(PtyStreamReader, "_run_tmux", new_callable=AsyncMock)
+    async def test_add_session(self, mock_tmux: AsyncMock, pool: PtyStreamPool) -> None:
+        mock_tmux.return_value = ""
+        reader = await pool.add_session("sess-1", "%0")
+        assert "sess-1" in pool.session_ids
+        assert pool.get_reader("sess-1") is reader
+        await pool.stop()
+
+    @patch.object(PtyStreamReader, "_run_tmux", new_callable=AsyncMock)
+    async def test_remove_session(self, mock_tmux: AsyncMock, pool: PtyStreamPool) -> None:
+        mock_tmux.return_value = ""
+        await pool.add_session("sess-1", "%0")
+        await pool.remove_session("sess-1")
+        assert "sess-1" not in pool.session_ids
+        assert pool.get_reader("sess-1") is None
+
+    @patch.object(PtyStreamReader, "_run_tmux", new_callable=AsyncMock)
+    async def test_add_session_replaces_existing(
+        self, mock_tmux: AsyncMock, pool: PtyStreamPool
+    ) -> None:
+        mock_tmux.return_value = ""
+        reader1 = await pool.add_session("sess-1", "%0")
+        reader2 = await pool.add_session("sess-1", "%1")
+        assert pool.get_reader("sess-1") is reader2
+        assert reader1.running is False
+        await pool.stop()
+
+    @patch.object(PtyStreamReader, "_run_tmux", new_callable=AsyncMock)
+    async def test_stop_all(self, mock_tmux: AsyncMock, pool: PtyStreamPool) -> None:
+        mock_tmux.return_value = ""
+        await pool.add_session("sess-1", "%0")
+        await pool.add_session("sess-2", "%1")
+        await pool.stop()
+        assert pool.session_ids == []
+
+    def test_get_reader_nonexistent(self, pool: PtyStreamPool) -> None:
+        assert pool.get_reader("nonexistent") is None
+
+    @patch.object(PtyStreamReader, "_run_tmux", new_callable=AsyncMock)
+    async def test_send_keys(self, mock_tmux: AsyncMock, pool: PtyStreamPool) -> None:
+        mock_tmux.return_value = ""
+        await pool.add_session("sess-1", "%0")
+        await pool.send_keys("sess-1", "ls -la")
+        # send_keys should call tmux send-keys
+        calls = [c for c in mock_tmux.call_args_list if c[0][0] == "send-keys"]
+        assert len(calls) == 1
+        assert calls[0][0] == ("send-keys", "-t", "%0", "ls -la")
+        await pool.stop()
+
+    async def test_send_keys_no_reader(self, pool: PtyStreamPool) -> None:
+        with pytest.raises(ValueError, match="No active reader"):
+            await pool.send_keys("nonexistent", "keys")
+
+    @patch.object(PtyStreamReader, "_run_tmux", new_callable=AsyncMock)
+    async def test_send_instruction(self, mock_tmux: AsyncMock, pool: PtyStreamPool) -> None:
+        mock_tmux.return_value = ""
+        await pool.add_session("sess-1", "%0")
+        await pool.send_instruction("sess-1", "do something")
+        # Should have send-keys calls for text + Enter
+        send_calls = [c for c in mock_tmux.call_args_list if c[0][0] == "send-keys"]
+        assert len(send_calls) == 2
+        assert send_calls[0][0] == ("send-keys", "-t", "%0", "do something")
+        assert send_calls[1][0] == ("send-keys", "-t", "%0", "Enter")
+        await pool.stop()
+
+    async def test_send_instruction_no_reader(self, pool: PtyStreamPool) -> None:
+        with pytest.raises(ValueError, match="No active reader"):
+            await pool.send_instruction("nonexistent", "text")
+
+    @patch.object(PtyStreamReader, "_run_tmux", new_callable=AsyncMock)
+    async def test_check_tui_ready(self, mock_tmux: AsyncMock, pool: PtyStreamPool) -> None:
+        mock_tmux.return_value = "0"
+        await pool.add_session("sess-1", "%0")
+        # Reset mock so we can check just check_tui_ready calls
+        mock_tmux.reset_mock()
+        mock_tmux.return_value = "0"
+        ready = await pool.check_tui_ready("sess-1")
+        assert ready is True
+        await pool.stop()
+
+    @patch.object(PtyStreamReader, "_run_tmux", new_callable=AsyncMock)
+    async def test_check_tui_not_ready(self, mock_tmux: AsyncMock, pool: PtyStreamPool) -> None:
+        mock_tmux.return_value = ""
+        await pool.add_session("sess-1", "%0")
+        mock_tmux.reset_mock()
+        mock_tmux.return_value = "1"
+        ready = await pool.check_tui_ready("sess-1")
+        assert ready is False
+        await pool.stop()
+
+    async def test_check_tui_ready_no_reader(self, pool: PtyStreamPool) -> None:
+        with pytest.raises(ValueError, match="No active reader"):
+            await pool.check_tui_ready("nonexistent")
+
+    @patch.object(PtyStreamReader, "_run_tmux", new_callable=AsyncMock)
+    async def test_capture_pane(self, mock_tmux: AsyncMock, pool: PtyStreamPool) -> None:
+        mock_tmux.return_value = ""
+        await pool.add_session("sess-1", "%0")
+        mock_tmux.reset_mock()
+        mock_tmux.return_value = "some terminal content"
+        content = await pool.capture_pane("sess-1")
+        assert content == "some terminal content"
+        await pool.stop()
+
+    async def test_capture_pane_no_reader(self, pool: PtyStreamPool) -> None:
+        with pytest.raises(ValueError, match="No active reader"):
+            await pool.capture_pane("nonexistent")


### PR DESCRIPTION
## Summary
- **PtyStreamReader**: reads raw PTY output from per-session FIFOs created by tmux pipe-pane, dispatches chunks to callbacks and event bus
- **PtyStreamPool**: manages reader lifecycle for all sessions, provides send-keys input path, capture-pane, and TUI readiness checks
- **OutputParser**: stateful regex-based TUI state detection (shell_prompt/claude_idle/claude_working/claude_waiting/alternate_screen) with cost, tool, and error extraction
- **SessionMonitor + MonitorPool**: per-session monitor loops that detect status transitions and publish events (session_status_changed, session_cost_update, session_error)
- **EventBus**: async in-process pub/sub for subsystem communication
- 101 unit tests across all modules, all passing, ruff-clean

## Testing Done
```
$ python3 -m pytest tests/unit/test_output_parser.py tests/unit/test_pty_stream.py tests/unit/test_monitor.py tests/unit/test_events.py -v
101 passed in 1.69s

$ python3 -m ruff check src/atc/terminal/ src/atc/core/events.py tests/unit/test_*.py
All checks passed!
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)