### PR TITLE
fix: use python3 instead of python for macOS compatibility

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,7 +19,7 @@ in isolated Claude Code sessions.
 ./scripts/dev.sh
 
 # Backend only
-python -m uvicorn atc.api.app:create_app --factory --reload --port 8420
+python3 -m uvicorn atc.api.app:create_app --factory --reload --port 8420
 
 # Frontend only
 cd frontend && npm run dev

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Open http://localhost:5173 in any Windows browser.
 
 # Or run them separately:
 # Backend (port 8420)
-python -m uvicorn atc.api.app:create_app --factory --reload --port 8420
+python3 -m uvicorn atc.api.app:create_app --factory --reload --port 8420
 
 # Frontend (port 5173, proxies API to 8420)
 cd frontend && npm run dev

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -10,7 +10,7 @@ git clone <repo-url>
 cd atc
 
 # Python backend
-python -m venv .venv
+python3 -m venv .venv
 source .venv/bin/activate
 pip install -e ".[dev]"
 pre-commit install

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -9,7 +9,7 @@ echo "Starting ATC in development mode..."
 
 # Start backend
 echo "→ Starting backend (uvicorn with reload)..."
-(cd "$ROOT_DIR" && python -m uvicorn atc.api.app:create_app --factory --reload --host 127.0.0.1 --port 8420) &
+(cd "$ROOT_DIR" && python3 -m uvicorn atc.api.app:create_app --factory --reload --host 127.0.0.1 --port 8420) &
 BACKEND_PID=$!
 
 # Start frontend

--- a/src/atc/__main__.py
+++ b/src/atc/__main__.py
@@ -1,4 +1,4 @@
-"""Allow running ATC via ``python -m atc``."""
+"""Allow running ATC via ``python3 -m atc``."""
 
 from atc.api.app import main
 


### PR DESCRIPTION
## Summary
- Updated `scripts/dev.sh` to invoke `python3` instead of `python` — macOS does not ship a `python` binary
- Updated all documentation (`CLAUDE.md`, `README.md`, `docs/CONTRIBUTING.md`) and `src/atc/__main__.py` docstring to match
- Last M1 polish item

## Test plan
- [x] All 257 existing tests pass (`pytest` — 257 passed in 4.06s)
- [ ] Verify `./scripts/dev.sh` starts correctly on a fresh macOS machine

🤖 Generated with [Claude Code](https://claude.com/claude-code)