### PR TITLE
feat: wire end-to-end agent flow — Tower → Leader → Ace with deploy.py

### DIFF
--- a/src/atc/api/routers/aces.py
+++ b/src/atc/api/routers/aces.py
@@ -18,6 +18,7 @@ from typing import Any
 from fastapi import APIRouter, HTTPException, Request
 from pydantic import BaseModel
 
+from atc.agents.deploy import AceDeploySpec, deploy_ace_files
 from atc.session import ace as ace_ops
 from atc.session.state_machine import InvalidTransitionError
 from atc.state import db as db_ops
@@ -34,6 +35,8 @@ class CreateAceRequest(BaseModel):
     name: str
     task_id: str | None = None
     host: str | None = None
+    task_title: str | None = None
+    task_description: str | None = None
 
 
 class StartAceRequest(BaseModel):
@@ -118,6 +121,21 @@ async def create_ace(project_id: str, body: CreateAceRequest, request: Request) 
     if project is None:
         raise HTTPException(status_code=404, detail=f"Project {project_id} not found")
 
+    # Deploy config files so the Ace gets CLAUDE.md + hooks
+    import uuid
+
+    preview_id = str(uuid.uuid4())
+    spec = AceDeploySpec(
+        session_id=preview_id,
+        project_name=project.name,
+        task_title=body.task_title or body.name,
+        task_description=body.task_description,
+        repo_path=project.repo_path,
+        github_repo=project.github_repo,
+    )
+    deployed = deploy_ace_files(spec)
+    working_dir = project.repo_path or str(deployed.root)
+
     session_id = await ace_ops.create_ace(
         db,
         project_id,
@@ -125,6 +143,8 @@ async def create_ace(project_id: str, body: CreateAceRequest, request: Request) 
         task_id=body.task_id,
         host=body.host,
         event_bus=event_bus,
+        working_dir=working_dir,
+        launch_command="claude --dangerously-skip-permissions",
     )
     session = await db_ops.get_session(db, session_id)
     if session is None:
@@ -160,7 +180,9 @@ async def stop_ace(session_id: str, request: Request) -> dict[str, str]:
 
 @router.patch("/aces/{session_id}/status")
 async def update_ace_status(
-    session_id: str, body: StatusUpdateRequest, request: Request,
+    session_id: str,
+    body: StatusUpdateRequest,
+    request: Request,
 ) -> dict[str, str]:
     """Update session status — called by PostToolUse and Stop hooks."""
     from atc.session.state_machine import SessionStatus, transition
@@ -175,9 +197,7 @@ async def update_ace_status(
     try:
         target = SessionStatus(body.status)
     except ValueError:
-        raise HTTPException(
-            status_code=400, detail=f"Invalid status: {body.status}"
-        ) from None
+        raise HTTPException(status_code=400, detail=f"Invalid status: {body.status}") from None
 
     current = SessionStatus(session.status)
     if current == target:
@@ -194,7 +214,9 @@ async def update_ace_status(
 
 @router.post("/aces/{session_id}/notify")
 async def notify_ace(
-    session_id: str, body: NotifyRequest, request: Request,
+    session_id: str,
+    body: NotifyRequest,
+    request: Request,
 ) -> dict[str, str]:
     """Receive a notification from an agent's Notification hook."""
     import logging
@@ -218,10 +240,13 @@ async def notify_ace(
     # Broadcast to WebSocket clients
     ws_hub = getattr(request.app.state, "ws_hub", None)
     if ws_hub is not None:
-        await ws_hub.broadcast("notifications", {
-            "session_id": session_id,
-            "message": body.message,
-        })
+        await ws_hub.broadcast(
+            "notifications",
+            {
+                "session_id": session_id,
+                "message": body.message,
+            },
+        )
 
     logger = logging.getLogger(__name__)
     logger.info("Notification from %s: %s", session_id, body.message)
@@ -231,7 +256,9 @@ async def notify_ace(
 
 @router.post("/aces/{session_id}/message")
 async def message_ace(
-    session_id: str, body: MessageRequest, request: Request,
+    session_id: str,
+    body: MessageRequest,
+    request: Request,
 ) -> dict[str, str]:
     db = await _get_db(request)
     event_bus = await _get_event_bus(request)
@@ -250,9 +277,7 @@ async def message_ace(
     if current in (SessionStatus.IDLE, SessionStatus.WAITING):
         try:
             await transition(session.id, current, SessionStatus.WORKING, event_bus)
-            await db_ops.update_session_status(
-                db, session.id, SessionStatus.WORKING.value
-            )
+            await db_ops.update_session_status(db, session.id, SessionStatus.WORKING.value)
         except InvalidTransitionError:
             pass
 

--- a/src/atc/leader/leader.py
+++ b/src/atc/leader/leader.py
@@ -4,13 +4,18 @@ A Leader is one per project.  It uses the same session infrastructure as aces
 but has session_type ``manager``.  The Leader row in the ``leaders`` table
 tracks the goal and context package; the underlying tmux pane lives in the
 ``sessions`` table.
+
+The start flow deploys config files (CLAUDE.md, hooks) via ``deploy.py``
+before spawning the tmux pane so that Claude Code picks up the Leader's
+instructions automatically.
 """
 
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
+from atc.agents.deploy import ManagerDeploySpec, deploy_manager_files
 from atc.session.ace import (
     ATC_TMUX_SESSION,
     _ensure_tmux_session,
@@ -28,6 +33,29 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+# The command used to launch a Claude Code session in each tmux pane.
+_CLAUDE_LAUNCH_CMD = "claude --dangerously-skip-permissions"
+
+
+def _build_manager_deploy_spec(
+    leader_id: str,
+    project_name: str,
+    goal: str,
+    *,
+    repo_path: str | None = None,
+    github_repo: str | None = None,
+    context_entries: list[dict[str, Any]] | None = None,
+) -> ManagerDeploySpec:
+    """Build a ManagerDeploySpec from project metadata."""
+    return ManagerDeploySpec(
+        leader_id=leader_id,
+        project_name=project_name,
+        goal=goal,
+        repo_path=repo_path,
+        github_repo=github_repo,
+        context_entries=context_entries or [],
+    )
+
 
 async def start_leader(
     conn: aiosqlite.Connection,
@@ -35,11 +63,18 @@ async def start_leader(
     *,
     goal: str | None = None,
     event_bus: EventBus | None = None,
+    context_package: dict[str, Any] | None = None,
 ) -> str:
     """Start the Leader session for a project.
 
-    Creates a session of type ``manager``, spawns its tmux pane, and links
+    Creates a session of type ``manager``, deploys config files via
+    ``deploy.py``, spawns a tmux pane running ``claude``, and links
     it to the leader row.  Returns the session id.
+
+    Args:
+        context_package: The assembled context package from Tower.
+            Used to populate the ManagerDeploySpec with project metadata
+            and context entries.
     """
     leader = await db_ops.get_leader_by_project(conn, project_id)
     if leader is None:
@@ -73,8 +108,32 @@ async def start_leader(
         )
 
     try:
+        # Deploy config files (CLAUDE.md, hooks, settings.json) before launch
+        ctx = context_package or {}
+        spec = _build_manager_deploy_spec(
+            leader_id=leader.id,
+            project_name=ctx.get("project_name") or (project.name if project else ""),
+            goal=goal or leader.goal or "",
+            repo_path=ctx.get("repo_path") or (project.repo_path if project else None),
+            github_repo=ctx.get("github_repo") or (project.github_repo if project else None),
+            context_entries=ctx.get("context_entries"),
+        )
+        deployed = deploy_manager_files(spec)
+        logger.info(
+            "Deployed manager config for leader %s → %s",
+            leader.id,
+            deployed.root,
+        )
+
+        # Spawn tmux pane in the repo working directory, running claude
+        working_dir = spec.repo_path or str(deployed.root)
+
         await _ensure_tmux_session(ATC_TMUX_SESSION)
-        pane_id = await _spawn_pane(ATC_TMUX_SESSION)
+        pane_id = await _spawn_pane(
+            ATC_TMUX_SESSION,
+            _CLAUDE_LAUNCH_CMD,
+            working_dir=working_dir,
+        )
         await db_ops.update_session_tmux(conn, session.id, ATC_TMUX_SESSION, pane_id)
 
         await transition(session.id, SessionStatus.CONNECTING, SessionStatus.IDLE, event_bus)

--- a/src/atc/leader/orchestrator.py
+++ b/src/atc/leader/orchestrator.py
@@ -18,11 +18,14 @@ import logging
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
 
+from atc.agents.deploy import AceDeploySpec, cleanup_deployed_files, deploy_ace_files
 from atc.leader.decomposer import get_completion_status, get_ready_tasks
 from atc.session.ace import create_ace, destroy_ace, start_ace
 from atc.state import db as db_ops
 
 if TYPE_CHECKING:
+    from pathlib import Path
+
     import aiosqlite
 
     from atc.core.events import EventBus
@@ -38,6 +41,7 @@ class AceAssignment:
     task_graph_id: str
     task_title: str
     status: str = "assigned"  # assigned|working|done|failed
+    deployed_root: Path | None = None  # staging dir for cleanup
 
 
 @dataclass
@@ -62,7 +66,8 @@ class LeaderOrchestrator:
         assignments created.
         """
         task_graphs = await db_ops.list_task_graphs(
-            self.conn, project_id=self.project_id,
+            self.conn,
+            project_id=self.project_id,
         )
 
         ready = get_ready_tasks(task_graphs)
@@ -71,8 +76,7 @@ class LeaderOrchestrator:
 
         # Count currently active Aces
         active_count = sum(
-            1 for a in self.assignments.values()
-            if a.status in ("assigned", "working")
+            1 for a in self.assignments.values() if a.status in ("assigned", "working")
         )
         available_slots = max(0, self._max_concurrent_aces - active_count)
 
@@ -102,16 +106,48 @@ class LeaderOrchestrator:
         title: str,
         description: str | None,
     ) -> AceAssignment | None:
-        """Spawn a single Ace session and assign it to a task graph entry."""
+        """Spawn a single Ace session and assign it to a task graph entry.
+
+        Deploys config files (CLAUDE.md, hooks) via ``deploy_ace_files``
+        before launching the tmux pane so Claude Code reads the task
+        instructions automatically.
+        """
         ace_name = f"ace-{title[:30]}"
 
         try:
+            # Look up project metadata for the deploy spec
+            project = await db_ops.get_project(self.conn, self.project_id)
+            project_name = project.name if project else ""
+            repo_path = project.repo_path if project else None
+            github_repo = project.github_repo if project else None
+
+            # Generate a stable session id up-front so deploy can use it
+            import uuid
+
+            session_id_preview = str(uuid.uuid4())
+
+            # Deploy config files before launching the session
+            spec = AceDeploySpec(
+                session_id=session_id_preview,
+                project_name=project_name,
+                task_title=title,
+                task_description=description,
+                repo_path=repo_path,
+                github_repo=github_repo,
+            )
+            deployed = deploy_ace_files(spec)
+            logger.info("Deployed ace config for task '%s' → %s", title, deployed.root)
+
+            working_dir = repo_path or str(deployed.root)
+
             session_id = await create_ace(
                 self.conn,
                 self.project_id,
                 ace_name,
                 task_id=task_graph_id,
                 event_bus=self.event_bus,
+                working_dir=working_dir,
+                launch_command="claude --dangerously-skip-permissions",
             )
         except Exception:
             logger.exception(
@@ -123,12 +159,16 @@ class LeaderOrchestrator:
 
         # Link the task_graph entry to this Ace
         await db_ops.update_task_graph(
-            self.conn, task_graph_id, assigned_ace_id=session_id,
+            self.conn,
+            task_graph_id,
+            assigned_ace_id=session_id,
         )
 
         # Transition the task to in_progress
         await db_ops.update_task_graph_status(
-            self.conn, task_graph_id, "in_progress",
+            self.conn,
+            task_graph_id,
+            "in_progress",
         )
 
         assignment = AceAssignment(
@@ -136,6 +176,7 @@ class LeaderOrchestrator:
             task_graph_id=task_graph_id,
             task_title=title,
             status="assigned",
+            deployed_root=deployed.root,
         )
         self.assignments[task_graph_id] = assignment
 
@@ -184,7 +225,9 @@ class LeaderOrchestrator:
 
         # Update task graph status
         await db_ops.update_task_graph_status(
-            self.conn, task_graph_id, "done",
+            self.conn,
+            task_graph_id,
+            "done",
         )
 
         if assignment is not None:
@@ -203,6 +246,11 @@ class LeaderOrchestrator:
                     assignment.ace_session_id,
                     assignment.task_title,
                 )
+
+            # Clean up deployed config files
+            if assignment.deployed_root:
+                with contextlib.suppress(Exception):
+                    cleanup_deployed_files(assignment.deployed_root)
 
         if self.event_bus:
             await self.event_bus.publish(
@@ -226,7 +274,9 @@ class LeaderOrchestrator:
         # Transition back to todo so it can be retried
         with contextlib.suppress(ValueError):
             await db_ops.update_task_graph_status(
-                self.conn, task_graph_id, "todo",
+                self.conn,
+                task_graph_id,
+                "todo",
             )
 
         if assignment is not None:
@@ -243,6 +293,12 @@ class LeaderOrchestrator:
                     assignment.ace_session_id,
                     assignment.task_title,
                 )
+
+            # Clean up deployed config files
+            if assignment.deployed_root:
+                with contextlib.suppress(Exception):
+                    cleanup_deployed_files(assignment.deployed_root)
+
             # Remove assignment so the task can be re-assigned
             del self.assignments[task_graph_id]
 
@@ -260,7 +316,8 @@ class LeaderOrchestrator:
     async def get_progress(self) -> dict[str, Any]:
         """Return current progress summary for the Leader's task graph."""
         task_graphs = await db_ops.list_task_graphs(
-            self.conn, project_id=self.project_id,
+            self.conn,
+            project_id=self.project_id,
         )
 
         status = get_completion_status(task_graphs)
@@ -314,7 +371,8 @@ class LeaderOrchestrator:
                         assignment.task_title,
                     )
                     await self.mark_task_failed(
-                        tg_id, reason="Ace session entered error state",
+                        tg_id,
+                        reason="Ace session entered error state",
                     )
                 elif new_status == "disconnected":
                     logger.warning(
@@ -323,6 +381,7 @@ class LeaderOrchestrator:
                         assignment.task_title,
                     )
                     await self.mark_task_failed(
-                        tg_id, reason="Ace session disconnected",
+                        tg_id,
+                        reason="Ace session disconnected",
                     )
                 break

--- a/src/atc/session/ace.py
+++ b/src/atc/session/ace.py
@@ -74,9 +74,16 @@ async def _ensure_tmux_session(session_name: str) -> None:
         await _tmux_run("new-session", "-d", "-s", session_name)
 
 
-async def _spawn_pane(session_name: str, command: str | None = None) -> str:
+async def _spawn_pane(
+    session_name: str,
+    command: str | None = None,
+    *,
+    working_dir: str | None = None,
+) -> str:
     """Split a new pane in *session_name* and return its pane id (e.g. ``%5``)."""
     args = ["split-window", "-t", session_name, "-d", "-P", "-F", "#{pane_id}"]
+    if working_dir:
+        args.extend(["-c", working_dir])
     if command:
         args.extend([command])
     pane_id = await _tmux_run(*args)
@@ -229,11 +236,18 @@ async def create_ace(
     task_id: str | None = None,
     host: str | None = None,
     event_bus: EventBus | None = None,
+    working_dir: str | None = None,
+    launch_command: str | None = None,
 ) -> str:
     """Create an ace session (DB-first). Returns the session id.
 
     The session is created with status ``connecting`` and a tmux pane is
     spawned.  On success the status moves to ``idle``; on failure to ``error``.
+
+    Args:
+        working_dir: Working directory for the tmux pane (e.g. the repo path).
+        launch_command: Shell command to run in the pane (e.g. ``claude``).
+            When provided, the pane launches this command instead of a bare shell.
     """
     # Step 1: DB row first — guarantees the UI always sees every entity
     session = await db_ops.create_session(
@@ -256,7 +270,11 @@ async def create_ace(
     # Step 3: spawn tmux pane
     try:
         await _ensure_tmux_session(ATC_TMUX_SESSION)
-        pane_id = await _spawn_pane(ATC_TMUX_SESSION)
+        pane_id = await _spawn_pane(
+            ATC_TMUX_SESSION,
+            launch_command,
+            working_dir=working_dir,
+        )
         await db_ops.update_session_tmux(conn, session.id, ATC_TMUX_SESSION, pane_id)
 
         # Step 4a: success → idle

--- a/src/atc/tower/controller.py
+++ b/src/atc/tower/controller.py
@@ -158,6 +158,7 @@ class TowerController:
                 project_id,
                 goal=goal,
                 event_bus=self._event_bus,
+                context_package=context_package,
             )
             self._current_session_id = session_id
 

--- a/tests/unit/test_e2e_wiring.py
+++ b/tests/unit/test_e2e_wiring.py
@@ -1,0 +1,464 @@
+"""Tests for end-to-end agent wiring — deploy.py integration with session lifecycle.
+
+Verifies that:
+  - Tower → Leader flow deploys manager config before spawning
+  - Leader → Ace flow deploys ace config before spawning
+  - Config files contain correct task/goal information
+  - tmux panes receive the correct launch command and working directory
+  - Deployed files are cleaned up on task completion/failure
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from atc.agents.deploy import AceDeploySpec, ManagerDeploySpec, deploy_ace_files
+from atc.core.events import EventBus
+from atc.leader.leader import _CLAUDE_LAUNCH_CMD, _build_manager_deploy_spec
+from atc.leader.orchestrator import LeaderOrchestrator
+from atc.state.db import (
+    _SCHEMA_SQL,
+    create_leader,
+    create_project,
+    create_task_graph,
+    get_connection,
+    run_migrations,
+)
+
+
+@pytest.fixture
+async def db():
+    """In-memory database with schema applied."""
+    await run_migrations(":memory:")
+    async with get_connection(":memory:") as conn:
+        await conn.executescript(_SCHEMA_SQL)
+        await conn.commit()
+        yield conn
+
+
+@pytest.fixture
+def event_bus() -> EventBus:
+    return EventBus()
+
+
+# ---------------------------------------------------------------------------
+# Manager deploy spec builder
+# ---------------------------------------------------------------------------
+
+
+class TestBuildManagerDeploySpec:
+    def test_basic_spec(self) -> None:
+        spec = _build_manager_deploy_spec(
+            leader_id="leader-1",
+            project_name="Phoenix",
+            goal="Ship the MVP",
+            repo_path="/home/user/phoenix",
+            github_repo="acme/phoenix",
+        )
+        assert isinstance(spec, ManagerDeploySpec)
+        assert spec.leader_id == "leader-1"
+        assert spec.project_name == "Phoenix"
+        assert spec.goal == "Ship the MVP"
+        assert spec.repo_path == "/home/user/phoenix"
+        assert spec.github_repo == "acme/phoenix"
+
+    def test_with_context_entries(self) -> None:
+        entries = [{"key": "stack", "value": "Python"}]
+        spec = _build_manager_deploy_spec(
+            leader_id="l-1",
+            project_name="Test",
+            goal="Test goal",
+            context_entries=entries,
+        )
+        assert spec.context_entries == entries
+
+    def test_defaults_to_empty_context(self) -> None:
+        spec = _build_manager_deploy_spec(
+            leader_id="l-1",
+            project_name="Test",
+            goal="Test goal",
+        )
+        assert spec.context_entries == []
+
+
+# ---------------------------------------------------------------------------
+# Tower → Leader: deploy + launch wiring
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+class TestTowerToLeaderWiring:
+    """Verify that Tower → Leader flow deploys config and launches claude."""
+
+    @patch("atc.leader.leader._spawn_pane", new_callable=AsyncMock, return_value="%1")
+    @patch("atc.leader.leader._ensure_tmux_session", new_callable=AsyncMock)
+    @patch("atc.leader.leader.deploy_manager_files")
+    async def test_start_leader_deploys_config(
+        self,
+        mock_deploy: AsyncMock,
+        mock_ensure: AsyncMock,
+        mock_spawn: AsyncMock,
+        db,
+        event_bus: EventBus,
+    ) -> None:
+        from atc.agents.deploy import DeployedFiles
+
+        mock_deploy.return_value = DeployedFiles(root=Path("/tmp/atc-agents/leader-1"), files=[])
+
+        project = await create_project(db, "test-proj", repo_path="/tmp/repo")
+        await create_leader(db, project.id)
+
+        from atc.leader.leader import start_leader
+
+        context_package = {
+            "goal": "Build feature X",
+            "project_name": "test-proj",
+            "repo_path": "/tmp/repo",
+            "github_repo": None,
+            "context_entries": [{"key": "stack", "value": "Python"}],
+        }
+
+        await start_leader(
+            db,
+            project.id,
+            goal="Build feature X",
+            event_bus=event_bus,
+            context_package=context_package,
+        )
+
+        # Verify deploy_manager_files was called
+        mock_deploy.assert_called_once()
+        spec = mock_deploy.call_args[0][0]
+        assert isinstance(spec, ManagerDeploySpec)
+        assert spec.goal == "Build feature X"
+        assert spec.project_name == "test-proj"
+
+    @patch("atc.leader.leader._spawn_pane", new_callable=AsyncMock, return_value="%1")
+    @patch("atc.leader.leader._ensure_tmux_session", new_callable=AsyncMock)
+    @patch("atc.leader.leader.deploy_manager_files")
+    async def test_start_leader_launches_claude(
+        self,
+        mock_deploy: AsyncMock,
+        mock_ensure: AsyncMock,
+        mock_spawn: AsyncMock,
+        db,
+        event_bus: EventBus,
+    ) -> None:
+        from atc.agents.deploy import DeployedFiles
+
+        mock_deploy.return_value = DeployedFiles(root=Path("/tmp/atc-agents/leader-1"), files=[])
+
+        project = await create_project(db, "test-proj", repo_path="/tmp/repo")
+        await create_leader(db, project.id)
+
+        from atc.leader.leader import start_leader
+
+        await start_leader(db, project.id, goal="Build it", event_bus=event_bus)
+
+        # Verify tmux pane was spawned with claude command and working_dir
+        mock_spawn.assert_called_once()
+        args, kwargs = mock_spawn.call_args
+        assert args[0] == "atc"  # tmux session name
+        assert args[1] == _CLAUDE_LAUNCH_CMD
+        assert kwargs.get("working_dir") == "/tmp/repo"
+
+    @patch("atc.leader.leader._spawn_pane", new_callable=AsyncMock, return_value="%1")
+    @patch("atc.leader.leader._ensure_tmux_session", new_callable=AsyncMock)
+    @patch("atc.leader.leader.deploy_manager_files")
+    async def test_start_leader_uses_deploy_root_when_no_repo(
+        self,
+        mock_deploy: AsyncMock,
+        mock_ensure: AsyncMock,
+        mock_spawn: AsyncMock,
+        db,
+        event_bus: EventBus,
+    ) -> None:
+        from atc.agents.deploy import DeployedFiles
+
+        mock_deploy.return_value = DeployedFiles(root=Path("/tmp/atc-agents/leader-1"), files=[])
+
+        project = await create_project(db, "test-proj")  # no repo_path
+        await create_leader(db, project.id)
+
+        from atc.leader.leader import start_leader
+
+        await start_leader(db, project.id, goal="Test", event_bus=event_bus)
+
+        # Without repo_path, should fall back to deployed root
+        _, kwargs = mock_spawn.call_args
+        assert kwargs.get("working_dir") == "/tmp/atc-agents/leader-1"
+
+
+# ---------------------------------------------------------------------------
+# Leader → Ace: deploy + launch wiring
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+class TestLeaderToAceWiring:
+    """Verify that Leader → Ace flow deploys config and launches claude."""
+
+    @patch("atc.leader.orchestrator.create_ace", new_callable=AsyncMock, return_value="ace-1")
+    @patch("atc.leader.orchestrator.deploy_ace_files")
+    async def test_spawn_ace_deploys_config(
+        self,
+        mock_deploy: AsyncMock,
+        mock_create: AsyncMock,
+        db,
+        event_bus: EventBus,
+    ) -> None:
+        from atc.agents.deploy import DeployedFiles
+
+        mock_deploy.return_value = DeployedFiles(root=Path("/tmp/atc-agents/ace-preview"), files=[])
+
+        project = await create_project(db, "test-proj", repo_path="/tmp/repo")
+        leader = await create_leader(db, project.id, goal="Build auth")
+
+        orchestrator = LeaderOrchestrator(
+            project_id=project.id,
+            leader_id=leader.id,
+            conn=db,
+            event_bus=event_bus,
+        )
+
+        await create_task_graph(
+            db,
+            project.id,
+            "Login page",
+            description="Build OAuth login flow",
+        )
+
+        assignments = await orchestrator.spawn_aces_for_ready_tasks()
+
+        assert len(assignments) == 1
+        # Verify deploy was called
+        mock_deploy.assert_called_once()
+        spec = mock_deploy.call_args[0][0]
+        assert isinstance(spec, AceDeploySpec)
+        assert spec.task_title == "Login page"
+        assert spec.task_description == "Build OAuth login flow"
+        assert spec.project_name == "test-proj"
+        assert spec.repo_path == "/tmp/repo"
+
+    @patch("atc.leader.orchestrator.create_ace", new_callable=AsyncMock, return_value="ace-1")
+    @patch("atc.leader.orchestrator.deploy_ace_files")
+    async def test_spawn_ace_passes_working_dir_and_command(
+        self,
+        mock_deploy: AsyncMock,
+        mock_create: AsyncMock,
+        db,
+        event_bus: EventBus,
+    ) -> None:
+        from atc.agents.deploy import DeployedFiles
+
+        mock_deploy.return_value = DeployedFiles(root=Path("/tmp/atc-agents/ace-preview"), files=[])
+
+        project = await create_project(db, "test-proj", repo_path="/tmp/repo")
+        leader = await create_leader(db, project.id, goal="Test")
+
+        orchestrator = LeaderOrchestrator(
+            project_id=project.id,
+            leader_id=leader.id,
+            conn=db,
+            event_bus=event_bus,
+        )
+
+        await create_task_graph(db, project.id, "Task A")
+        await orchestrator.spawn_aces_for_ready_tasks()
+
+        # Verify create_ace was called with working_dir and launch_command
+        mock_create.assert_called_once()
+        _, kwargs = mock_create.call_args
+        assert kwargs["working_dir"] == "/tmp/repo"
+        assert kwargs["launch_command"] == "claude --dangerously-skip-permissions"
+
+    @patch("atc.leader.orchestrator.create_ace", new_callable=AsyncMock, return_value="ace-1")
+    @patch("atc.leader.orchestrator.deploy_ace_files")
+    async def test_assignment_stores_deployed_root(
+        self,
+        mock_deploy: AsyncMock,
+        mock_create: AsyncMock,
+        db,
+        event_bus: EventBus,
+    ) -> None:
+        from atc.agents.deploy import DeployedFiles
+
+        deploy_root = Path("/tmp/atc-agents/ace-preview")
+        mock_deploy.return_value = DeployedFiles(root=deploy_root, files=[])
+
+        project = await create_project(db, "test-proj")
+        leader = await create_leader(db, project.id, goal="Test")
+
+        orchestrator = LeaderOrchestrator(
+            project_id=project.id,
+            leader_id=leader.id,
+            conn=db,
+            event_bus=event_bus,
+        )
+
+        tg = await create_task_graph(db, project.id, "Task A")
+        await orchestrator.spawn_aces_for_ready_tasks()
+
+        assignment = orchestrator.assignments[tg.id]
+        assert assignment.deployed_root == deploy_root
+
+
+# ---------------------------------------------------------------------------
+# Cleanup of deployed files
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+class TestDeployedFileCleanup:
+    @patch("atc.leader.orchestrator.cleanup_deployed_files")
+    @patch("atc.leader.orchestrator.destroy_ace", new_callable=AsyncMock)
+    async def test_mark_done_cleans_up_deployed_files(
+        self,
+        mock_destroy: AsyncMock,
+        mock_cleanup: AsyncMock,
+        db,
+        event_bus: EventBus,
+    ) -> None:
+        from atc.leader.orchestrator import AceAssignment
+
+        project = await create_project(db, "test-proj")
+        leader = await create_leader(db, project.id, goal="Test")
+
+        orchestrator = LeaderOrchestrator(
+            project_id=project.id,
+            leader_id=leader.id,
+            conn=db,
+            event_bus=event_bus,
+        )
+
+        tg = await create_task_graph(db, project.id, "Task A")
+        from atc.state import db as db_ops
+
+        await db_ops.update_task_graph_status(db, tg.id, "in_progress")
+
+        deploy_root = Path("/tmp/atc-agents/ace-123")
+        orchestrator.assignments[tg.id] = AceAssignment(
+            ace_session_id="ace-1",
+            task_graph_id=tg.id,
+            task_title="Task A",
+            status="working",
+            deployed_root=deploy_root,
+        )
+
+        await orchestrator.mark_task_done(tg.id)
+
+        mock_cleanup.assert_called_once_with(deploy_root)
+
+    @patch("atc.leader.orchestrator.cleanup_deployed_files")
+    @patch("atc.leader.orchestrator.destroy_ace", new_callable=AsyncMock)
+    async def test_mark_failed_cleans_up_deployed_files(
+        self,
+        mock_destroy: AsyncMock,
+        mock_cleanup: AsyncMock,
+        db,
+        event_bus: EventBus,
+    ) -> None:
+        from atc.leader.orchestrator import AceAssignment
+
+        project = await create_project(db, "test-proj")
+        leader = await create_leader(db, project.id, goal="Test")
+
+        orchestrator = LeaderOrchestrator(
+            project_id=project.id,
+            leader_id=leader.id,
+            conn=db,
+            event_bus=event_bus,
+        )
+
+        tg = await create_task_graph(db, project.id, "Task A")
+        from atc.state import db as db_ops
+
+        await db_ops.update_task_graph_status(db, tg.id, "in_progress")
+
+        deploy_root = Path("/tmp/atc-agents/ace-456")
+        orchestrator.assignments[tg.id] = AceAssignment(
+            ace_session_id="ace-1",
+            task_graph_id=tg.id,
+            task_title="Task A",
+            status="working",
+            deployed_root=deploy_root,
+        )
+
+        await orchestrator.mark_task_failed(tg.id, reason="test failure")
+
+        mock_cleanup.assert_called_once_with(deploy_root)
+
+
+# ---------------------------------------------------------------------------
+# _spawn_pane working_dir parameter
+# ---------------------------------------------------------------------------
+
+
+class TestSpawnPaneWorkingDir:
+    """Verify that _spawn_pane passes -c working_dir to tmux."""
+
+    @pytest.mark.asyncio
+    @patch("atc.session.ace._tmux_run", new_callable=AsyncMock, return_value="%5")
+    async def test_spawn_pane_with_working_dir(self, mock_tmux: AsyncMock) -> None:
+        from atc.session.ace import _spawn_pane
+
+        pane_id = await _spawn_pane("atc", "claude", working_dir="/tmp/repo")
+        assert pane_id == "%5"
+
+        args = mock_tmux.call_args[0]
+        # Should include -c /tmp/repo before the command
+        assert "-c" in args
+        idx = args.index("-c")
+        assert args[idx + 1] == "/tmp/repo"
+
+    @pytest.mark.asyncio
+    @patch("atc.session.ace._tmux_run", new_callable=AsyncMock, return_value="%6")
+    async def test_spawn_pane_without_working_dir(self, mock_tmux: AsyncMock) -> None:
+        from atc.session.ace import _spawn_pane
+
+        pane_id = await _spawn_pane("atc", "claude")
+        assert pane_id == "%6"
+
+        args = mock_tmux.call_args[0]
+        assert "-c" not in args
+
+
+# ---------------------------------------------------------------------------
+# Full deploy.py content verification
+# ---------------------------------------------------------------------------
+
+
+class TestDeployedContentIntegrity:
+    """Verify that deployed config files contain the right information."""
+
+    def test_ace_deploy_has_hooks_pointing_to_api(self, tmp_path: Path) -> None:
+        spec = AceDeploySpec(
+            session_id="ace-test",
+            project_name="TestProj",
+            task_title="Build login",
+            task_description="Implement OAuth flow",
+        )
+        deployed = deploy_ace_files(spec, staging_root=tmp_path)
+
+        # CLAUDE.md should mention the task
+        claude_md = deployed.claude_md_path.read_text()
+        assert "Build login" in claude_md
+        assert "OAuth flow" in claude_md
+        assert "atc ace status" in claude_md
+
+        # Settings should have hooks
+        settings = json.loads(deployed.settings_path.read_text())
+        assert "PostToolUse" in settings["hooks"]
+        assert "Stop" in settings["hooks"]
+
+        # Hook scripts should report to the API
+        post_hook = (deployed.root / ".claude" / "hooks" / "PostToolUse.sh").read_text()
+        assert "ace-test" in post_hook
+        assert "working" in post_hook
+
+        stop_hook = (deployed.root / ".claude" / "hooks" / "Stop.sh").read_text()
+        assert "waiting" in stop_hook


### PR DESCRIPTION
## Summary

- **Wire deploy.py into session lifecycle** so Tower → Leader → Ace spawns real Claude Code sessions with pre-configured CLAUDE.md, hooks, and settings.json
- **Leader sessions** now get `ManagerDeploySpec` config deployed before tmux pane launches `claude --dangerously-skip-permissions` in the repo working directory
- **Ace sessions** now get `AceDeploySpec` config deployed before each tmux pane spawns, with task-specific instructions and API-reporting hooks
- **Context flows end-to-end**: Tower builds context_package → passes to start_leader → populates ManagerDeploySpec with goal, project metadata, context entries
- **Cleanup**: deployed config files are cleaned up when Aces complete or fail
- **REST API**: Ace creation endpoint also deploys config, so UI-spawned Aces get the same treatment

### Files changed (6)
| File | Change |
|------|--------|
| `src/atc/tower/controller.py` | Pass `context_package` to `start_leader` |
| `src/atc/leader/leader.py` | Deploy `ManagerDeploySpec` config; launch `claude` CLI in tmux pane with `working_dir` |
| `src/atc/leader/orchestrator.py` | Deploy `AceDeploySpec` config before each Ace; track `deployed_root` for cleanup |
| `src/atc/session/ace.py` | Add `working_dir` and `launch_command` params to `create_ace`/`_spawn_pane` |
| `src/atc/api/routers/aces.py` | Deploy ace config in REST create endpoint |
| `tests/unit/test_e2e_wiring.py` | 14 new tests covering deploy integration, working_dir, cleanup |

## Test plan

- [x] All 440 unit tests pass (426 existing + 14 new)
- [x] ruff lint clean on all modified files
- [ ] Manual smoke test: submit a goal via UI and verify Claude Code launches in tmux with correct CLAUDE.md
- [ ] Verify hooks report status back to `/api/aces/{id}/status`
- [ ] Verify deployed files cleaned up after task completion

🤖 Generated with [Claude Code](https://claude.com/claude-code)