### PR TITLE
feat: Frontend controls, xterm.js terminals, Create Project modal

### DIFF
--- a/frontend/src/components/ace/AceList.css
+++ b/frontend/src/components/ace/AceList.css
@@ -1,0 +1,103 @@
+.ace-list {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+}
+
+.ace-list__header {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+}
+
+.ace-list__header h3 {
+  font-size: var(--text-sm);
+  color: var(--color-text-secondary);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.ace-list__count {
+  font-size: var(--text-xs);
+  color: var(--color-text-muted);
+  background: var(--color-bg-active);
+  padding: 1px 6px;
+  border-radius: var(--radius-sm);
+}
+
+.ace-list__create {
+  display: flex;
+  gap: var(--space-2);
+}
+
+.ace-list__create input {
+  flex: 1;
+  padding: var(--space-2) var(--space-3);
+  font-size: var(--text-sm);
+  color: var(--color-text);
+  background: var(--color-bg);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  outline: none;
+  font-family: var(--font-sans);
+}
+
+.ace-list__create input:focus {
+  border-color: var(--color-accent);
+}
+
+.ace-list__tabs {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+}
+
+.ace-list__tab {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: var(--space-2) var(--space-3);
+  border: 1px solid transparent;
+  border-radius: var(--radius-md);
+  transition: background var(--transition-fast);
+}
+
+.ace-list__tab:hover {
+  background: var(--color-bg-hover);
+}
+
+.ace-list__tab.selected {
+  background: var(--color-accent-muted);
+  border-color: var(--color-accent);
+}
+
+.ace-list__tab-name {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  background: none;
+  border: none;
+  color: var(--color-text);
+  font-family: var(--font-sans);
+  font-size: var(--text-sm);
+  font-weight: 500;
+  cursor: pointer;
+  padding: 0;
+}
+
+.ace-list__tab-actions {
+  display: flex;
+  gap: var(--space-1);
+}
+
+.ace-list__terminal-container {
+  display: flex;
+  flex-direction: column;
+  min-height: 250px;
+}
+
+.ace-list__empty {
+  font-size: var(--text-sm);
+  color: var(--color-text-muted);
+  padding: var(--space-4) 0;
+}

--- a/frontend/src/components/ace/AceList.tsx
+++ b/frontend/src/components/ace/AceList.tsx
@@ -1,3 +1,184 @@
-export default function AceList() {
-  return <div>AceList</div>;
+import { useState } from "react";
+import { api } from "../../utils/api";
+import StatusBadge from "../common/StatusBadge";
+import ConfirmPopover from "../common/ConfirmPopover";
+import AceTerminal from "./AceTerminal";
+import type { Session } from "../../types";
+import "./AceList.css";
+
+interface AceListProps {
+  projectId: string;
+  sessions: Session[];
+  onRefresh: () => void;
+}
+
+export default function AceList({
+  projectId,
+  sessions,
+  onRefresh,
+}: AceListProps) {
+  const [newName, setNewName] = useState("");
+  const [creating, setCreating] = useState(false);
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+  const [loadingId, setLoadingId] = useState<string | null>(null);
+
+  const selectedSession = sessions.find((s) => s.id === selectedId);
+
+  async function handleCreate(e: React.FormEvent) {
+    e.preventDefault();
+    if (!newName.trim()) return;
+    setCreating(true);
+    try {
+      const created = await api.post<Session>(`/projects/${projectId}/aces`, {
+        name: newName.trim(),
+      });
+      setNewName("");
+      setSelectedId(created.id);
+      onRefresh();
+    } catch (err) {
+      console.error("Failed to create ace:", err);
+    } finally {
+      setCreating(false);
+    }
+  }
+
+  async function handleStart(sessionId: string) {
+    setLoadingId(sessionId);
+    try {
+      await api.post(`/aces/${sessionId}/start`, {});
+      onRefresh();
+    } catch (err) {
+      console.error("Failed to start ace:", err);
+    } finally {
+      setLoadingId(null);
+    }
+  }
+
+  async function handleStop(sessionId: string) {
+    setLoadingId(sessionId);
+    try {
+      await api.post(`/aces/${sessionId}/stop`);
+      onRefresh();
+    } catch (err) {
+      console.error("Failed to stop ace:", err);
+    } finally {
+      setLoadingId(null);
+    }
+  }
+
+  async function handleDelete(sessionId: string) {
+    setLoadingId(sessionId);
+    try {
+      await api.delete(`/aces/${sessionId}`);
+      if (selectedId === sessionId) setSelectedId(null);
+      onRefresh();
+    } catch (err) {
+      console.error("Failed to delete ace:", err);
+    } finally {
+      setLoadingId(null);
+    }
+  }
+
+  function isRunning(s: Session) {
+    return s.status === "working" || s.status === "waiting" || s.status === "connecting";
+  }
+
+  return (
+    <div className="ace-list" data-testid="ace-list">
+      <div className="ace-list__header">
+        <h3>Aces</h3>
+        <span className="ace-list__count">{sessions.length}</span>
+      </div>
+
+      {/* Create new ace */}
+      <form className="ace-list__create" onSubmit={handleCreate}>
+        <input
+          type="text"
+          value={newName}
+          onChange={(e) => setNewName(e.target.value)}
+          placeholder="New ace name..."
+          disabled={creating}
+        />
+        <button
+          type="submit"
+          className="btn btn-sm btn-primary"
+          disabled={creating || !newName.trim()}
+        >
+          {creating ? "..." : "+ Add"}
+        </button>
+      </form>
+
+      {/* Session tabs */}
+      {sessions.length > 0 && (
+        <div className="ace-list__tabs">
+          {sessions.map((session) => (
+            <div
+              key={session.id}
+              className={`ace-list__tab ${selectedId === session.id ? "selected" : ""}`}
+            >
+              <button
+                className="ace-list__tab-name"
+                onClick={() => setSelectedId(session.id)}
+              >
+                <span>{session.name}</span>
+                <StatusBadge status={session.status} size="sm" />
+              </button>
+              <div className="ace-list__tab-actions">
+                {!isRunning(session) ? (
+                  <button
+                    className="btn btn-sm"
+                    onClick={() => handleStart(session.id)}
+                    disabled={loadingId === session.id}
+                    title="Start"
+                  >
+                    Start
+                  </button>
+                ) : (
+                  <ConfirmPopover
+                    message={`Stop ${session.name}?`}
+                    confirmLabel="Stop"
+                    onConfirm={() => handleStop(session.id)}
+                    variant="danger"
+                  >
+                    <button
+                      className="btn btn-sm btn-danger"
+                      disabled={loadingId === session.id}
+                      title="Stop"
+                    >
+                      Stop
+                    </button>
+                  </ConfirmPopover>
+                )}
+                <ConfirmPopover
+                  message={`Delete ${session.name}? This cannot be undone.`}
+                  confirmLabel="Delete"
+                  onConfirm={() => handleDelete(session.id)}
+                  variant="danger"
+                >
+                  <button
+                    className="btn btn-sm btn-danger"
+                    disabled={loadingId === session.id || isRunning(session)}
+                    title="Delete"
+                  >
+                    Del
+                  </button>
+                </ConfirmPopover>
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+
+      {/* Terminal for selected ace */}
+      {selectedSession && (
+        <div className="ace-list__terminal-container">
+          <AceTerminal key={selectedSession.id} session={selectedSession} />
+        </div>
+      )}
+
+      {sessions.length === 0 && (
+        <p className="ace-list__empty">No aces yet. Create one above.</p>
+      )}
+    </div>
+  );
 }

--- a/frontend/src/components/ace/AceTerminal.css
+++ b/frontend/src/components/ace/AceTerminal.css
@@ -1,0 +1,42 @@
+.ace-terminal {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  flex: 1;
+  min-height: 0;
+}
+
+.ace-terminal__view {
+  flex: 1;
+  min-height: 200px;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  overflow: hidden;
+  background: #0d1117;
+}
+
+.ace-terminal__input {
+  display: flex;
+  gap: var(--space-2);
+}
+
+.ace-terminal__input input {
+  flex: 1;
+  padding: var(--space-2) var(--space-3);
+  font-size: var(--text-sm);
+  font-family: var(--font-mono);
+  color: var(--color-text);
+  background: var(--color-bg);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  outline: none;
+}
+
+.ace-terminal__input input:focus {
+  border-color: var(--color-accent);
+}
+
+.ace-terminal__input input:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}

--- a/frontend/src/components/ace/AceTerminal.tsx
+++ b/frontend/src/components/ace/AceTerminal.tsx
@@ -1,3 +1,59 @@
-export default function AceTerminal() {
-  return <div>AceTerminal</div>;
+import { useState } from "react";
+import { api } from "../../utils/api";
+import { useTerminal } from "../../hooks/useTerminal";
+import type { Session } from "../../types";
+import "./AceTerminal.css";
+
+interface AceTerminalProps {
+  session: Session;
+}
+
+export default function AceTerminal({ session }: AceTerminalProps) {
+  const [message, setMessage] = useState("");
+
+  const isActive =
+    session.status === "working" ||
+    session.status === "waiting" ||
+    session.status === "idle";
+
+  const { attachRef } = useTerminal({
+    channel: `terminal:${session.id}`,
+    enabled: isActive,
+  });
+
+  async function handleSendMessage(e: React.FormEvent) {
+    e.preventDefault();
+    if (!message.trim()) return;
+    try {
+      await api.post(`/aces/${session.id}/message`, {
+        message: message.trim(),
+      });
+      setMessage("");
+    } catch (err) {
+      console.error("Failed to send message:", err);
+    }
+  }
+
+  return (
+    <div className="ace-terminal" data-testid="ace-terminal">
+      <div className="ace-terminal__view" ref={attachRef} />
+
+      <form className="ace-terminal__input" onSubmit={handleSendMessage}>
+        <input
+          type="text"
+          value={message}
+          onChange={(e) => setMessage(e.target.value)}
+          placeholder={`Send to ${session.name}...`}
+          disabled={!isActive}
+        />
+        <button
+          type="submit"
+          className="btn btn-sm btn-primary"
+          disabled={!message.trim() || !isActive}
+        >
+          Send
+        </button>
+      </form>
+    </div>
+  );
 }

--- a/frontend/src/components/common/CreateProjectModal.css
+++ b/frontend/src/components/common/CreateProjectModal.css
@@ -1,0 +1,66 @@
+.modal-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.6);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+}
+
+.modal {
+  width: 100%;
+  max-width: 480px;
+  max-height: 90vh;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+}
+
+.modal__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: var(--space-4);
+}
+
+.modal__header h2 {
+  font-size: var(--text-lg);
+  font-weight: 600;
+}
+
+.modal__close {
+  background: none;
+  border: none;
+  color: var(--color-text-muted);
+  font-size: var(--text-xl);
+  cursor: pointer;
+  padding: var(--space-1);
+  line-height: 1;
+}
+
+.modal__close:hover {
+  color: var(--color-text);
+}
+
+.modal__body {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+}
+
+.modal__error {
+  padding: var(--space-2) var(--space-3);
+  background: rgba(248, 81, 73, 0.1);
+  border: 1px solid var(--color-status-red);
+  border-radius: var(--radius-md);
+  color: var(--color-status-red);
+  font-size: var(--text-sm);
+}
+
+.modal__footer {
+  display: flex;
+  justify-content: flex-end;
+  gap: var(--space-3);
+  margin-top: var(--space-6);
+}

--- a/frontend/src/components/common/CreateProjectModal.tsx
+++ b/frontend/src/components/common/CreateProjectModal.tsx
@@ -1,0 +1,152 @@
+import { useState, useRef, useEffect } from "react";
+import { api } from "../../utils/api";
+import type { Project } from "../../types";
+import "./CreateProjectModal.css";
+
+interface CreateProjectModalProps {
+  open: boolean;
+  onClose: () => void;
+  onCreated: (project: Project) => void;
+}
+
+export default function CreateProjectModal({
+  open,
+  onClose,
+  onCreated,
+}: CreateProjectModalProps) {
+  const [name, setName] = useState("");
+  const [description, setDescription] = useState("");
+  const [repoPath, setRepoPath] = useState("");
+  const [githubRepo, setGithubRepo] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const nameRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    if (open) {
+      setName("");
+      setDescription("");
+      setRepoPath("");
+      setGithubRepo("");
+      setError(null);
+      setTimeout(() => nameRef.current?.focus(), 50);
+    }
+  }, [open]);
+
+  useEffect(() => {
+    if (!open) return;
+    function handleEscape(e: KeyboardEvent) {
+      if (e.key === "Escape") onClose();
+    }
+    document.addEventListener("keydown", handleEscape);
+    return () => document.removeEventListener("keydown", handleEscape);
+  }, [open, onClose]);
+
+  if (!open) return null;
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    if (!name.trim()) {
+      setError("Project name is required");
+      return;
+    }
+    setSubmitting(true);
+    setError(null);
+    try {
+      const project = await api.post<Project>("/projects", {
+        name: name.trim(),
+        description: description.trim() || null,
+        repo_path: repoPath.trim() || null,
+        github_repo: githubRepo.trim() || null,
+      });
+      onCreated(project);
+      onClose();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to create project");
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <div className="modal-overlay" onClick={onClose}>
+      <div
+        className="modal panel"
+        onClick={(e) => e.stopPropagation()}
+        data-testid="create-project-modal"
+      >
+        <div className="modal__header">
+          <h2>Create Project</h2>
+          <button className="modal__close" onClick={onClose} aria-label="Close">
+            &times;
+          </button>
+        </div>
+
+        <form onSubmit={handleSubmit}>
+          <div className="modal__body">
+            {error && <div className="modal__error">{error}</div>}
+
+            <div className="form-group">
+              <label htmlFor="project-name">Name *</label>
+              <input
+                ref={nameRef}
+                id="project-name"
+                type="text"
+                value={name}
+                onChange={(e) => setName(e.target.value)}
+                placeholder="my-project"
+                required
+              />
+            </div>
+
+            <div className="form-group">
+              <label htmlFor="project-desc">Description</label>
+              <textarea
+                id="project-desc"
+                value={description}
+                onChange={(e) => setDescription(e.target.value)}
+                placeholder="What this project does..."
+                rows={2}
+              />
+            </div>
+
+            <div className="form-group">
+              <label htmlFor="project-repo">Repository Path</label>
+              <input
+                id="project-repo"
+                type="text"
+                value={repoPath}
+                onChange={(e) => setRepoPath(e.target.value)}
+                placeholder="/path/to/repo"
+              />
+            </div>
+
+            <div className="form-group">
+              <label htmlFor="project-github">GitHub Repo</label>
+              <input
+                id="project-github"
+                type="text"
+                value={githubRepo}
+                onChange={(e) => setGithubRepo(e.target.value)}
+                placeholder="owner/repo"
+              />
+            </div>
+          </div>
+
+          <div className="modal__footer">
+            <button type="button" className="btn" onClick={onClose}>
+              Cancel
+            </button>
+            <button
+              type="submit"
+              className="btn btn-primary"
+              disabled={submitting}
+            >
+              {submitting ? "Creating..." : "Create Project"}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/leader/ContextViewer.css
+++ b/frontend/src/components/leader/ContextViewer.css
@@ -1,0 +1,42 @@
+.context-viewer h3 {
+  font-size: var(--text-sm);
+  color: var(--color-text-secondary);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  margin-bottom: var(--space-3);
+}
+
+.context-viewer__empty {
+  font-size: var(--text-sm);
+  color: var(--color-text-muted);
+}
+
+.context-viewer__entries {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+
+.context-viewer__entry {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+  padding: var(--space-2) var(--space-3);
+  background: var(--color-bg);
+  border: 1px solid var(--color-border-subtle);
+  border-radius: var(--radius-md);
+}
+
+.context-viewer__key {
+  font-size: var(--text-xs);
+  font-family: var(--font-mono);
+  color: var(--color-accent);
+  font-weight: 500;
+}
+
+.context-viewer__value {
+  font-size: var(--text-sm);
+  color: var(--color-text);
+  white-space: pre-wrap;
+  word-break: break-word;
+}

--- a/frontend/src/components/leader/ContextViewer.tsx
+++ b/frontend/src/components/leader/ContextViewer.tsx
@@ -1,3 +1,37 @@
-export default function ContextViewer() {
-  return <div>ContextViewer</div>;
+import type { Leader } from "../../types";
+import "./ContextViewer.css";
+
+interface ContextViewerProps {
+  leader: Leader | undefined;
+}
+
+export default function ContextViewer({ leader }: ContextViewerProps) {
+  if (!leader?.context || Object.keys(leader.context).length === 0) {
+    return (
+      <div className="context-viewer" data-testid="context-viewer">
+        <h3>Context</h3>
+        <p className="context-viewer__empty">No context entries yet.</p>
+      </div>
+    );
+  }
+
+  const entries = Object.entries(leader.context);
+
+  return (
+    <div className="context-viewer" data-testid="context-viewer">
+      <h3>Context</h3>
+      <div className="context-viewer__entries">
+        {entries.map(([key, value]) => (
+          <div key={key} className="context-viewer__entry">
+            <span className="context-viewer__key">{key}</span>
+            <span className="context-viewer__value">
+              {typeof value === "string"
+                ? value
+                : JSON.stringify(value, null, 2)}
+            </span>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
 }

--- a/frontend/src/components/leader/LeaderConsole.css
+++ b/frontend/src/components/leader/LeaderConsole.css
@@ -1,0 +1,63 @@
+.leader-console {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+}
+
+.leader-console__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.leader-console__header h3 {
+  font-size: var(--text-sm);
+  color: var(--color-text-secondary);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.leader-console__controls {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+}
+
+.leader-console__start-form {
+  margin-top: var(--space-1);
+}
+
+.leader-console__goal {
+  font-size: var(--text-sm);
+  color: var(--color-text-secondary);
+  padding: var(--space-2) 0;
+}
+
+.leader-console__terminal {
+  height: 300px;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  overflow: hidden;
+  background: #0d1117;
+}
+
+.leader-console__input {
+  display: flex;
+  gap: var(--space-2);
+}
+
+.leader-console__input input {
+  flex: 1;
+  padding: var(--space-2) var(--space-3);
+  font-size: var(--text-sm);
+  font-family: var(--font-mono);
+  color: var(--color-text);
+  background: var(--color-bg);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  outline: none;
+}
+
+.leader-console__input input:focus {
+  border-color: var(--color-accent);
+}

--- a/frontend/src/components/leader/LeaderConsole.tsx
+++ b/frontend/src/components/leader/LeaderConsole.tsx
@@ -1,3 +1,153 @@
-export default function LeaderConsole() {
-  return <div>LeaderConsole</div>;
+import { useState } from "react";
+import { api } from "../../utils/api";
+import { useTerminal } from "../../hooks/useTerminal";
+import StatusBadge from "../common/StatusBadge";
+import ConfirmPopover from "../common/ConfirmPopover";
+import type { Leader } from "../../types";
+import "./LeaderConsole.css";
+
+interface LeaderConsoleProps {
+  projectId: string;
+  leader: Leader | undefined;
+  onRefresh: () => void;
+}
+
+export default function LeaderConsole({
+  projectId,
+  leader,
+  onRefresh,
+}: LeaderConsoleProps) {
+  const [goal, setGoal] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [message, setMessage] = useState("");
+
+  const isRunning =
+    leader?.status === "planning" || leader?.status === "managing";
+
+  const terminalChannel = leader?.session_id
+    ? `terminal:${leader.session_id}`
+    : undefined;
+
+  const { attachRef } = useTerminal({
+    channel: terminalChannel,
+    enabled: isRunning && !!terminalChannel,
+  });
+
+  async function handleStart() {
+    setLoading(true);
+    try {
+      await api.post(`/projects/${projectId}/leader/start`, {
+        goal: goal.trim() || null,
+      });
+      setGoal("");
+      onRefresh();
+    } catch (err) {
+      console.error("Failed to start leader:", err);
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  async function handleStop() {
+    setLoading(true);
+    try {
+      await api.post(`/projects/${projectId}/leader/stop`);
+      onRefresh();
+    } catch (err) {
+      console.error("Failed to stop leader:", err);
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  async function handleSendMessage(e: React.FormEvent) {
+    e.preventDefault();
+    if (!message.trim()) return;
+    try {
+      await api.post(`/projects/${projectId}/leader/message`, {
+        message: message.trim(),
+      });
+      setMessage("");
+    } catch (err) {
+      console.error("Failed to send message:", err);
+    }
+  }
+
+  return (
+    <div className="leader-console" data-testid="leader-console">
+      <div className="leader-console__header">
+        <h3>Leader</h3>
+        <div className="leader-console__controls">
+          {leader && <StatusBadge status={leader.status} size="sm" />}
+          {!isRunning ? (
+            <button
+              className="btn btn-primary btn-sm"
+              onClick={handleStart}
+              disabled={loading}
+            >
+              {loading ? "Starting..." : "Start"}
+            </button>
+          ) : (
+            <ConfirmPopover
+              message="Stop the Leader session?"
+              confirmLabel="Stop"
+              onConfirm={handleStop}
+              variant="danger"
+            >
+              <button className="btn btn-danger btn-sm" disabled={loading}>
+                Stop
+              </button>
+            </ConfirmPopover>
+          )}
+        </div>
+      </div>
+
+      {!isRunning && (
+        <div className="leader-console__start-form">
+          <div className="form-group">
+            <label htmlFor="leader-goal">Goal (optional)</label>
+            <input
+              id="leader-goal"
+              type="text"
+              value={goal}
+              onChange={(e) => setGoal(e.target.value)}
+              placeholder="Describe the goal for this leader..."
+              onKeyDown={(e) => {
+                if (e.key === "Enter") handleStart();
+              }}
+            />
+          </div>
+        </div>
+      )}
+
+      {leader?.goal && (
+        <p className="leader-console__goal">{leader.goal}</p>
+      )}
+
+      {isRunning && (
+        <>
+          <div className="leader-console__terminal" ref={attachRef} />
+
+          <form
+            className="leader-console__input"
+            onSubmit={handleSendMessage}
+          >
+            <input
+              type="text"
+              value={message}
+              onChange={(e) => setMessage(e.target.value)}
+              placeholder="Send message to leader..."
+            />
+            <button
+              type="submit"
+              className="btn btn-sm btn-primary"
+              disabled={!message.trim()}
+            >
+              Send
+            </button>
+          </form>
+        </>
+      )}
+    </div>
+  );
 }

--- a/frontend/src/components/leader/TaskBoard.css
+++ b/frontend/src/components/leader/TaskBoard.css
@@ -1,0 +1,70 @@
+.task-board h3 {
+  font-size: var(--text-sm);
+  color: var(--color-text-secondary);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  margin-bottom: var(--space-3);
+}
+
+.task-board__empty {
+  font-size: var(--text-sm);
+  color: var(--color-text-muted);
+}
+
+.task-board__grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: var(--space-3);
+}
+
+.task-board__col h4 {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  font-size: var(--text-xs);
+  text-transform: uppercase;
+  color: var(--color-text-muted);
+  letter-spacing: 0.05em;
+  margin-bottom: var(--space-2);
+}
+
+.task-board__col-count {
+  font-size: var(--text-xs);
+  background: var(--color-bg-active);
+  padding: 0 5px;
+  border-radius: var(--radius-sm);
+  font-weight: 400;
+}
+
+.task-board__card {
+  padding: var(--space-2) var(--space-3);
+  background: var(--color-bg);
+  border: 1px solid var(--color-border-subtle);
+  border-radius: var(--radius-md);
+  margin-bottom: var(--space-2);
+}
+
+.task-board__card-title {
+  font-size: var(--text-sm);
+  font-weight: 500;
+  margin-bottom: var(--space-1);
+}
+
+.task-board__card-meta {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+}
+
+.task-board__assignee {
+  font-size: var(--text-xs);
+  color: var(--color-text-muted);
+  font-family: var(--font-mono);
+}
+
+.task-board__card-desc {
+  font-size: var(--text-xs);
+  color: var(--color-text-muted);
+  margin-top: var(--space-1);
+  line-height: 1.4;
+}

--- a/frontend/src/components/leader/TaskBoard.tsx
+++ b/frontend/src/components/leader/TaskBoard.tsx
@@ -1,3 +1,56 @@
-export default function TaskBoard() {
-  return <div>TaskBoard</div>;
+import StatusBadge from "../common/StatusBadge";
+import type { Task } from "../../types";
+import "./TaskBoard.css";
+
+interface TaskBoardProps {
+  tasks: Task[];
+}
+
+const COLUMNS = ["pending", "in_progress", "done"] as const;
+
+export default function TaskBoard({ tasks }: TaskBoardProps) {
+  return (
+    <div className="task-board" data-testid="task-board">
+      <h3>Tasks</h3>
+      {tasks.length === 0 ? (
+        <p className="task-board__empty">No tasks yet.</p>
+      ) : (
+        <div className="task-board__grid">
+          {COLUMNS.map((col) => {
+            const colTasks = tasks.filter((t) => t.status === col);
+            return (
+              <div key={col} className="task-board__col">
+                <h4>
+                  {col.replace(/_/g, " ")}
+                  <span className="task-board__col-count">
+                    {colTasks.length}
+                  </span>
+                </h4>
+                {colTasks.map((task) => (
+                  <div key={task.id} className="task-board__card">
+                    <div className="task-board__card-title">{task.title}</div>
+                    <div className="task-board__card-meta">
+                      <StatusBadge status={task.status} size="sm" />
+                      {task.assigned_to && (
+                        <span className="task-board__assignee">
+                          {task.assigned_to.slice(0, 8)}
+                        </span>
+                      )}
+                    </div>
+                    {task.description && (
+                      <p className="task-board__card-desc">
+                        {task.description.length > 80
+                          ? task.description.slice(0, 80) + "..."
+                          : task.description}
+                      </p>
+                    )}
+                  </div>
+                ))}
+              </div>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
 }

--- a/frontend/src/components/tower/TowerModal.css
+++ b/frontend/src/components/tower/TowerModal.css
@@ -1,0 +1,69 @@
+.tower-modal {
+  max-width: 520px;
+}
+
+.tower-modal__status {
+  display: flex;
+  gap: var(--space-4);
+  margin-bottom: var(--space-4);
+}
+
+.tower-modal__stat {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+}
+
+.tower-modal__stat-label {
+  font-size: var(--text-xs);
+  color: var(--color-text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.tower-modal__stat-value {
+  font-size: var(--text-lg);
+  font-weight: 600;
+  font-family: var(--font-mono);
+}
+
+.tower-modal__goal-form {
+  display: flex;
+  gap: var(--space-2);
+  align-items: flex-end;
+  margin-bottom: var(--space-4);
+}
+
+.tower-modal__goal-form .form-group {
+  flex: 1;
+}
+
+.tower-modal__memory h3 {
+  font-size: var(--text-sm);
+  color: var(--color-text-secondary);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  margin-bottom: var(--space-2);
+}
+
+.tower-modal__memory-entry {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+  padding: var(--space-2) var(--space-3);
+  background: var(--color-bg);
+  border: 1px solid var(--color-border-subtle);
+  border-radius: var(--radius-md);
+  margin-bottom: var(--space-2);
+}
+
+.tower-modal__memory-key {
+  font-size: var(--text-xs);
+  font-family: var(--font-mono);
+  color: var(--color-accent);
+}
+
+.tower-modal__memory-value {
+  font-size: var(--text-sm);
+  color: var(--color-text);
+}

--- a/frontend/src/components/tower/TowerModal.tsx
+++ b/frontend/src/components/tower/TowerModal.tsx
@@ -1,3 +1,122 @@
-export default function TowerModal() {
-  return <div>TowerModal</div>;
+import { useState, useEffect } from "react";
+import { api } from "../../utils/api";
+import { useAppContext } from "../../context/AppContext";
+import "./TowerModal.css";
+
+interface TowerModalProps {
+  open: boolean;
+  onClose: () => void;
+}
+
+interface TowerMemoryEntry {
+  key: string;
+  value: unknown;
+}
+
+export default function TowerModal({ open, onClose }: TowerModalProps) {
+  const { state } = useAppContext();
+  const [memory, setMemory] = useState<TowerMemoryEntry[]>([]);
+  const [goal, setGoal] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+
+  useEffect(() => {
+    if (!open) return;
+    api
+      .get<TowerMemoryEntry[]>("/tower/memory")
+      .then(setMemory)
+      .catch(() => setMemory([]));
+  }, [open]);
+
+  useEffect(() => {
+    if (!open) return;
+    function handleEscape(e: KeyboardEvent) {
+      if (e.key === "Escape") onClose();
+    }
+    document.addEventListener("keydown", handleEscape);
+    return () => document.removeEventListener("keydown", handleEscape);
+  }, [open, onClose]);
+
+  if (!open) return null;
+
+  async function handleSetGoal(e: React.FormEvent) {
+    e.preventDefault();
+    if (!goal.trim()) return;
+    setSubmitting(true);
+    try {
+      await api.post("/tower/goal", { goal: goal.trim() });
+      setGoal("");
+    } catch (err) {
+      console.error("Failed to set tower goal:", err);
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <div className="modal-overlay" onClick={onClose}>
+      <div
+        className="modal panel tower-modal"
+        onClick={(e) => e.stopPropagation()}
+        data-testid="tower-modal"
+      >
+        <div className="modal__header">
+          <h2>Tower Control</h2>
+          <button className="modal__close" onClick={onClose} aria-label="Close">
+            &times;
+          </button>
+        </div>
+
+        <div className="tower-modal__status">
+          <div className="tower-modal__stat">
+            <span className="tower-modal__stat-label">Status</span>
+            <span className="tower-modal__stat-value">
+              {state.brainStatus.status}
+            </span>
+          </div>
+          <div className="tower-modal__stat">
+            <span className="tower-modal__stat-label">Active Projects</span>
+            <span className="tower-modal__stat-value">
+              {state.brainStatus.active_projects}
+            </span>
+          </div>
+        </div>
+
+        <form className="tower-modal__goal-form" onSubmit={handleSetGoal}>
+          <div className="form-group">
+            <label htmlFor="tower-goal">Set Tower Goal</label>
+            <input
+              id="tower-goal"
+              type="text"
+              value={goal}
+              onChange={(e) => setGoal(e.target.value)}
+              placeholder="Describe a high-level goal..."
+            />
+          </div>
+          <button
+            type="submit"
+            className="btn btn-primary btn-sm"
+            disabled={submitting || !goal.trim()}
+          >
+            {submitting ? "Setting..." : "Set Goal"}
+          </button>
+        </form>
+
+        {memory.length > 0 && (
+          <div className="tower-modal__memory">
+            <h3>Tower Memory</h3>
+            {memory.map((entry) => (
+              <div key={entry.key} className="tower-modal__memory-entry">
+                <span className="tower-modal__memory-key">{entry.key}</span>
+                <span className="tower-modal__memory-value">
+                  {typeof entry.value === "string"
+                    ? entry.value
+                    : JSON.stringify(entry.value)}
+                </span>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
 }

--- a/frontend/src/context/AppContext.tsx
+++ b/frontend/src/context/AppContext.tsx
@@ -127,14 +127,28 @@ export function AppProvider({ children }: AppProviderProps) {
 
   const fetchAll = useCallback(async () => {
     try {
-      const [projects, sessions, notifications] = await Promise.all([
-        api.get<Project[]>("/projects"),
-        api.get<Session[]>("/sessions"),
-        api.get<Notification[]>("/notifications"),
-      ]);
+      const projects = await api.get<Project[]>("/projects");
       dispatch({ type: "SET_PROJECTS", payload: projects });
-      dispatch({ type: "SET_SESSIONS", payload: sessions });
-      dispatch({ type: "SET_NOTIFICATIONS", payload: notifications });
+
+      // Fetch aces per project + leader per project
+      const sessionResults = await Promise.allSettled(
+        projects.map((p) => api.get<Session[]>(`/projects/${p.id}/aces`)),
+      );
+      const allSessions: Session[] = [];
+      for (const r of sessionResults) {
+        if (r.status === "fulfilled") allSessions.push(...r.value);
+      }
+      dispatch({ type: "SET_SESSIONS", payload: allSessions });
+
+      const leaderResults = await Promise.allSettled(
+        projects.map((p) => api.get<Leader>(`/projects/${p.id}/manager`)),
+      );
+      const leaders: Record<string, Leader> = {};
+      for (let i = 0; i < projects.length; i++) {
+        const r = leaderResults[i]!;
+        if (r.status === "fulfilled") leaders[projects[i]!.id] = r.value;
+      }
+      dispatch({ type: "SET_LEADERS", payload: leaders });
     } catch {
       /* backend may not be running yet — silent fail */
     }

--- a/frontend/src/context/__tests__/AppContext.test.tsx
+++ b/frontend/src/context/__tests__/AppContext.test.tsx
@@ -17,8 +17,8 @@ class MockWebSocket {
 
 beforeEach(() => {
   vi.restoreAllMocks();
-  vi.spyOn(globalThis, "fetch").mockResolvedValue(
-    new Response(JSON.stringify([]), { status: 200 }),
+  vi.spyOn(globalThis, "fetch").mockImplementation(() =>
+    Promise.resolve(new Response(JSON.stringify([]), { status: 200 })),
   );
   vi.stubGlobal("WebSocket", MockWebSocket);
 });
@@ -91,6 +91,10 @@ describe("AppContext", () => {
 
   it("dispatches SET_PROJECTS", async () => {
     renderWithContext(<TestConsumer />);
+    // Wait for initial fetchAll to settle
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 10));
+    });
     await act(async () => {
       screen.getByTestId("set-projects").click();
     });

--- a/frontend/src/hooks/useTerminal.ts
+++ b/frontend/src/hooks/useTerminal.ts
@@ -1,0 +1,156 @@
+import { useEffect, useRef, useCallback } from "react";
+import { Terminal } from "@xterm/xterm";
+import { FitAddon } from "@xterm/addon-fit";
+import "@xterm/xterm/css/xterm.css";
+
+interface UseTerminalOptions {
+  /** WebSocket channel to subscribe to for terminal data (e.g. "terminal:abc-123") */
+  channel?: string;
+  /** Whether the terminal should be active */
+  enabled?: boolean;
+}
+
+/**
+ * Hook that manages an xterm.js Terminal instance and connects it to the
+ * ATC WebSocket for streaming PTY output.
+ *
+ * Returns a ref callback to attach to a container div.
+ */
+export function useTerminal({ channel, enabled = true }: UseTerminalOptions) {
+  const termRef = useRef<Terminal | null>(null);
+  const fitRef = useRef<FitAddon | null>(null);
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const wsRef = useRef<WebSocket | null>(null);
+  const reconnectRef = useRef<ReturnType<typeof setTimeout>>(undefined);
+
+  // Create terminal once
+  useEffect(() => {
+    if (!enabled) return;
+
+    const term = new Terminal({
+      cursorBlink: true,
+      fontSize: 13,
+      fontFamily: '"SF Mono", "Fira Code", "Fira Mono", "Roboto Mono", monospace',
+      theme: {
+        background: "#0d1117",
+        foreground: "#e6edf3",
+        cursor: "#58a6ff",
+        selectionBackground: "#388bfd33",
+        black: "#0d1117",
+        red: "#f85149",
+        green: "#3fb950",
+        yellow: "#d29922",
+        blue: "#58a6ff",
+        magenta: "#bc8cff",
+        cyan: "#39d353",
+        white: "#e6edf3",
+      },
+      scrollback: 5000,
+      convertEol: true,
+    });
+
+    const fit = new FitAddon();
+    term.loadAddon(fit);
+
+    termRef.current = term;
+    fitRef.current = fit;
+
+    // If container already mounted, open immediately
+    if (containerRef.current) {
+      term.open(containerRef.current);
+      fit.fit();
+    }
+
+    return () => {
+      term.dispose();
+      termRef.current = null;
+      fitRef.current = null;
+    };
+  }, [enabled]);
+
+  // Fit on resize
+  useEffect(() => {
+    if (!enabled) return;
+    const handleResize = () => fitRef.current?.fit();
+    window.addEventListener("resize", handleResize);
+    return () => window.removeEventListener("resize", handleResize);
+  }, [enabled]);
+
+  // WebSocket connection for terminal channel
+  useEffect(() => {
+    if (!enabled || !channel) return;
+
+    function connect() {
+      const protocol = window.location.protocol === "https:" ? "wss:" : "ws:";
+      const ws = new WebSocket(`${protocol}//${window.location.host}/ws`);
+      wsRef.current = ws;
+
+      ws.onopen = () => {
+        ws.send(JSON.stringify({ channel: "subscribe", data: [channel] }));
+      };
+
+      ws.onmessage = (evt) => {
+        try {
+          const msg = JSON.parse(evt.data);
+          if (msg.channel === channel && msg.data) {
+            termRef.current?.write(
+              typeof msg.data === "string" ? msg.data : JSON.stringify(msg.data),
+            );
+          }
+        } catch {
+          /* ignore malformed */
+        }
+      };
+
+      ws.onclose = () => {
+        reconnectRef.current = setTimeout(connect, 3000);
+      };
+
+      ws.onerror = () => ws.close();
+    }
+
+    connect();
+
+    return () => {
+      clearTimeout(reconnectRef.current);
+      wsRef.current?.close();
+      wsRef.current = null;
+    };
+  }, [channel, enabled]);
+
+  // Handle user input → send to backend via WebSocket
+  useEffect(() => {
+    if (!enabled || !channel) return;
+    const term = termRef.current;
+    if (!term) return;
+
+    const disposable = term.onData((data) => {
+      const ws = wsRef.current;
+      if (ws?.readyState === WebSocket.OPEN) {
+        ws.send(JSON.stringify({ channel, data }));
+      }
+    });
+
+    return () => disposable.dispose();
+  }, [channel, enabled]);
+
+  // Ref callback for container div
+  const attachRef = useCallback((el: HTMLDivElement | null) => {
+    containerRef.current = el;
+    if (el && termRef.current && !termRef.current.element) {
+      termRef.current.open(el);
+      // Delay fit to ensure container has dimensions
+      requestAnimationFrame(() => fitRef.current?.fit());
+    }
+  }, []);
+
+  const writeLine = useCallback((text: string) => {
+    termRef.current?.writeln(text);
+  }, []);
+
+  const fit = useCallback(() => {
+    fitRef.current?.fit();
+  }, []);
+
+  return { attachRef, terminal: termRef, writeLine, fit };
+}

--- a/frontend/src/pages/Dashboard.css
+++ b/frontend/src/pages/Dashboard.css
@@ -6,6 +6,9 @@
 }
 
 .dashboard__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
   margin-bottom: var(--space-6);
 }
 

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -1,13 +1,16 @@
+import { useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { useAppContext } from "../context/AppContext";
 import StatusBadge from "../components/common/StatusBadge";
 import TimeAgo from "../components/common/TimeAgo";
+import CreateProjectModal from "../components/common/CreateProjectModal";
 import "./Dashboard.css";
 
 export default function Dashboard() {
   const navigate = useNavigate();
-  const { state } = useAppContext();
+  const { state, fetchAll } = useAppContext();
   const { projects, sessions, usage, notifications } = state;
+  const [showCreate, setShowCreate] = useState(false);
 
   const activeProjects = projects.filter((p) => p.status === "active");
 
@@ -15,6 +18,12 @@ export default function Dashboard() {
     <div className="dashboard" data-testid="dashboard-page">
       <div className="dashboard__header">
         <h1>Dashboard</h1>
+        <button
+          className="btn btn-primary"
+          onClick={() => setShowCreate(true)}
+        >
+          + New Project
+        </button>
       </div>
 
       <div className="dashboard__grid">
@@ -90,7 +99,14 @@ export default function Dashboard() {
         <h2>Projects</h2>
         {activeProjects.length === 0 ? (
           <div className="dashboard__empty">
-            No active projects. Create one to get started.
+            <p>No active projects.</p>
+            <button
+              className="btn btn-primary"
+              onClick={() => setShowCreate(true)}
+              style={{ marginTop: "var(--space-3)" }}
+            >
+              Create your first project
+            </button>
           </div>
         ) : (
           <div className="dashboard__project-grid">
@@ -124,6 +140,14 @@ export default function Dashboard() {
           </div>
         )}
       </section>
+
+      <CreateProjectModal
+        open={showCreate}
+        onClose={() => setShowCreate(false)}
+        onCreated={() => {
+          void fetchAll();
+        }}
+      />
     </div>
   );
 }

--- a/frontend/src/pages/ProjectView.css
+++ b/frontend/src/pages/ProjectView.css
@@ -37,63 +37,17 @@
 
 .project-view__layout {
   display: grid;
-  grid-template-columns: var(--sidebar-width) 1fr;
+  grid-template-columns: 1fr 1fr;
   gap: var(--space-4);
   flex: 1;
   min-height: 0;
 }
 
 .project-view__left {
-  overflow-y: auto;
-}
-
-.project-view__left h3 {
-  font-size: var(--text-sm);
-  color: var(--color-text-secondary);
-  text-transform: uppercase;
-  letter-spacing: 0.05em;
-  margin-bottom: var(--space-3);
-}
-
-.project-view__muted {
-  font-size: var(--text-sm);
-  color: var(--color-text-muted);
-}
-
-.project-view__session-list {
-  list-style: none;
   display: flex;
   flex-direction: column;
-  gap: var(--space-1);
-}
-
-.project-view__session-item {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  width: 100%;
-  padding: var(--space-2) var(--space-3);
-  background: none;
-  border: 1px solid transparent;
-  border-radius: var(--radius-md);
-  cursor: pointer;
-  font-family: var(--font-sans);
-  color: var(--color-text);
-  transition: background var(--transition-fast);
-}
-
-.project-view__session-item:hover {
-  background: var(--color-bg-hover);
-}
-
-.project-view__session-item.selected {
-  background: var(--color-accent-muted);
-  border-color: var(--color-accent);
-}
-
-.project-view__session-name {
-  font-size: var(--text-sm);
-  font-weight: 500;
+  gap: var(--space-4);
+  overflow-y: auto;
 }
 
 .project-view__right {
@@ -101,55 +55,4 @@
   flex-direction: column;
   gap: var(--space-4);
   overflow-y: auto;
-}
-
-.project-view__leader h3,
-.project-view__tasks h3 {
-  font-size: var(--text-sm);
-  color: var(--color-text-secondary);
-  text-transform: uppercase;
-  letter-spacing: 0.05em;
-  margin-bottom: var(--space-3);
-}
-
-.project-view__leader-info {
-  display: flex;
-  flex-direction: column;
-  gap: var(--space-2);
-}
-
-.project-view__leader-goal {
-  font-size: var(--text-sm);
-  color: var(--color-text);
-}
-
-.project-view__leader-meta {
-  font-size: var(--text-xs);
-  color: var(--color-text-muted);
-}
-
-.project-view__task-grid {
-  display: grid;
-  grid-template-columns: repeat(3, 1fr);
-  gap: var(--space-3);
-}
-
-.project-view__task-col h4 {
-  font-size: var(--text-xs);
-  text-transform: uppercase;
-  color: var(--color-text-muted);
-  letter-spacing: 0.05em;
-  margin-bottom: var(--space-2);
-}
-
-.project-view__task-card {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  padding: var(--space-2) var(--space-3);
-  background: var(--color-bg);
-  border: 1px solid var(--color-border-subtle);
-  border-radius: var(--radius-md);
-  font-size: var(--text-sm);
-  margin-bottom: var(--space-2);
 }

--- a/frontend/src/pages/ProjectView.tsx
+++ b/frontend/src/pages/ProjectView.tsx
@@ -1,12 +1,15 @@
 import { useParams } from "react-router-dom";
 import { useAppContext } from "../context/AppContext";
 import StatusBadge from "../components/common/StatusBadge";
-import TimeAgo from "../components/common/TimeAgo";
+import LeaderConsole from "../components/leader/LeaderConsole";
+import TaskBoard from "../components/leader/TaskBoard";
+import ContextViewer from "../components/leader/ContextViewer";
+import AceList from "../components/ace/AceList";
 import "./ProjectView.css";
 
 export default function ProjectView() {
   const { id } = useParams<{ id: string }>();
-  const { state, dispatch } = useAppContext();
+  const { state, fetchAll } = useAppContext();
   const { projects, sessions, leaders, tasks } = state;
 
   const project = projects.find((p) => p.id === id);
@@ -38,84 +41,33 @@ export default function ProjectView() {
       </div>
 
       <div className="project-view__layout">
-        {/* Left panel — Sessions */}
-        <aside className="project-view__left panel">
-          <h3>Sessions</h3>
-          {projectSessions.length === 0 ? (
-            <p className="project-view__muted">No sessions yet.</p>
-          ) : (
-            <ul className="project-view__session-list">
-              {projectSessions.map((session) => (
-                <li key={session.id}>
-                  <button
-                    className={`project-view__session-item ${
-                      state.selectedSessionId === session.id ? "selected" : ""
-                    }`}
-                    onClick={() =>
-                      dispatch({
-                        type: "SELECT_SESSION",
-                        payload: session.id,
-                      })
-                    }
-                  >
-                    <span className="project-view__session-name">
-                      {session.name}
-                    </span>
-                    <StatusBadge status={session.status} size="sm" />
-                  </button>
-                </li>
-              ))}
-            </ul>
-          )}
-        </aside>
-
-        {/* Right panel — Leader + Tasks */}
-        <main className="project-view__right">
-          {/* Leader console */}
-          <div className="panel project-view__leader">
-            <h3>Leader</h3>
-            {leader ? (
-              <div className="project-view__leader-info">
-                <StatusBadge status={leader.status} />
-                {leader.goal && (
-                  <p className="project-view__leader-goal">{leader.goal}</p>
-                )}
-                <div className="project-view__leader-meta">
-                  Updated <TimeAgo datetime={leader.updated_at} />
-                </div>
-              </div>
-            ) : (
-              <p className="project-view__muted">No leader assigned.</p>
-            )}
+        {/* Left panel — Leader + Context */}
+        <aside className="project-view__left">
+          <div className="panel">
+            <LeaderConsole
+              projectId={project.id}
+              leader={leader}
+              onRefresh={fetchAll}
+            />
           </div>
 
-          {/* Task board */}
-          <div className="panel project-view__tasks">
-            <h3>Tasks</h3>
-            {projectTasks.length === 0 ? (
-              <p className="project-view__muted">No tasks yet.</p>
-            ) : (
-              <div className="project-view__task-grid">
-                {(
-                  ["pending", "in_progress", "done"] as const
-                ).map((col) => (
-                  <div key={col} className="project-view__task-col">
-                    <h4>{col.replace(/_/g, " ")}</h4>
-                    {projectTasks
-                      .filter((t) => t.status === col)
-                      .map((task) => (
-                        <div
-                          key={task.id}
-                          className="project-view__task-card"
-                        >
-                          <span>{task.title}</span>
-                          <StatusBadge status={task.status} size="sm" />
-                        </div>
-                      ))}
-                  </div>
-                ))}
-              </div>
-            )}
+          <div className="panel">
+            <ContextViewer leader={leader} />
+          </div>
+        </aside>
+
+        {/* Right panel — Aces + Tasks */}
+        <main className="project-view__right">
+          <div className="panel">
+            <AceList
+              projectId={project.id}
+              sessions={projectSessions}
+              onRefresh={fetchAll}
+            />
+          </div>
+
+          <div className="panel">
+            <TaskBoard tasks={projectTasks} />
           </div>
         </main>
       </div>

--- a/frontend/src/pages/__tests__/Dashboard.test.tsx
+++ b/frontend/src/pages/__tests__/Dashboard.test.tsx
@@ -31,7 +31,10 @@ describe("Dashboard", () => {
   it("shows empty state for projects", () => {
     renderWithProviders(<Dashboard />);
     expect(
-      screen.getByText("No active projects. Create one to get started."),
+      screen.getByText("No active projects."),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText("Create your first project"),
     ).toBeInTheDocument();
   });
 


### PR DESCRIPTION
## Summary

Implements all Milestone 1 frontend functionality — the critical missing piece between a working backend and a usable UI.

- **Create Project modal** on Dashboard — form wired to `POST /api/projects` (name, description, repo_path, github_repo)
- **LeaderConsole** — start/stop buttons wired to `/api/projects/{id}/leader/start|stop`, xterm.js terminal for PTY streaming, message input
- **AceList** — create/start/stop/delete controls for ace sessions, tab-based session selector
- **AceTerminal** — xterm.js terminal connected via WebSocket `terminal:{id}` channel, message input
- **useTerminal hook** — reusable xterm.js lifecycle management with WebSocket integration, auto-reconnect, fit addon
- **TaskBoard** — 3-column Kanban (pending/in_progress/done) with task cards
- **ContextViewer** — displays Leader context key-value entries
- **TowerModal** — Tower status display, goal setting, memory viewer
- **AppContext fix** — removed broken `/sessions` and `/notifications` fetches, now uses correct per-project endpoints (`/projects/{id}/aces`, `/projects/{id}/manager`)
- **ProjectView rewrite** — integrates LeaderConsole, AceList, TaskBoard, ContextViewer in a split-panel layout

## Testing Done

- `npm run build` — clean production build (126 modules)
- `npx tsc --noEmit` — zero TypeScript errors (strict mode with noUncheckedIndexedAccess)
- `npm run test` — all 69 tests pass, including updated tests for changed Dashboard empty state text and AppContext API call patterns