### PR TITLE
feat: Tower controller — goal intake, context packages, Leader lifecycle

### DIFF
--- a/src/atc/api/app.py
+++ b/src/atc/api/app.py
@@ -50,6 +50,12 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
     ws_hub = WsHub()
     app.state.ws_hub = ws_hub
 
+    # 4b. Start Tower controller
+    from atc.tower.controller import TowerController
+
+    tower_controller = TowerController(db, event_bus, ws_hub=ws_hub)
+    app.state.tower_controller = tower_controller
+
     # 5. Start PTY stream pool and wire to WsHub
     pty_pool = PtyStreamPool(event_bus)
     await pty_pool.start()

--- a/src/atc/api/routers/tower.py
+++ b/src/atc/api/routers/tower.py
@@ -1,8 +1,9 @@
-"""Tower REST endpoints — minimal for Milestone 1.
+"""Tower REST endpoints — goal intake and tower status.
 
 Routes:
   GET    /api/tower/status           → Tower status summary
-  POST   /api/tower/goal             → submit new goal
+  POST   /api/tower/goal             → submit new goal (creates Leader + context)
+  POST   /api/tower/cancel           → cancel current goal
   GET    /api/tower/memory           → list tower memory entries
   DELETE /api/tower/memory/{key}     → forget a memory entry
 """
@@ -11,6 +12,8 @@ from __future__ import annotations
 
 from fastapi import APIRouter, HTTPException, Request
 from pydantic import BaseModel
+
+from atc.tower.controller import TowerBusyError, TowerController
 
 router = APIRouter()
 
@@ -24,6 +27,10 @@ class TowerStatusResponse(BaseModel):
     status: str
     active_projects: int
     total_sessions: int
+    state: str
+    current_goal: str | None
+    current_project_id: str | None
+    current_session_id: str | None
 
 
 class MemoryEntry(BaseModel):
@@ -39,10 +46,18 @@ async def _get_db(request: Request):  # noqa: ANN202
     return request.app.state.db
 
 
+def _get_tower(request: Request) -> TowerController:
+    tower: TowerController | None = getattr(request.app.state, "tower_controller", None)
+    if tower is None:
+        raise HTTPException(status_code=503, detail="Tower controller not initialized")
+    return tower
+
+
 @router.get("/status", response_model=TowerStatusResponse)
 async def tower_status(request: Request) -> TowerStatusResponse:
     """Return a summary of the Tower's current state."""
     db = await _get_db(request)
+    tower = _get_tower(request)
 
     cursor = await db.execute("SELECT COUNT(*) FROM projects WHERE status = 'active'")
     row = await cursor.fetchone()
@@ -52,18 +67,28 @@ async def tower_status(request: Request) -> TowerStatusResponse:
     row = await cursor.fetchone()
     total_sessions = row[0] if row else 0
 
+    controller_status = tower.get_status()
+
     return TowerStatusResponse(
         status="running",
         active_projects=active_projects,
         total_sessions=total_sessions,
+        state=controller_status["state"],
+        current_goal=controller_status["current_goal"],
+        current_project_id=controller_status["current_project_id"],
+        current_session_id=controller_status["current_session_id"],
     )
 
 
 @router.post("/goal")
-async def submit_goal(body: GoalRequest, request: Request) -> dict[str, str]:
-    """Submit a new goal for a project's Leader to work on."""
+async def submit_goal(body: GoalRequest, request: Request) -> dict:
+    """Submit a new goal for a project's Leader to work on.
+
+    The Tower controller builds a context package, starts the Leader
+    session, and begins monitoring progress.
+    """
     db = await _get_db(request)
-    event_bus = getattr(request.app.state, "event_bus", None)
+    tower = _get_tower(request)
 
     # Verify project exists
     cursor = await db.execute("SELECT id FROM projects WHERE id = ?", (body.project_id,))
@@ -71,20 +96,26 @@ async def submit_goal(body: GoalRequest, request: Request) -> dict[str, str]:
     if row is None:
         raise HTTPException(status_code=404, detail=f"Project {body.project_id} not found")
 
-    # Update leader goal
-    await db.execute(
-        "UPDATE leaders SET goal = ?, updated_at = datetime('now') WHERE project_id = ?",
-        (body.goal, body.project_id),
-    )
-    await db.commit()
+    try:
+        result = await tower.submit_goal(body.project_id, body.goal)
+    except TowerBusyError as exc:
+        raise HTTPException(status_code=409, detail=str(exc)) from exc
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
 
-    if event_bus:
-        await event_bus.publish(
-            "tower_goal_submitted",
-            {"project_id": body.project_id, "goal": body.goal},
-        )
+    return result
 
-    return {"status": "accepted", "project_id": body.project_id}
+
+@router.post("/cancel")
+async def cancel_goal(request: Request) -> dict:
+    """Cancel the current goal and stop the Leader session."""
+    tower = _get_tower(request)
+
+    if tower.state.value == "idle":
+        raise HTTPException(status_code=409, detail="No active goal to cancel")
+
+    await tower.cancel_goal()
+    return {"status": "cancelled"}
 
 
 @router.get("/memory", response_model=list[MemoryEntry])

--- a/src/atc/leader/context_package.py
+++ b/src/atc/leader/context_package.py
@@ -1,1 +1,69 @@
-"""Leader context_package — stub."""
+"""Leader context package — assembles project context for a Leader session.
+
+A context package is a dict containing everything a Leader needs to start
+working on a goal: the goal itself, project metadata, repo path, and any
+relevant context entries from the project's context hub.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import json
+import logging
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    import aiosqlite
+
+logger = logging.getLogger(__name__)
+
+
+async def build_context_package(
+    db: aiosqlite.Connection,
+    project_id: str,
+    goal: str,
+) -> dict[str, Any]:
+    """Assemble a context package for a Leader session.
+
+    Returns a dict with:
+      - goal: the user's goal string
+      - project_id: project identifier
+      - project_name: human-readable project name
+      - repo_path: filesystem path to the project repo (if set)
+      - github_repo: GitHub owner/repo (if set)
+      - context_entries: list of context hub entries for the project
+    """
+    # Fetch project metadata
+    cursor = await db.execute(
+        "SELECT id, name, repo_path, github_repo, description FROM projects WHERE id = ?",
+        (project_id,),
+    )
+    row = await cursor.fetchone()
+    if row is None:
+        raise ValueError(f"Project {project_id} not found")
+
+    project = dict(row)
+
+    # Fetch context entries for the project
+    cursor = await db.execute(
+        "SELECT key, entry_type, value FROM context_entries WHERE project_id = ? ORDER BY position",
+        (project_id,),
+    )
+    entries = await cursor.fetchall()
+    context_entries = []
+    for entry in entries:
+        entry_dict = dict(entry)
+        # Parse JSON values
+        with contextlib.suppress(json.JSONDecodeError, TypeError):
+            entry_dict["value"] = json.loads(entry_dict["value"])
+        context_entries.append(entry_dict)
+
+    return {
+        "goal": goal,
+        "project_id": project_id,
+        "project_name": project["name"],
+        "repo_path": project.get("repo_path"),
+        "github_repo": project.get("github_repo"),
+        "description": project.get("description"),
+        "context_entries": context_entries,
+    }

--- a/src/atc/tower/controller.py
+++ b/src/atc/tower/controller.py
@@ -1,1 +1,277 @@
-"""Tower controller — stub."""
+"""Tower controller — manages goal intake and Leader lifecycle.
+
+The Tower controller receives goals from the UI, builds context packages,
+creates/starts Leader sessions, and monitors their progress. It publishes
+status changes through the event bus so the WebSocket hub can relay them
+to connected clients.
+
+Tower lifecycle states: idle → planning → managing → complete | error
+"""
+
+from __future__ import annotations
+
+import enum
+import json
+import logging
+from typing import TYPE_CHECKING, Any
+
+from atc.leader.context_package import build_context_package
+from atc.leader.leader import start_leader, stop_leader
+
+if TYPE_CHECKING:
+    import aiosqlite
+
+    from atc.api.ws.hub import WsHub
+    from atc.core.events import EventBus
+
+logger = logging.getLogger(__name__)
+
+
+class TowerState(enum.StrEnum):
+    """Tower lifecycle states."""
+
+    IDLE = "idle"
+    PLANNING = "planning"
+    MANAGING = "managing"
+    COMPLETE = "complete"
+    ERROR = "error"
+
+
+# Valid state transitions for the tower lifecycle.
+_VALID_TRANSITIONS: dict[TowerState, set[TowerState]] = {
+    TowerState.IDLE: {TowerState.PLANNING},
+    TowerState.PLANNING: {TowerState.MANAGING, TowerState.ERROR},
+    TowerState.MANAGING: {TowerState.COMPLETE, TowerState.ERROR, TowerState.IDLE},
+    TowerState.COMPLETE: {TowerState.IDLE},
+    TowerState.ERROR: {TowerState.IDLE},
+}
+
+
+class TowerController:
+    """Singleton controller that manages goal intake and Leader sessions.
+
+    One TowerController per application instance. It tracks the current
+    state of goal processing and coordinates with the Leader subsystem.
+    """
+
+    def __init__(
+        self,
+        db: aiosqlite.Connection,
+        event_bus: EventBus,
+        ws_hub: WsHub | None = None,
+    ) -> None:
+        self._db = db
+        self._event_bus = event_bus
+        self._ws_hub = ws_hub
+        self._state = TowerState.IDLE
+        self._current_goal: str | None = None
+        self._current_project_id: str | None = None
+        self._current_session_id: str | None = None
+
+        # Subscribe to leader session events for monitoring
+        self._event_bus.subscribe("session_status_changed", self._on_session_status_changed)
+
+    @property
+    def state(self) -> TowerState:
+        return self._state
+
+    @property
+    def current_goal(self) -> str | None:
+        return self._current_goal
+
+    @property
+    def current_project_id(self) -> str | None:
+        return self._current_project_id
+
+    @property
+    def current_session_id(self) -> str | None:
+        return self._current_session_id
+
+    async def _transition(self, target: TowerState) -> None:
+        """Validate and perform a tower state transition."""
+        allowed = _VALID_TRANSITIONS.get(self._state, set())
+        if target not in allowed:
+            raise InvalidTowerTransitionError(self._state, target)
+
+        previous = self._state
+        self._state = target
+        logger.info("Tower: %s → %s", previous.value, target.value)
+
+        await self._event_bus.publish(
+            "tower_state_changed",
+            {
+                "previous_state": previous.value,
+                "new_state": target.value,
+                "project_id": self._current_project_id,
+                "goal": self._current_goal,
+            },
+        )
+
+        # Broadcast to WebSocket clients on the "tower" channel
+        if self._ws_hub is not None:
+            await self._ws_hub.broadcast(
+                "tower",
+                {
+                    "type": "state_changed",
+                    "previous_state": previous.value,
+                    "new_state": target.value,
+                    "project_id": self._current_project_id,
+                    "goal": self._current_goal,
+                },
+            )
+
+    async def submit_goal(self, project_id: str, goal: str) -> dict[str, Any]:
+        """Process a new goal: build context, start Leader, begin monitoring.
+
+        Returns a dict with status, project_id, session_id, and context_package.
+        Raises if the tower is not idle (already processing a goal).
+        """
+        if self._state not in (TowerState.IDLE, TowerState.COMPLETE, TowerState.ERROR):
+            raise TowerBusyError(self._state, project_id)
+
+        # Reset to idle first if coming from complete/error
+        if self._state in (TowerState.COMPLETE, TowerState.ERROR):
+            self._state = TowerState.IDLE
+
+        self._current_project_id = project_id
+        self._current_goal = goal
+
+        try:
+            # Phase 1: Planning — build the context package
+            await self._transition(TowerState.PLANNING)
+
+            context_package = await build_context_package(self._db, project_id, goal)
+
+            # Store context on the leader row
+            await self._db.execute(
+                "UPDATE leaders SET context = ?, goal = ?, updated_at = datetime('now') "
+                "WHERE project_id = ?",
+                (json.dumps(context_package), goal, project_id),
+            )
+            await self._db.commit()
+
+            # Phase 2: Managing — start the Leader session
+            await self._transition(TowerState.MANAGING)
+
+            session_id = await start_leader(
+                self._db,
+                project_id,
+                goal=goal,
+                event_bus=self._event_bus,
+            )
+            self._current_session_id = session_id
+
+            await self._event_bus.publish(
+                "tower_goal_submitted",
+                {
+                    "project_id": project_id,
+                    "goal": goal,
+                    "session_id": session_id,
+                },
+            )
+
+            return {
+                "status": "accepted",
+                "project_id": project_id,
+                "session_id": session_id,
+                "context_package": context_package,
+            }
+
+        except Exception:
+            logger.exception("Tower failed to process goal for project %s", project_id)
+            await self._transition(TowerState.ERROR)
+            raise
+
+    async def mark_complete(self) -> None:
+        """Mark the current goal as complete and return tower to idle."""
+        await self._transition(TowerState.COMPLETE)
+        self._current_goal = None
+        self._current_project_id = None
+        self._current_session_id = None
+
+    async def cancel_goal(self) -> None:
+        """Cancel the current goal, stop the Leader, and return to idle."""
+        if self._current_project_id and self._state == TowerState.MANAGING:
+            await stop_leader(
+                self._db,
+                self._current_project_id,
+                event_bus=self._event_bus,
+            )
+
+        # Transition through error → idle for cancellation
+        if self._state == TowerState.MANAGING:
+            await self._transition(TowerState.ERROR)
+
+        if self._state in (TowerState.ERROR, TowerState.COMPLETE):
+            self._state = TowerState.IDLE
+            self._current_goal = None
+            self._current_project_id = None
+            self._current_session_id = None
+
+            await self._event_bus.publish(
+                "tower_state_changed",
+                {"previous_state": "error", "new_state": "idle", "project_id": None, "goal": None},
+            )
+
+    async def reset(self) -> None:
+        """Force-reset tower to idle state (e.g. after unrecoverable error)."""
+        self._state = TowerState.IDLE
+        self._current_goal = None
+        self._current_project_id = None
+        self._current_session_id = None
+
+    def get_status(self) -> dict[str, Any]:
+        """Return the current tower controller status."""
+        return {
+            "state": self._state.value,
+            "current_goal": self._current_goal,
+            "current_project_id": self._current_project_id,
+            "current_session_id": self._current_session_id,
+        }
+
+    async def _on_session_status_changed(self, data: dict[str, Any]) -> None:
+        """Monitor Leader session status changes for error detection."""
+        session_id = data.get("session_id")
+        new_status = data.get("new_status")
+
+        if session_id != self._current_session_id:
+            return
+
+        if new_status == "error" and self._state == TowerState.MANAGING:
+            logger.warning(
+                "Leader session %s entered error state — transitioning tower to error",
+                session_id,
+            )
+            await self._transition(TowerState.ERROR)
+
+        # Broadcast leader status through the tower channel too
+        if self._ws_hub is not None:
+            await self._ws_hub.broadcast(
+                "tower",
+                {
+                    "type": "leader_status",
+                    "session_id": session_id,
+                    "status": new_status,
+                    "project_id": self._current_project_id,
+                },
+            )
+
+
+class InvalidTowerTransitionError(Exception):
+    """Raised when a tower state transition is not allowed."""
+
+    def __init__(self, current: TowerState, target: TowerState) -> None:
+        self.current = current
+        self.target = target
+        super().__init__(f"Invalid tower transition: {current.value} → {target.value}")
+
+
+class TowerBusyError(Exception):
+    """Raised when a goal is submitted while the tower is busy."""
+
+    def __init__(self, state: TowerState, project_id: str) -> None:
+        self.state = state
+        self.project_id = project_id
+        super().__init__(
+            f"Tower is busy (state={state.value}), cannot accept goal for {project_id}"
+        )

--- a/tests/e2e/test_smoke.py
+++ b/tests/e2e/test_smoke.py
@@ -246,6 +246,7 @@ class TestTowerStatus:
         assert data["status"] == "running"
         assert data["active_projects"] == 0
         assert data["total_sessions"] == 0
+        assert data["state"] == "idle"
 
     def test_tower_status_after_project(self, client: TestClient) -> None:
         client.post("/api/projects", json={"name": "counted-proj"})
@@ -266,7 +267,16 @@ class TestTowerStatus:
         # At least 1 session (the ace; leader session is only created on start)
         assert data["total_sessions"] >= 1
 
-    def test_submit_goal(self, client: TestClient) -> None:
+    @patch("atc.leader.leader._send_keys", new_callable=AsyncMock)
+    @patch("atc.leader.leader._spawn_pane", new_callable=AsyncMock, return_value="%1")
+    @patch("atc.leader.leader._ensure_tmux_session", new_callable=AsyncMock)
+    def test_submit_goal(
+        self,
+        mock_ensure: AsyncMock,
+        mock_spawn: AsyncMock,
+        mock_send: AsyncMock,
+        client: TestClient,
+    ) -> None:
         resp = client.post("/api/projects", json={"name": "goal-proj"})
         project_id = resp.json()["id"]
 
@@ -275,7 +285,12 @@ class TestTowerStatus:
             json={"project_id": project_id, "goal": "Ship v1"},
         )
         assert resp.status_code == 200
-        assert resp.json()["status"] == "accepted"
+        data = resp.json()
+        assert data["status"] == "accepted"
+        assert data["project_id"] == project_id
+        assert "session_id" in data
+        assert "context_package" in data
+        assert data["context_package"]["goal"] == "Ship v1"
 
     def test_submit_goal_missing_project(self, client: TestClient) -> None:
         resp = client.post(
@@ -283,6 +298,63 @@ class TestTowerStatus:
             json={"project_id": "nonexistent", "goal": "Ship v1"},
         )
         assert resp.status_code == 404
+
+    @patch("atc.leader.leader._send_keys", new_callable=AsyncMock)
+    @patch("atc.leader.leader._spawn_pane", new_callable=AsyncMock, return_value="%1")
+    @patch("atc.leader.leader._ensure_tmux_session", new_callable=AsyncMock)
+    def test_submit_goal_twice_returns_conflict(
+        self,
+        mock_ensure: AsyncMock,
+        mock_spawn: AsyncMock,
+        mock_send: AsyncMock,
+        client: TestClient,
+    ) -> None:
+        resp = client.post("/api/projects", json={"name": "busy-proj"})
+        project_id = resp.json()["id"]
+
+        resp = client.post(
+            "/api/tower/goal",
+            json={"project_id": project_id, "goal": "First goal"},
+        )
+        assert resp.status_code == 200
+
+        resp = client.post(
+            "/api/tower/goal",
+            json={"project_id": project_id, "goal": "Second goal"},
+        )
+        assert resp.status_code == 409
+
+    @patch("atc.leader.leader._kill_pane", new_callable=AsyncMock)
+    @patch("atc.leader.leader._send_keys", new_callable=AsyncMock)
+    @patch("atc.leader.leader._spawn_pane", new_callable=AsyncMock, return_value="%1")
+    @patch("atc.leader.leader._ensure_tmux_session", new_callable=AsyncMock)
+    def test_cancel_goal(
+        self,
+        mock_ensure: AsyncMock,
+        mock_spawn: AsyncMock,
+        mock_send: AsyncMock,
+        mock_kill: AsyncMock,
+        client: TestClient,
+    ) -> None:
+        resp = client.post("/api/projects", json={"name": "cancel-proj"})
+        project_id = resp.json()["id"]
+
+        client.post(
+            "/api/tower/goal",
+            json={"project_id": project_id, "goal": "Cancel me"},
+        )
+
+        resp = client.post("/api/tower/cancel")
+        assert resp.status_code == 200
+        assert resp.json()["status"] == "cancelled"
+
+        # Tower should be idle again
+        resp = client.get("/api/tower/status")
+        assert resp.json()["state"] == "idle"
+
+    def test_cancel_no_active_goal(self, client: TestClient) -> None:
+        resp = client.post("/api/tower/cancel")
+        assert resp.status_code == 409
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_context_package.py
+++ b/tests/unit/test_context_package.py
@@ -1,0 +1,92 @@
+"""Tests for Leader context package builder."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from atc.leader.context_package import build_context_package
+from atc.state.db import (
+    _SCHEMA_SQL,
+    create_project,
+    get_connection,
+    run_migrations,
+)
+
+
+@pytest.fixture
+async def db():
+    """In-memory database with schema applied."""
+    await run_migrations(":memory:")
+    async with get_connection(":memory:") as conn:
+        await conn.executescript(_SCHEMA_SQL)
+        await conn.commit()
+        yield conn
+
+
+@pytest.mark.asyncio
+class TestBuildContextPackage:
+    async def test_basic_package(self, db) -> None:
+        project = await create_project(
+            db, "my-project", description="A test", repo_path="/tmp/repo"
+        )
+
+        pkg = await build_context_package(db, project.id, "Build feature X")
+
+        assert pkg["goal"] == "Build feature X"
+        assert pkg["project_id"] == project.id
+        assert pkg["project_name"] == "my-project"
+        assert pkg["repo_path"] == "/tmp/repo"
+        assert pkg["description"] == "A test"
+        assert pkg["context_entries"] == []
+
+    async def test_package_with_github_repo(self, db) -> None:
+        project = await create_project(db, "gh-proj", github_repo="org/repo")
+
+        pkg = await build_context_package(db, project.id, "Deploy")
+
+        assert pkg["github_repo"] == "org/repo"
+
+    async def test_package_with_context_entries(self, db) -> None:
+        project = await create_project(db, "ctx-proj")
+
+        # Insert context entries
+        cols = (
+            "id, project_id, key, entry_type, value,"
+            " position, updated_by, created_at, updated_at"
+        )
+        vals = "?, ?, ?, ?, ?, ?, ?, datetime('now'), datetime('now')"
+        sql = f"INSERT INTO context_entries ({cols}) VALUES ({vals})"
+        await db.execute(
+            sql,
+            ("e1", project.id, "tech-stack", "text", json.dumps("Python + FastAPI"), 0, "test"),
+        )
+        await db.execute(
+            sql,
+            ("e2", project.id, "conventions", "list", json.dumps(["ruff", "mypy"]), 1, "test"),
+        )
+        await db.commit()
+
+        pkg = await build_context_package(db, project.id, "Follow conventions")
+
+        assert len(pkg["context_entries"]) == 2
+        assert pkg["context_entries"][0]["key"] == "tech-stack"
+        assert pkg["context_entries"][0]["value"] == "Python + FastAPI"
+        assert pkg["context_entries"][1]["key"] == "conventions"
+        assert pkg["context_entries"][1]["value"] == ["ruff", "mypy"]
+
+    async def test_package_project_not_found(self, db) -> None:
+        with pytest.raises(ValueError, match="not found"):
+            await build_context_package(db, "nonexistent-id", "Some goal")
+
+    async def test_package_minimal_project(self, db) -> None:
+        """Project with only required fields — optional fields are None."""
+        project = await create_project(db, "minimal")
+
+        pkg = await build_context_package(db, project.id, "Minimal goal")
+
+        assert pkg["repo_path"] is None
+        assert pkg["github_repo"] is None
+        assert pkg["description"] is None
+        assert pkg["context_entries"] == []

--- a/tests/unit/test_tower_controller.py
+++ b/tests/unit/test_tower_controller.py
@@ -1,0 +1,287 @@
+"""Tests for TowerController lifecycle and state transitions."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from atc.core.events import EventBus
+from atc.state.db import (
+    _SCHEMA_SQL,
+    create_leader,
+    create_project,
+    get_connection,
+    run_migrations,
+)
+from atc.tower.controller import (
+    InvalidTowerTransitionError,
+    TowerBusyError,
+    TowerController,
+    TowerState,
+)
+
+
+@pytest.fixture
+async def db():
+    """In-memory database with schema applied."""
+    await run_migrations(":memory:")
+    async with get_connection(":memory:") as conn:
+        await conn.executescript(_SCHEMA_SQL)
+        await conn.commit()
+        yield conn
+
+
+@pytest.fixture
+def event_bus() -> EventBus:
+    return EventBus()
+
+
+@pytest.fixture
+def tower(db, event_bus) -> TowerController:
+    return TowerController(db, event_bus)
+
+
+@pytest.mark.asyncio
+class TestTowerState:
+    async def test_initial_state_is_idle(self, tower: TowerController) -> None:
+        assert tower.state == TowerState.IDLE
+
+    async def test_get_status(self, tower: TowerController) -> None:
+        status = tower.get_status()
+        assert status["state"] == "idle"
+        assert status["current_goal"] is None
+        assert status["current_project_id"] is None
+        assert status["current_session_id"] is None
+
+    async def test_invalid_transition_raises(self, tower: TowerController) -> None:
+        with pytest.raises(InvalidTowerTransitionError):
+            await tower._transition(TowerState.COMPLETE)
+
+    async def test_valid_transitions(self, tower: TowerController) -> None:
+        await tower._transition(TowerState.PLANNING)
+        assert tower.state == TowerState.PLANNING
+
+        await tower._transition(TowerState.MANAGING)
+        assert tower.state == TowerState.MANAGING
+
+        await tower._transition(TowerState.COMPLETE)
+        assert tower.state == TowerState.COMPLETE
+
+        await tower._transition(TowerState.IDLE)
+        assert tower.state == TowerState.IDLE
+
+    async def test_error_transition(self, tower: TowerController) -> None:
+        await tower._transition(TowerState.PLANNING)
+        await tower._transition(TowerState.ERROR)
+        assert tower.state == TowerState.ERROR
+
+        # Can recover to idle from error
+        await tower._transition(TowerState.IDLE)
+        assert tower.state == TowerState.IDLE
+
+    async def test_reset(self, tower: TowerController) -> None:
+        tower._state = TowerState.MANAGING
+        tower._current_goal = "test"
+        tower._current_project_id = "proj-1"
+        await tower.reset()
+        assert tower.state == TowerState.IDLE
+        assert tower.current_goal is None
+        assert tower.current_project_id is None
+
+
+@patch("atc.tower.controller.start_leader", new_callable=AsyncMock, return_value="session-123")
+@pytest.mark.asyncio
+class TestSubmitGoal:
+    async def test_submit_goal_success(
+        self, mock_start: AsyncMock, db, event_bus: EventBus
+    ) -> None:
+        project = await create_project(db, "test-proj", repo_path="/tmp/repo")
+        await create_leader(db, project.id)
+        tower = TowerController(db, event_bus)
+
+        result = await tower.submit_goal(project.id, "Build feature X")
+
+        assert result["status"] == "accepted"
+        assert result["project_id"] == project.id
+        assert result["session_id"] == "session-123"
+        assert result["context_package"]["goal"] == "Build feature X"
+        assert result["context_package"]["project_name"] == "test-proj"
+        assert result["context_package"]["repo_path"] == "/tmp/repo"
+        assert tower.state == TowerState.MANAGING
+
+    async def test_submit_goal_publishes_event(
+        self, mock_start: AsyncMock, db, event_bus: EventBus
+    ) -> None:
+        project = await create_project(db, "test-proj")
+        await create_leader(db, project.id)
+        tower = TowerController(db, event_bus)
+
+        captured: list[dict] = []
+        event_bus.subscribe("tower_goal_submitted", lambda d: captured.append(d))
+
+        await tower.submit_goal(project.id, "Test goal")
+
+        assert len(captured) == 1
+        assert captured[0]["goal"] == "Test goal"
+        assert captured[0]["session_id"] == "session-123"
+
+    async def test_submit_goal_publishes_state_changes(
+        self, mock_start: AsyncMock, db, event_bus: EventBus
+    ) -> None:
+        project = await create_project(db, "test-proj")
+        await create_leader(db, project.id)
+        tower = TowerController(db, event_bus)
+
+        states: list[str] = []
+        event_bus.subscribe(
+            "tower_state_changed", lambda d: states.append(d["new_state"])
+        )
+
+        await tower.submit_goal(project.id, "Test goal")
+
+        assert "planning" in states
+        assert "managing" in states
+
+    async def test_submit_goal_project_not_found(
+        self, mock_start: AsyncMock, db, event_bus: EventBus
+    ) -> None:
+        tower = TowerController(db, event_bus)
+        with pytest.raises(ValueError, match="not found"):
+            await tower.submit_goal("nonexistent-id", "Some goal")
+        # Tower should be in error state after failure
+        assert tower.state == TowerState.ERROR
+
+    async def test_submit_goal_while_busy(
+        self, mock_start: AsyncMock, db, event_bus: EventBus
+    ) -> None:
+        project = await create_project(db, "test-proj")
+        await create_leader(db, project.id)
+        tower = TowerController(db, event_bus)
+
+        await tower.submit_goal(project.id, "First goal")
+        assert tower.state == TowerState.MANAGING
+
+        with pytest.raises(TowerBusyError):
+            await tower.submit_goal(project.id, "Second goal")
+
+    async def test_submit_goal_after_complete(
+        self, mock_start: AsyncMock, db, event_bus: EventBus
+    ) -> None:
+        """Can submit a new goal after previous one completes."""
+        project = await create_project(db, "test-proj")
+        await create_leader(db, project.id)
+        tower = TowerController(db, event_bus)
+
+        await tower.submit_goal(project.id, "First goal")
+        await tower.mark_complete()
+
+        result = await tower.submit_goal(project.id, "Second goal")
+        assert result["status"] == "accepted"
+
+    async def test_submit_goal_after_error(
+        self, mock_start: AsyncMock, db, event_bus: EventBus
+    ) -> None:
+        """Can submit a new goal after a previous error."""
+        project = await create_project(db, "test-proj")
+        await create_leader(db, project.id)
+        tower = TowerController(db, event_bus)
+
+        await tower.submit_goal(project.id, "First goal")
+        tower._state = TowerState.ERROR  # simulate error
+
+        result = await tower.submit_goal(project.id, "Recovery goal")
+        assert result["status"] == "accepted"
+
+
+@patch("atc.tower.controller.stop_leader", new_callable=AsyncMock)
+@patch("atc.tower.controller.start_leader", new_callable=AsyncMock, return_value="session-123")
+@pytest.mark.asyncio
+class TestCancelGoal:
+    async def test_cancel_active_goal(
+        self, mock_start: AsyncMock, mock_stop: AsyncMock, db, event_bus: EventBus
+    ) -> None:
+        project = await create_project(db, "test-proj")
+        await create_leader(db, project.id)
+        tower = TowerController(db, event_bus)
+
+        await tower.submit_goal(project.id, "Cancel me")
+        await tower.cancel_goal()
+
+        mock_stop.assert_called_once()
+        assert tower.state == TowerState.IDLE
+
+    async def test_cancel_resets_properties(
+        self, mock_start: AsyncMock, mock_stop: AsyncMock, db, event_bus: EventBus
+    ) -> None:
+        project = await create_project(db, "test-proj")
+        await create_leader(db, project.id)
+        tower = TowerController(db, event_bus)
+
+        await tower.submit_goal(project.id, "Cancel me")
+        await tower.cancel_goal()
+
+        assert tower.current_goal is None
+        assert tower.current_project_id is None
+        assert tower.current_session_id is None
+
+
+@pytest.mark.asyncio
+class TestSessionMonitoring:
+    @patch("atc.tower.controller.start_leader", new_callable=AsyncMock, return_value="sess-1")
+    async def test_leader_error_transitions_tower(
+        self, mock_start: AsyncMock, db, event_bus: EventBus
+    ) -> None:
+        project = await create_project(db, "test-proj")
+        await create_leader(db, project.id)
+        tower = TowerController(db, event_bus)
+
+        await tower.submit_goal(project.id, "Watch me fail")
+        assert tower.state == TowerState.MANAGING
+
+        # Simulate leader session entering error state
+        await event_bus.publish(
+            "session_status_changed",
+            {"session_id": "sess-1", "new_status": "error"},
+        )
+
+        assert tower.state == TowerState.ERROR
+
+    @patch("atc.tower.controller.start_leader", new_callable=AsyncMock, return_value="sess-1")
+    async def test_unrelated_session_error_ignored(
+        self, mock_start: AsyncMock, db, event_bus: EventBus
+    ) -> None:
+        project = await create_project(db, "test-proj")
+        await create_leader(db, project.id)
+        tower = TowerController(db, event_bus)
+
+        await tower.submit_goal(project.id, "Stable goal")
+
+        # Error on a different session should not affect tower
+        await event_bus.publish(
+            "session_status_changed",
+            {"session_id": "other-session", "new_status": "error"},
+        )
+
+        assert tower.state == TowerState.MANAGING
+
+
+@pytest.mark.asyncio
+class TestWebSocketBroadcast:
+    @patch("atc.tower.controller.start_leader", new_callable=AsyncMock, return_value="sess-1")
+    async def test_state_changes_broadcast_to_ws(
+        self, mock_start: AsyncMock, db, event_bus: EventBus
+    ) -> None:
+        ws_hub = AsyncMock()
+        project = await create_project(db, "test-proj")
+        await create_leader(db, project.id)
+        tower = TowerController(db, event_bus, ws_hub=ws_hub)
+
+        await tower.submit_goal(project.id, "WS goal")
+
+        # Should have broadcast at least planning and managing transitions
+        calls = [c for c in ws_hub.broadcast.call_args_list if c[0][0] == "tower"]
+        assert len(calls) >= 2
+        states_broadcast = [c[0][1]["new_state"] for c in calls if "new_state" in c[0][1]]
+        assert "planning" in states_broadcast
+        assert "managing" in states_broadcast


### PR DESCRIPTION
## Summary
- Implement `TowerController` with full lifecycle state machine (idle→planning→managing→complete/error) that receives goals, builds context packages, starts Leader sessions, and monitors progress
- Implement `build_context_package()` to assemble project metadata, repo path, GitHub repo, and context hub entries into a structured dict for Leader sessions
- Enhance `POST /api/tower/goal` to use TowerController instead of bare DB writes — now creates Leader sessions with context packages and returns session IDs
- Add `POST /api/tower/cancel` endpoint for cancelling active goals
- Wire tower state changes through EventBus and WebSocket hub (`tower` channel) for real-time UI updates
- Add `GET /api/tower/status` fields: `state`, `current_goal`, `current_project_id`, `current_session_id`

## Testing Done
All 283 tests pass (28 new):

```
$ python3 -m pytest -x -v
283 passed in 11.65s
```

**Unit tests** (23 new):
- `test_tower_controller.py` — state transitions, goal submission, event publishing, cancel, session monitoring, WebSocket broadcast, error recovery
- `test_context_package.py` — basic package, GitHub repo, context entries, project not found, minimal project

**E2E tests** (5 new/updated):
- `test_submit_goal` — verifies full flow returns context_package + session_id
- `test_submit_goal_twice_returns_conflict` — 409 when tower is busy
- `test_cancel_goal` — cancel returns tower to idle
- `test_cancel_no_active_goal` — 409 when nothing to cancel
- `test_tower_status_empty` — verifies new `state` field

**Lint clean**: `ruff check` passes on all changed files