### PR TITLE
fix: port conflict crash + agent provider dropdown silent failure

### DIFF
--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -41,6 +41,7 @@ export default function SettingsPage() {
     useState<AgentProviderConfig | null>(null);
   const [providers, setProviders] = useState<ProviderInfo[]>([]);
   const [providerSaving, setProviderSaving] = useState(false);
+  const [providerError, setProviderError] = useState("");
 
   useEffect(() => {
     api.get<AgentProviderConfig>("/settings/agent-provider").then(setProviderConfig).catch(() => {});
@@ -49,14 +50,17 @@ export default function SettingsPage() {
 
   async function handleProviderChange(newDefault: string) {
     setProviderSaving(true);
+    setProviderError("");
     try {
       const updated = await api.put<AgentProviderConfig>(
         "/settings/agent-provider",
         { default: newDefault },
       );
       setProviderConfig(updated);
-    } catch {
-      // silently fail — config read-only in worst case
+    } catch (e) {
+      setProviderError(
+        e instanceof Error ? e.message : "Failed to update agent provider",
+      );
     } finally {
       setProviderSaving(false);
     }
@@ -298,6 +302,14 @@ export default function SettingsPage() {
                 </div>
               </div>
             ))}
+          {providerError && (
+            <p
+              className="settings-page__error"
+              data-testid="agent-provider-error"
+            >
+              {providerError}
+            </p>
+          )}
         </section>
 
         {/* Export Section */}

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -7,6 +7,20 @@ ROOT_DIR="$(dirname "$SCRIPT_DIR")"
 
 echo "Starting ATC in development mode..."
 
+# Check for port conflicts before starting
+if lsof -i :8420 -sTCP:LISTEN -t >/dev/null 2>&1; then
+  STALE_PID=$(lsof -i :8420 -sTCP:LISTEN -t 2>/dev/null | head -1)
+  echo "⚠ Port 8420 is already in use by PID $STALE_PID."
+  echo "  Killing stale process..."
+  kill "$STALE_PID" 2>/dev/null
+  sleep 1
+  if lsof -i :8420 -sTCP:LISTEN -t >/dev/null 2>&1; then
+    echo "✗ Could not free port 8420. Please kill PID $STALE_PID manually."
+    exit 1
+  fi
+  echo "  Port 8420 freed."
+fi
+
 # Start backend
 echo "→ Starting backend (uvicorn with reload)..."
 (cd "$ROOT_DIR" && python3 -m uvicorn atc.api.app:create_app --factory --reload --host 127.0.0.1 --port 8420) &

--- a/src/atc/api/app.py
+++ b/src/atc/api/app.py
@@ -110,16 +110,20 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
             if session and session.tmux_pane:
                 logger.info(
                     "Auto-starting PTY reader for session %s (pane %s)",
-                    session_id, session.tmux_pane,
+                    session_id,
+                    session.tmux_pane,
                 )
                 await pty_pool.add_session(session_id, session.tmux_pane)
 
         # Broadcast status changes on the state channel for AppContext
-        await ws_hub.broadcast("state", {
-            "sessions_updated": True,
-            "session_id": session_id,
-            "new_status": new_status,
-        })
+        await ws_hub.broadcast(
+            "state",
+            {
+                "sessions_updated": True,
+                "session_id": session_id,
+                "new_status": new_status,
+            },
+        )
 
     async def _on_session_destroyed(data: dict[str, Any]) -> None:
         session_id = data.get("session_id", "")
@@ -201,12 +205,34 @@ def create_app(settings: Settings | None = None) -> FastAPI:
 
 def main() -> None:
     """Entry point for the ATC server."""
+    import socket
+
     settings = load_settings()
     logging.basicConfig(level=getattr(logging, settings.logging.level))
+
+    # Check if port is already in use before starting
+    host = settings.server.host
+    port = settings.server.port
+    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    try:
+        sock.bind((host, port))
+    except OSError as exc:
+        logger.error(
+            "Port %d is already in use on %s: %s. "
+            "Kill the stale process (lsof -i :%d) or choose a different port.",
+            port,
+            host,
+            exc,
+            port,
+        )
+        raise SystemExit(1) from exc
+    finally:
+        sock.close()
+
     app = create_app(settings)
     uvicorn.run(
         app,
-        host=settings.server.host,
-        port=settings.server.port,
+        host=host,
+        port=port,
         reload=settings.server.reload,
     )


### PR DESCRIPTION
## Summary
- **Backend port conflict**: dev.sh now detects if port 8420 is already occupied, kills the stale process, and exits cleanly if it can't free the port. The Python main() entry point also pre-checks with a socket bind test, providing a clear error message instead of an unhandled [Errno 48] Address already in use crash.
- **Agent provider dropdown error**: The Settings page agent provider dropdown now displays an error message when the PUT /api/settings/agent-provider call fails, instead of silently swallowing the error and leaving the UI in an inconsistent state.

## Test plan
- [x] All 446 Python unit tests pass
- [x] All 142 frontend tests pass
- [x] ruff check passes on changed files
- [ ] Manual: run atc dev with port 8420 already occupied - verify it kills stale process or exits with clear message
- [ ] Manual: trigger a provider change error (e.g. stop backend) - verify error message appears below dropdown