### PR TITLE
fix: UI fixes — Workers→Aces, clipped popover, settings toggle

### DIFF
--- a/frontend/src/components/ace/AceList.tsx
+++ b/frontend/src/components/ace/AceList.tsx
@@ -89,7 +89,7 @@ export default function AceList({
     return (
       <div className="ace-list ace-list--compact" data-testid="ace-list">
         <div className="ace-list__header">
-          <h3>Workers</h3>
+          <h3>Aces</h3>
           <span className="ace-list__count">{sessions.length}</span>
         </div>
 

--- a/frontend/src/components/ace/__tests__/AceList.test.tsx
+++ b/frontend/src/components/ace/__tests__/AceList.test.tsx
@@ -137,11 +137,11 @@ describe("AceList", () => {
     expect(list).toHaveClass("ace-list--compact");
   });
 
-  it("shows Workers heading in compact mode", () => {
+  it("shows Aces heading in compact mode", () => {
     renderWithProviders(
       <AceList projectId="proj-1" sessions={baseSessions} onRefresh={vi.fn()} compact />,
     );
-    expect(screen.getByText("Workers")).toBeInTheDocument();
+    expect(screen.getByText("Aces")).toBeInTheDocument();
   });
 
   it("shows Aces heading in default mode", () => {

--- a/frontend/src/components/common/ConfirmPopover.css
+++ b/frontend/src/components/common/ConfirmPopover.css
@@ -4,28 +4,25 @@
 }
 
 .confirm-popover {
-  position: absolute;
-  bottom: calc(100% + var(--space-2));
-  left: 50%;
-  transform: translateX(-50%);
+  position: fixed;
   min-width: 220px;
   padding: var(--space-3);
   background: var(--color-bg-elevated);
   border: 1px solid var(--color-border);
   border-radius: var(--radius-lg);
   box-shadow: var(--shadow-md);
-  z-index: 100;
+  z-index: 1000;
   animation: popover-in 150ms ease-out;
 }
 
 @keyframes popover-in {
   from {
     opacity: 0;
-    transform: translateX(-50%) translateY(4px);
+    transform: translateY(4px);
   }
   to {
     opacity: 1;
-    transform: translateX(-50%) translateY(0);
+    transform: translateY(0);
   }
 }
 

--- a/frontend/src/components/common/ConfirmPopover.tsx
+++ b/frontend/src/components/common/ConfirmPopover.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef, useEffect, type ReactNode } from "react";
+import { useState, useRef, useEffect, useCallback, type ReactNode } from "react";
 import "./ConfirmPopover.css";
 
 interface ConfirmPopoverProps {
@@ -19,12 +19,47 @@ export default function ConfirmPopover({
   variant = "default",
 }: ConfirmPopoverProps) {
   const [open, setOpen] = useState(false);
+  const wrapperRef = useRef<HTMLDivElement>(null);
   const popoverRef = useRef<HTMLDivElement>(null);
+
+  const updatePosition = useCallback(() => {
+    const trigger = wrapperRef.current;
+    const popover = popoverRef.current;
+    if (!trigger || !popover) return;
+
+    const rect = trigger.getBoundingClientRect();
+    const popRect = popover.getBoundingClientRect();
+
+    // Try to position above the trigger, centered
+    let top = rect.top - popRect.height - 8;
+    let left = rect.left + rect.width / 2 - popRect.width / 2;
+
+    // If clipped at top, position below instead
+    if (top < 8) {
+      top = rect.bottom + 8;
+    }
+
+    // Keep within horizontal bounds
+    if (left < 8) left = 8;
+    if (left + popRect.width > window.innerWidth - 8) {
+      left = window.innerWidth - popRect.width - 8;
+    }
+
+    popover.style.top = `${top}px`;
+    popover.style.left = `${left}px`;
+  }, []);
+
+  useEffect(() => {
+    if (!open) return;
+    requestAnimationFrame(updatePosition);
+  }, [open, updatePosition]);
 
   useEffect(() => {
     if (!open) return;
     function handleClickOutside(e: MouseEvent) {
       if (
+        wrapperRef.current &&
+        !wrapperRef.current.contains(e.target as Node) &&
         popoverRef.current &&
         !popoverRef.current.contains(e.target as Node)
       ) {
@@ -45,10 +80,10 @@ export default function ConfirmPopover({
   }, [open]);
 
   return (
-    <div className="confirm-popover-wrapper" ref={popoverRef}>
+    <div className="confirm-popover-wrapper" ref={wrapperRef}>
       <div onClick={() => setOpen(true)}>{children}</div>
       {open && (
-        <div className="confirm-popover" data-testid="confirm-popover">
+        <div className="confirm-popover" ref={popoverRef} data-testid="confirm-popover">
           <p className="confirm-popover__message">{message}</p>
           <div className="confirm-popover__actions">
             <button

--- a/frontend/src/components/tower/TowerBar.css
+++ b/frontend/src/components/tower/TowerBar.css
@@ -116,6 +116,11 @@
   background: var(--color-bg-hover);
 }
 
+.tower-bar__icon-btn.active {
+  color: var(--color-accent);
+  background: var(--color-accent-muted);
+}
+
 .tower-bar__badge {
   position: absolute;
   top: 2px;

--- a/frontend/src/components/tower/TowerBar.tsx
+++ b/frontend/src/components/tower/TowerBar.tsx
@@ -117,9 +117,11 @@ export default function TowerBar() {
           </button>
 
           <button
-            className="tower-bar__icon-btn"
+            className={`tower-bar__icon-btn ${isActive("/settings") ? "active" : ""}`}
             data-testid="settings-button"
-            onClick={() => navigate("/settings")}
+            onClick={() =>
+              isActive("/settings") ? navigate("/dashboard") : navigate("/settings")
+            }
             title="Settings"
           >
             <SettingsIcon />


### PR DESCRIPTION
## Summary
- **ATC-46**: Rename remaining "Workers" heading to "Aces" in compact AceList mode (+ update test)
- **ATC-48**: Fix Stop confirmation dialog clipping off-screen by switching ConfirmPopover from `position: absolute` to `position: fixed` with viewport-aware JS placement
- **ATC-50**: Settings cog now toggles open/closed — clicking while on Settings navigates back to Dashboard, with active highlight state

## Changes
- `AceList.tsx`: Line 92 "Workers" → "Aces"
- `AceList.test.tsx`: Update test expectation to match
- `ConfirmPopover.tsx`: Add viewport-aware fixed positioning with automatic flip when near edges
- `ConfirmPopover.css`: Switch to `position: fixed`, raise z-index to 1000
- `TowerBar.tsx`: Settings button toggles between /settings and /dashboard
- `TowerBar.css`: Add `.tower-bar__icon-btn.active` style

## Test plan
- [x] All 142 frontend tests pass
- [ ] Verify compact AceList shows "Aces" heading
- [ ] Click Stop on an ace near the top of the viewport — popover should not clip
- [ ] Click settings cog → navigates to Settings, cog highlights
- [ ] Click settings cog again → navigates back to Dashboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)