### PR TITLE
feat: agent deployment SOT (deploy.py)

### DIFF
--- a/src/atc/agents/deploy.py
+++ b/src/atc/agents/deploy.py
@@ -1,1 +1,487 @@
-"""Agent deployment SOT — stub."""
+"""Agent deployment SOT — single source of truth for all agent configuration files.
+
+Writes CLAUDE.md, .claude/settings.json, and hook scripts into a staging
+directory (typically /tmp/{session_id}/) before launching an Ace or Manager.
+Hook scripts report status back to the ATC API via the ``atc`` CLI.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import stat
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+# Default staging root for deployed agent files
+_DEFAULT_STAGING_ROOT = Path("/tmp/atc-agents")
+
+
+@dataclass(frozen=True)
+class DeployedFiles:
+    """Result of a deployment: root directory and manifest of written files."""
+
+    root: Path
+    files: list[str]
+
+    @property
+    def claude_md_path(self) -> Path:
+        return self.root / "CLAUDE.md"
+
+    @property
+    def settings_path(self) -> Path:
+        return self.root / ".claude" / "settings.json"
+
+    @property
+    def manifest_path(self) -> Path:
+        return self.root / ".manifest.json"
+
+
+@dataclass(frozen=True)
+class HookConfig:
+    """Configuration for a single Claude Code hook."""
+
+    event: str
+    command: str
+
+
+@dataclass
+class AceDeploySpec:
+    """Everything needed to deploy an Ace session's config files."""
+
+    session_id: str
+    project_name: str
+    task_title: str
+    task_description: str | None = None
+    repo_path: str | None = None
+    github_repo: str | None = None
+    api_base_url: str = "http://127.0.0.1:8420"
+    model: str = "opus"
+    allowed_commands: list[str] = field(default_factory=list)
+    constraints: list[str] = field(default_factory=list)
+    extra_context: str = ""
+
+
+@dataclass
+class ManagerDeploySpec:
+    """Everything needed to deploy a Manager/Leader session's config files."""
+
+    leader_id: str
+    project_name: str
+    goal: str
+    repo_path: str | None = None
+    github_repo: str | None = None
+    api_base_url: str = "http://127.0.0.1:8420"
+    model: str = "opus"
+    allowed_commands: list[str] = field(default_factory=list)
+    constraints: list[str] = field(default_factory=list)
+    context_entries: list[dict[str, Any]] = field(default_factory=list)
+    initial_tasks: list[str] = field(default_factory=list)
+    budget_ceiling_usd: float | None = None
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def deploy_ace_files(
+    spec: AceDeploySpec,
+    *,
+    staging_root: Path | None = None,
+) -> DeployedFiles:
+    """Write CLAUDE.md, .claude/settings.json, and hooks for an Ace session.
+
+    Args:
+        spec: Deployment specification for the Ace.
+        staging_root: Override the staging root directory (default: /tmp/atc-agents).
+
+    Returns:
+        DeployedFiles with the root directory and list of all written file paths.
+    """
+    root = (staging_root or _DEFAULT_STAGING_ROOT) / spec.session_id
+    written: list[str] = []
+
+    # CLAUDE.md
+    claude_md = _build_ace_claude_md(spec)
+    written.append(_write_file(root / "CLAUDE.md", claude_md))
+
+    # .claude/settings.json
+    settings = _build_settings(
+        model=spec.model,
+        allowed_commands=_ace_allowed_commands(spec),
+        hooks=_ace_hooks(spec),
+    )
+    written.append(_write_file(root / ".claude" / "settings.json", json.dumps(settings, indent=2)))
+
+    # Hook scripts
+    for hook in _ace_hook_scripts(spec):
+        path = root / ".claude" / "hooks" / f"{hook.event}.sh"
+        written.append(_write_executable(path, hook.command))
+
+    # Manifest
+    manifest = {"session_id": spec.session_id, "session_type": "ace", "files": written}
+    written.append(_write_file(root / ".manifest.json", json.dumps(manifest, indent=2)))
+
+    logger.info("Deployed ace files for %s → %s (%d files)", spec.session_id, root, len(written))
+    return DeployedFiles(root=root, files=written)
+
+
+def deploy_manager_files(
+    spec: ManagerDeploySpec,
+    *,
+    staging_root: Path | None = None,
+) -> DeployedFiles:
+    """Write CLAUDE.md, .claude/settings.json, and hooks for a Manager/Leader session.
+
+    Args:
+        spec: Deployment specification for the Manager.
+        staging_root: Override the staging root directory (default: /tmp/atc-agents).
+
+    Returns:
+        DeployedFiles with the root directory and list of all written file paths.
+    """
+    root = (staging_root or _DEFAULT_STAGING_ROOT) / spec.leader_id
+    written: list[str] = []
+
+    # CLAUDE.md
+    claude_md = _build_manager_claude_md(spec)
+    written.append(_write_file(root / "CLAUDE.md", claude_md))
+
+    # .claude/settings.json
+    settings = _build_settings(
+        model=spec.model,
+        allowed_commands=_manager_allowed_commands(spec),
+        hooks=_manager_hooks(spec),
+    )
+    written.append(_write_file(root / ".claude" / "settings.json", json.dumps(settings, indent=2)))
+
+    # Hook scripts
+    for hook in _manager_hook_scripts(spec):
+        path = root / ".claude" / "hooks" / f"{hook.event}.sh"
+        written.append(_write_executable(path, hook.command))
+
+    # Manifest
+    manifest = {"session_id": spec.leader_id, "session_type": "manager", "files": written}
+    written.append(_write_file(root / ".manifest.json", json.dumps(manifest, indent=2)))
+
+    logger.info("Deployed manager files for %s → %s (%d files)", spec.leader_id, root, len(written))
+    return DeployedFiles(root=root, files=written)
+
+
+def cleanup_deployed_files(root: Path) -> None:
+    """Remove all files listed in a deployment manifest, then the directory tree.
+
+    Args:
+        root: The deployment root directory containing .manifest.json.
+    """
+    manifest_path = root / ".manifest.json"
+    if manifest_path.exists():
+        manifest = json.loads(manifest_path.read_text())
+        for filepath in manifest.get("files", []):
+            p = Path(filepath)
+            if p.exists():
+                p.unlink()
+        manifest_path.unlink()
+
+    # Remove empty directories bottom-up
+    if root.exists():
+        for dirpath, _dirnames, _filenames in os.walk(str(root), topdown=False):
+            dp = Path(dirpath)
+            if not any(dp.iterdir()):
+                dp.rmdir()
+
+
+# ---------------------------------------------------------------------------
+# CLAUDE.md builders
+# ---------------------------------------------------------------------------
+
+
+def _build_ace_claude_md(spec: AceDeploySpec) -> str:
+    """Build the CLAUDE.md content for an Ace session."""
+    lines = [
+        f"# {spec.project_name} — Ace Session",
+        "",
+        f"Session ID: `{spec.session_id}`",
+        "",
+        "## Task",
+        "",
+        f"**{spec.task_title}**",
+        "",
+    ]
+
+    if spec.task_description:
+        lines.extend([spec.task_description, ""])
+
+    lines.extend(
+        [
+            "## Reporting",
+            "",
+            "Use the `atc` CLI to report status back to the ATC tower:",
+            "",
+            "```bash",
+            f'atc ace status "{spec.session_id}" working   # when actively working',
+            f'atc ace status "{spec.session_id}" waiting   # when idle/waiting',
+            f'atc ace done "{spec.session_id}"              # when task is complete',
+            f'atc ace blocked "{spec.session_id}" --reason "description"  # when blocked',
+            "```",
+            "",
+        ]
+    )
+
+    if spec.constraints:
+        lines.extend(["## Constraints", ""])
+        for c in spec.constraints:
+            lines.append(f"- {c}")
+        lines.append("")
+
+    if spec.extra_context:
+        lines.extend(["## Context", "", spec.extra_context, ""])
+
+    if spec.github_repo:
+        lines.extend(
+            [
+                "## Repository",
+                "",
+                f"GitHub: `{spec.github_repo}`",
+                "",
+            ]
+        )
+
+    return "\n".join(lines)
+
+
+def _build_manager_claude_md(spec: ManagerDeploySpec) -> str:
+    """Build the CLAUDE.md content for a Manager/Leader session."""
+    lines = [
+        f"# {spec.project_name} — Leader Session",
+        "",
+        f"Leader ID: `{spec.leader_id}`",
+        "",
+        "## Goal",
+        "",
+        spec.goal,
+        "",
+    ]
+
+    if spec.budget_ceiling_usd is not None:
+        lines.extend(
+            [
+                "## Budget",
+                "",
+                f"Ceiling: **${spec.budget_ceiling_usd:.2f} USD**",
+                "",
+            ]
+        )
+
+    if spec.constraints:
+        lines.extend(["## Constraints", ""])
+        for c in spec.constraints:
+            lines.append(f"- {c}")
+        lines.append("")
+
+    if spec.initial_tasks:
+        lines.extend(["## Initial Task Breakdown", ""])
+        for i, task in enumerate(spec.initial_tasks, 1):
+            lines.append(f"{i}. {task}")
+        lines.append("")
+
+    if spec.context_entries:
+        lines.extend(["## Project Context", ""])
+        for entry in spec.context_entries:
+            key = entry.get("key", "")
+            value = entry.get("value", "")
+            if isinstance(value, dict):
+                value = json.dumps(value, indent=2)
+            lines.extend([f"### {key}", "", str(value), ""])
+
+    lines.extend(
+        [
+            "## Reporting",
+            "",
+            "Use the `atc` CLI to report status:",
+            "",
+            "```bash",
+            f'atc ace status "{spec.leader_id}" working',
+            f'atc ace status "{spec.leader_id}" waiting',
+            "```",
+            "",
+        ]
+    )
+
+    if spec.github_repo:
+        lines.extend(
+            [
+                "## Repository",
+                "",
+                f"GitHub: `{spec.github_repo}`",
+                "",
+            ]
+        )
+
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# settings.json builder
+# ---------------------------------------------------------------------------
+
+
+def _build_settings(
+    *,
+    model: str,
+    allowed_commands: list[str],
+    hooks: dict[str, list[dict[str, str]]],
+) -> dict[str, Any]:
+    """Build the .claude/settings.json content."""
+    return {
+        "model": model,
+        "autoMemoryEnabled": False,
+        "spinnerTipsEnabled": False,
+        "permissions": {
+            "allow": allowed_commands,
+            "deny": [],
+        },
+        "hooks": hooks,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Hook configuration
+# ---------------------------------------------------------------------------
+
+_STATUS_HOOK_TEMPLATE = """#!/usr/bin/env bash
+set -euo pipefail
+ATC_API="{api_base_url}"
+SESSION_ID="{session_id}"
+"""
+
+_POST_TOOL_USE_BODY = """
+# Report working status after each tool use
+curl -sf -X PATCH "$ATC_API/api/aces/$SESSION_ID/status" \
+  -H "Content-Type: application/json" \
+  -d '{{"status": "working"}}' >/dev/null 2>&1 || true
+"""
+
+_STOP_HOOK_BODY = """
+# Report waiting status when agent stops
+curl -sf -X PATCH "$ATC_API/api/aces/$SESSION_ID/status" \
+  -H "Content-Type: application/json" \
+  -d '{{"status": "waiting"}}' >/dev/null 2>&1 || true
+"""
+
+_NOTIFICATION_HOOK_BODY = """
+# Forward notifications to ATC
+NOTIFICATION="${{1:-}}"
+curl -sf -X POST "$ATC_API/api/aces/$SESSION_ID/notify" \
+  -H "Content-Type: application/json" \
+  -d "{{\\"message\\": \\"$NOTIFICATION\\"}}" >/dev/null 2>&1 || true
+"""
+
+
+def _ace_hook_scripts(spec: AceDeploySpec) -> list[HookConfig]:
+    """Build the hook shell scripts for an Ace session."""
+    header = _STATUS_HOOK_TEMPLATE.format(
+        api_base_url=spec.api_base_url,
+        session_id=spec.session_id,
+    )
+    return [
+        HookConfig(event="PostToolUse", command=header + _POST_TOOL_USE_BODY),
+        HookConfig(event="Stop", command=header + _STOP_HOOK_BODY),
+        HookConfig(event="Notification", command=header + _NOTIFICATION_HOOK_BODY),
+    ]
+
+
+def _manager_hook_scripts(spec: ManagerDeploySpec) -> list[HookConfig]:
+    """Build the hook shell scripts for a Manager session."""
+    header = _STATUS_HOOK_TEMPLATE.format(
+        api_base_url=spec.api_base_url,
+        session_id=spec.leader_id,
+    )
+    return [
+        HookConfig(event="PostToolUse", command=header + _POST_TOOL_USE_BODY),
+        HookConfig(event="Stop", command=header + _STOP_HOOK_BODY),
+        HookConfig(event="Notification", command=header + _NOTIFICATION_HOOK_BODY),
+    ]
+
+
+def _ace_hooks(spec: AceDeploySpec) -> dict[str, list[dict[str, str]]]:
+    """Build the hooks section for .claude/settings.json (Ace)."""
+    hooks_dir = f"/tmp/atc-agents/{spec.session_id}/.claude/hooks"
+    return _hooks_dict(hooks_dir)
+
+
+def _manager_hooks(spec: ManagerDeploySpec) -> dict[str, list[dict[str, str]]]:
+    """Build the hooks section for .claude/settings.json (Manager)."""
+    hooks_dir = f"/tmp/atc-agents/{spec.leader_id}/.claude/hooks"
+    return _hooks_dict(hooks_dir)
+
+
+def _hooks_dict(hooks_dir: str) -> dict[str, list[dict[str, str]]]:
+    """Build a hooks dict pointing to shell scripts in the given directory."""
+    return {
+        "PostToolUse": [{"type": "command", "command": f"bash {hooks_dir}/PostToolUse.sh"}],
+        "Stop": [{"type": "command", "command": f"bash {hooks_dir}/Stop.sh"}],
+        "Notification": [{"type": "command", "command": f"bash {hooks_dir}/Notification.sh"}],
+    }
+
+
+# ---------------------------------------------------------------------------
+# Allowed commands
+# ---------------------------------------------------------------------------
+
+_BASE_ALLOWED_COMMANDS = [
+    "Bash(atc ace *)",
+    "Bash(git *)",
+    "Bash(gh *)",
+    "Bash(npm *)",
+    "Bash(npx *)",
+    "Bash(python3 *)",
+    "Bash(pip *)",
+    "Bash(pytest *)",
+    "Bash(ruff *)",
+    "Bash(mypy *)",
+    "Bash(ls *)",
+    "Bash(cat *)",
+    "Bash(mkdir *)",
+    "Bash(cp *)",
+    "Bash(mv *)",
+]
+
+
+def _ace_allowed_commands(spec: AceDeploySpec) -> list[str]:
+    """Build the allowed commands list for an Ace."""
+    commands = list(_BASE_ALLOWED_COMMANDS)
+    commands.extend(spec.allowed_commands)
+    return commands
+
+
+def _manager_allowed_commands(spec: ManagerDeploySpec) -> list[str]:
+    """Build the allowed commands list for a Manager."""
+    commands = list(_BASE_ALLOWED_COMMANDS)
+    commands.append("Bash(atc tower *)")
+    commands.extend(spec.allowed_commands)
+    return commands
+
+
+# ---------------------------------------------------------------------------
+# File I/O helpers
+# ---------------------------------------------------------------------------
+
+
+def _write_file(path: Path, content: str) -> str:
+    """Write a text file, creating parent directories as needed. Returns the path string."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content)
+    return str(path)
+
+
+def _write_executable(path: Path, content: str) -> str:
+    """Write a file and make it executable. Returns the path string."""
+    filepath = _write_file(path, content)
+    path.chmod(path.stat().st_mode | stat.S_IEXEC | stat.S_IXGRP | stat.S_IXOTH)
+    return filepath

--- a/tests/unit/test_deploy.py
+++ b/tests/unit/test_deploy.py
@@ -1,0 +1,342 @@
+"""Unit tests for agent deployment SOT (src/atc/agents/deploy.py)."""
+
+from __future__ import annotations
+
+import json
+import stat
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+import pytest
+
+from atc.agents.deploy import (
+    AceDeploySpec,
+    DeployedFiles,
+    ManagerDeploySpec,
+    cleanup_deployed_files,
+    deploy_ace_files,
+    deploy_manager_files,
+)
+
+
+@pytest.fixture
+def staging_root(tmp_path: Path) -> Path:
+    """Provide a temporary staging root for each test."""
+    return tmp_path / "staging"
+
+
+@pytest.fixture
+def ace_spec() -> AceDeploySpec:
+    return AceDeploySpec(
+        session_id="ace-001",
+        project_name="Phoenix",
+        task_title="Implement login page",
+        task_description="Build OAuth login with GitHub provider.",
+        repo_path="/home/user/phoenix",
+        github_repo="acme/phoenix",
+        api_base_url="http://127.0.0.1:8420",
+        model="opus",
+        constraints=["No direct SQL queries", "Must use TypeScript"],
+        extra_context="The auth module lives in src/auth/.",
+    )
+
+
+@pytest.fixture
+def manager_spec() -> ManagerDeploySpec:
+    return ManagerDeploySpec(
+        leader_id="leader-bravo",
+        project_name="Phoenix",
+        goal="Ship the MVP by end of sprint",
+        repo_path="/home/user/phoenix",
+        github_repo="acme/phoenix",
+        api_base_url="http://127.0.0.1:8420",
+        model="opus",
+        constraints=["Stay under budget", "No force-pushes"],
+        context_entries=[
+            {"key": "tech-stack", "value": "React + FastAPI"},
+            {"key": "deploy-target", "value": {"cloud": "aws", "region": "us-east-1"}},
+        ],
+        initial_tasks=["Set up CI", "Scaffold frontend", "Design DB schema"],
+        budget_ceiling_usd=50.0,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Ace deployment
+# ---------------------------------------------------------------------------
+
+
+class TestDeployAceFiles:
+    def test_returns_deployed_files(self, ace_spec: AceDeploySpec, staging_root: Path) -> None:
+        result = deploy_ace_files(ace_spec, staging_root=staging_root)
+        assert isinstance(result, DeployedFiles)
+        assert result.root == staging_root / "ace-001"
+
+    def test_creates_claude_md(self, ace_spec: AceDeploySpec, staging_root: Path) -> None:
+        result = deploy_ace_files(ace_spec, staging_root=staging_root)
+        assert result.claude_md_path.exists()
+        content = result.claude_md_path.read_text()
+        assert "Phoenix — Ace Session" in content
+        assert "ace-001" in content
+        assert "Implement login page" in content
+        assert "OAuth login" in content
+
+    def test_claude_md_includes_constraints(
+        self, ace_spec: AceDeploySpec, staging_root: Path
+    ) -> None:
+        result = deploy_ace_files(ace_spec, staging_root=staging_root)
+        content = result.claude_md_path.read_text()
+        assert "No direct SQL queries" in content
+        assert "Must use TypeScript" in content
+
+    def test_claude_md_includes_github_repo(
+        self, ace_spec: AceDeploySpec, staging_root: Path
+    ) -> None:
+        result = deploy_ace_files(ace_spec, staging_root=staging_root)
+        content = result.claude_md_path.read_text()
+        assert "acme/phoenix" in content
+
+    def test_claude_md_includes_reporting_instructions(
+        self, ace_spec: AceDeploySpec, staging_root: Path
+    ) -> None:
+        result = deploy_ace_files(ace_spec, staging_root=staging_root)
+        content = result.claude_md_path.read_text()
+        assert "atc ace status" in content
+        assert "atc ace done" in content
+        assert "atc ace blocked" in content
+
+    def test_claude_md_includes_extra_context(
+        self, ace_spec: AceDeploySpec, staging_root: Path
+    ) -> None:
+        result = deploy_ace_files(ace_spec, staging_root=staging_root)
+        content = result.claude_md_path.read_text()
+        assert "auth module" in content
+
+    def test_creates_settings_json(self, ace_spec: AceDeploySpec, staging_root: Path) -> None:
+        result = deploy_ace_files(ace_spec, staging_root=staging_root)
+        assert result.settings_path.exists()
+        settings = json.loads(result.settings_path.read_text())
+        assert settings["model"] == "opus"
+        assert settings["autoMemoryEnabled"] is False
+
+    def test_settings_has_permissions(self, ace_spec: AceDeploySpec, staging_root: Path) -> None:
+        result = deploy_ace_files(ace_spec, staging_root=staging_root)
+        settings = json.loads(result.settings_path.read_text())
+        allowed = settings["permissions"]["allow"]
+        assert "Bash(git *)" in allowed
+        assert "Bash(atc ace *)" in allowed
+
+    def test_settings_has_hooks(self, ace_spec: AceDeploySpec, staging_root: Path) -> None:
+        result = deploy_ace_files(ace_spec, staging_root=staging_root)
+        settings = json.loads(result.settings_path.read_text())
+        assert "PostToolUse" in settings["hooks"]
+        assert "Stop" in settings["hooks"]
+        assert "Notification" in settings["hooks"]
+
+    def test_creates_hook_scripts(self, ace_spec: AceDeploySpec, staging_root: Path) -> None:
+        result = deploy_ace_files(ace_spec, staging_root=staging_root)
+        hooks_dir = result.root / ".claude" / "hooks"
+        assert (hooks_dir / "PostToolUse.sh").exists()
+        assert (hooks_dir / "Stop.sh").exists()
+        assert (hooks_dir / "Notification.sh").exists()
+
+    def test_hook_scripts_are_executable(self, ace_spec: AceDeploySpec, staging_root: Path) -> None:
+        result = deploy_ace_files(ace_spec, staging_root=staging_root)
+        hook = result.root / ".claude" / "hooks" / "PostToolUse.sh"
+        assert hook.stat().st_mode & stat.S_IEXEC
+
+    def test_hook_scripts_report_to_api(self, ace_spec: AceDeploySpec, staging_root: Path) -> None:
+        result = deploy_ace_files(ace_spec, staging_root=staging_root)
+        post_hook = (result.root / ".claude" / "hooks" / "PostToolUse.sh").read_text()
+        assert "127.0.0.1:8420" in post_hook
+        assert "ace-001" in post_hook
+        assert '"working"' in post_hook
+
+        stop_hook = (result.root / ".claude" / "hooks" / "Stop.sh").read_text()
+        assert '"waiting"' in stop_hook
+
+    def test_hook_scripts_have_shebang(self, ace_spec: AceDeploySpec, staging_root: Path) -> None:
+        result = deploy_ace_files(ace_spec, staging_root=staging_root)
+        hook = (result.root / ".claude" / "hooks" / "PostToolUse.sh").read_text()
+        assert hook.startswith("#!/usr/bin/env bash")
+
+    def test_creates_manifest(self, ace_spec: AceDeploySpec, staging_root: Path) -> None:
+        result = deploy_ace_files(ace_spec, staging_root=staging_root)
+        assert result.manifest_path.exists()
+        manifest = json.loads(result.manifest_path.read_text())
+        assert manifest["session_id"] == "ace-001"
+        assert manifest["session_type"] == "ace"
+        assert len(manifest["files"]) > 0
+
+    def test_manifest_lists_all_files(self, ace_spec: AceDeploySpec, staging_root: Path) -> None:
+        result = deploy_ace_files(ace_spec, staging_root=staging_root)
+        manifest = json.loads(result.manifest_path.read_text())
+        paths = manifest["files"]
+        # CLAUDE.md, settings.json, 3 hooks, manifest itself is NOT in the list
+        # (manifest is added last, so it IS in the list)
+        assert any("CLAUDE.md" in p for p in paths)
+        assert any("settings.json" in p for p in paths)
+        assert any("PostToolUse.sh" in p for p in paths)
+
+    def test_custom_allowed_commands(self, staging_root: Path) -> None:
+        spec = AceDeploySpec(
+            session_id="ace-002",
+            project_name="Test",
+            task_title="Test task",
+            allowed_commands=["Bash(cargo *)"],
+        )
+        result = deploy_ace_files(spec, staging_root=staging_root)
+        settings = json.loads(result.settings_path.read_text())
+        assert "Bash(cargo *)" in settings["permissions"]["allow"]
+
+    def test_no_github_repo_omits_section(self, staging_root: Path) -> None:
+        spec = AceDeploySpec(
+            session_id="ace-003",
+            project_name="Test",
+            task_title="Test task",
+        )
+        result = deploy_ace_files(spec, staging_root=staging_root)
+        content = result.claude_md_path.read_text()
+        assert "Repository" not in content
+
+    def test_no_constraints_omits_section(self, staging_root: Path) -> None:
+        spec = AceDeploySpec(
+            session_id="ace-004",
+            project_name="Test",
+            task_title="Test task",
+        )
+        result = deploy_ace_files(spec, staging_root=staging_root)
+        content = result.claude_md_path.read_text()
+        assert "Constraints" not in content
+
+
+# ---------------------------------------------------------------------------
+# Manager deployment
+# ---------------------------------------------------------------------------
+
+
+class TestDeployManagerFiles:
+    def test_returns_deployed_files(
+        self, manager_spec: ManagerDeploySpec, staging_root: Path
+    ) -> None:
+        result = deploy_manager_files(manager_spec, staging_root=staging_root)
+        assert isinstance(result, DeployedFiles)
+        assert result.root == staging_root / "leader-bravo"
+
+    def test_creates_claude_md(self, manager_spec: ManagerDeploySpec, staging_root: Path) -> None:
+        result = deploy_manager_files(manager_spec, staging_root=staging_root)
+        content = result.claude_md_path.read_text()
+        assert "Phoenix — Leader Session" in content
+        assert "leader-bravo" in content
+        assert "Ship the MVP" in content
+
+    def test_claude_md_includes_budget(
+        self, manager_spec: ManagerDeploySpec, staging_root: Path
+    ) -> None:
+        result = deploy_manager_files(manager_spec, staging_root=staging_root)
+        content = result.claude_md_path.read_text()
+        assert "$50.00" in content
+
+    def test_claude_md_includes_initial_tasks(
+        self, manager_spec: ManagerDeploySpec, staging_root: Path
+    ) -> None:
+        result = deploy_manager_files(manager_spec, staging_root=staging_root)
+        content = result.claude_md_path.read_text()
+        assert "Set up CI" in content
+        assert "Scaffold frontend" in content
+        assert "Design DB schema" in content
+
+    def test_claude_md_includes_context_entries(
+        self, manager_spec: ManagerDeploySpec, staging_root: Path
+    ) -> None:
+        result = deploy_manager_files(manager_spec, staging_root=staging_root)
+        content = result.claude_md_path.read_text()
+        assert "tech-stack" in content
+        assert "React + FastAPI" in content
+        assert "deploy-target" in content
+        assert "us-east-1" in content
+
+    def test_claude_md_includes_constraints(
+        self, manager_spec: ManagerDeploySpec, staging_root: Path
+    ) -> None:
+        result = deploy_manager_files(manager_spec, staging_root=staging_root)
+        content = result.claude_md_path.read_text()
+        assert "Stay under budget" in content
+        assert "No force-pushes" in content
+
+    def test_settings_includes_tower_command(
+        self, manager_spec: ManagerDeploySpec, staging_root: Path
+    ) -> None:
+        result = deploy_manager_files(manager_spec, staging_root=staging_root)
+        settings = json.loads(result.settings_path.read_text())
+        allowed = settings["permissions"]["allow"]
+        assert "Bash(atc tower *)" in allowed
+
+    def test_creates_hook_scripts(
+        self, manager_spec: ManagerDeploySpec, staging_root: Path
+    ) -> None:
+        result = deploy_manager_files(manager_spec, staging_root=staging_root)
+        hooks_dir = result.root / ".claude" / "hooks"
+        assert (hooks_dir / "PostToolUse.sh").exists()
+        assert (hooks_dir / "Stop.sh").exists()
+
+    def test_manifest_session_type_is_manager(
+        self, manager_spec: ManagerDeploySpec, staging_root: Path
+    ) -> None:
+        result = deploy_manager_files(manager_spec, staging_root=staging_root)
+        manifest = json.loads(result.manifest_path.read_text())
+        assert manifest["session_type"] == "manager"
+
+    def test_no_budget_omits_section(self, staging_root: Path) -> None:
+        spec = ManagerDeploySpec(
+            leader_id="leader-x",
+            project_name="Test",
+            goal="Do something",
+        )
+        result = deploy_manager_files(spec, staging_root=staging_root)
+        content = result.claude_md_path.read_text()
+        assert "Budget" not in content
+
+
+# ---------------------------------------------------------------------------
+# Cleanup
+# ---------------------------------------------------------------------------
+
+
+class TestCleanup:
+    def test_cleanup_removes_files(self, ace_spec: AceDeploySpec, staging_root: Path) -> None:
+        result = deploy_ace_files(ace_spec, staging_root=staging_root)
+        assert result.claude_md_path.exists()
+
+        cleanup_deployed_files(result.root)
+        assert not result.claude_md_path.exists()
+        assert not result.settings_path.exists()
+
+    def test_cleanup_removes_empty_dirs(self, ace_spec: AceDeploySpec, staging_root: Path) -> None:
+        result = deploy_ace_files(ace_spec, staging_root=staging_root)
+        cleanup_deployed_files(result.root)
+        assert not result.root.exists()
+
+    def test_cleanup_nonexistent_root_is_noop(self, staging_root: Path) -> None:
+        cleanup_deployed_files(staging_root / "nonexistent")
+        # Should not raise
+
+
+# ---------------------------------------------------------------------------
+# DeployedFiles dataclass
+# ---------------------------------------------------------------------------
+
+
+class TestDeployedFiles:
+    def test_paths(self, tmp_path: Path) -> None:
+        df = DeployedFiles(root=tmp_path / "test", files=[])
+        assert df.claude_md_path == tmp_path / "test" / "CLAUDE.md"
+        assert df.settings_path == tmp_path / "test" / ".claude" / "settings.json"
+        assert df.manifest_path == tmp_path / "test" / ".manifest.json"
+
+    def test_frozen(self, tmp_path: Path) -> None:
+        df = DeployedFiles(root=tmp_path, files=["a.txt"])
+        with pytest.raises(AttributeError):
+            df.root = tmp_path / "other"  # type: ignore[misc]


### PR DESCRIPTION
## Summary

- Implements `src/atc/agents/deploy.py` — the single source of truth for all agent configuration files written before launching Ace or Manager sessions
- `deploy_ace_files()` writes CLAUDE.md (task context, reporting instructions, constraints), `.claude/settings.json` (model, permissions, hooks), and PostToolUse/Stop/Notification hook scripts
- `deploy_manager_files()` does the same for Leader sessions, including context entries, initial task breakdown, and budget ceiling
- Hook scripts report session status back to ATC API via `curl` (working on PostToolUse, waiting on Stop)
- `cleanup_deployed_files()` removes all deployed files using the `.manifest.json`
- 33 unit tests covering file generation, hook content, permissions, manifests, and cleanup

## Testing Done

```
$ pytest tests/unit/test_deploy.py -x -q
.................................
33 passed in 0.36s

$ pytest tests/unit/ -x -q
306 passed in 6.33s

$ ruff check src/atc/agents/deploy.py tests/unit/test_deploy.py
All checks passed!

$ ruff format --check src/atc/agents/deploy.py tests/unit/test_deploy.py
2 files already formatted
```