### PR TITLE
feat: Export/Import project backup from Settings

### DIFF
--- a/frontend/src/pages/SettingsPage.css
+++ b/frontend/src/pages/SettingsPage.css
@@ -64,3 +64,117 @@
   font-family: var(--font-mono);
   text-transform: capitalize;
 }
+
+/* Export / Import sections */
+
+.settings-page__description {
+  font-size: var(--text-sm);
+  color: var(--color-text-secondary);
+  margin-bottom: var(--space-4);
+}
+
+.settings-page__export-actions,
+.settings-page__import-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-3);
+  align-items: flex-end;
+  margin-bottom: var(--space-3);
+}
+
+.settings-page__export-group,
+.settings-page__import-group,
+.settings-page__restore-group {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+
+.settings-page__restore-group {
+  margin-top: var(--space-4);
+  padding-top: var(--space-4);
+  border-top: 1px solid var(--color-border-subtle);
+}
+
+.settings-page__row {
+  display: flex;
+  gap: var(--space-2);
+  align-items: center;
+}
+
+.settings-page__file-input {
+  display: none;
+}
+
+.settings-page__progress {
+  margin-top: var(--space-3);
+}
+
+.settings-page__progress-bar {
+  height: 4px;
+  background: var(--color-border-subtle);
+  border-radius: 2px;
+  overflow: hidden;
+}
+
+.settings-page__progress-fill--indeterminate {
+  height: 100%;
+  width: 30%;
+  background: var(--color-accent);
+  border-radius: 2px;
+  animation: progress-indeterminate 1.2s ease-in-out infinite;
+}
+
+@keyframes progress-indeterminate {
+  0% { transform: translateX(-100%); }
+  100% { transform: translateX(400%); }
+}
+
+.settings-page__success {
+  margin-top: var(--space-3);
+  font-size: var(--text-sm);
+  color: var(--color-status-green);
+}
+
+.settings-page__error {
+  margin-top: var(--space-3);
+  font-size: var(--text-sm);
+  color: var(--color-status-red, #ef4444);
+}
+
+/* Restore confirmation dialog */
+
+.settings-page__overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.6);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+}
+
+.settings-page__dialog {
+  max-width: 480px;
+  width: 90%;
+  padding: var(--space-6);
+}
+
+.settings-page__dialog h3 {
+  font-size: var(--text-base);
+  font-weight: 600;
+  margin-bottom: var(--space-3);
+}
+
+.settings-page__dialog p {
+  font-size: var(--text-sm);
+  color: var(--color-text-secondary);
+  margin-bottom: var(--space-3);
+}
+
+.settings-page__dialog-actions {
+  display: flex;
+  gap: var(--space-2);
+  justify-content: flex-end;
+  margin-top: var(--space-4);
+}

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -1,8 +1,20 @@
-import { useState } from "react";
+import { useState, useRef } from "react";
 import { useAppContext } from "../context/AppContext";
+import { api } from "../utils/api";
 import "./SettingsPage.css";
 
 const GITHUB_ORG_KEY = "atc:github_default_org";
+
+type ExportStatus = "idle" | "exporting" | "done" | "error";
+type ImportStatus = "idle" | "importing" | "done" | "error";
+
+interface ImportResult {
+  project_id?: string;
+  project_name?: string;
+  auto_backup_path?: string | null;
+  imported_projects?: { id: string; name: string }[];
+  auto_backup_paths?: string[];
+}
 
 export default function SettingsPage() {
   const { state } = useAppContext();
@@ -11,6 +23,23 @@ export default function SettingsPage() {
     () => localStorage.getItem(GITHUB_ORG_KEY) ?? "",
   );
 
+  // Export state
+  const [exportStatus, setExportStatus] = useState<ExportStatus>("idle");
+  const [exportError, setExportError] = useState("");
+
+  // Import state
+  const [importStatus, setImportStatus] = useState<ImportStatus>("idle");
+  const [importError, setImportError] = useState("");
+  const [importResult, setImportResult] = useState<ImportResult | null>(null);
+  const importFileRef = useRef<HTMLInputElement>(null);
+  const importAllFileRef = useRef<HTMLInputElement>(null);
+
+  // Restore confirm state
+  const [restoreConfirm, setRestoreConfirm] = useState<{
+    file: File;
+    projectId: string;
+  } | null>(null);
+
   function handleGithubOrgChange(value: string) {
     setGithubOrg(value);
     if (value.trim()) {
@@ -18,6 +47,101 @@ export default function SettingsPage() {
     } else {
       localStorage.removeItem(GITHUB_ORG_KEY);
     }
+  }
+
+  async function handleExportProject(projectId: string) {
+    setExportStatus("exporting");
+    setExportError("");
+    try {
+      const blob = await api.postBlob(`/settings/export/${projectId}`);
+      const project = state.projects.find((p) => p.id === projectId);
+      const name = project?.name ?? "project";
+      const safeName = name.replace(/[^a-zA-Z0-9_-]/g, "_");
+      const date = new Date().toISOString().slice(0, 10);
+      downloadBlob(blob, `${safeName}-${date}.atc-backup.zip`);
+      setExportStatus("done");
+    } catch (e) {
+      setExportError(e instanceof Error ? e.message : "Export failed");
+      setExportStatus("error");
+    }
+  }
+
+  async function handleExportAll() {
+    setExportStatus("exporting");
+    setExportError("");
+    try {
+      const blob = await api.postBlob("/settings/export-all");
+      const date = new Date().toISOString().slice(0, 10);
+      downloadBlob(blob, `atc-full-backup-${date}.atc-backup.zip`);
+      setExportStatus("done");
+    } catch (e) {
+      setExportError(e instanceof Error ? e.message : "Export failed");
+      setExportStatus("error");
+    }
+  }
+
+  async function handleImportFile(file: File, targetProjectId?: string) {
+    setImportStatus("importing");
+    setImportError("");
+    setImportResult(null);
+    try {
+      const b64 = await fileToBase64(file);
+      const result = await api.post<ImportResult>("/settings/import", {
+        data: b64,
+        target_project_id: targetProjectId ?? null,
+      });
+      setImportResult(result);
+      setImportStatus("done");
+    } catch (e) {
+      setImportError(e instanceof Error ? e.message : "Import failed");
+      setImportStatus("error");
+    }
+  }
+
+  async function handleImportAllFile(file: File) {
+    setImportStatus("importing");
+    setImportError("");
+    setImportResult(null);
+    try {
+      const b64 = await fileToBase64(file);
+      const result = await api.post<ImportResult>("/settings/import-all", {
+        data: b64,
+      });
+      setImportResult(result);
+      setImportStatus("done");
+    } catch (e) {
+      setImportError(e instanceof Error ? e.message : "Import failed");
+      setImportStatus("error");
+    }
+  }
+
+  function onImportFileSelected(e: React.ChangeEvent<HTMLInputElement>) {
+    const file = e.target.files?.[0];
+    if (file) handleImportFile(file);
+    e.target.value = "";
+  }
+
+  function onImportAllFileSelected(e: React.ChangeEvent<HTMLInputElement>) {
+    const file = e.target.files?.[0];
+    if (file) handleImportAllFile(file);
+    e.target.value = "";
+  }
+
+  function onRestoreFileSelected(
+    e: React.ChangeEvent<HTMLInputElement>,
+    projectId: string,
+  ) {
+    const file = e.target.files?.[0];
+    if (file) {
+      setRestoreConfirm({ file, projectId });
+    }
+    e.target.value = "";
+  }
+
+  function confirmRestore() {
+    if (!restoreConfirm) return;
+    handleImportFile(restoreConfirm.file, restoreConfirm.projectId);
+    setRestoreConfirm(null);
   }
 
   return (
@@ -82,7 +206,268 @@ export default function SettingsPage() {
             <span className="settings-page__value">Dark</span>
           </div>
         </section>
+
+        {/* Export Section */}
+        <section
+          className="panel settings-page__section"
+          data-testid="export-section"
+        >
+          <h2>Export</h2>
+          <p className="settings-page__description">
+            Download a backup of your project data as a .atc-backup.zip file.
+          </p>
+
+          <div className="settings-page__export-actions">
+            {state.projects.length > 0 && (
+              <div className="settings-page__export-group">
+                <label htmlFor="export-project-select">Export Project</label>
+                <div className="settings-page__row">
+                  <select
+                    id="export-project-select"
+                    data-testid="export-project-select"
+                    defaultValue=""
+                    onChange={(e) => {
+                      if (e.target.value) handleExportProject(e.target.value);
+                      e.target.value = "";
+                    }}
+                    disabled={exportStatus === "exporting"}
+                  >
+                    <option value="" disabled>
+                      Select a project...
+                    </option>
+                    {state.projects.map((p) => (
+                      <option key={p.id} value={p.id}>
+                        {p.name}
+                      </option>
+                    ))}
+                  </select>
+                </div>
+              </div>
+            )}
+
+            <button
+              className="btn btn-primary"
+              onClick={handleExportAll}
+              disabled={exportStatus === "exporting"}
+              data-testid="export-all-btn"
+            >
+              {exportStatus === "exporting" ? "Exporting..." : "Export All"}
+            </button>
+          </div>
+
+          {exportStatus === "exporting" && (
+            <div className="settings-page__progress" data-testid="export-progress">
+              <div className="settings-page__progress-bar">
+                <div className="settings-page__progress-fill settings-page__progress-fill--indeterminate" />
+              </div>
+            </div>
+          )}
+          {exportStatus === "done" && (
+            <p className="settings-page__success" data-testid="export-success">
+              Export complete. Check your downloads.
+            </p>
+          )}
+          {exportError && (
+            <p className="settings-page__error" data-testid="export-error">
+              {exportError}
+            </p>
+          )}
+        </section>
+
+        {/* Import Section */}
+        <section
+          className="panel settings-page__section"
+          data-testid="import-section"
+        >
+          <h2>Import</h2>
+          <p className="settings-page__description">
+            Restore from a .atc-backup.zip file. Importing always creates a new
+            project.
+          </p>
+
+          <div className="settings-page__import-actions">
+            <div className="settings-page__import-group">
+              <button
+                className="btn"
+                onClick={() => importFileRef.current?.click()}
+                disabled={importStatus === "importing"}
+                data-testid="import-project-btn"
+              >
+                Import Project
+              </button>
+              <input
+                ref={importFileRef}
+                type="file"
+                accept=".zip"
+                className="settings-page__file-input"
+                onChange={onImportFileSelected}
+                data-testid="import-project-file"
+              />
+            </div>
+
+            <div className="settings-page__import-group">
+              <button
+                className="btn"
+                onClick={() => importAllFileRef.current?.click()}
+                disabled={importStatus === "importing"}
+                data-testid="import-all-btn"
+              >
+                Import All
+              </button>
+              <input
+                ref={importAllFileRef}
+                type="file"
+                accept=".zip"
+                className="settings-page__file-input"
+                onChange={onImportAllFileSelected}
+                data-testid="import-all-file"
+              />
+            </div>
+          </div>
+
+          {/* Restore into existing project */}
+          {state.projects.length > 0 && (
+            <div className="settings-page__restore-group">
+              <label htmlFor="restore-project-select">
+                Restore into Existing Project
+              </label>
+              <span className="form-hint">
+                Current data will be auto-backed up before replacing.
+              </span>
+              <div className="settings-page__row">
+                <select
+                  id="restore-project-select"
+                  data-testid="restore-project-select"
+                  defaultValue=""
+                  onChange={(e) => {
+                    if (!e.target.value) return;
+                    const pid = e.target.value;
+                    // Create a hidden file input for this restore
+                    const input = document.createElement("input");
+                    input.type = "file";
+                    input.accept = ".zip";
+                    input.onchange = (ev) => {
+                      const file = (ev.target as HTMLInputElement).files?.[0];
+                      if (file) setRestoreConfirm({ file, projectId: pid });
+                    };
+                    input.click();
+                    e.target.value = "";
+                  }}
+                  disabled={importStatus === "importing"}
+                >
+                  <option value="" disabled>
+                    Select project to restore into...
+                  </option>
+                  {state.projects.map((p) => (
+                    <option key={p.id} value={p.id}>
+                      {p.name}
+                    </option>
+                  ))}
+                </select>
+              </div>
+            </div>
+          )}
+
+          {importStatus === "importing" && (
+            <div className="settings-page__progress" data-testid="import-progress">
+              <div className="settings-page__progress-bar">
+                <div className="settings-page__progress-fill settings-page__progress-fill--indeterminate" />
+              </div>
+            </div>
+          )}
+          {importStatus === "done" && importResult && (
+            <div className="settings-page__success" data-testid="import-success">
+              <p>Import complete.</p>
+              {importResult.project_name && (
+                <p>
+                  Project &ldquo;{importResult.project_name}&rdquo; created.
+                </p>
+              )}
+              {importResult.imported_projects &&
+                importResult.imported_projects.length > 0 && (
+                  <p>
+                    {importResult.imported_projects.length} project(s) imported.
+                  </p>
+                )}
+              {importResult.auto_backup_path && (
+                <p className="form-hint">
+                  Previous data backed up to:{" "}
+                  {importResult.auto_backup_path}
+                </p>
+              )}
+            </div>
+          )}
+          {importError && (
+            <p className="settings-page__error" data-testid="import-error">
+              {importError}
+            </p>
+          )}
+        </section>
       </div>
+
+      {/* Restore Confirmation Dialog */}
+      {restoreConfirm && (
+        <div
+          className="settings-page__overlay"
+          data-testid="restore-confirm-dialog"
+        >
+          <div className="settings-page__dialog panel">
+            <h3>Confirm Restore</h3>
+            <p>
+              This will replace all data in the selected project. The current
+              data will be automatically backed up before replacing.
+            </p>
+            <p className="form-hint">
+              Backup will be saved to ~/Library/Application
+              Support/com.atc/backups/
+            </p>
+            <div className="settings-page__dialog-actions">
+              <button
+                className="btn"
+                onClick={() => setRestoreConfirm(null)}
+              >
+                Cancel
+              </button>
+              <button
+                className="btn btn-danger"
+                onClick={confirmRestore}
+                data-testid="restore-confirm-btn"
+              >
+                Replace & Restore
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
     </div>
   );
+}
+
+// ---------------------------------------------------------------------------
+// Utilities
+// ---------------------------------------------------------------------------
+
+function downloadBlob(blob: Blob, filename: string) {
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = url;
+  a.download = filename;
+  document.body.appendChild(a);
+  a.click();
+  document.body.removeChild(a);
+  URL.revokeObjectURL(url);
+}
+
+function fileToBase64(file: File): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => {
+      const result = reader.result as string;
+      // Strip data URL prefix (e.g. "data:application/zip;base64,")
+      const b64 = result.includes(",") ? result.split(",")[1] : result;
+      resolve(b64);
+    };
+    reader.onerror = reject;
+    reader.readAsDataURL(file);
+  });
 }

--- a/frontend/src/pages/__tests__/SettingsPage.test.tsx
+++ b/frontend/src/pages/__tests__/SettingsPage.test.tsx
@@ -64,4 +64,31 @@ describe("SettingsPage", () => {
     fireEvent.change(input, { target: { value: "" } });
     expect(localStorage.getItem("atc:github_default_org")).toBeNull();
   });
+
+  it("shows export section", () => {
+    renderWithProviders(<SettingsPage />);
+    expect(screen.getByTestId("export-section")).toBeInTheDocument();
+    expect(screen.getByText("Export")).toBeInTheDocument();
+  });
+
+  it("shows export all button", () => {
+    renderWithProviders(<SettingsPage />);
+    expect(screen.getByTestId("export-all-btn")).toBeInTheDocument();
+  });
+
+  it("shows import section", () => {
+    renderWithProviders(<SettingsPage />);
+    expect(screen.getByTestId("import-section")).toBeInTheDocument();
+    expect(screen.getByText("Import")).toBeInTheDocument();
+  });
+
+  it("shows import project button", () => {
+    renderWithProviders(<SettingsPage />);
+    expect(screen.getByTestId("import-project-btn")).toBeInTheDocument();
+  });
+
+  it("shows import all button", () => {
+    renderWithProviders(<SettingsPage />);
+    expect(screen.getByTestId("import-all-btn")).toBeInTheDocument();
+  });
 });

--- a/frontend/src/utils/api.ts
+++ b/frontend/src/utils/api.ts
@@ -50,4 +50,18 @@ export const api = {
     }),
 
   delete: <T>(path: string) => request<T>(path, { method: "DELETE" }),
+
+  /** POST that returns a Blob (for zip downloads). */
+  postBlob: async (path: string, body?: unknown): Promise<Blob> => {
+    const res = await fetch(`${BASE}${path}`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: body !== undefined ? JSON.stringify(body) : undefined,
+    });
+    if (!res.ok) {
+      const text = await res.text().catch(() => res.statusText);
+      throw new ApiError(res.status, text);
+    }
+    return res.blob();
+  },
 };

--- a/src/atc/api/routers/settings.py
+++ b/src/atc/api/routers/settings.py
@@ -1,7 +1,120 @@
-"""settings router — stub."""
+"""Settings router — export/import backup endpoints.
+
+Routes:
+  POST /api/settings/export/{project_id}  → export single project as zip
+  POST /api/settings/export-all           → export all projects as zip
+  POST /api/settings/import               → import project from zip
+  POST /api/settings/import-all           → import all from full backup zip
+"""
 
 from __future__ import annotations
 
-from fastapi import APIRouter
+import base64
+import logging
+
+from fastapi import APIRouter, HTTPException, Request
+from fastapi.responses import Response
+from pydantic import BaseModel
+
+from atc.backup.service import export_all, export_project, import_all, import_project
 
 router = APIRouter()
+logger = logging.getLogger(__name__)
+
+
+async def _get_db(request: Request):  # noqa: ANN202
+    return request.app.state.db
+
+
+# ---------------------------------------------------------------------------
+# Export endpoints
+# ---------------------------------------------------------------------------
+
+
+@router.post("/export/{project_id}")
+async def export_project_endpoint(project_id: str, request: Request) -> Response:
+    """Export a single project as a .atc-backup.zip."""
+    db = await _get_db(request)
+    try:
+        zip_bytes = await export_project(db, project_id)
+    except ValueError as e:
+        raise HTTPException(status_code=404, detail=str(e)) from None
+    return Response(
+        content=zip_bytes,
+        media_type="application/zip",
+        headers={"Content-Disposition": f'attachment; filename="{project_id}.atc-backup.zip"'},
+    )
+
+
+@router.post("/export-all")
+async def export_all_endpoint(request: Request) -> Response:
+    """Export all projects as a single .atc-backup.zip."""
+    db = await _get_db(request)
+    zip_bytes = await export_all(db)
+    return Response(
+        content=zip_bytes,
+        media_type="application/zip",
+        headers={"Content-Disposition": 'attachment; filename="atc-full-backup.atc-backup.zip"'},
+    )
+
+
+# ---------------------------------------------------------------------------
+# Import endpoints
+# ---------------------------------------------------------------------------
+
+
+class ImportRequest(BaseModel):
+    """Import request with base64-encoded zip data."""
+
+    data: str  # base64-encoded zip
+    target_project_id: str | None = None
+
+
+class ImportAllRequest(BaseModel):
+    """Import-all request with base64-encoded zip data."""
+
+    data: str  # base64-encoded zip
+
+
+@router.post("/import")
+async def import_project_endpoint(
+    body: ImportRequest, request: Request,
+) -> dict[str, object]:
+    """Import a project from a base64-encoded zip.
+
+    If target_project_id is given and exists, auto-backup + replace.
+    Otherwise creates a new project.
+    """
+    db = await _get_db(request)
+    try:
+        raw = base64.b64decode(body.data)
+    except Exception as e:
+        raise HTTPException(status_code=422, detail=f"Invalid base64 data: {e}") from None
+
+    try:
+        result = await import_project(
+            db, raw, target_project_id=body.target_project_id,
+        )
+    except ValueError as e:
+        raise HTTPException(status_code=422, detail=str(e)) from None
+
+    return result
+
+
+@router.post("/import-all")
+async def import_all_endpoint(
+    body: ImportAllRequest, request: Request,
+) -> dict[str, object]:
+    """Import all projects from a base64-encoded full backup zip."""
+    db = await _get_db(request)
+    try:
+        raw = base64.b64decode(body.data)
+    except Exception as e:
+        raise HTTPException(status_code=422, detail=f"Invalid base64 data: {e}") from None
+
+    try:
+        result = await import_all(db, raw)
+    except ValueError as e:
+        raise HTTPException(status_code=422, detail=str(e)) from None
+
+    return result

--- a/src/atc/backup/__init__.py
+++ b/src/atc/backup/__init__.py
@@ -1,0 +1,1 @@
+"""Backup and restore utilities for ATC projects."""

--- a/src/atc/backup/service.py
+++ b/src/atc/backup/service.py
@@ -1,0 +1,360 @@
+"""Export and import services for ATC project backups.
+
+Exports project data (or all projects) into a .atc-backup.zip archive.
+Imports from a zip, always creating new projects (or replacing with auto-backup).
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import logging
+import uuid
+import zipfile
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    import aiosqlite
+
+logger = logging.getLogger(__name__)
+
+BACKUP_VERSION = 1
+BACKUP_DIR = Path.home() / "Library" / "Application Support" / "com.atc" / "backups"
+
+
+def _now() -> str:
+    return datetime.now(UTC).isoformat()
+
+
+def _uuid() -> str:
+    return str(uuid.uuid4())
+
+
+# ---------------------------------------------------------------------------
+# Export helpers
+# ---------------------------------------------------------------------------
+
+
+async def _export_table_rows(
+    db: aiosqlite.Connection,
+    table: str,
+    *,
+    where: str = "",
+    params: tuple[Any, ...] = (),
+) -> list[dict[str, Any]]:
+    """Fetch all rows from a table as dicts."""
+    query = f"SELECT * FROM {table}"
+    if where:
+        query += f" WHERE {where}"
+    cursor = await db.execute(query, params)
+    rows = await cursor.fetchall()
+    return [dict(r) for r in rows]
+
+
+async def export_project(db: aiosqlite.Connection, project_id: str) -> bytes:
+    """Export a single project and all its data into a zip archive (bytes)."""
+    # Verify project exists
+    cursor = await db.execute("SELECT * FROM projects WHERE id = ?", (project_id,))
+    project_row = await cursor.fetchone()
+    if project_row is None:
+        raise ValueError(f"Project {project_id} not found")
+
+    project = dict(project_row)
+
+    data: dict[str, Any] = {
+        "backup_version": BACKUP_VERSION,
+        "backup_type": "project",
+        "exported_at": _now(),
+        "project": project,
+    }
+
+    # Export related tables
+    pid = (project_id,)
+    data["leaders"] = await _export_table_rows(
+        db, "leaders", where="project_id = ?", params=pid
+    )
+    data["sessions"] = await _export_table_rows(
+        db, "sessions", where="project_id = ?", params=pid
+    )
+    data["tasks"] = await _export_table_rows(
+        db, "tasks", where="project_id = ?", params=pid
+    )
+    data["task_graphs"] = await _export_table_rows(
+        db, "task_graphs", where="project_id = ?", params=pid
+    )
+    data["context_entries"] = await _export_table_rows(
+        db, "context_entries", where="project_id = ?", params=pid
+    )
+    data["project_budgets"] = await _export_table_rows(
+        db, "project_budgets", where="project_id = ?", params=pid
+    )
+    data["notifications"] = await _export_table_rows(
+        db, "notifications", where="project_id = ?", params=pid
+    )
+    data["config"] = await _export_table_rows(db, "config")
+    data["tower_memory"] = await _export_table_rows(
+        db, "tower_memory", where="project_id = ?", params=pid
+    )
+
+    return _create_zip(data)
+
+
+async def export_all(db: aiosqlite.Connection) -> bytes:
+    """Export all projects and global data into a zip archive (bytes)."""
+    data: dict[str, Any] = {
+        "backup_version": BACKUP_VERSION,
+        "backup_type": "all",
+        "exported_at": _now(),
+    }
+
+    # All tables, no project filter
+    data["projects"] = await _export_table_rows(db, "projects")
+    data["leaders"] = await _export_table_rows(db, "leaders")
+    data["sessions"] = await _export_table_rows(db, "sessions")
+    data["tasks"] = await _export_table_rows(db, "tasks")
+    data["task_graphs"] = await _export_table_rows(db, "task_graphs")
+    data["context_entries"] = await _export_table_rows(db, "context_entries")
+    data["project_budgets"] = await _export_table_rows(db, "project_budgets")
+    data["notifications"] = await _export_table_rows(db, "notifications")
+    data["config"] = await _export_table_rows(db, "config")
+    data["tower_memory"] = await _export_table_rows(db, "tower_memory")
+
+    return _create_zip(data)
+
+
+def _create_zip(data: dict[str, Any]) -> bytes:
+    """Create a zip archive containing backup.json."""
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w", zipfile.ZIP_DEFLATED) as zf:
+        zf.writestr("backup.json", json.dumps(data, indent=2))
+    return buf.getvalue()
+
+
+# ---------------------------------------------------------------------------
+# Import helpers
+# ---------------------------------------------------------------------------
+
+
+def _parse_zip(raw: bytes) -> dict[str, Any]:
+    """Parse a .atc-backup.zip and return the backup data dict."""
+    buf = io.BytesIO(raw)
+    with zipfile.ZipFile(buf, "r") as zf:
+        if "backup.json" not in zf.namelist():
+            raise ValueError("Invalid backup: missing backup.json")
+        content = zf.read("backup.json")
+    data = json.loads(content)
+    if data.get("backup_version") != BACKUP_VERSION:
+        raise ValueError(
+            f"Unsupported backup version: {data.get('backup_version')}"
+        )
+    return data
+
+
+async def _auto_backup_project(db: aiosqlite.Connection, project_id: str) -> Path:
+    """Create an auto-backup of an existing project before overwriting."""
+    BACKUP_DIR.mkdir(parents=True, exist_ok=True)
+    backup_bytes = await export_project(db, project_id)
+    cursor = await db.execute(
+        "SELECT name FROM projects WHERE id = ?", (project_id,)
+    )
+    row = await cursor.fetchone()
+    name = row["name"] if row else "unknown"
+    safe_name = "".join(c if c.isalnum() or c in "-_" else "_" for c in name)
+    ts = datetime.now(UTC).strftime("%Y%m%d-%H%M%S")
+    path = BACKUP_DIR / f"{safe_name}-{ts}.atc-backup.zip"
+    path.write_bytes(backup_bytes)
+    logger.info("Auto-backup created: %s", path)
+    return path
+
+
+async def _delete_project_data(db: aiosqlite.Connection, project_id: str) -> None:
+    """Delete all data for a project (reverse order of FK dependencies)."""
+    pid = (project_id,)
+    await db.execute("DELETE FROM context_entries WHERE project_id = ?", pid)
+    await db.execute("DELETE FROM task_graphs WHERE project_id = ?", pid)
+    await db.execute("DELETE FROM notifications WHERE project_id = ?", pid)
+    await db.execute("DELETE FROM project_budgets WHERE project_id = ?", pid)
+    await db.execute("DELETE FROM tower_memory WHERE project_id = ?", pid)
+    await db.execute("DELETE FROM tasks WHERE project_id = ?", pid)
+    await db.execute("DELETE FROM sessions WHERE project_id = ?", pid)
+    await db.execute("DELETE FROM leaders WHERE project_id = ?", pid)
+    await db.execute("DELETE FROM projects WHERE id = ?", pid)
+    await db.commit()
+
+
+async def _insert_rows(
+    db: aiosqlite.Connection,
+    table: str,
+    rows: list[dict[str, Any]],
+) -> None:
+    """Insert rows into a table from dicts."""
+    if not rows:
+        return
+    columns = list(rows[0].keys())
+    placeholders = ", ".join("?" for _ in columns)
+    col_names = ", ".join(columns)
+    for row in rows:
+        values = [row[c] for c in columns]
+        await db.execute(
+            f"INSERT OR IGNORE INTO {table} ({col_names}) VALUES ({placeholders})",
+            values,
+        )
+
+
+async def import_project(
+    db: aiosqlite.Connection,
+    raw: bytes,
+    *,
+    target_project_id: str | None = None,
+) -> dict[str, Any]:
+    """Import a project from a zip archive.
+
+    If target_project_id is given AND exists, auto-backup + replace.
+    Otherwise, create a new project with a new ID.
+
+    Returns dict with created/replaced project info.
+    """
+    data = _parse_zip(raw)
+    if data.get("backup_type") not in ("project", "all"):
+        raise ValueError(f"Unexpected backup type: {data.get('backup_type')}")
+
+    # For "all" type backups, extract first project
+    if data["backup_type"] == "all":
+        projects = data.get("projects", [])
+        if not projects:
+            raise ValueError("No projects found in backup")
+        project_data = projects[0]
+    else:
+        project_data = data["project"]
+
+    original_id = project_data["id"]
+    auto_backup_path: str | None = None
+
+    if target_project_id:
+        # Check if target project exists
+        cursor = await db.execute(
+            "SELECT id FROM projects WHERE id = ?", (target_project_id,)
+        )
+        existing = await cursor.fetchone()
+        if existing:
+            # Auto-backup before replacing
+            backup_path = await _auto_backup_project(db, target_project_id)
+            auto_backup_path = str(backup_path)
+            await _delete_project_data(db, target_project_id)
+            # Reuse the target project ID
+            new_id = target_project_id
+        else:
+            new_id = _uuid()
+    else:
+        new_id = _uuid()
+
+    # Remap project ID in all data
+    project_data["id"] = new_id
+    now = _now()
+    project_data["created_at"] = now
+    project_data["updated_at"] = now
+
+    # Insert project
+    await _insert_rows(db, "projects", [project_data])
+
+    # Insert related data, remapping project_id
+    for table in [
+        "leaders", "sessions", "tasks", "task_graphs",
+        "context_entries", "notifications", "tower_memory",
+    ]:
+        rows = data.get(table, [])
+        for row in rows:
+            if row.get("project_id") == original_id:
+                row["project_id"] = new_id
+            # Generate new IDs to avoid collisions
+            if "id" in row:
+                row["id"] = _uuid()
+        await _insert_rows(db, table, rows)
+
+    # Budget uses project_id as PK
+    for row in data.get("project_budgets", []):
+        if row.get("project_id") == original_id:
+            row["project_id"] = new_id
+    await _insert_rows(db, "project_budgets", data.get("project_budgets", []))
+
+    await db.commit()
+
+    return {
+        "project_id": new_id,
+        "project_name": project_data.get("name", ""),
+        "auto_backup_path": auto_backup_path,
+    }
+
+
+async def import_all(
+    db: aiosqlite.Connection,
+    raw: bytes,
+) -> dict[str, Any]:
+    """Import all projects from a full backup.
+
+    Auto-backs up all existing projects before replacing.
+    Returns info about the import.
+    """
+    data = _parse_zip(raw)
+    if data.get("backup_type") != "all":
+        raise ValueError(f"Expected 'all' backup type, got: {data.get('backup_type')}")
+
+    # Auto-backup all existing projects
+    existing_projects = await _export_table_rows(db, "projects")
+    auto_backup_paths: list[str] = []
+    for proj in existing_projects:
+        try:
+            path = await _auto_backup_project(db, proj["id"])
+            auto_backup_paths.append(str(path))
+        except Exception:
+            logger.exception("Failed to auto-backup project %s", proj["id"])
+
+    # Delete all existing project data
+    for proj in existing_projects:
+        await _delete_project_data(db, proj["id"])
+
+    # Import all projects with fresh IDs
+    imported_projects: list[dict[str, str]] = []
+    backup_projects = data.get("projects", [])
+    id_map: dict[str, str] = {}
+
+    for proj in backup_projects:
+        old_id = proj["id"]
+        new_id = _uuid()
+        id_map[old_id] = new_id
+        proj["id"] = new_id
+        proj["updated_at"] = _now()
+        await _insert_rows(db, "projects", [proj])
+        imported_projects.append({"id": new_id, "name": proj.get("name", "")})
+
+    # Import related data with remapped IDs
+    for table in [
+        "leaders", "sessions", "tasks", "task_graphs",
+        "context_entries", "notifications", "tower_memory",
+    ]:
+        rows = data.get(table, [])
+        for row in rows:
+            old_pid = row.get("project_id", "")
+            if old_pid in id_map:
+                row["project_id"] = id_map[old_pid]
+            if "id" in row:
+                row["id"] = _uuid()
+        await _insert_rows(db, table, rows)
+
+    for row in data.get("project_budgets", []):
+        old_pid = row.get("project_id", "")
+        if old_pid in id_map:
+            row["project_id"] = id_map[old_pid]
+    await _insert_rows(db, "project_budgets", data.get("project_budgets", []))
+
+    # Import global config
+    await _insert_rows(db, "config", data.get("config", []))
+
+    await db.commit()
+
+    return {
+        "imported_projects": imported_projects,
+        "auto_backup_paths": auto_backup_paths,
+    }

--- a/tests/unit/test_backup.py
+++ b/tests/unit/test_backup.py
@@ -1,0 +1,174 @@
+"""Tests for backup export/import service."""
+
+from __future__ import annotations
+
+import json
+import zipfile
+from io import BytesIO
+
+import aiosqlite
+import pytest
+
+from atc.backup.service import (
+    BACKUP_VERSION,
+    _create_zip,
+    _parse_zip,
+    export_all,
+    export_project,
+    import_all,
+    import_project,
+)
+from atc.state.db import _SCHEMA_SQL, _now, _uuid
+
+
+@pytest.fixture
+async def db() -> aiosqlite.Connection:
+    """In-memory aiosqlite connection with schema applied."""
+    conn = await aiosqlite.connect(":memory:")
+    await conn.execute("PRAGMA foreign_keys=ON")
+    conn.row_factory = aiosqlite.Row
+    await conn.executescript(_SCHEMA_SQL)
+    await conn.commit()
+    yield conn  # type: ignore[misc]
+    await conn.close()
+
+
+async def _seed_project(db: aiosqlite.Connection) -> str:
+    """Insert a test project and related data, return project ID."""
+    pid = _uuid()
+    now = _now()
+    await db.execute(
+        "INSERT INTO projects (id, name, status, description, created_at, updated_at) "
+        "VALUES (?, ?, ?, ?, ?, ?)",
+        (pid, "Test Project", "active", "A test", now, now),
+    )
+    # Leader
+    lid = _uuid()
+    await db.execute(
+        "INSERT INTO leaders (id, project_id, status, created_at, updated_at) "
+        "VALUES (?, ?, ?, ?, ?)",
+        (lid, pid, "idle", now, now),
+    )
+    # Task graph
+    await db.execute(
+        "INSERT INTO task_graphs (id, project_id, title, status, created_at, updated_at) "
+        "VALUES (?, ?, ?, ?, ?, ?)",
+        (_uuid(), pid, "Task 1", "todo", now, now),
+    )
+    # Context entry
+    await db.execute(
+        "INSERT INTO context_entries (id, project_id, key, entry_type, value, position, updated_by, created_at, updated_at) "
+        "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        (_uuid(), pid, "intro", "text", '"hello"', 0, "test", now, now),
+    )
+    await db.commit()
+    return pid
+
+
+class TestCreateAndParseZip:
+    def test_roundtrip(self) -> None:
+        data = {"backup_version": BACKUP_VERSION, "hello": "world"}
+        raw = _create_zip(data)
+        parsed = _parse_zip(raw)
+        assert parsed["hello"] == "world"
+        assert parsed["backup_version"] == BACKUP_VERSION
+
+    def test_parse_missing_backup_json_raises(self) -> None:
+        buf = BytesIO()
+        with zipfile.ZipFile(buf, "w") as zf:
+            zf.writestr("other.txt", "nope")
+        with pytest.raises(ValueError, match="missing backup.json"):
+            _parse_zip(buf.getvalue())
+
+    def test_parse_wrong_version_raises(self) -> None:
+        data = {"backup_version": 999}
+        raw = _create_zip(data)
+        with pytest.raises(ValueError, match="Unsupported backup version"):
+            _parse_zip(raw)
+
+
+@pytest.mark.asyncio
+class TestExportProject:
+    async def test_export_creates_valid_zip(self, db: aiosqlite.Connection) -> None:
+        pid = await _seed_project(db)
+        raw = await export_project(db, pid)
+        data = _parse_zip(raw)
+        assert data["backup_type"] == "project"
+        assert data["project"]["id"] == pid
+        assert data["project"]["name"] == "Test Project"
+        assert len(data["leaders"]) == 1
+        assert len(data["task_graphs"]) == 1
+        assert len(data["context_entries"]) == 1
+
+    async def test_export_nonexistent_raises(self, db: aiosqlite.Connection) -> None:
+        with pytest.raises(ValueError, match="not found"):
+            await export_project(db, "fake-id")
+
+
+@pytest.mark.asyncio
+class TestExportAll:
+    async def test_export_all(self, db: aiosqlite.Connection) -> None:
+        await _seed_project(db)
+        raw = await export_all(db)
+        data = _parse_zip(raw)
+        assert data["backup_type"] == "all"
+        assert len(data["projects"]) == 1
+
+
+@pytest.mark.asyncio
+class TestImportProject:
+    async def test_import_creates_new_project(self, db: aiosqlite.Connection) -> None:
+        pid = await _seed_project(db)
+        raw = await export_project(db, pid)
+
+        result = await import_project(db, raw)
+        new_pid = result["project_id"]
+        assert new_pid != pid  # New ID assigned
+
+        # Verify project exists
+        cursor = await db.execute("SELECT * FROM projects WHERE id = ?", (new_pid,))
+        row = await cursor.fetchone()
+        assert row is not None
+        assert dict(row)["name"] == "Test Project"
+
+        # Verify related data was imported
+        cursor = await db.execute(
+            "SELECT * FROM leaders WHERE project_id = ?", (new_pid,)
+        )
+        assert await cursor.fetchone() is not None
+
+    async def test_import_into_existing_replaces(self, db: aiosqlite.Connection) -> None:
+        pid = await _seed_project(db)
+        raw = await export_project(db, pid)
+
+        # Create a second project to restore into
+        pid2 = await _seed_project(db)
+
+        result = await import_project(db, raw, target_project_id=pid2)
+        assert result["project_id"] == pid2
+        assert result["auto_backup_path"] is not None
+
+        # Verify data was replaced
+        cursor = await db.execute(
+            "SELECT name FROM projects WHERE id = ?", (pid2,)
+        )
+        row = await cursor.fetchone()
+        assert dict(row)["name"] == "Test Project"
+
+
+@pytest.mark.asyncio
+class TestImportAll:
+    async def test_import_all(self, db: aiosqlite.Connection) -> None:
+        pid = await _seed_project(db)
+        raw = await export_all(db)
+
+        # Import all replaces
+        result = await import_all(db, raw)
+        assert len(result["imported_projects"]) == 1
+        assert result["imported_projects"][0]["name"] == "Test Project"
+
+    async def test_import_all_wrong_type_raises(self, db: aiosqlite.Connection) -> None:
+        pid = await _seed_project(db)
+        raw = await export_project(db, pid)
+        with pytest.raises(ValueError, match="Expected 'all'"):
+            await import_all(db, raw)


### PR DESCRIPTION
## Summary
- **Backend**: New `atc.backup.service` module with `export_project`, `export_all`, `import_project`, `import_all` functions. Exports project data (config, leaders, sessions, tasks, task graphs, context entries, budgets, notifications) into a `.atc-backup.zip` archive containing `backup.json`.
- **API**: Settings router gains 4 new POST endpoints: `/api/settings/export/{project_id}`, `/api/settings/export-all`, `/api/settings/import`, `/api/settings/import-all`. Export returns zip bytes directly; import accepts base64-encoded zip.
- **Frontend**: Settings page now has Export and Import sections. Export offers per-project dropdown + Export All button. Import offers Import Project (new project), Import All, and Restore into Existing Project with confirmation dialog and auto-backup notice. Progress bar and success/error feedback included.
- **Import behavior**: Always creates new projects with fresh UUIDs. Restoring into an existing project auto-backs up current state to `~/Library/Application Support/com.atc/backups/` before replacing.

## Testing Done
- 10 backend unit tests (`tests/unit/test_backup.py`) — all pass
  - Zip roundtrip, invalid zip handling, wrong version rejection
  - Export single project, export nonexistent project error
  - Export all projects
  - Import creates new project with fresh IDs
  - Import into existing project with auto-backup
  - Import all projects
  - Import all with wrong backup type rejection
- 14 frontend tests (`SettingsPage.test.tsx`) — all pass, including new tests for export/import sections
- Full backend suite: 283 tests pass
- Full frontend suite: 139 tests pass
- `ruff check` passes on all new Python files

🤖 Generated with [Claude Code](https://claude.com/claude-code)