### PR TITLE
fix: Create Project dialog hangs on "Creating..." forever

### DIFF
--- a/frontend/src/utils/__tests__/api.test.ts
+++ b/frontend/src/utils/__tests__/api.test.ts
@@ -88,4 +88,34 @@ describe("api client", () => {
     const result = await api.delete("/projects/1");
     expect(result).toBeUndefined();
   });
+
+  it("throws ApiError with timeout message on AbortError", async () => {
+    vi.spyOn(globalThis, "fetch").mockRejectedValue(
+      new DOMException("The operation was aborted.", "AbortError"),
+    );
+
+    await expect(api.get("/projects")).rejects.toThrow(ApiError);
+    try {
+      await api.get("/projects");
+    } catch (e) {
+      expect(e).toBeInstanceOf(ApiError);
+      expect((e as ApiError).status).toBe(0);
+      expect((e as ApiError).message).toContain("timed out");
+    }
+  });
+
+  it("throws ApiError with network message on fetch failure", async () => {
+    vi.spyOn(globalThis, "fetch").mockRejectedValue(
+      new TypeError("Failed to fetch"),
+    );
+
+    await expect(api.get("/projects")).rejects.toThrow(ApiError);
+    try {
+      await api.get("/projects");
+    } catch (e) {
+      expect(e).toBeInstanceOf(ApiError);
+      expect((e as ApiError).status).toBe(0);
+      expect((e as ApiError).message).toContain("Network error");
+    }
+  });
 });

--- a/frontend/src/utils/api.ts
+++ b/frontend/src/utils/api.ts
@@ -5,6 +5,9 @@
 
 const BASE = "/api";
 
+/** Default request timeout in milliseconds (30 seconds). */
+const REQUEST_TIMEOUT_MS = 30_000;
+
 export class ApiError extends Error {
   constructor(
     public status: number,
@@ -19,19 +22,33 @@ async function request<T>(
   path: string,
   options: RequestInit = {},
 ): Promise<T> {
-  const res = await fetch(`${BASE}${path}`, {
-    headers: {
-      "Content-Type": "application/json",
-      ...options.headers,
-    },
-    ...options,
-  });
-  if (!res.ok) {
-    const text = await res.text().catch(() => res.statusText);
-    throw new ApiError(res.status, text);
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
+
+  try {
+    const res = await fetch(`${BASE}${path}`, {
+      headers: {
+        "Content-Type": "application/json",
+        ...options.headers,
+      },
+      ...options,
+      signal: options.signal ?? controller.signal,
+    });
+    if (!res.ok) {
+      const text = await res.text().catch(() => res.statusText);
+      throw new ApiError(res.status, text);
+    }
+    if (res.status === 204) return undefined as T;
+    return res.json() as Promise<T>;
+  } catch (err) {
+    if (err instanceof ApiError) throw err;
+    if (err instanceof DOMException && err.name === "AbortError") {
+      throw new ApiError(0, "Request timed out — is the backend running?");
+    }
+    throw new ApiError(0, "Network error — could not reach the server");
+  } finally {
+    clearTimeout(timeout);
   }
-  if (res.status === 204) return undefined as T;
-  return res.json() as Promise<T>;
 }
 
 export const api = {

--- a/src/atc/api/routers/projects.py
+++ b/src/atc/api/routers/projects.py
@@ -12,11 +12,15 @@ Routes:
 
 from __future__ import annotations
 
+import logging
+
 from fastapi import APIRouter, HTTPException, Request
 from pydantic import BaseModel
 
 from atc.leader import leader as leader_ops
 from atc.state import db as db_ops
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter()
 
@@ -75,15 +79,26 @@ async def list_projects(request: Request) -> list[ProjectResponse]:
 @router.post("", response_model=ProjectResponse, status_code=201)
 async def create_project(body: CreateProjectRequest, request: Request) -> ProjectResponse:
     db = await _get_db(request)
-    project = await db_ops.create_project(
-        db,
-        body.name,
-        description=body.description,
-        repo_path=body.repo_path,
-        github_repo=body.github_repo,
-    )
+    try:
+        project = await db_ops.create_project(
+            db,
+            body.name,
+            description=body.description,
+            repo_path=body.repo_path,
+            github_repo=body.github_repo,
+        )
+    except Exception:
+        logger.exception("Failed to create project %r", body.name)
+        raise HTTPException(status_code=500, detail="Failed to create project") from None
+
     # Auto-create Leader for the project
-    await db_ops.create_leader(db, project.id)
+    try:
+        await db_ops.create_leader(db, project.id)
+    except Exception:
+        logger.exception("Failed to create leader for project %s", project.id)
+        # Project was created but leader failed — don't leave the user hanging
+        # Return the project anyway; leader can be created later.
+
     return ProjectResponse(**project.__dict__)
 
 


### PR DESCRIPTION
## Summary
- Add a 30-second `AbortController` timeout to the frontend API client (`api.ts`) so requests to an unreachable backend surface a clear error message ("Request timed out — is the backend running?") instead of hanging indefinitely
- Add error handling to the backend `create_project` endpoint so DB failures return proper HTTP 500 errors with descriptive messages instead of unhandled exceptions
- Add frontend tests for timeout and network error scenarios

## Testing Done
- All 488 backend tests pass (`pytest tests/ -q`)
- All 142 frontend tests pass (`npm run test -- --run`)
- `ruff check` passes on modified Python file
- Verified via curl that when backend is unreachable through Vite proxy, the request hangs (confirming the root cause); with the fix, the frontend AbortController fires after 30s and surfaces the error

## Root Cause
When the backend process crashes or becomes unresponsive, the Vite dev proxy accepts the TCP connection but never gets a response from the backend. This causes `fetch()` to hang forever — the Promise never resolves or rejects, so `setSubmitting(false)` never runs and the button stays on "Creating..." indefinitely.