### PR TITLE
fix: prevent export auto-fire on Settings, fix project card text

### DIFF
--- a/frontend/src/pages/Dashboard.css
+++ b/frontend/src/pages/Dashboard.css
@@ -83,6 +83,7 @@
   transition: border-color var(--transition-fast),
     box-shadow var(--transition-fast);
   font-family: var(--font-sans);
+  color: var(--color-text);
   width: 100%;
 }
 

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -26,6 +26,7 @@ export default function SettingsPage() {
   // Export state
   const [exportStatus, setExportStatus] = useState<ExportStatus>("idle");
   const [exportError, setExportError] = useState("");
+  const [selectedExportProjectId, setSelectedExportProjectId] = useState("");
 
   // Import state
   const [importStatus, setImportStatus] = useState<ImportStatus>("idle");
@@ -153,12 +154,7 @@ export default function SettingsPage() {
           <h2>Connection</h2>
           <div className="form-group">
             <label htmlFor="backend-url">Backend URL</label>
-            <input
-              id="backend-url"
-              type="text"
-              value={backendUrl}
-              readOnly
-            />
+            <input id="backend-url" type="text" value={backendUrl} readOnly />
           </div>
           <div className="settings-page__status">
             <span className="settings-page__dot settings-page__dot--connected" />
@@ -225,11 +221,8 @@ export default function SettingsPage() {
                   <select
                     id="export-project-select"
                     data-testid="export-project-select"
-                    defaultValue=""
-                    onChange={(e) => {
-                      if (e.target.value) handleExportProject(e.target.value);
-                      e.target.value = "";
-                    }}
+                    value={selectedExportProjectId}
+                    onChange={(e) => setSelectedExportProjectId(e.target.value)}
                     disabled={exportStatus === "exporting"}
                   >
                     <option value="" disabled>
@@ -241,13 +234,28 @@ export default function SettingsPage() {
                       </option>
                     ))}
                   </select>
+                  <button
+                    className="btn"
+                    onClick={() => {
+                      if (selectedExportProjectId) {
+                        handleExportProject(selectedExportProjectId);
+                        setSelectedExportProjectId("");
+                      }
+                    }}
+                    disabled={
+                      exportStatus === "exporting" || !selectedExportProjectId
+                    }
+                    data-testid="export-project-btn"
+                  >
+                    Export
+                  </button>
                 </div>
               </div>
             )}
 
             <button
               className="btn btn-primary"
-              onClick={handleExportAll}
+              onClick={() => handleExportAll()}
               disabled={exportStatus === "exporting"}
               data-testid="export-all-btn"
             >
@@ -256,7 +264,10 @@ export default function SettingsPage() {
           </div>
 
           {exportStatus === "exporting" && (
-            <div className="settings-page__progress" data-testid="export-progress">
+            <div
+              className="settings-page__progress"
+              data-testid="export-progress"
+            >
               <div className="settings-page__progress-bar">
                 <div className="settings-page__progress-fill settings-page__progress-fill--indeterminate" />
               </div>
@@ -369,14 +380,20 @@ export default function SettingsPage() {
           )}
 
           {importStatus === "importing" && (
-            <div className="settings-page__progress" data-testid="import-progress">
+            <div
+              className="settings-page__progress"
+              data-testid="import-progress"
+            >
               <div className="settings-page__progress-bar">
                 <div className="settings-page__progress-fill settings-page__progress-fill--indeterminate" />
               </div>
             </div>
           )}
           {importStatus === "done" && importResult && (
-            <div className="settings-page__success" data-testid="import-success">
+            <div
+              className="settings-page__success"
+              data-testid="import-success"
+            >
               <p>Import complete.</p>
               {importResult.project_name && (
                 <p>
@@ -391,8 +408,7 @@ export default function SettingsPage() {
                 )}
               {importResult.auto_backup_path && (
                 <p className="form-hint">
-                  Previous data backed up to:{" "}
-                  {importResult.auto_backup_path}
+                  Previous data backed up to: {importResult.auto_backup_path}
                 </p>
               )}
             </div>
@@ -422,10 +438,7 @@ export default function SettingsPage() {
               Support/com.atc/backups/
             </p>
             <div className="settings-page__dialog-actions">
-              <button
-                className="btn"
-                onClick={() => setRestoreConfirm(null)}
-              >
+              <button className="btn" onClick={() => setRestoreConfirm(null)}>
                 Cancel
               </button>
               <button

--- a/frontend/src/pages/__tests__/SettingsPage.test.tsx
+++ b/frontend/src/pages/__tests__/SettingsPage.test.tsx
@@ -1,13 +1,15 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { screen, fireEvent } from "@testing-library/react";
+import { screen, fireEvent, waitFor } from "@testing-library/react";
 import SettingsPage from "../SettingsPage";
 import { renderWithProviders } from "../../test/helpers";
 
+let fetchSpy: ReturnType<typeof vi.spyOn>;
+
 beforeEach(() => {
   localStorage.clear();
-  vi.spyOn(globalThis, "fetch").mockResolvedValue(
-    new Response(JSON.stringify([]), { status: 200 }),
-  );
+  fetchSpy = vi
+    .spyOn(globalThis, "fetch")
+    .mockResolvedValue(new Response(JSON.stringify([]), { status: 200 }));
 });
 
 describe("SettingsPage", () => {
@@ -52,7 +54,9 @@ describe("SettingsPage", () => {
 
   it("persists GitHub org to localStorage", () => {
     renderWithProviders(<SettingsPage />);
-    const input = screen.getByLabelText("Default Org / Username") as HTMLInputElement;
+    const input = screen.getByLabelText(
+      "Default Org / Username",
+    ) as HTMLInputElement;
     fireEvent.change(input, { target: { value: "my-org" } });
     expect(localStorage.getItem("atc:github_default_org")).toBe("my-org");
   });
@@ -60,7 +64,9 @@ describe("SettingsPage", () => {
   it("clears localStorage when GitHub org is emptied", () => {
     localStorage.setItem("atc:github_default_org", "old-org");
     renderWithProviders(<SettingsPage />);
-    const input = screen.getByLabelText("Default Org / Username") as HTMLInputElement;
+    const input = screen.getByLabelText(
+      "Default Org / Username",
+    ) as HTMLInputElement;
     fireEvent.change(input, { target: { value: "" } });
     expect(localStorage.getItem("atc:github_default_org")).toBeNull();
   });
@@ -90,5 +96,21 @@ describe("SettingsPage", () => {
   it("shows import all button", () => {
     renderWithProviders(<SettingsPage />);
     expect(screen.getByTestId("import-all-btn")).toBeInTheDocument();
+  });
+
+  it("does not call export API on initial render", async () => {
+    renderWithProviders(<SettingsPage />);
+    // Wait for any async effects to settle
+    await waitFor(() => {
+      expect(screen.getByTestId("settings-page")).toBeInTheDocument();
+    });
+    // Verify no calls to export endpoints
+    const exportCalls = fetchSpy.mock.calls.filter(
+      (call) =>
+        typeof call[0] === "string" &&
+        (call[0].includes("/settings/export") ||
+          call[0].includes("/settings/export-all")),
+    );
+    expect(exportCalls).toHaveLength(0);
   });
 });


### PR DESCRIPTION
## Summary
- **Export auto-fire**: The export project select used an uncontrolled component that called handleExportProject directly in its onChange handler. Converted to a controlled component with explicit state + separate Export button so export only triggers on deliberate click. Also wrapped handleExportAll in an arrow function for defense.
- **Project card text color**: The Dashboard project cards use button elements which do not inherit color from body. On the dark theme, text rendered as black (browser default) on dark background. Added color: var(--color-text) to .dashboard__project-card.
- Added regression test verifying no export API calls fire on initial render.

## Testing Done
- All 140 frontend tests pass (npx vitest run)
- Prettier formatting verified clean
- New test: does not call export API on initial render -- asserts no fetch calls to /settings/export or /settings/export-all on mount