### PR TITLE
feat: Leader session logic — decompose goals, spawn Aces

### DIFF
--- a/src/atc/api/app.py
+++ b/src/atc/api/app.py
@@ -160,13 +160,14 @@ def create_app(settings: Settings | None = None) -> FastAPI:
     app.state.settings = settings
 
     # Register routers
-    from atc.api.routers import aces, projects, task_graphs, tasks, tower, usage
+    from atc.api.routers import aces, leader, projects, task_graphs, tasks, tower, usage
     from atc.api.routers import settings as settings_router
 
     app.include_router(tower.router, prefix="/api/tower", tags=["tower"])
     app.include_router(projects.router, prefix="/api/projects", tags=["projects"])
     app.include_router(tasks.router, prefix="/api", tags=["tasks"])
     app.include_router(task_graphs.router, prefix="/api", tags=["task_graphs"])
+    app.include_router(leader.router, prefix="/api", tags=["leader"])
     app.include_router(aces.router, prefix="/api", tags=["aces"])
     app.include_router(usage.router, prefix="/api/usage", tags=["usage"])
     app.include_router(settings_router.router, prefix="/api/settings", tags=["settings"])

--- a/src/atc/api/routers/leader.py
+++ b/src/atc/api/routers/leader.py
@@ -1,0 +1,292 @@
+"""Leader REST endpoints — decomposition, Ace orchestration, and progress.
+
+Routes:
+  POST   /api/projects/{project_id}/leader/decompose     → decompose goal into tasks
+  POST   /api/projects/{project_id}/leader/spawn-aces     → spawn Aces for ready tasks
+  POST   /api/projects/{project_id}/leader/instruct       → send instruction to an Ace
+  POST   /api/projects/{project_id}/leader/task-done      → mark a task as done
+  POST   /api/projects/{project_id}/leader/task-failed    → mark a task as failed
+  GET    /api/projects/{project_id}/leader/progress       → get progress summary
+  POST   /api/projects/{project_id}/leader/cleanup        → destroy all active Aces
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from fastapi import APIRouter, HTTPException, Request
+from pydantic import BaseModel
+
+from atc.leader.decomposer import TaskSpec, decompose_goal
+from atc.leader.orchestrator import LeaderOrchestrator
+from atc.state import db as db_ops
+
+router = APIRouter()
+
+# Store orchestrators per project (in-process cache)
+_orchestrators: dict[str, LeaderOrchestrator] = {}
+
+
+# ---------------------------------------------------------------------------
+# Request / response models
+# ---------------------------------------------------------------------------
+
+
+class TaskSpecRequest(BaseModel):
+    title: str
+    description: str | None = None
+    priority: int = 0
+    dependencies: list[str] | None = None
+
+
+class DecomposeRequest(BaseModel):
+    task_specs: list[TaskSpecRequest]
+
+
+class InstructRequest(BaseModel):
+    task_graph_id: str
+    instruction: str
+
+
+class TaskDoneRequest(BaseModel):
+    task_graph_id: str
+
+
+class TaskFailedRequest(BaseModel):
+    task_graph_id: str
+    reason: str | None = None
+
+
+class DecomposeResponse(BaseModel):
+    project_id: str
+    goal: str
+    task_graphs: list[dict[str, Any]]
+    error: str | None = None
+
+
+class SpawnAcesResponse(BaseModel):
+    spawned: list[dict[str, Any]]
+
+
+class ProgressResponse(BaseModel):
+    leader_id: str
+    project_id: str
+    total: int
+    done: int
+    in_progress: int
+    todo: int
+    all_done: bool
+    progress_pct: int
+    assignments: list[dict[str, Any]]
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+async def _get_db(request: Request) -> Any:
+    return request.app.state.db
+
+
+def _get_event_bus(request: Request) -> Any:
+    return getattr(request.app.state, "event_bus", None)
+
+
+async def _get_or_create_orchestrator(
+    request: Request,
+    project_id: str,
+) -> LeaderOrchestrator:
+    """Retrieve or create a LeaderOrchestrator for a project."""
+    if project_id in _orchestrators:
+        return _orchestrators[project_id]
+
+    db = await _get_db(request)
+    event_bus = _get_event_bus(request)
+
+    leader = await db_ops.get_leader_by_project(db, project_id)
+    if leader is None:
+        raise HTTPException(
+            status_code=404,
+            detail=f"No leader found for project {project_id}",
+        )
+
+    orch = LeaderOrchestrator(
+        project_id=project_id,
+        leader_id=leader.id,
+        conn=db,
+        event_bus=event_bus,
+    )
+
+    # Subscribe to session status changes for Ace monitoring
+    if event_bus:
+        event_bus.subscribe(
+            "session_status_changed",
+            orch.on_session_status_changed,
+        )
+
+    _orchestrators[project_id] = orch
+    return orch
+
+
+# ---------------------------------------------------------------------------
+# Routes
+# ---------------------------------------------------------------------------
+
+
+@router.post(
+    "/projects/{project_id}/leader/decompose",
+    response_model=DecomposeResponse,
+    status_code=201,
+)
+async def decompose(
+    project_id: str,
+    body: DecomposeRequest,
+    request: Request,
+) -> DecomposeResponse:
+    """Decompose a project's goal into task graph entries.
+
+    Reads the context package from the leader row and creates task_graph
+    entries for each provided task specification.
+    """
+    db = await _get_db(request)
+
+    leader = await db_ops.get_leader_by_project(db, project_id)
+    if leader is None:
+        raise HTTPException(
+            status_code=404,
+            detail=f"No leader found for project {project_id}",
+        )
+
+    # Build context package from leader row
+    context_package = leader.context or {
+        "project_id": project_id,
+        "goal": leader.goal or "",
+    }
+
+    specs = [
+        TaskSpec(
+            title=s.title,
+            description=s.description,
+            priority=s.priority,
+            dependencies=s.dependencies,
+        )
+        for s in body.task_specs
+    ]
+
+    result = await decompose_goal(db, context_package, specs)
+
+    if result.error:
+        raise HTTPException(status_code=422, detail=result.error)
+
+    return DecomposeResponse(
+        project_id=result.project_id,
+        goal=result.goal,
+        task_graphs=[
+            {
+                "id": tg.id,
+                "title": tg.title,
+                "description": tg.description,
+                "status": tg.status,
+                "dependencies": tg.dependencies,
+            }
+            for tg in result.task_graphs
+        ],
+    )
+
+
+@router.post(
+    "/projects/{project_id}/leader/spawn-aces",
+    response_model=SpawnAcesResponse,
+)
+async def spawn_aces(
+    project_id: str,
+    request: Request,
+) -> SpawnAcesResponse:
+    """Spawn Ace sessions for all ready (unblocked) tasks."""
+    orch = await _get_or_create_orchestrator(request, project_id)
+    assignments = await orch.spawn_aces_for_ready_tasks()
+
+    return SpawnAcesResponse(
+        spawned=[
+            {
+                "ace_session_id": a.ace_session_id,
+                "task_graph_id": a.task_graph_id,
+                "task_title": a.task_title,
+            }
+            for a in assignments
+        ],
+    )
+
+
+@router.post("/projects/{project_id}/leader/instruct")
+async def instruct_ace(
+    project_id: str,
+    body: InstructRequest,
+    request: Request,
+) -> dict[str, str]:
+    """Send a work instruction to the Ace assigned to a task."""
+    orch = await _get_or_create_orchestrator(request, project_id)
+
+    try:
+        await orch.send_instruction_to_ace(
+            body.task_graph_id,
+            body.instruction,
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+
+    return {"status": "sent"}
+
+
+@router.post("/projects/{project_id}/leader/task-done")
+async def task_done(
+    project_id: str,
+    body: TaskDoneRequest,
+    request: Request,
+) -> dict[str, str]:
+    """Mark a task graph entry as done and clean up its Ace."""
+    orch = await _get_or_create_orchestrator(request, project_id)
+    await orch.mark_task_done(body.task_graph_id)
+    return {"status": "done"}
+
+
+@router.post("/projects/{project_id}/leader/task-failed")
+async def task_failed(
+    project_id: str,
+    body: TaskFailedRequest,
+    request: Request,
+) -> dict[str, str]:
+    """Mark a task graph entry as failed and allow retry."""
+    orch = await _get_or_create_orchestrator(request, project_id)
+    await orch.mark_task_failed(body.task_graph_id, reason=body.reason)
+    return {"status": "failed"}
+
+
+@router.get(
+    "/projects/{project_id}/leader/progress",
+    response_model=ProgressResponse,
+)
+async def get_progress(
+    project_id: str,
+    request: Request,
+) -> ProgressResponse:
+    """Return a summary of the Leader's task graph progress."""
+    orch = await _get_or_create_orchestrator(request, project_id)
+    progress = await orch.get_progress()
+    return ProgressResponse(**progress)
+
+
+@router.post("/projects/{project_id}/leader/cleanup")
+async def cleanup(
+    project_id: str,
+    request: Request,
+) -> dict[str, str]:
+    """Destroy all active Ace sessions for a project's Leader."""
+    orch = await _get_or_create_orchestrator(request, project_id)
+    await orch.cleanup()
+
+    # Remove the orchestrator from cache
+    _orchestrators.pop(project_id, None)
+
+    return {"status": "cleaned_up"}

--- a/src/atc/leader/decomposer.py
+++ b/src/atc/leader/decomposer.py
@@ -1,0 +1,209 @@
+"""Goal decomposition — breaks a goal into task graph entries.
+
+The decomposer takes a context package (built by Tower) and produces a list
+of task graph entries with titles, descriptions, dependencies, and priorities.
+Each entry becomes a row in the ``task_graphs`` table and is later assigned
+to an Ace session by the Leader orchestrator.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any
+
+from atc.state import db as db_ops
+
+if TYPE_CHECKING:
+    import aiosqlite
+
+    from atc.state.models import TaskGraph
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class TaskSpec:
+    """Specification for a single task to be created in the task graph."""
+
+    title: str
+    description: str | None = None
+    priority: int = 0
+    dependencies: list[str] | None = None  # titles of tasks this depends on
+
+
+@dataclass
+class DecompositionResult:
+    """Result of decomposing a goal into task graph entries."""
+
+    project_id: str
+    goal: str
+    task_graphs: list[TaskGraph] = field(default_factory=list)
+    error: str | None = None
+
+
+async def decompose_goal(
+    conn: aiosqlite.Connection,
+    context_package: dict[str, Any],
+    task_specs: list[TaskSpec],
+) -> DecompositionResult:
+    """Decompose a goal into task graph entries in the database.
+
+    Takes the context package from Tower and a list of TaskSpec objects
+    (produced by the Leader's planning phase) and creates corresponding
+    task_graph rows in the database.
+
+    The decomposition flow:
+      1. Validate context package has required fields
+      2. Create task_graph entries for each TaskSpec
+      3. Resolve dependency titles to task_graph IDs
+      4. Return the created entries
+
+    Parameters
+    ----------
+    conn:
+        Active database connection.
+    context_package:
+        The context package from Tower containing goal, project_id, etc.
+    task_specs:
+        List of task specifications to create in the task graph.
+
+    Returns
+    -------
+    DecompositionResult with created task_graph entries.
+    """
+    project_id = context_package.get("project_id")
+    goal = context_package.get("goal", "")
+
+    if not project_id:
+        return DecompositionResult(
+            project_id="",
+            goal=goal,
+            error="Context package missing project_id",
+        )
+
+    if not task_specs:
+        return DecompositionResult(
+            project_id=project_id,
+            goal=goal,
+            error="No task specifications provided",
+        )
+
+    # Verify project exists
+    project = await db_ops.get_project(conn, project_id)
+    if project is None:
+        return DecompositionResult(
+            project_id=project_id,
+            goal=goal,
+            error=f"Project {project_id} not found",
+        )
+
+    created: list[TaskGraph] = []
+    title_to_id: dict[str, str] = {}
+
+    # Phase 1: Create all task_graph entries (without dependency IDs)
+    for spec in task_specs:
+        tg = await db_ops.create_task_graph(
+            conn,
+            project_id,
+            spec.title,
+            description=spec.description,
+            status="todo",
+        )
+        created.append(tg)
+        title_to_id[spec.title] = tg.id
+
+    # Phase 2: Resolve dependency titles to IDs and update
+    for spec, tg in zip(task_specs, created, strict=True):
+        if not spec.dependencies:
+            continue
+
+        dep_ids: list[str] = []
+        for dep_title in spec.dependencies:
+            dep_id = title_to_id.get(dep_title)
+            if dep_id is not None:
+                dep_ids.append(dep_id)
+            else:
+                logger.warning(
+                    "Task '%s' depends on unknown task '%s' — skipping dependency",
+                    spec.title,
+                    dep_title,
+                )
+
+        if dep_ids:
+            updated = await db_ops.update_task_graph(
+                conn, tg.id, dependencies=dep_ids,
+            )
+            if updated is not None:
+                # Replace the entry in created list with updated version
+                idx = created.index(tg)
+                created[idx] = updated
+
+    logger.info(
+        "Decomposed goal '%s' into %d task graph entries for project %s",
+        goal,
+        len(created),
+        project_id,
+    )
+
+    return DecompositionResult(
+        project_id=project_id,
+        goal=goal,
+        task_graphs=created,
+    )
+
+
+def get_ready_tasks(task_graphs: list[TaskGraph]) -> list[TaskGraph]:
+    """Return task graphs that are ready to be assigned (no unfinished deps).
+
+    A task is ready if:
+      - Its status is ``todo``
+      - It has no dependencies, OR all its dependencies are ``done``
+    """
+    done_ids = {tg.id for tg in task_graphs if tg.status == "done"}
+
+    ready: list[TaskGraph] = []
+    for tg in task_graphs:
+        if tg.status != "todo":
+            continue
+        deps = tg.dependencies or []
+        if all(dep_id in done_ids for dep_id in deps):
+            ready.append(tg)
+
+    return ready
+
+
+def get_completion_status(task_graphs: list[TaskGraph]) -> dict[str, Any]:
+    """Return a summary of task graph completion status.
+
+    Returns a dict with counts and overall status:
+      - total: total number of tasks
+      - done: number of completed tasks
+      - in_progress: number of in-progress tasks
+      - todo: number of pending tasks
+      - all_done: True if every task is done
+      - progress_pct: percentage complete (0-100)
+    """
+    total = len(task_graphs)
+    if total == 0:
+        return {
+            "total": 0,
+            "done": 0,
+            "in_progress": 0,
+            "todo": 0,
+            "all_done": True,
+            "progress_pct": 100,
+        }
+
+    done = sum(1 for tg in task_graphs if tg.status == "done")
+    in_progress = sum(1 for tg in task_graphs if tg.status == "in_progress")
+    todo = sum(1 for tg in task_graphs if tg.status == "todo")
+
+    return {
+        "total": total,
+        "done": done,
+        "in_progress": in_progress,
+        "todo": todo,
+        "all_done": done == total,
+        "progress_pct": round((done / total) * 100),
+    }

--- a/src/atc/leader/orchestrator.py
+++ b/src/atc/leader/orchestrator.py
@@ -1,0 +1,328 @@
+"""Leader orchestrator — spawns and manages Ace sessions for task graph entries.
+
+The orchestrator is the main runtime loop for a Leader session.  After the
+decomposer creates task graph entries, the orchestrator:
+
+  1. Finds ready tasks (no unfinished dependencies)
+  2. Spawns Ace sessions for each ready task
+  3. Assigns task graph entries to their Ace sessions
+  4. Monitors Ace progress via the event bus
+  5. Marks tasks done when Aces complete
+  6. Reports overall progress back to Tower
+"""
+
+from __future__ import annotations
+
+import contextlib
+import logging
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any
+
+from atc.leader.decomposer import get_completion_status, get_ready_tasks
+from atc.session.ace import create_ace, destroy_ace, start_ace
+from atc.state import db as db_ops
+
+if TYPE_CHECKING:
+    import aiosqlite
+
+    from atc.core.events import EventBus
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class AceAssignment:
+    """Tracks the association between an Ace session and a task graph entry."""
+
+    ace_session_id: str
+    task_graph_id: str
+    task_title: str
+    status: str = "assigned"  # assigned|working|done|failed
+
+
+@dataclass
+class LeaderOrchestrator:
+    """Manages Ace session lifecycle for a project's task graph.
+
+    One orchestrator per active Leader session.  It maintains a mapping
+    of task_graph_id → ace_session_id and coordinates the work.
+    """
+
+    project_id: str
+    leader_id: str
+    conn: aiosqlite.Connection
+    event_bus: EventBus | None = None
+    assignments: dict[str, AceAssignment] = field(default_factory=dict)
+    _max_concurrent_aces: int = 5
+
+    async def spawn_aces_for_ready_tasks(self) -> list[AceAssignment]:
+        """Find ready tasks and spawn Ace sessions for them.
+
+        Respects the max concurrent Aces limit. Returns a list of new
+        assignments created.
+        """
+        task_graphs = await db_ops.list_task_graphs(
+            self.conn, project_id=self.project_id,
+        )
+
+        ready = get_ready_tasks(task_graphs)
+        if not ready:
+            return []
+
+        # Count currently active Aces
+        active_count = sum(
+            1 for a in self.assignments.values()
+            if a.status in ("assigned", "working")
+        )
+        available_slots = max(0, self._max_concurrent_aces - active_count)
+
+        if available_slots == 0:
+            logger.info(
+                "Leader %s: all %d Ace slots occupied, waiting for completion",
+                self.leader_id,
+                self._max_concurrent_aces,
+            )
+            return []
+
+        new_assignments: list[AceAssignment] = []
+        for tg in ready[:available_slots]:
+            # Skip if already assigned
+            if tg.id in self.assignments:
+                continue
+
+            assignment = await self._spawn_ace_for_task(tg.id, tg.title, tg.description)
+            if assignment is not None:
+                new_assignments.append(assignment)
+
+        return new_assignments
+
+    async def _spawn_ace_for_task(
+        self,
+        task_graph_id: str,
+        title: str,
+        description: str | None,
+    ) -> AceAssignment | None:
+        """Spawn a single Ace session and assign it to a task graph entry."""
+        ace_name = f"ace-{title[:30]}"
+
+        try:
+            session_id = await create_ace(
+                self.conn,
+                self.project_id,
+                ace_name,
+                task_id=task_graph_id,
+                event_bus=self.event_bus,
+            )
+        except Exception:
+            logger.exception(
+                "Failed to spawn Ace for task '%s' (graph %s)",
+                title,
+                task_graph_id,
+            )
+            return None
+
+        # Link the task_graph entry to this Ace
+        await db_ops.update_task_graph(
+            self.conn, task_graph_id, assigned_ace_id=session_id,
+        )
+
+        # Transition the task to in_progress
+        await db_ops.update_task_graph_status(
+            self.conn, task_graph_id, "in_progress",
+        )
+
+        assignment = AceAssignment(
+            ace_session_id=session_id,
+            task_graph_id=task_graph_id,
+            task_title=title,
+            status="assigned",
+        )
+        self.assignments[task_graph_id] = assignment
+
+        logger.info(
+            "Leader %s: spawned Ace %s for task '%s'",
+            self.leader_id,
+            session_id,
+            title,
+        )
+
+        if self.event_bus:
+            await self.event_bus.publish(
+                "leader_ace_spawned",
+                {
+                    "leader_id": self.leader_id,
+                    "project_id": self.project_id,
+                    "session_id": session_id,
+                    "task_graph_id": task_graph_id,
+                    "task_title": title,
+                },
+            )
+
+        return assignment
+
+    async def send_instruction_to_ace(
+        self,
+        task_graph_id: str,
+        instruction: str,
+    ) -> None:
+        """Send a work instruction to the Ace assigned to a task graph entry."""
+        assignment = self.assignments.get(task_graph_id)
+        if assignment is None:
+            raise ValueError(f"No Ace assigned to task graph {task_graph_id}")
+
+        await start_ace(
+            self.conn,
+            assignment.ace_session_id,
+            instruction=instruction,
+            event_bus=self.event_bus,
+        )
+        assignment.status = "working"
+
+    async def mark_task_done(self, task_graph_id: str) -> None:
+        """Mark a task graph entry as done and clean up its Ace session."""
+        assignment = self.assignments.get(task_graph_id)
+
+        # Update task graph status
+        await db_ops.update_task_graph_status(
+            self.conn, task_graph_id, "done",
+        )
+
+        if assignment is not None:
+            assignment.status = "done"
+
+            # Destroy the Ace session (free resources)
+            try:
+                await destroy_ace(
+                    self.conn,
+                    assignment.ace_session_id,
+                    event_bus=self.event_bus,
+                )
+            except Exception:
+                logger.warning(
+                    "Failed to destroy Ace %s for completed task '%s'",
+                    assignment.ace_session_id,
+                    assignment.task_title,
+                )
+
+        if self.event_bus:
+            await self.event_bus.publish(
+                "leader_task_completed",
+                {
+                    "leader_id": self.leader_id,
+                    "project_id": self.project_id,
+                    "task_graph_id": task_graph_id,
+                },
+            )
+
+    async def mark_task_failed(
+        self,
+        task_graph_id: str,
+        *,
+        reason: str | None = None,
+    ) -> None:
+        """Handle a failed task — update status and clean up Ace."""
+        assignment = self.assignments.get(task_graph_id)
+
+        # Transition back to todo so it can be retried
+        with contextlib.suppress(ValueError):
+            await db_ops.update_task_graph_status(
+                self.conn, task_graph_id, "todo",
+            )
+
+        if assignment is not None:
+            assignment.status = "failed"
+            try:
+                await destroy_ace(
+                    self.conn,
+                    assignment.ace_session_id,
+                    event_bus=self.event_bus,
+                )
+            except Exception:
+                logger.warning(
+                    "Failed to destroy Ace %s for failed task '%s'",
+                    assignment.ace_session_id,
+                    assignment.task_title,
+                )
+            # Remove assignment so the task can be re-assigned
+            del self.assignments[task_graph_id]
+
+        if self.event_bus:
+            await self.event_bus.publish(
+                "leader_task_failed",
+                {
+                    "leader_id": self.leader_id,
+                    "project_id": self.project_id,
+                    "task_graph_id": task_graph_id,
+                    "reason": reason,
+                },
+            )
+
+    async def get_progress(self) -> dict[str, Any]:
+        """Return current progress summary for the Leader's task graph."""
+        task_graphs = await db_ops.list_task_graphs(
+            self.conn, project_id=self.project_id,
+        )
+
+        status = get_completion_status(task_graphs)
+        status["assignments"] = [
+            {
+                "task_graph_id": a.task_graph_id,
+                "ace_session_id": a.ace_session_id,
+                "task_title": a.task_title,
+                "status": a.status,
+            }
+            for a in self.assignments.values()
+        ]
+        status["leader_id"] = self.leader_id
+        status["project_id"] = self.project_id
+
+        return status
+
+    async def cleanup(self) -> None:
+        """Destroy all active Ace sessions (called on Leader shutdown)."""
+        for assignment in list(self.assignments.values()):
+            if assignment.status in ("assigned", "working"):
+                try:
+                    await destroy_ace(
+                        self.conn,
+                        assignment.ace_session_id,
+                        event_bus=self.event_bus,
+                    )
+                except Exception:
+                    logger.warning(
+                        "Failed to destroy Ace %s during cleanup",
+                        assignment.ace_session_id,
+                    )
+        self.assignments.clear()
+
+    async def on_session_status_changed(self, data: dict[str, Any]) -> None:
+        """Handle Ace session status changes (event bus callback).
+
+        Detects when an Ace enters error/disconnected state and marks
+        the corresponding task as failed for retry.
+        """
+        session_id = data.get("session_id", "")
+        new_status = data.get("new_status", "")
+
+        # Find which assignment this session belongs to
+        for tg_id, assignment in self.assignments.items():
+            if assignment.ace_session_id == session_id:
+                if new_status == "error":
+                    logger.warning(
+                        "Ace %s for task '%s' entered error state",
+                        session_id,
+                        assignment.task_title,
+                    )
+                    await self.mark_task_failed(
+                        tg_id, reason="Ace session entered error state",
+                    )
+                elif new_status == "disconnected":
+                    logger.warning(
+                        "Ace %s for task '%s' disconnected",
+                        session_id,
+                        assignment.task_title,
+                    )
+                    await self.mark_task_failed(
+                        tg_id, reason="Ace session disconnected",
+                    )
+                break

--- a/tests/unit/test_decomposer.py
+++ b/tests/unit/test_decomposer.py
@@ -1,0 +1,287 @@
+"""Tests for Leader goal decomposer."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from atc.leader.decomposer import (
+    DecompositionResult,
+    TaskSpec,
+    decompose_goal,
+    get_completion_status,
+    get_ready_tasks,
+)
+from atc.state.db import (
+    _SCHEMA_SQL,
+    create_project,
+    create_task_graph,
+    get_connection,
+    get_task_graph,
+    list_task_graphs,
+    run_migrations,
+)
+from atc.state.models import TaskGraph
+
+
+@pytest.fixture
+async def db():
+    """In-memory database with schema applied."""
+    await run_migrations(":memory:")
+    async with get_connection(":memory:") as conn:
+        await conn.executescript(_SCHEMA_SQL)
+        await conn.commit()
+        yield conn
+
+
+# ---------------------------------------------------------------------------
+# decompose_goal
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+class TestDecomposeGoal:
+    async def test_basic_decomposition(self, db) -> None:
+        project = await create_project(db, "test-proj")
+        context = {"project_id": project.id, "goal": "Build auth system"}
+        specs = [
+            TaskSpec(title="Login page", description="Build login UI"),
+            TaskSpec(title="Auth API", description="Build auth endpoints"),
+        ]
+
+        result = await decompose_goal(db, context, specs)
+
+        assert result.error is None
+        assert result.project_id == project.id
+        assert result.goal == "Build auth system"
+        assert len(result.task_graphs) == 2
+        assert result.task_graphs[0].title == "Login page"
+        assert result.task_graphs[1].title == "Auth API"
+        assert result.task_graphs[0].status == "todo"
+
+    async def test_decomposition_with_dependencies(self, db) -> None:
+        project = await create_project(db, "test-proj")
+        context = {"project_id": project.id, "goal": "Build feature"}
+        specs = [
+            TaskSpec(title="Task A"),
+            TaskSpec(title="Task B", dependencies=["Task A"]),
+            TaskSpec(title="Task C", dependencies=["Task A", "Task B"]),
+        ]
+
+        result = await decompose_goal(db, context, specs)
+
+        assert result.error is None
+        assert len(result.task_graphs) == 3
+
+        # Task B should depend on Task A's ID
+        task_b = result.task_graphs[1]
+        assert task_b.dependencies is not None
+        assert result.task_graphs[0].id in task_b.dependencies
+
+        # Task C should depend on both A and B
+        task_c = result.task_graphs[2]
+        assert task_c.dependencies is not None
+        assert len(task_c.dependencies) == 2
+        assert result.task_graphs[0].id in task_c.dependencies
+        assert result.task_graphs[1].id in task_c.dependencies
+
+    async def test_decomposition_missing_project_id(self, db) -> None:
+        context = {"goal": "Build something"}
+        specs = [TaskSpec(title="Task A")]
+
+        result = await decompose_goal(db, context, specs)
+
+        assert result.error == "Context package missing project_id"
+
+    async def test_decomposition_empty_specs(self, db) -> None:
+        project = await create_project(db, "test-proj")
+        context = {"project_id": project.id, "goal": "Build something"}
+
+        result = await decompose_goal(db, context, [])
+
+        assert result.error == "No task specifications provided"
+
+    async def test_decomposition_project_not_found(self, db) -> None:
+        context = {"project_id": "nonexistent", "goal": "Build something"}
+        specs = [TaskSpec(title="Task A")]
+
+        result = await decompose_goal(db, context, specs)
+
+        assert result.error is not None
+        assert "not found" in result.error
+
+    async def test_decomposition_unknown_dependency_skipped(self, db) -> None:
+        project = await create_project(db, "test-proj")
+        context = {"project_id": project.id, "goal": "Build feature"}
+        specs = [
+            TaskSpec(title="Task A", dependencies=["Nonexistent Task"]),
+        ]
+
+        result = await decompose_goal(db, context, specs)
+
+        assert result.error is None
+        # Unknown dependency should be skipped (not crash)
+        task_a = result.task_graphs[0]
+        assert task_a.dependencies is None  # No valid deps resolved
+
+    async def test_tasks_persisted_to_db(self, db) -> None:
+        project = await create_project(db, "test-proj")
+        context = {"project_id": project.id, "goal": "Build feature"}
+        specs = [
+            TaskSpec(title="Persist Me", description="Should be in DB"),
+        ]
+
+        result = await decompose_goal(db, context, specs)
+
+        # Verify it's in the database
+        tg = await get_task_graph(db, result.task_graphs[0].id)
+        assert tg is not None
+        assert tg.title == "Persist Me"
+        assert tg.description == "Should be in DB"
+        assert tg.project_id == project.id
+
+    async def test_decomposition_multiple_with_descriptions(self, db) -> None:
+        project = await create_project(db, "test-proj")
+        context = {"project_id": project.id, "goal": "Full feature"}
+        specs = [
+            TaskSpec(title="T1", description="First task", priority=1),
+            TaskSpec(title="T2", description="Second task", priority=2),
+            TaskSpec(title="T3", description="Third task", priority=0),
+        ]
+
+        result = await decompose_goal(db, context, specs)
+
+        assert len(result.task_graphs) == 3
+        all_in_db = await list_task_graphs(db, project_id=project.id)
+        assert len(all_in_db) == 3
+
+
+# ---------------------------------------------------------------------------
+# get_ready_tasks
+# ---------------------------------------------------------------------------
+
+
+class TestGetReadyTasks:
+    def _make_tg(
+        self, id: str, status: str = "todo", dependencies: list[str] | None = None,
+    ) -> TaskGraph:
+        return TaskGraph(
+            id=id,
+            project_id="proj-1",
+            title=f"Task {id}",
+            status=status,
+            dependencies=dependencies,
+        )
+
+    def test_no_tasks(self) -> None:
+        assert get_ready_tasks([]) == []
+
+    def test_all_ready_no_deps(self) -> None:
+        tasks = [self._make_tg("1"), self._make_tg("2")]
+        ready = get_ready_tasks(tasks)
+        assert len(ready) == 2
+
+    def test_skip_non_todo(self) -> None:
+        tasks = [
+            self._make_tg("1", status="in_progress"),
+            self._make_tg("2", status="done"),
+            self._make_tg("3", status="todo"),
+        ]
+        ready = get_ready_tasks(tasks)
+        assert len(ready) == 1
+        assert ready[0].id == "3"
+
+    def test_blocked_by_dependency(self) -> None:
+        tasks = [
+            self._make_tg("1", status="todo"),
+            self._make_tg("2", status="todo", dependencies=["1"]),
+        ]
+        ready = get_ready_tasks(tasks)
+        assert len(ready) == 1
+        assert ready[0].id == "1"
+
+    def test_unblocked_when_dep_done(self) -> None:
+        tasks = [
+            self._make_tg("1", status="done"),
+            self._make_tg("2", status="todo", dependencies=["1"]),
+        ]
+        ready = get_ready_tasks(tasks)
+        assert len(ready) == 1
+        assert ready[0].id == "2"
+
+    def test_partially_blocked(self) -> None:
+        tasks = [
+            self._make_tg("1", status="done"),
+            self._make_tg("2", status="in_progress"),
+            self._make_tg("3", status="todo", dependencies=["1", "2"]),
+        ]
+        ready = get_ready_tasks(tasks)
+        # Task 3 blocked because task 2 is not done
+        assert len(ready) == 0
+
+    def test_chain_dependency(self) -> None:
+        tasks = [
+            self._make_tg("1", status="done"),
+            self._make_tg("2", status="done", dependencies=["1"]),
+            self._make_tg("3", status="todo", dependencies=["2"]),
+        ]
+        ready = get_ready_tasks(tasks)
+        assert len(ready) == 1
+        assert ready[0].id == "3"
+
+    def test_empty_dependencies_treated_as_ready(self) -> None:
+        tasks = [self._make_tg("1", status="todo", dependencies=[])]
+        ready = get_ready_tasks(tasks)
+        assert len(ready) == 1
+
+
+# ---------------------------------------------------------------------------
+# get_completion_status
+# ---------------------------------------------------------------------------
+
+
+class TestGetCompletionStatus:
+    def _make_tg(self, id: str, status: str = "todo") -> TaskGraph:
+        return TaskGraph(
+            id=id,
+            project_id="proj-1",
+            title=f"Task {id}",
+            status=status,
+        )
+
+    def test_empty(self) -> None:
+        status = get_completion_status([])
+        assert status["total"] == 0
+        assert status["all_done"] is True
+        assert status["progress_pct"] == 100
+
+    def test_all_done(self) -> None:
+        tasks = [self._make_tg("1", "done"), self._make_tg("2", "done")]
+        status = get_completion_status(tasks)
+        assert status["total"] == 2
+        assert status["done"] == 2
+        assert status["all_done"] is True
+        assert status["progress_pct"] == 100
+
+    def test_partial_progress(self) -> None:
+        tasks = [
+            self._make_tg("1", "done"),
+            self._make_tg("2", "in_progress"),
+            self._make_tg("3", "todo"),
+            self._make_tg("4", "todo"),
+        ]
+        status = get_completion_status(tasks)
+        assert status["total"] == 4
+        assert status["done"] == 1
+        assert status["in_progress"] == 1
+        assert status["todo"] == 2
+        assert status["all_done"] is False
+        assert status["progress_pct"] == 25
+
+    def test_none_done(self) -> None:
+        tasks = [self._make_tg("1", "todo"), self._make_tg("2", "todo")]
+        status = get_completion_status(tasks)
+        assert status["done"] == 0
+        assert status["all_done"] is False
+        assert status["progress_pct"] == 0

--- a/tests/unit/test_leader_api.py
+++ b/tests/unit/test_leader_api.py
@@ -1,0 +1,268 @@
+"""Tests for Leader REST API endpoints."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from atc.core.events import EventBus
+from atc.leader.decomposer import DecompositionResult, TaskSpec
+from atc.leader.orchestrator import AceAssignment, LeaderOrchestrator
+from atc.state.db import (
+    _SCHEMA_SQL,
+    create_leader,
+    create_project,
+    create_task_graph,
+    get_connection,
+    run_migrations,
+    update_task_graph_status,
+)
+from atc.state.models import TaskGraph
+
+# We need to reset the module-level orchestrator cache between tests
+from atc.api.routers import leader as leader_module
+
+
+@pytest.fixture
+async def db():
+    """In-memory database with schema applied."""
+    await run_migrations(":memory:")
+    async with get_connection(":memory:") as conn:
+        await conn.executescript(_SCHEMA_SQL)
+        await conn.commit()
+        yield conn
+
+
+@pytest.fixture
+def event_bus() -> EventBus:
+    return EventBus()
+
+
+@pytest.fixture(autouse=True)
+def clear_orchestrator_cache():
+    """Clear the orchestrator cache before each test."""
+    leader_module._orchestrators.clear()
+    yield
+    leader_module._orchestrators.clear()
+
+
+@pytest.fixture
+async def project_with_leader(db):
+    """Create project + leader, return (project, leader)."""
+    project = await create_project(db, "test-proj", repo_path="/tmp/repo")
+    leader = await create_leader(db, project.id, goal="Build auth system")
+    return project, leader
+
+
+@pytest.fixture
+def mock_request(db, event_bus):
+    """Create a mock FastAPI request with app state."""
+    request = MagicMock()
+    request.app.state.db = db
+    request.app.state.event_bus = event_bus
+    return request
+
+
+# ---------------------------------------------------------------------------
+# decompose endpoint
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+class TestDecomposeEndpoint:
+    async def test_decompose_creates_task_graphs(
+        self, db, project_with_leader, mock_request,
+    ) -> None:
+        from atc.api.routers.leader import DecomposeRequest, decompose
+
+        project, leader = project_with_leader
+        body = DecomposeRequest(
+            task_specs=[
+                {"title": "Task A", "description": "First task"},
+                {"title": "Task B", "description": "Second task"},
+            ],
+        )
+
+        result = await decompose(project.id, body, mock_request)
+
+        assert result.error is None
+        assert result.project_id == project.id
+        assert len(result.task_graphs) == 2
+
+    async def test_decompose_no_leader_returns_404(
+        self, db, mock_request,
+    ) -> None:
+        from atc.api.routers.leader import DecomposeRequest, decompose
+        from fastapi import HTTPException
+
+        project = await create_project(db, "orphan-proj")
+        body = DecomposeRequest(task_specs=[{"title": "Task A"}])
+
+        with pytest.raises(HTTPException) as exc_info:
+            await decompose(project.id, body, mock_request)
+        assert exc_info.value.status_code == 404
+
+    async def test_decompose_empty_specs_returns_422(
+        self, db, project_with_leader, mock_request,
+    ) -> None:
+        from atc.api.routers.leader import DecomposeRequest, decompose
+        from fastapi import HTTPException
+
+        project, _ = project_with_leader
+        body = DecomposeRequest(task_specs=[])
+
+        with pytest.raises(HTTPException) as exc_info:
+            await decompose(project.id, body, mock_request)
+        assert exc_info.value.status_code == 422
+
+    async def test_decompose_with_dependencies(
+        self, db, project_with_leader, mock_request,
+    ) -> None:
+        from atc.api.routers.leader import DecomposeRequest, decompose
+
+        project, _ = project_with_leader
+        body = DecomposeRequest(
+            task_specs=[
+                {"title": "Base"},
+                {"title": "Derived", "dependencies": ["Base"]},
+            ],
+        )
+
+        result = await decompose(project.id, body, mock_request)
+
+        assert len(result.task_graphs) == 2
+        derived = next(t for t in result.task_graphs if t["title"] == "Derived")
+        assert derived["dependencies"] is not None
+
+
+# ---------------------------------------------------------------------------
+# spawn-aces endpoint
+# ---------------------------------------------------------------------------
+
+
+@patch("atc.leader.orchestrator.create_ace", new_callable=AsyncMock, return_value="ace-1")
+@pytest.mark.asyncio
+class TestSpawnAcesEndpoint:
+    async def test_spawn_returns_assignments(
+        self, mock_create: AsyncMock, db, project_with_leader, mock_request,
+    ) -> None:
+        from atc.api.routers.leader import spawn_aces
+
+        project, _ = project_with_leader
+        await create_task_graph(db, project.id, "Ready Task")
+
+        result = await spawn_aces(project.id, mock_request)
+
+        assert len(result.spawned) == 1
+        assert result.spawned[0]["task_title"] == "Ready Task"
+
+    async def test_spawn_with_no_ready_tasks(
+        self, mock_create: AsyncMock, db, project_with_leader, mock_request,
+    ) -> None:
+        from atc.api.routers.leader import spawn_aces
+
+        project, _ = project_with_leader
+        # Create task with unmet dependency
+        tg1 = await create_task_graph(db, project.id, "Blocker")
+        await create_task_graph(db, project.id, "Blocked", dependencies=[tg1.id])
+
+        # First spawn gets the blocker
+        await spawn_aces(project.id, mock_request)
+
+        # No more ready tasks (blocked one still waiting)
+        result = await spawn_aces(project.id, mock_request)
+        # Blocker is already assigned, blocked is waiting
+        assert len(result.spawned) == 0
+
+
+# ---------------------------------------------------------------------------
+# progress endpoint
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+class TestProgressEndpoint:
+    async def test_progress_returns_summary(
+        self, db, project_with_leader, mock_request,
+    ) -> None:
+        from atc.api.routers.leader import get_progress
+
+        project, leader = project_with_leader
+        tg1 = await create_task_graph(db, project.id, "Done Task")
+        await update_task_graph_status(db, tg1.id, "in_progress")
+        await update_task_graph_status(db, tg1.id, "done")
+        await create_task_graph(db, project.id, "Todo Task")
+
+        result = await get_progress(project.id, mock_request)
+
+        assert result.total == 2
+        assert result.done == 1
+        assert result.todo == 1
+        assert result.all_done is False
+        assert result.leader_id == leader.id
+
+
+# ---------------------------------------------------------------------------
+# task-done and task-failed endpoints
+# ---------------------------------------------------------------------------
+
+
+@patch("atc.leader.orchestrator.destroy_ace", new_callable=AsyncMock)
+@patch("atc.leader.orchestrator.create_ace", new_callable=AsyncMock, return_value="ace-1")
+@pytest.mark.asyncio
+class TestTaskLifecycleEndpoints:
+    async def test_task_done(
+        self, mock_create: AsyncMock, mock_destroy: AsyncMock,
+        db, project_with_leader, mock_request,
+    ) -> None:
+        from atc.api.routers.leader import TaskDoneRequest, spawn_aces, task_done
+
+        project, _ = project_with_leader
+        tg = await create_task_graph(db, project.id, "Finish Me")
+
+        # Spawn ace first
+        await spawn_aces(project.id, mock_request)
+
+        body = TaskDoneRequest(task_graph_id=tg.id)
+        result = await task_done(project.id, body, mock_request)
+
+        assert result["status"] == "done"
+
+    async def test_task_failed(
+        self, mock_create: AsyncMock, mock_destroy: AsyncMock,
+        db, project_with_leader, mock_request,
+    ) -> None:
+        from atc.api.routers.leader import TaskFailedRequest, spawn_aces, task_failed
+
+        project, _ = project_with_leader
+        tg = await create_task_graph(db, project.id, "Fail Me")
+
+        # Spawn ace first
+        await spawn_aces(project.id, mock_request)
+
+        body = TaskFailedRequest(task_graph_id=tg.id, reason="Test error")
+        result = await task_failed(project.id, body, mock_request)
+
+        assert result["status"] == "failed"
+
+
+# ---------------------------------------------------------------------------
+# cleanup endpoint
+# ---------------------------------------------------------------------------
+
+
+@patch("atc.leader.orchestrator.destroy_ace", new_callable=AsyncMock)
+@pytest.mark.asyncio
+class TestCleanupEndpoint:
+    async def test_cleanup_removes_orchestrator(
+        self, mock_destroy: AsyncMock, db, project_with_leader, mock_request,
+    ) -> None:
+        from atc.api.routers.leader import cleanup
+
+        project, _ = project_with_leader
+
+        result = await cleanup(project.id, mock_request)
+
+        assert result["status"] == "cleaned_up"
+        assert project.id not in leader_module._orchestrators

--- a/tests/unit/test_leader_orchestrator.py
+++ b/tests/unit/test_leader_orchestrator.py
@@ -1,0 +1,461 @@
+"""Tests for Leader orchestrator — Ace spawning, task lifecycle, monitoring."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from atc.core.events import EventBus
+from atc.leader.orchestrator import AceAssignment, LeaderOrchestrator
+from atc.state.db import (
+    _SCHEMA_SQL,
+    create_leader,
+    create_project,
+    create_task_graph,
+    get_connection,
+    get_task_graph,
+    list_task_graphs,
+    run_migrations,
+)
+
+
+@pytest.fixture
+async def db():
+    """In-memory database with schema applied."""
+    await run_migrations(":memory:")
+    async with get_connection(":memory:") as conn:
+        await conn.executescript(_SCHEMA_SQL)
+        await conn.commit()
+        yield conn
+
+
+@pytest.fixture
+def event_bus() -> EventBus:
+    return EventBus()
+
+
+@pytest.fixture
+async def project_with_leader(db):
+    """Create a project and leader, return (project, leader)."""
+    project = await create_project(db, "test-proj", repo_path="/tmp/repo")
+    leader = await create_leader(db, project.id, goal="Build auth")
+    return project, leader
+
+
+@pytest.fixture
+def orchestrator(db, event_bus, project_with_leader) -> LeaderOrchestrator:
+    project, leader = project_with_leader
+    return LeaderOrchestrator(
+        project_id=project.id,
+        leader_id=leader.id,
+        conn=db,
+        event_bus=event_bus,
+    )
+
+
+# ---------------------------------------------------------------------------
+# spawn_aces_for_ready_tasks
+# ---------------------------------------------------------------------------
+
+
+@patch("atc.leader.orchestrator.create_ace", new_callable=AsyncMock, return_value="ace-session-1")
+@pytest.mark.asyncio
+class TestSpawnAces:
+    async def test_spawns_for_ready_tasks(
+        self, mock_create: AsyncMock, db, orchestrator: LeaderOrchestrator,
+    ) -> None:
+        project, _ = await create_project(db, "p2"), None
+        # Use orchestrator's project_id
+        tg = await create_task_graph(db, orchestrator.project_id, "Login page")
+
+        assignments = await orchestrator.spawn_aces_for_ready_tasks()
+
+        assert len(assignments) == 1
+        assert assignments[0].task_title == "Login page"
+        assert assignments[0].ace_session_id == "ace-session-1"
+        mock_create.assert_called_once()
+
+    async def test_skips_tasks_with_unmet_deps(
+        self, mock_create: AsyncMock, db, orchestrator: LeaderOrchestrator,
+    ) -> None:
+        tg1 = await create_task_graph(db, orchestrator.project_id, "Task A")
+        tg2 = await create_task_graph(
+            db, orchestrator.project_id, "Task B",
+            dependencies=[tg1.id],
+        )
+
+        assignments = await orchestrator.spawn_aces_for_ready_tasks()
+
+        # Only Task A should be spawned (Task B blocked on A)
+        assert len(assignments) == 1
+        assert assignments[0].task_title == "Task A"
+
+    async def test_respects_max_concurrent_limit(
+        self, mock_create: AsyncMock, db, orchestrator: LeaderOrchestrator,
+    ) -> None:
+        orchestrator._max_concurrent_aces = 2
+
+        for i in range(5):
+            await create_task_graph(db, orchestrator.project_id, f"Task {i}")
+
+        assignments = await orchestrator.spawn_aces_for_ready_tasks()
+
+        assert len(assignments) == 2
+
+    async def test_no_tasks_returns_empty(
+        self, mock_create: AsyncMock, db, orchestrator: LeaderOrchestrator,
+    ) -> None:
+        assignments = await orchestrator.spawn_aces_for_ready_tasks()
+        assert assignments == []
+
+    async def test_skip_already_assigned(
+        self, mock_create: AsyncMock, db, orchestrator: LeaderOrchestrator,
+    ) -> None:
+        tg = await create_task_graph(db, orchestrator.project_id, "Task A")
+
+        # Manually add assignment
+        orchestrator.assignments[tg.id] = AceAssignment(
+            ace_session_id="existing-ace",
+            task_graph_id=tg.id,
+            task_title="Task A",
+        )
+
+        assignments = await orchestrator.spawn_aces_for_ready_tasks()
+        assert len(assignments) == 0
+
+    async def test_marks_task_in_progress(
+        self, mock_create: AsyncMock, db, orchestrator: LeaderOrchestrator,
+    ) -> None:
+        tg = await create_task_graph(db, orchestrator.project_id, "Task A")
+
+        await orchestrator.spawn_aces_for_ready_tasks()
+
+        updated = await get_task_graph(db, tg.id)
+        assert updated is not None
+        assert updated.status == "in_progress"
+
+    async def test_assigns_ace_to_task_graph(
+        self, mock_create: AsyncMock, db, orchestrator: LeaderOrchestrator,
+    ) -> None:
+        tg = await create_task_graph(db, orchestrator.project_id, "Task A")
+
+        await orchestrator.spawn_aces_for_ready_tasks()
+
+        updated = await get_task_graph(db, tg.id)
+        assert updated is not None
+        assert updated.assigned_ace_id == "ace-session-1"
+
+    async def test_publishes_ace_spawned_event(
+        self, mock_create: AsyncMock, db, orchestrator: LeaderOrchestrator,
+        event_bus: EventBus,
+    ) -> None:
+        tg = await create_task_graph(db, orchestrator.project_id, "Task A")
+
+        captured: list[dict] = []
+        event_bus.subscribe("leader_ace_spawned", lambda d: captured.append(d))
+
+        await orchestrator.spawn_aces_for_ready_tasks()
+
+        assert len(captured) == 1
+        assert captured[0]["task_title"] == "Task A"
+        assert captured[0]["session_id"] == "ace-session-1"
+
+    async def test_spawn_failure_does_not_crash(
+        self, mock_create: AsyncMock, db, orchestrator: LeaderOrchestrator,
+    ) -> None:
+        mock_create.side_effect = RuntimeError("tmux failed")
+        await create_task_graph(db, orchestrator.project_id, "Task A")
+
+        # Should not raise
+        assignments = await orchestrator.spawn_aces_for_ready_tasks()
+        assert len(assignments) == 0
+
+
+# ---------------------------------------------------------------------------
+# send_instruction_to_ace
+# ---------------------------------------------------------------------------
+
+
+@patch("atc.leader.orchestrator.start_ace", new_callable=AsyncMock)
+@pytest.mark.asyncio
+class TestSendInstruction:
+    async def test_sends_instruction(
+        self, mock_start: AsyncMock, db, orchestrator: LeaderOrchestrator,
+    ) -> None:
+        tg = await create_task_graph(db, orchestrator.project_id, "Task A")
+
+        # Manually create session row for the Ace
+        from atc.state import db as db_ops
+        session = await db_ops.create_session(
+            db, orchestrator.project_id, "ace", "ace-task-a",
+        )
+
+        orchestrator.assignments[tg.id] = AceAssignment(
+            ace_session_id=session.id,
+            task_graph_id=tg.id,
+            task_title="Task A",
+        )
+
+        await orchestrator.send_instruction_to_ace(tg.id, "Build the login page")
+
+        mock_start.assert_called_once_with(
+            db, session.id,
+            instruction="Build the login page",
+            event_bus=orchestrator.event_bus,
+        )
+        assert orchestrator.assignments[tg.id].status == "working"
+
+    async def test_instruction_to_unknown_task_raises(
+        self, mock_start: AsyncMock, db, orchestrator: LeaderOrchestrator,
+    ) -> None:
+        with pytest.raises(ValueError, match="No Ace assigned"):
+            await orchestrator.send_instruction_to_ace("nonexistent", "Do something")
+
+
+# ---------------------------------------------------------------------------
+# mark_task_done
+# ---------------------------------------------------------------------------
+
+
+@patch("atc.leader.orchestrator.destroy_ace", new_callable=AsyncMock)
+@pytest.mark.asyncio
+class TestMarkTaskDone:
+    async def test_marks_done_and_destroys_ace(
+        self, mock_destroy: AsyncMock, db, orchestrator: LeaderOrchestrator,
+        event_bus: EventBus,
+    ) -> None:
+        tg = await create_task_graph(db, orchestrator.project_id, "Task A")
+        # Transition to in_progress first (required for done transition)
+        from atc.state import db as db_ops
+        await db_ops.update_task_graph_status(db, tg.id, "in_progress")
+
+        orchestrator.assignments[tg.id] = AceAssignment(
+            ace_session_id="ace-1",
+            task_graph_id=tg.id,
+            task_title="Task A",
+            status="working",
+        )
+
+        captured: list[dict] = []
+        event_bus.subscribe("leader_task_completed", lambda d: captured.append(d))
+
+        await orchestrator.mark_task_done(tg.id)
+
+        updated = await get_task_graph(db, tg.id)
+        assert updated is not None
+        assert updated.status == "done"
+        assert orchestrator.assignments[tg.id].status == "done"
+        mock_destroy.assert_called_once()
+        assert len(captured) == 1
+
+    async def test_done_without_assignment(
+        self, mock_destroy: AsyncMock, db, orchestrator: LeaderOrchestrator,
+    ) -> None:
+        tg = await create_task_graph(db, orchestrator.project_id, "Task A")
+        from atc.state import db as db_ops
+        await db_ops.update_task_graph_status(db, tg.id, "in_progress")
+
+        # Should not crash even without assignment
+        await orchestrator.mark_task_done(tg.id)
+
+        updated = await get_task_graph(db, tg.id)
+        assert updated is not None
+        assert updated.status == "done"
+        mock_destroy.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# mark_task_failed
+# ---------------------------------------------------------------------------
+
+
+@patch("atc.leader.orchestrator.destroy_ace", new_callable=AsyncMock)
+@pytest.mark.asyncio
+class TestMarkTaskFailed:
+    async def test_resets_to_todo_and_destroys_ace(
+        self, mock_destroy: AsyncMock, db, orchestrator: LeaderOrchestrator,
+        event_bus: EventBus,
+    ) -> None:
+        tg = await create_task_graph(db, orchestrator.project_id, "Task A")
+        from atc.state import db as db_ops
+        await db_ops.update_task_graph_status(db, tg.id, "in_progress")
+
+        orchestrator.assignments[tg.id] = AceAssignment(
+            ace_session_id="ace-1",
+            task_graph_id=tg.id,
+            task_title="Task A",
+            status="working",
+        )
+
+        captured: list[dict] = []
+        event_bus.subscribe("leader_task_failed", lambda d: captured.append(d))
+
+        await orchestrator.mark_task_failed(tg.id, reason="Test failure")
+
+        updated = await get_task_graph(db, tg.id)
+        assert updated is not None
+        assert updated.status == "todo"  # Reset for retry
+        assert tg.id not in orchestrator.assignments  # Assignment removed
+        mock_destroy.assert_called_once()
+        assert len(captured) == 1
+        assert captured[0]["reason"] == "Test failure"
+
+
+# ---------------------------------------------------------------------------
+# get_progress
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+class TestGetProgress:
+    async def test_progress_with_tasks(self, db, orchestrator: LeaderOrchestrator) -> None:
+        tg1 = await create_task_graph(db, orchestrator.project_id, "Done Task")
+        from atc.state import db as db_ops
+        await db_ops.update_task_graph_status(db, tg1.id, "in_progress")
+        await db_ops.update_task_graph_status(db, tg1.id, "done")
+
+        tg2 = await create_task_graph(db, orchestrator.project_id, "In Progress")
+        await db_ops.update_task_graph_status(db, tg2.id, "in_progress")
+
+        tg3 = await create_task_graph(db, orchestrator.project_id, "Todo Task")
+
+        progress = await orchestrator.get_progress()
+
+        assert progress["total"] == 3
+        assert progress["done"] == 1
+        assert progress["in_progress"] == 1
+        assert progress["todo"] == 1
+        assert progress["all_done"] is False
+        assert progress["progress_pct"] == 33
+        assert progress["leader_id"] == orchestrator.leader_id
+
+    async def test_progress_empty(self, db, orchestrator: LeaderOrchestrator) -> None:
+        progress = await orchestrator.get_progress()
+        assert progress["total"] == 0
+        assert progress["all_done"] is True
+
+
+# ---------------------------------------------------------------------------
+# cleanup
+# ---------------------------------------------------------------------------
+
+
+@patch("atc.leader.orchestrator.destroy_ace", new_callable=AsyncMock)
+@pytest.mark.asyncio
+class TestCleanup:
+    async def test_destroys_active_aces(
+        self, mock_destroy: AsyncMock, db, orchestrator: LeaderOrchestrator,
+    ) -> None:
+        orchestrator.assignments["tg-1"] = AceAssignment(
+            ace_session_id="ace-1", task_graph_id="tg-1",
+            task_title="Task 1", status="working",
+        )
+        orchestrator.assignments["tg-2"] = AceAssignment(
+            ace_session_id="ace-2", task_graph_id="tg-2",
+            task_title="Task 2", status="assigned",
+        )
+        orchestrator.assignments["tg-3"] = AceAssignment(
+            ace_session_id="ace-3", task_graph_id="tg-3",
+            task_title="Task 3", status="done",
+        )
+
+        await orchestrator.cleanup()
+
+        # Only active sessions (assigned/working) should be destroyed
+        assert mock_destroy.call_count == 2
+        assert len(orchestrator.assignments) == 0
+
+    async def test_cleanup_with_no_assignments(
+        self, mock_destroy: AsyncMock, db, orchestrator: LeaderOrchestrator,
+    ) -> None:
+        await orchestrator.cleanup()
+        mock_destroy.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# on_session_status_changed (event monitoring)
+# ---------------------------------------------------------------------------
+
+
+@patch("atc.leader.orchestrator.destroy_ace", new_callable=AsyncMock)
+@pytest.mark.asyncio
+class TestSessionMonitoring:
+    async def test_ace_error_triggers_task_failure(
+        self, mock_destroy: AsyncMock, db, orchestrator: LeaderOrchestrator,
+    ) -> None:
+        tg = await create_task_graph(db, orchestrator.project_id, "Task A")
+        from atc.state import db as db_ops
+        await db_ops.update_task_graph_status(db, tg.id, "in_progress")
+
+        orchestrator.assignments[tg.id] = AceAssignment(
+            ace_session_id="ace-1", task_graph_id=tg.id,
+            task_title="Task A", status="working",
+        )
+
+        await orchestrator.on_session_status_changed({
+            "session_id": "ace-1",
+            "new_status": "error",
+        })
+
+        assert tg.id not in orchestrator.assignments
+        updated = await get_task_graph(db, tg.id)
+        assert updated is not None
+        assert updated.status == "todo"
+
+    async def test_ace_disconnected_triggers_task_failure(
+        self, mock_destroy: AsyncMock, db, orchestrator: LeaderOrchestrator,
+    ) -> None:
+        tg = await create_task_graph(db, orchestrator.project_id, "Task A")
+        from atc.state import db as db_ops
+        await db_ops.update_task_graph_status(db, tg.id, "in_progress")
+
+        orchestrator.assignments[tg.id] = AceAssignment(
+            ace_session_id="ace-1", task_graph_id=tg.id,
+            task_title="Task A", status="working",
+        )
+
+        await orchestrator.on_session_status_changed({
+            "session_id": "ace-1",
+            "new_status": "disconnected",
+        })
+
+        assert tg.id not in orchestrator.assignments
+
+    async def test_unrelated_session_ignored(
+        self, mock_destroy: AsyncMock, db, orchestrator: LeaderOrchestrator,
+    ) -> None:
+        tg = await create_task_graph(db, orchestrator.project_id, "Task A")
+
+        orchestrator.assignments[tg.id] = AceAssignment(
+            ace_session_id="ace-1", task_graph_id=tg.id,
+            task_title="Task A", status="working",
+        )
+
+        await orchestrator.on_session_status_changed({
+            "session_id": "other-session",
+            "new_status": "error",
+        })
+
+        # Assignment should be unchanged
+        assert tg.id in orchestrator.assignments
+        assert orchestrator.assignments[tg.id].status == "working"
+
+    async def test_non_error_status_ignored(
+        self, mock_destroy: AsyncMock, db, orchestrator: LeaderOrchestrator,
+    ) -> None:
+        tg = await create_task_graph(db, orchestrator.project_id, "Task A")
+
+        orchestrator.assignments[tg.id] = AceAssignment(
+            ace_session_id="ace-1", task_graph_id=tg.id,
+            task_title="Task A", status="working",
+        )
+
+        await orchestrator.on_session_status_changed({
+            "session_id": "ace-1",
+            "new_status": "waiting",
+        })
+
+        # Should not trigger failure
+        assert tg.id in orchestrator.assignments
+        assert orchestrator.assignments[tg.id].status == "working"


### PR DESCRIPTION
## Summary
- **Goal decomposer** (leader/decomposer.py): Takes context package from Tower, creates task graph entries with dependency resolution. Provides get_ready_tasks() for dependency-aware scheduling and get_completion_status() for progress tracking.
- **Leader orchestrator** (leader/orchestrator.py): Spawns Ace sessions for ready tasks, monitors Ace health via event bus, handles task completion/failure with automatic retry, enforces max concurrent Ace limit, and provides cleanup on Leader shutdown.
- **REST API** (api/routers/leader.py): Seven endpoints — decompose, spawn-aces, instruct, task-done, task-failed, progress, and cleanup — registered under /api/projects/{project_id}/leader/.
- **52 new unit tests** across three test files covering decomposition, orchestrator lifecycle, event monitoring, and API endpoints. All 325 total tests pass.

Builds on Tower controller (PR #8) and task graph system (PR #9).

## Test plan
- [x] All 52 new unit tests pass
- [x] All 325 existing tests still pass (no regressions)
- [x] Ruff lint passes on all new files
- [ ] Integration test with Tower goal submission → Leader decomposition → Ace spawning

🤖 Generated with [Claude Code](https://claude.com/claude-code)
