### PR TITLE
fix: Leader respects project agent_provider setting

### DIFF
--- a/src/atc/agents/factory.py
+++ b/src/atc/agents/factory.py
@@ -66,6 +66,24 @@ def get_provider_class(name: str) -> ProviderConstructor | None:
     return _REGISTRY.get(name)
 
 
+# Default launch commands per provider
+_LAUNCH_COMMANDS: dict[str, str] = {
+    "claude_code": "claude --dangerously-skip-permissions",
+    "opencode": "opencode",
+}
+
+
+def get_launch_command(provider_name: str) -> str:
+    """Return the shell launch command for a given provider name.
+
+    Falls back to ``claude --dangerously-skip-permissions`` for unknown
+    providers so existing behaviour is preserved.
+    """
+    return _LAUNCH_COMMANDS.get(
+        provider_name, _LAUNCH_COMMANDS["claude_code"]
+    )
+
+
 def _register_builtins() -> None:
     """Register the built-in providers (claude_code, opencode)."""
     from atc.agents.claude_provider import ClaudeCodeProvider

--- a/src/atc/api/routers/aces.py
+++ b/src/atc/api/routers/aces.py
@@ -19,6 +19,7 @@ from fastapi import APIRouter, HTTPException, Request
 from pydantic import BaseModel
 
 from atc.agents.deploy import AceDeploySpec, deploy_ace_files
+from atc.agents.factory import get_launch_command
 from atc.session import ace as ace_ops
 from atc.session.state_machine import InvalidTransitionError
 from atc.state import db as db_ops
@@ -136,6 +137,8 @@ async def create_ace(project_id: str, body: CreateAceRequest, request: Request) 
     deployed = deploy_ace_files(spec)
     working_dir = project.repo_path or str(deployed.root)
 
+    launch_cmd = get_launch_command(project.agent_provider)
+
     session_id = await ace_ops.create_ace(
         db,
         project_id,
@@ -144,7 +147,7 @@ async def create_ace(project_id: str, body: CreateAceRequest, request: Request) 
         host=body.host,
         event_bus=event_bus,
         working_dir=working_dir,
-        launch_command="claude --dangerously-skip-permissions",
+        launch_command=launch_cmd,
     )
     session = await db_ops.get_session(db, session_id)
     if session is None:

--- a/src/atc/leader/leader.py
+++ b/src/atc/leader/leader.py
@@ -16,6 +16,7 @@ import logging
 from typing import TYPE_CHECKING, Any
 
 from atc.agents.deploy import ManagerDeploySpec, deploy_manager_files
+from atc.agents.factory import get_launch_command
 from atc.session.ace import (
     ATC_TMUX_SESSION,
     _ensure_tmux_session,
@@ -33,8 +34,6 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-# The command used to launch a Claude Code session in each tmux pane.
-_CLAUDE_LAUNCH_CMD = "claude --dangerously-skip-permissions"
 
 
 def _build_manager_deploy_spec(
@@ -128,10 +127,14 @@ async def start_leader(
         # Spawn tmux pane in the repo working directory, running claude
         working_dir = spec.repo_path or str(deployed.root)
 
+        launch_cmd = get_launch_command(
+            project.agent_provider if project else "claude_code",
+        )
+
         await _ensure_tmux_session(ATC_TMUX_SESSION)
         pane_id = await _spawn_pane(
             ATC_TMUX_SESSION,
-            _CLAUDE_LAUNCH_CMD,
+            launch_cmd,
             working_dir=working_dir,
         )
         await db_ops.update_session_tmux(conn, session.id, ATC_TMUX_SESSION, pane_id)

--- a/src/atc/leader/orchestrator.py
+++ b/src/atc/leader/orchestrator.py
@@ -19,6 +19,7 @@ from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
 
 from atc.agents.deploy import AceDeploySpec, cleanup_deployed_files, deploy_ace_files
+from atc.agents.factory import get_launch_command
 from atc.leader.decomposer import get_completion_status, get_ready_tasks
 from atc.session.ace import create_ace, destroy_ace, start_ace
 from atc.state import db as db_ops
@@ -140,6 +141,10 @@ class LeaderOrchestrator:
 
             working_dir = repo_path or str(deployed.root)
 
+            launch_cmd = get_launch_command(
+                project.agent_provider if project else "claude_code",
+            )
+
             session_id = await create_ace(
                 self.conn,
                 self.project_id,
@@ -147,7 +152,7 @@ class LeaderOrchestrator:
                 task_id=task_graph_id,
                 event_bus=self.event_bus,
                 working_dir=working_dir,
-                launch_command="claude --dangerously-skip-permissions",
+                launch_command=launch_cmd,
             )
         except Exception:
             logger.exception(

--- a/tests/unit/test_agent_provider.py
+++ b/tests/unit/test_agent_provider.py
@@ -17,8 +17,10 @@ from atc.agents.base import (
 )
 from atc.agents.claude_provider import ClaudeCodeProvider
 from atc.agents.factory import (
+    _LAUNCH_COMMANDS,
     _REGISTRY,
     create_provider,
+    get_launch_command,
     get_provider_class,
     list_providers,
     register_provider,
@@ -604,3 +606,26 @@ class TestConfigIntegration:
             claude_command=cfg.claude_command,
         )
         assert provider.name == "claude_code"
+
+
+# ---------------------------------------------------------------------------
+# get_launch_command
+# ---------------------------------------------------------------------------
+
+
+class TestGetLaunchCommand:
+    def test_claude_code_returns_claude_cmd(self) -> None:
+        cmd = get_launch_command("claude_code")
+        assert cmd == "claude --dangerously-skip-permissions"
+
+    def test_opencode_returns_opencode_cmd(self) -> None:
+        cmd = get_launch_command("opencode")
+        assert cmd == "opencode"
+
+    def test_unknown_falls_back_to_claude(self) -> None:
+        cmd = get_launch_command("unknown_provider")
+        assert cmd == "claude --dangerously-skip-permissions"
+
+    def test_launch_commands_registry_has_both(self) -> None:
+        assert "claude_code" in _LAUNCH_COMMANDS
+        assert "opencode" in _LAUNCH_COMMANDS

--- a/tests/unit/test_e2e_wiring.py
+++ b/tests/unit/test_e2e_wiring.py
@@ -17,8 +17,9 @@ from unittest.mock import AsyncMock, patch
 import pytest
 
 from atc.agents.deploy import AceDeploySpec, ManagerDeploySpec, deploy_ace_files
+from atc.agents.factory import get_launch_command
 from atc.core.events import EventBus
-from atc.leader.leader import _CLAUDE_LAUNCH_CMD, _build_manager_deploy_spec
+from atc.leader.leader import _build_manager_deploy_spec
 from atc.leader.orchestrator import LeaderOrchestrator
 from atc.state.db import (
     _SCHEMA_SQL,
@@ -163,7 +164,7 @@ class TestTowerToLeaderWiring:
         mock_spawn.assert_called_once()
         args, kwargs = mock_spawn.call_args
         assert args[0] == "atc"  # tmux session name
-        assert args[1] == _CLAUDE_LAUNCH_CMD
+        assert args[1] == get_launch_command("claude_code")
         assert kwargs.get("working_dir") == "/tmp/repo"
 
     @patch("atc.leader.leader._spawn_pane", new_callable=AsyncMock, return_value="%1")
@@ -191,6 +192,40 @@ class TestTowerToLeaderWiring:
         # Without repo_path, should fall back to deployed root
         _, kwargs = mock_spawn.call_args
         assert kwargs.get("working_dir") == "/tmp/atc-agents/leader-1"
+
+    @patch("atc.leader.leader._spawn_pane", new_callable=AsyncMock, return_value="%1")
+    @patch("atc.leader.leader._ensure_tmux_session", new_callable=AsyncMock)
+    @patch("atc.leader.leader.deploy_manager_files")
+    async def test_start_leader_uses_project_agent_provider(
+        self,
+        mock_deploy: AsyncMock,
+        mock_ensure: AsyncMock,
+        mock_spawn: AsyncMock,
+        db,
+        event_bus: EventBus,
+    ) -> None:
+        """Leader must use project.agent_provider to pick the launch command."""
+        from atc.agents.deploy import DeployedFiles
+
+        mock_deploy.return_value = DeployedFiles(root=Path("/tmp/atc-agents/leader-1"), files=[])
+
+        project = await create_project(db, "test-proj", repo_path="/tmp/repo")
+        # Set project to use opencode
+        await db.execute(
+            "UPDATE projects SET agent_provider = ? WHERE id = ?",
+            ("opencode", project.id),
+        )
+        await db.commit()
+        await create_leader(db, project.id)
+
+        from atc.leader.leader import start_leader
+
+        await start_leader(db, project.id, goal="Build it", event_bus=event_bus)
+
+        mock_spawn.assert_called_once()
+        args, _ = mock_spawn.call_args
+        assert args[1] == get_launch_command("opencode")
+        assert args[1] == "opencode"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_leader_orchestrator.py
+++ b/tests/unit/test_leader_orchestrator.py
@@ -76,6 +76,36 @@ class TestSpawnAces:
         assert assignments[0].ace_session_id == "ace-session-1"
         mock_create.assert_called_once()
 
+    async def test_uses_project_agent_provider(
+        self, mock_create: AsyncMock, db, orchestrator: LeaderOrchestrator,
+    ) -> None:
+        """Ace sessions must use the project's configured agent_provider."""
+        # Set project to use opencode
+        await db.execute(
+            "UPDATE projects SET agent_provider = ? WHERE id = ?",
+            ("opencode", orchestrator.project_id),
+        )
+        await db.commit()
+
+        await create_task_graph(db, orchestrator.project_id, "Task A")
+        await orchestrator.spawn_aces_for_ready_tasks()
+
+        # Verify the launch_command used the opencode provider
+        call_kwargs = mock_create.call_args
+        assert call_kwargs is not None
+        assert call_kwargs.kwargs.get("launch_command") == "opencode"
+
+    async def test_default_provider_uses_claude(
+        self, mock_create: AsyncMock, db, orchestrator: LeaderOrchestrator,
+    ) -> None:
+        """Default agent_provider (claude_code) uses the Claude launch command."""
+        await create_task_graph(db, orchestrator.project_id, "Task B")
+        await orchestrator.spawn_aces_for_ready_tasks()
+
+        call_kwargs = mock_create.call_args
+        assert call_kwargs is not None
+        assert call_kwargs.kwargs.get("launch_command") == "claude --dangerously-skip-permissions"
+
     async def test_skips_tasks_with_unmet_deps(
         self, mock_create: AsyncMock, db, orchestrator: LeaderOrchestrator,
     ) -> None:


### PR DESCRIPTION
## Summary
- **Bug**: Leader and Ace session creation hardcoded `claude --dangerously-skip-permissions` instead of reading `project.agent_provider` from the database
- **Fix**: Added `get_launch_command()` helper to the factory module, wired it through `leader.py`, `orchestrator.py`, and `aces.py` so all session spawns use the configured provider
- **Tests**: Added 7 new tests covering `get_launch_command()`, leader start with opencode provider, and orchestrator Ace spawns with both providers

## Changes
- `src/atc/agents/factory.py` — Added `_LAUNCH_COMMANDS` registry and `get_launch_command()` factory function
- `src/atc/leader/leader.py` — Replaced hardcoded `_CLAUDE_LAUNCH_CMD` with `get_launch_command(project.agent_provider)`
- `src/atc/leader/orchestrator.py` — Replaced hardcoded launch command with `get_launch_command(project.agent_provider)`
- `src/atc/api/routers/aces.py` — Replaced hardcoded launch command with `get_launch_command(project.agent_provider)`
- Tests updated across `test_agent_provider.py`, `test_e2e_wiring.py`, `test_leader_orchestrator.py`

## Testing Done
- All 453 unit tests pass
- ruff check passes on all changed files
- New tests verify: claude_code returns correct command, opencode returns correct command, unknown provider falls back to claude, leader start uses project provider, orchestrator passes correct launch command per provider