### PR TITLE
feat: Tower terminal panel — persistent minimizable PTY view

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,6 +1,7 @@
 import { BrowserRouter, Routes, Route, Navigate, Outlet } from "react-router-dom";
 import { AppProvider } from "./context/AppContext";
 import TowerBar from "./components/tower/TowerBar";
+import TowerPanel from "./components/tower/TowerPanel";
 import Dashboard from "./pages/Dashboard";
 import ProjectView from "./pages/ProjectView";
 import SettingsPage from "./pages/SettingsPage";
@@ -10,9 +11,10 @@ function Layout() {
   return (
     <>
       <TowerBar />
-      <main style={{ flex: 1, overflow: "auto" }}>
+      <main style={{ flex: 1, overflow: "auto", minHeight: 0 }}>
         <Outlet />
       </main>
+      <TowerPanel />
     </>
   );
 }

--- a/frontend/src/components/tower/TowerModal.tsx
+++ b/frontend/src/components/tower/TowerModal.tsx
@@ -17,7 +17,16 @@ export default function TowerModal({ open, onClose }: TowerModalProps) {
   const { state } = useAppContext();
   const [memory, setMemory] = useState<TowerMemoryEntry[]>([]);
   const [goal, setGoal] = useState("");
+  const [projectId, setProjectId] = useState("");
   const [submitting, setSubmitting] = useState(false);
+
+  // Default to first active project when modal opens
+  useEffect(() => {
+    if (open && !projectId && state.projects.length > 0) {
+      const active = state.projects.find((p) => p.status === "active");
+      if (active) setProjectId(active.id);
+    }
+  }, [open, projectId, state.projects]);
 
   useEffect(() => {
     if (!open) return;
@@ -40,10 +49,13 @@ export default function TowerModal({ open, onClose }: TowerModalProps) {
 
   async function handleSetGoal(e: React.FormEvent) {
     e.preventDefault();
-    if (!goal.trim()) return;
+    if (!goal.trim() || !projectId) return;
     setSubmitting(true);
     try {
-      await api.post("/tower/goal", { goal: goal.trim() });
+      await api.post("/tower/goal", {
+        project_id: projectId,
+        goal: goal.trim(),
+      });
       setGoal("");
     } catch (err) {
       console.error("Failed to set tower goal:", err);
@@ -83,7 +95,26 @@ export default function TowerModal({ open, onClose }: TowerModalProps) {
 
         <form className="tower-modal__goal-form" onSubmit={handleSetGoal}>
           <div className="form-group">
-            <label htmlFor="tower-goal">Set Tower Goal</label>
+            <label htmlFor="tower-project">Project</label>
+            <select
+              id="tower-project"
+              value={projectId}
+              onChange={(e) => setProjectId(e.target.value)}
+            >
+              <option value="" disabled>
+                Select project...
+              </option>
+              {state.projects
+                .filter((p) => p.status === "active")
+                .map((p) => (
+                  <option key={p.id} value={p.id}>
+                    {p.name}
+                  </option>
+                ))}
+            </select>
+          </div>
+          <div className="form-group">
+            <label htmlFor="tower-goal">Goal</label>
             <input
               id="tower-goal"
               type="text"
@@ -95,7 +126,7 @@ export default function TowerModal({ open, onClose }: TowerModalProps) {
           <button
             type="submit"
             className="btn btn-primary btn-sm"
-            disabled={submitting || !goal.trim()}
+            disabled={submitting || !goal.trim() || !projectId}
           >
             {submitting ? "Setting..." : "Set Goal"}
           </button>

--- a/frontend/src/components/tower/TowerPanel.css
+++ b/frontend/src/components/tower/TowerPanel.css
@@ -1,0 +1,140 @@
+.tower-panel {
+  display: flex;
+  flex-direction: column;
+  flex-shrink: 0;
+  background: var(--color-bg-surface);
+  border-top: 1px solid var(--color-border);
+}
+
+/* Minimized: just the bar */
+.tower-panel__bar {
+  display: flex;
+  align-items: center;
+  height: 32px;
+  padding: 0 var(--space-3);
+  gap: var(--space-2);
+  flex-shrink: 0;
+}
+
+.tower-panel__toggle {
+  display: flex;
+  align-items: center;
+  gap: var(--space-1);
+  background: none;
+  border: none;
+  color: var(--color-text-secondary);
+  cursor: pointer;
+  font-size: var(--text-sm);
+  font-family: var(--font-sans);
+  padding: var(--space-1) var(--space-2);
+  border-radius: var(--radius-sm);
+  transition: color var(--transition-fast), background var(--transition-fast);
+}
+
+.tower-panel__toggle:hover {
+  color: var(--color-text);
+  background: var(--color-bg-hover);
+}
+
+.tower-panel__caret {
+  font-size: 10px;
+  line-height: 1;
+}
+
+.tower-panel__label {
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  font-size: var(--text-xs);
+}
+
+.tower-panel__dot {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
+.tower-panel__ticker {
+  flex: 1;
+  font-size: var(--text-xs);
+  color: var(--color-text-muted);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: var(--font-mono);
+}
+
+.tower-panel__bar-actions {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  flex-shrink: 0;
+}
+
+/* Expanded content */
+.tower-panel__content {
+  flex: 1;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+  border-top: 1px solid var(--color-border-subtle);
+}
+
+.tower-panel--expanded {
+  height: 280px;
+}
+
+/* Goal form — shown when idle */
+.tower-panel__goal-form {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  padding: var(--space-3);
+}
+
+.tower-panel__project-select {
+  padding: var(--space-1) var(--space-2);
+  font-size: var(--text-sm);
+  font-family: var(--font-sans);
+  color: var(--color-text);
+  background: var(--color-bg);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  outline: none;
+  min-width: 140px;
+}
+
+.tower-panel__project-select:focus {
+  border-color: var(--color-accent);
+}
+
+.tower-panel__goal-input {
+  flex: 1;
+  padding: var(--space-1) var(--space-3);
+  font-size: var(--text-sm);
+  font-family: var(--font-sans);
+  color: var(--color-text);
+  background: var(--color-bg);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  outline: none;
+}
+
+.tower-panel__goal-input:focus {
+  border-color: var(--color-accent);
+}
+
+/* Terminal area */
+.tower-panel__terminal {
+  flex: 1;
+  min-height: 0;
+  padding: var(--space-1) var(--space-2);
+}
+
+/* Error message */
+.tower-panel__error {
+  padding: var(--space-3);
+  font-size: var(--text-sm);
+  color: var(--color-status-red);
+}

--- a/frontend/src/components/tower/TowerPanel.tsx
+++ b/frontend/src/components/tower/TowerPanel.tsx
@@ -1,0 +1,215 @@
+import { useState, useEffect, useCallback } from "react";
+import { useAppContext } from "../../context/AppContext";
+import { useTerminal } from "../../hooks/useTerminal";
+import { api } from "../../utils/api";
+import "./TowerPanel.css";
+
+/**
+ * Persistent bottom panel for Tower — lives in the shell layout,
+ * persists across all pages. Think VS Code integrated terminal.
+ *
+ * Minimized: single-line ticker showing latest Tower activity.
+ * Expanded + idle: goal input form.
+ * Expanded + running: full PTY terminal streaming Leader output.
+ */
+export default function TowerPanel() {
+  const { state } = useAppContext();
+  const { towerDetail, brainStatus, projects } = state;
+
+  const [expanded, setExpanded] = useState(false);
+  const [goal, setGoal] = useState("");
+  const [projectId, setProjectId] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+
+  const isRunning =
+    towerDetail.state === "planning" || towerDetail.state === "managing";
+  const isIdle =
+    towerDetail.state === "idle" ||
+    towerDetail.state === "complete" ||
+    towerDetail.state === "error";
+
+  const terminalChannel = towerDetail.current_session_id
+    ? `terminal:${towerDetail.current_session_id}`
+    : undefined;
+
+  const { attachRef, fit } = useTerminal({
+    channel: terminalChannel,
+    enabled: isRunning && !!terminalChannel,
+  });
+
+  // Re-fit terminal when panel expands
+  useEffect(() => {
+    if (expanded && isRunning) {
+      // Delay to let CSS transition finish
+      const timer = setTimeout(() => fit(), 200);
+      return () => clearTimeout(timer);
+    }
+  }, [expanded, isRunning, fit]);
+
+  // Auto-expand when Tower starts running
+  useEffect(() => {
+    if (isRunning) {
+      setExpanded(true);
+    }
+  }, [isRunning]);
+
+  // Default to first active project
+  useEffect(() => {
+    if (!projectId && projects.length > 0) {
+      const active = projects.find((p) => p.status === "active");
+      if (active) setProjectId(active.id);
+    }
+  }, [projectId, projects]);
+
+  const handleSubmitGoal = useCallback(
+    async (e: React.FormEvent) => {
+      e.preventDefault();
+      if (!goal.trim() || !projectId) return;
+      setSubmitting(true);
+      try {
+        await api.post("/tower/goal", {
+          project_id: projectId,
+          goal: goal.trim(),
+        });
+        setGoal("");
+      } catch (err) {
+        console.error("Failed to set tower goal:", err);
+      } finally {
+        setSubmitting(false);
+      }
+    },
+    [goal, projectId],
+  );
+
+  const handleCancel = useCallback(async () => {
+    try {
+      await api.post("/tower/cancel");
+    } catch (err) {
+      console.error("Failed to cancel tower goal:", err);
+    }
+  }, []);
+
+  const tickerText =
+    brainStatus.message ||
+    (towerDetail.current_goal
+      ? `Goal: ${towerDetail.current_goal}`
+      : "Idle");
+
+  return (
+    <div
+      className={`tower-panel ${expanded ? "tower-panel--expanded" : ""}`}
+      data-testid="tower-panel"
+    >
+      {/* Minimized bar — always visible */}
+      <div className="tower-panel__bar">
+        <button
+          className="tower-panel__toggle"
+          onClick={() => setExpanded((v) => !v)}
+          aria-label={expanded ? "Minimize Tower" : "Expand Tower"}
+          data-testid="tower-panel-toggle"
+        >
+          <span className="tower-panel__caret">
+            {expanded ? "\u25BE" : "\u25B4"}
+          </span>
+          <span className="tower-panel__label">Tower</span>
+        </button>
+
+        <TowerStateDot state={towerDetail.state} />
+
+        <span className="tower-panel__ticker" title={tickerText}>
+          {tickerText}
+        </span>
+
+        <div className="tower-panel__bar-actions">
+          {isRunning && (
+            <button
+              className="btn btn-danger btn-sm"
+              onClick={handleCancel}
+              data-testid="tower-panel-cancel"
+            >
+              Cancel
+            </button>
+          )}
+        </div>
+      </div>
+
+      {/* Expanded content */}
+      {expanded && (
+        <div className="tower-panel__content" data-testid="tower-panel-content">
+          {isIdle && (
+            <form
+              className="tower-panel__goal-form"
+              onSubmit={handleSubmitGoal}
+            >
+              <select
+                className="tower-panel__project-select"
+                value={projectId}
+                onChange={(e) => setProjectId(e.target.value)}
+                data-testid="tower-panel-project"
+              >
+                <option value="" disabled>
+                  Select project...
+                </option>
+                {projects
+                  .filter((p) => p.status === "active")
+                  .map((p) => (
+                    <option key={p.id} value={p.id}>
+                      {p.name}
+                    </option>
+                  ))}
+              </select>
+              <input
+                type="text"
+                className="tower-panel__goal-input"
+                value={goal}
+                onChange={(e) => setGoal(e.target.value)}
+                placeholder="Describe a goal for Tower..."
+                data-testid="tower-panel-goal"
+              />
+              <button
+                type="submit"
+                className="btn btn-primary btn-sm"
+                disabled={submitting || !goal.trim() || !projectId}
+                data-testid="tower-panel-start"
+              >
+                {submitting ? "Starting..." : "Start"}
+              </button>
+            </form>
+          )}
+
+          {isRunning && (
+            <div
+              className="tower-panel__terminal"
+              ref={attachRef}
+              data-testid="tower-panel-terminal"
+            />
+          )}
+
+          {towerDetail.state === "error" && towerDetail.current_goal && (
+            <div className="tower-panel__error">
+              Tower encountered an error while processing:{" "}
+              <strong>{towerDetail.current_goal}</strong>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function TowerStateDot({ state }: { state: string }) {
+  const colorMap: Record<string, string> = {
+    idle: "var(--color-text-muted)",
+    planning: "var(--color-accent)",
+    managing: "var(--color-status-green)",
+    complete: "var(--color-status-green)",
+    error: "var(--color-status-red)",
+  };
+  return (
+    <span
+      className="tower-panel__dot"
+      style={{ background: colorMap[state] ?? "var(--color-text-muted)" }}
+      title={`Tower: ${state}`}
+    />
+  );
+}

--- a/frontend/src/context/AppContext.tsx
+++ b/frontend/src/context/AppContext.tsx
@@ -19,6 +19,7 @@ import type {
   UsageSummary,
   GitHubSummary,
   TowerStatus,
+  TowerDetail,
 } from "../types";
 import { useWebSocket, type WsMessage } from "../hooks/useWebSocket";
 import { api } from "../utils/api";
@@ -34,6 +35,12 @@ const initialState: AppState = {
   taskGraphs: {},
   budgets: {},
   brainStatus: { status: "idle", message: "", active_projects: 0 },
+  towerDetail: {
+    state: "idle",
+    current_goal: null,
+    current_project_id: null,
+    current_session_id: null,
+  },
   notifications: [],
   failureLogs: [],
   usage: { today_cost: 0, month_cost: 0, today_tokens: 0, month_tokens: 0 },
@@ -54,6 +61,7 @@ type Action =
   | { type: "SET_TASK_GRAPHS"; payload: Record<string, TaskGraph[]> }
   | { type: "SET_BUDGETS"; payload: Record<string, Budget> }
   | { type: "SET_BRAIN_STATUS"; payload: TowerStatus }
+  | { type: "SET_TOWER_DETAIL"; payload: Partial<TowerDetail> }
   | { type: "SET_NOTIFICATIONS"; payload: Notification[] }
   | { type: "SET_USAGE"; payload: UsageSummary }
   | { type: "SET_GITHUB"; payload: Record<string, GitHubSummary> }
@@ -83,6 +91,11 @@ function reducer(state: AppState, action: Action): AppState {
       return { ...state, budgets: action.payload };
     case "SET_BRAIN_STATUS":
       return { ...state, brainStatus: action.payload };
+    case "SET_TOWER_DETAIL":
+      return {
+        ...state,
+        towerDetail: { ...state.towerDetail, ...action.payload },
+      };
     case "SET_NOTIFICATIONS":
       return { ...state, notifications: action.payload };
     case "SET_USAGE":
@@ -189,6 +202,23 @@ export function AppProvider({ children }: AppProviderProps) {
       // Fetch failure logs
       const failureLogs = await api.get<FailureLog[]>("/failure-logs?limit=200");
       dispatch({ type: "SET_FAILURE_LOGS", payload: failureLogs });
+
+      // Fetch tower status for panel state
+      const towerStatus = await api.get<{
+        state: string;
+        current_goal: string | null;
+        current_project_id: string | null;
+        current_session_id: string | null;
+      }>("/tower/status");
+      dispatch({
+        type: "SET_TOWER_DETAIL",
+        payload: {
+          state: towerStatus.state,
+          current_goal: towerStatus.current_goal,
+          current_project_id: towerStatus.current_project_id,
+          current_session_id: towerStatus.current_session_id,
+        },
+      });
     } catch {
       /* backend may not be running yet — silent fail */
     }
@@ -198,6 +228,25 @@ export function AppProvider({ children }: AppProviderProps) {
     if (msg.channel === "state") {
       const data = msg.data as Partial<AppState>;
       dispatch({ type: "SET_STATE", payload: data });
+    } else if (msg.channel === "tower") {
+      const data = msg.data as Record<string, unknown>;
+      if (data.type === "state_changed") {
+        dispatch({
+          type: "SET_TOWER_DETAIL",
+          payload: {
+            state: data.new_state as string,
+            current_goal: (data.goal as string) ?? null,
+            current_project_id: (data.project_id as string) ?? null,
+          },
+        });
+      } else if (data.type === "leader_status") {
+        dispatch({
+          type: "SET_TOWER_DETAIL",
+          payload: {
+            current_session_id: (data.session_id as string) ?? null,
+          },
+        });
+      }
     } else if (msg.channel === "failure_logs") {
       const data = msg.data as Record<string, unknown>;
       if (data.new) {
@@ -210,7 +259,7 @@ export function AppProvider({ children }: AppProviderProps) {
   }, []);
 
   useWebSocket({
-    channels: ["state", "failure_logs"],
+    channels: ["state", "failure_logs", "tower"],
     onMessage: handleWsMessage,
   });
 

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -117,6 +117,13 @@ export interface TowerStatus {
   active_projects: number;
 }
 
+export interface TowerDetail {
+  state: string;
+  current_goal: string | null;
+  current_project_id: string | null;
+  current_session_id: string | null;
+}
+
 export interface FailureLog {
   id: string;
   level: "info" | "warning" | "error" | "critical";
@@ -139,6 +146,7 @@ export interface AppState {
   taskGraphs: Record<string, TaskGraph[]>;
   budgets: Record<string, Budget>;
   brainStatus: TowerStatus;
+  towerDetail: TowerDetail;
   notifications: Notification[];
   failureLogs: FailureLog[];
   usage: UsageSummary;


### PR DESCRIPTION
## Summary
- Add a VS Code-style persistent bottom panel for Tower that lives in the shell layout and persists across Dashboard, ProjectView, and all other pages
- **Minimized**: single-line activity ticker showing Tower state and latest action text
- **Expanded + idle**: project selector + goal input form with Start button
- **Expanded + running**: full PTY terminal streaming Leader tmux output via WebSocket
- Fix TowerModal `project_id` bug: was sending `{goal}` but `POST /api/tower/goal` expects `{project_id, goal}`

## Changes
- **`TowerPanel.tsx`** + **`TowerPanel.css`**: New persistent bottom panel component
- **`App.tsx`**: Add TowerPanel to Layout (below `<main>`, persists across routes)
- **`types/index.ts`**: Add `TowerDetail` interface and extend `AppState`
- **`AppContext.tsx`**: Add `towerDetail` state, `SET_TOWER_DETAIL` action, subscribe to `tower` WebSocket channel, fetch tower status on init
- **`TowerModal.tsx`**: Add project selector, send `{project_id, goal}` instead of just `{goal}`

## Test plan
- [ ] Verify Tower panel appears at bottom of all pages (Dashboard, ProjectView, Settings, Usage)
- [ ] Verify minimized ticker shows Tower status text
- [ ] Verify expanding shows goal form when idle with project selector
- [ ] Verify submitting a goal auto-expands panel and shows terminal
- [ ] Verify terminal streams PTY output from Leader session
- [ ] Verify Cancel button stops Tower goal
- [ ] Verify TowerModal now sends project_id with goal
- [ ] All 142 existing frontend tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)