### PR TITLE
feat: Tower controls Leader via terminal — full orchestration loop

### DIFF
--- a/frontend/src/components/tower/TowerPanel.css
+++ b/frontend/src/components/tower/TowerPanel.css
@@ -132,6 +132,44 @@
   padding: var(--space-1) var(--space-2);
 }
 
+/* Message input bar — below terminal when managing */
+.tower-panel__message-form {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  padding: var(--space-2) var(--space-3);
+  border-top: 1px solid var(--color-border-subtle);
+  flex-shrink: 0;
+}
+
+.tower-panel__message-input {
+  flex: 1;
+  padding: var(--space-1) var(--space-3);
+  font-size: var(--text-sm);
+  font-family: var(--font-mono);
+  color: var(--color-text);
+  background: var(--color-bg);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  outline: none;
+}
+
+.tower-panel__message-input:focus {
+  border-color: var(--color-accent);
+}
+
+.tower-panel__message-input:disabled {
+  opacity: 0.6;
+}
+
+/* Progress indicator in the bar */
+.tower-panel__progress {
+  font-size: var(--text-xs);
+  font-family: var(--font-mono);
+  color: var(--color-text-muted);
+  white-space: nowrap;
+}
+
 /* Error message */
 .tower-panel__error {
   padding: var(--space-3);

--- a/frontend/src/components/tower/TowerPanel.tsx
+++ b/frontend/src/components/tower/TowerPanel.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from "react";
+import { useState, useEffect, useCallback, useRef } from "react";
 import { useAppContext } from "../../context/AppContext";
 import { useTerminal } from "../../hooks/useTerminal";
 import { api } from "../../utils/api";
@@ -10,16 +10,23 @@ import "./TowerPanel.css";
  *
  * Minimized: single-line ticker showing latest Tower activity.
  * Expanded + idle: goal input form.
- * Expanded + running: full PTY terminal streaming Leader output.
+ * Expanded + running: full PTY terminal + message input bar.
+ *
+ * The message input bar allows the user to send instructions to the
+ * Leader through Tower. This is the top of the chain of command —
+ * Tower is the user's interface to the entire hierarchy.
  */
 export default function TowerPanel() {
   const { state } = useAppContext();
-  const { towerDetail, brainStatus, projects } = state;
+  const { towerDetail, towerProgress, brainStatus, projects } = state;
 
   const [expanded, setExpanded] = useState(false);
   const [goal, setGoal] = useState("");
   const [projectId, setProjectId] = useState("");
   const [submitting, setSubmitting] = useState(false);
+  const [message, setMessage] = useState("");
+  const [sending, setSending] = useState(false);
+  const messageInputRef = useRef<HTMLInputElement>(null);
 
   const isRunning =
     towerDetail.state === "planning" || towerDetail.state === "managing";
@@ -89,6 +96,32 @@ export default function TowerPanel() {
     }
   }, []);
 
+  const handleSendMessage = useCallback(
+    async (e: React.FormEvent) => {
+      e.preventDefault();
+      if (!message.trim()) return;
+      setSending(true);
+      try {
+        await api.post("/tower/message", { message: message.trim() });
+        setMessage("");
+        messageInputRef.current?.focus();
+      } catch (err) {
+        console.error("Failed to send message to Leader:", err);
+      } finally {
+        setSending(false);
+      }
+    },
+    [message],
+  );
+
+  const handleMarkComplete = useCallback(async () => {
+    try {
+      await api.post("/tower/complete");
+    } catch (err) {
+      console.error("Failed to mark Tower goal complete:", err);
+    }
+  }, []);
+
   const tickerText =
     brainStatus.message ||
     (towerDetail.current_goal
@@ -121,14 +154,31 @@ export default function TowerPanel() {
         </span>
 
         <div className="tower-panel__bar-actions">
-          {isRunning && (
-            <button
-              className="btn btn-danger btn-sm"
-              onClick={handleCancel}
-              data-testid="tower-panel-cancel"
+          {isRunning && towerProgress.total > 0 && (
+            <span
+              className="tower-panel__progress"
+              data-testid="tower-panel-progress"
             >
-              Cancel
-            </button>
+              {towerProgress.done}/{towerProgress.total} tasks ({towerProgress.progress_pct}%)
+            </span>
+          )}
+          {isRunning && (
+            <>
+              <button
+                className="btn btn-sm"
+                onClick={handleMarkComplete}
+                data-testid="tower-panel-complete"
+              >
+                Complete
+              </button>
+              <button
+                className="btn btn-danger btn-sm"
+                onClick={handleCancel}
+                data-testid="tower-panel-cancel"
+              >
+                Cancel
+              </button>
+            </>
           )}
         </div>
       </div>
@@ -178,11 +228,37 @@ export default function TowerPanel() {
           )}
 
           {isRunning && (
-            <div
-              className="tower-panel__terminal"
-              ref={attachRef}
-              data-testid="tower-panel-terminal"
-            />
+            <>
+              <div
+                className="tower-panel__terminal"
+                ref={attachRef}
+                data-testid="tower-panel-terminal"
+              />
+              <form
+                className="tower-panel__message-form"
+                onSubmit={handleSendMessage}
+                data-testid="tower-panel-message-form"
+              >
+                <input
+                  ref={messageInputRef}
+                  type="text"
+                  className="tower-panel__message-input"
+                  value={message}
+                  onChange={(e) => setMessage(e.target.value)}
+                  placeholder="Send instruction to Leader..."
+                  disabled={sending}
+                  data-testid="tower-panel-message"
+                />
+                <button
+                  type="submit"
+                  className="btn btn-primary btn-sm"
+                  disabled={sending || !message.trim()}
+                  data-testid="tower-panel-send"
+                >
+                  {sending ? "Sending..." : "Send"}
+                </button>
+              </form>
+            </>
           )}
 
           {towerDetail.state === "error" && towerDetail.current_goal && (

--- a/frontend/src/components/tower/__tests__/TowerPanel.test.tsx
+++ b/frontend/src/components/tower/__tests__/TowerPanel.test.tsx
@@ -1,0 +1,81 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import TowerPanel from "../TowerPanel";
+import { renderWithProviders } from "../../../test/helpers";
+
+// Mock useTerminal since it requires WebSocket/xterm
+vi.mock("../../../hooks/useTerminal", () => ({
+  useTerminal: () => ({
+    attachRef: vi.fn(),
+    fit: vi.fn(),
+  }),
+}));
+
+beforeEach(() => {
+  vi.spyOn(globalThis, "fetch").mockResolvedValue(
+    new Response(JSON.stringify([]), { status: 200 }),
+  );
+});
+
+describe("TowerPanel", () => {
+  it("renders the tower panel", () => {
+    renderWithProviders(<TowerPanel />);
+    expect(screen.getByTestId("tower-panel")).toBeInTheDocument();
+  });
+
+  it("shows Tower label in the bar", () => {
+    renderWithProviders(<TowerPanel />);
+    expect(screen.getByText("Tower")).toBeInTheDocument();
+  });
+
+  it("starts minimized", () => {
+    renderWithProviders(<TowerPanel />);
+    expect(screen.queryByTestId("tower-panel-content")).not.toBeInTheDocument();
+  });
+
+  it("expands when toggle is clicked", async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<TowerPanel />);
+
+    await user.click(screen.getByTestId("tower-panel-toggle"));
+    expect(screen.getByTestId("tower-panel-content")).toBeInTheDocument();
+  });
+
+  it("shows goal form when expanded and idle", async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<TowerPanel />);
+
+    await user.click(screen.getByTestId("tower-panel-toggle"));
+    expect(screen.getByTestId("tower-panel-goal")).toBeInTheDocument();
+    expect(screen.getByTestId("tower-panel-project")).toBeInTheDocument();
+    expect(screen.getByTestId("tower-panel-start")).toBeInTheDocument();
+  });
+
+  it("shows Idle in ticker when no goal is set", () => {
+    renderWithProviders(<TowerPanel />);
+    expect(screen.getByText("Idle")).toBeInTheDocument();
+  });
+
+  it("disables Start button when goal is empty", async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<TowerPanel />);
+
+    await user.click(screen.getByTestId("tower-panel-toggle"));
+    const startBtn = screen.getByTestId("tower-panel-start");
+    expect(startBtn).toBeDisabled();
+  });
+
+  it("collapses when toggle is clicked again", async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<TowerPanel />);
+
+    // Expand
+    await user.click(screen.getByTestId("tower-panel-toggle"));
+    expect(screen.getByTestId("tower-panel-content")).toBeInTheDocument();
+
+    // Collapse
+    await user.click(screen.getByTestId("tower-panel-toggle"));
+    expect(screen.queryByTestId("tower-panel-content")).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/context/AppContext.tsx
+++ b/frontend/src/context/AppContext.tsx
@@ -20,6 +20,7 @@ import type {
   GitHubSummary,
   TowerStatus,
   TowerDetail,
+  TowerProgress,
 } from "../types";
 import { useWebSocket, type WsMessage } from "../hooks/useWebSocket";
 import { api } from "../utils/api";
@@ -40,6 +41,16 @@ const initialState: AppState = {
     current_goal: null,
     current_project_id: null,
     current_session_id: null,
+    leader_activity_preview: null,
+  },
+  towerProgress: {
+    project_id: null,
+    total: 0,
+    done: 0,
+    in_progress: 0,
+    todo: 0,
+    progress_pct: 0,
+    all_done: false,
   },
   notifications: [],
   failureLogs: [],
@@ -71,7 +82,8 @@ type Action =
   | { type: "MARK_NOTIFICATION_READ"; payload: string }
   | { type: "SET_FAILURE_LOGS"; payload: FailureLog[] }
   | { type: "ADD_FAILURE_LOG"; payload: FailureLog }
-  | { type: "RESOLVE_FAILURE_LOG"; payload: string };
+  | { type: "RESOLVE_FAILURE_LOG"; payload: string }
+  | { type: "SET_TOWER_PROGRESS"; payload: TowerProgress };
 
 function reducer(state: AppState, action: Action): AppState {
   switch (action.type) {
@@ -132,6 +144,8 @@ function reducer(state: AppState, action: Action): AppState {
           f.id === action.payload ? { ...f, resolved: true } : f,
         ),
       };
+    case "SET_TOWER_PROGRESS":
+      return { ...state, towerProgress: action.payload };
   }
 }
 
@@ -217,6 +231,7 @@ export function AppProvider({ children }: AppProviderProps) {
           current_goal: towerStatus.current_goal,
           current_project_id: towerStatus.current_project_id,
           current_session_id: towerStatus.current_session_id,
+          leader_activity_preview: null,
         },
       });
     } catch {
@@ -244,6 +259,26 @@ export function AppProvider({ children }: AppProviderProps) {
           type: "SET_TOWER_DETAIL",
           payload: {
             current_session_id: (data.session_id as string) ?? null,
+          },
+        });
+      } else if (data.type === "progress") {
+        dispatch({
+          type: "SET_TOWER_PROGRESS",
+          payload: {
+            project_id: (data.project_id as string) ?? null,
+            total: (data.total as number) ?? 0,
+            done: (data.done as number) ?? 0,
+            in_progress: (data.in_progress as number) ?? 0,
+            todo: (data.todo as number) ?? 0,
+            progress_pct: (data.progress_pct as number) ?? 0,
+            all_done: (data.all_done as boolean) ?? false,
+          },
+        });
+      } else if (data.type === "leader_activity") {
+        dispatch({
+          type: "SET_TOWER_DETAIL",
+          payload: {
+            leader_activity_preview: (data.preview as string) ?? null,
           },
         });
       }

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -138,6 +138,17 @@ export interface TowerDetail {
   current_goal: string | null;
   current_project_id: string | null;
   current_session_id: string | null;
+  leader_activity_preview: string | null;
+}
+
+export interface TowerProgress {
+  project_id: string | null;
+  total: number;
+  done: number;
+  in_progress: number;
+  todo: number;
+  progress_pct: number;
+  all_done: boolean;
 }
 
 export interface FailureLog {
@@ -163,6 +174,7 @@ export interface AppState {
   budgets: Record<string, Budget>;
   brainStatus: TowerStatus;
   towerDetail: TowerDetail;
+  towerProgress: TowerProgress;
   notifications: Notification[];
   failureLogs: FailureLog[];
   usage: UsageSummary;

--- a/src/atc/api/routers/tower.py
+++ b/src/atc/api/routers/tower.py
@@ -1,9 +1,12 @@
-"""Tower REST endpoints — goal intake and tower status.
+"""Tower REST endpoints — goal intake, messaging, progress, and memory.
 
 Routes:
   GET    /api/tower/status           → Tower status summary
   POST   /api/tower/goal             → submit new goal (creates Leader + context)
+  POST   /api/tower/message          → send message to current Leader
   POST   /api/tower/cancel           → cancel current goal
+  POST   /api/tower/complete         → mark current goal as complete
+  GET    /api/tower/progress         → get Leader task graph progress
   GET    /api/tower/memory           → list tower memory entries
   DELETE /api/tower/memory/{key}     → forget a memory entry
 """
@@ -23,6 +26,10 @@ class GoalRequest(BaseModel):
     goal: str
 
 
+class MessageRequest(BaseModel):
+    message: str
+
+
 class TowerStatusResponse(BaseModel):
     status: str
     active_projects: int
@@ -31,6 +38,17 @@ class TowerStatusResponse(BaseModel):
     current_goal: str | None
     current_project_id: str | None
     current_session_id: str | None
+    output_line_count: int
+
+
+class TowerProgressResponse(BaseModel):
+    project_id: str | None
+    total: int
+    done: int
+    in_progress: int
+    todo: int
+    progress_pct: int
+    all_done: bool
 
 
 class MemoryEntry(BaseModel):
@@ -77,6 +95,7 @@ async def tower_status(request: Request) -> TowerStatusResponse:
         current_goal=controller_status["current_goal"],
         current_project_id=controller_status["current_project_id"],
         current_session_id=controller_status["current_session_id"],
+        output_line_count=controller_status.get("output_line_count", 0),
     )
 
 
@@ -106,6 +125,23 @@ async def submit_goal(body: GoalRequest, request: Request) -> dict:
     return result
 
 
+@router.post("/message")
+async def send_message(body: MessageRequest, request: Request) -> dict[str, str]:
+    """Send a message to the current Leader's terminal.
+
+    The Tower types this message into the Leader's Claude Code session,
+    allowing the user to communicate with the Leader through Tower.
+    """
+    tower = _get_tower(request)
+
+    try:
+        await tower.send_message(body.message)
+    except ValueError as exc:
+        raise HTTPException(status_code=409, detail=str(exc)) from exc
+
+    return {"status": "sent"}
+
+
 @router.post("/cancel")
 async def cancel_goal(request: Request) -> dict:
     """Cancel the current goal and stop the Leader session."""
@@ -116,6 +152,29 @@ async def cancel_goal(request: Request) -> dict:
 
     await tower.cancel_goal()
     return {"status": "cancelled"}
+
+
+@router.post("/complete")
+async def mark_complete(request: Request) -> dict[str, str]:
+    """Mark the current goal as complete and return Tower to idle."""
+    tower = _get_tower(request)
+
+    if tower.state.value != "managing":
+        raise HTTPException(
+            status_code=409,
+            detail=f"Cannot complete — Tower is {tower.state.value}, not managing",
+        )
+
+    await tower.mark_complete()
+    return {"status": "completed"}
+
+
+@router.get("/progress", response_model=TowerProgressResponse)
+async def get_progress(request: Request) -> TowerProgressResponse:
+    """Get the current Leader's task graph progress."""
+    tower = _get_tower(request)
+    progress = await tower.get_progress()
+    return TowerProgressResponse(**progress)
 
 
 @router.get("/memory", response_model=list[MemoryEntry])

--- a/src/atc/tower/controller.py
+++ b/src/atc/tower/controller.py
@@ -6,6 +6,13 @@ status changes through the event bus so the WebSocket hub can relay them
 to connected clients.
 
 Tower lifecycle states: idle → planning → managing → complete | error
+
+The full orchestration loop:
+  User → Tower.submit_goal() → start_leader() → Leader running
+  User → Tower.send_message() → send_leader_message() → Leader receives
+  Leader PTY output → Tower._on_leader_output() → broadcast to UI
+  Tower.get_progress() → Leader task graph status → broadcast to UI
+  Leader all done → Tower.mark_complete() → idle
 """
 
 from __future__ import annotations
@@ -16,7 +23,7 @@ import logging
 from typing import TYPE_CHECKING, Any
 
 from atc.leader.context_package import build_context_package
-from atc.leader.leader import start_leader, stop_leader
+from atc.leader.leader import send_leader_message, start_leader, stop_leader
 
 if TYPE_CHECKING:
     import aiosqlite
@@ -68,8 +75,13 @@ class TowerController:
         self._current_project_id: str | None = None
         self._current_session_id: str | None = None
 
+        # Track Leader output lines for monitoring
+        self._leader_output_lines: list[str] = []
+        self._max_output_lines = 200
+
         # Subscribe to leader session events for monitoring
         self._event_bus.subscribe("session_status_changed", self._on_session_status_changed)
+        self._event_bus.subscribe("pty_output", self._on_leader_output)
 
     @property
     def state(self) -> TowerState:
@@ -189,6 +201,7 @@ class TowerController:
         self._current_goal = None
         self._current_project_id = None
         self._current_session_id = None
+        self._leader_output_lines.clear()
 
     async def cancel_goal(self) -> None:
         """Cancel the current goal, stop the Leader, and return to idle."""
@@ -208,6 +221,7 @@ class TowerController:
             self._current_goal = None
             self._current_project_id = None
             self._current_session_id = None
+            self._leader_output_lines.clear()
 
             await self._event_bus.publish(
                 "tower_state_changed",
@@ -220,6 +234,7 @@ class TowerController:
         self._current_goal = None
         self._current_project_id = None
         self._current_session_id = None
+        self._leader_output_lines.clear()
 
     def get_status(self) -> dict[str, Any]:
         """Return the current tower controller status."""
@@ -228,7 +243,130 @@ class TowerController:
             "current_goal": self._current_goal,
             "current_project_id": self._current_project_id,
             "current_session_id": self._current_session_id,
+            "output_line_count": len(self._leader_output_lines),
         }
+
+    async def send_message(self, message: str) -> None:
+        """Send a message to the current Leader's terminal.
+
+        This is the Tower → Leader communication channel. The message is
+        typed into the Leader's Claude Code terminal just like a human
+        would, triggering the Leader to process the instruction.
+
+        Raises ``ValueError`` if no Leader is currently active.
+        """
+        if self._state != TowerState.MANAGING:
+            raise ValueError(f"Cannot send message — Tower is {self._state.value}, not managing")
+        if not self._current_project_id:
+            raise ValueError("No active project")
+
+        await send_leader_message(
+            self._db,
+            self._current_project_id,
+            message,
+            event_bus=self._event_bus,
+        )
+
+        logger.info("Tower sent message to Leader (project %s)", self._current_project_id)
+
+        if self._ws_hub is not None:
+            await self._ws_hub.broadcast(
+                "tower",
+                {
+                    "type": "message_sent",
+                    "project_id": self._current_project_id,
+                    "message": message,
+                },
+            )
+
+    async def get_progress(self) -> dict[str, Any]:
+        """Query the current Leader's task graph progress.
+
+        Returns a dict with task counts and completion percentage.
+        If no goal is active, returns an empty progress summary.
+        """
+        if not self._current_project_id or self._state != TowerState.MANAGING:
+            return {
+                "project_id": self._current_project_id,
+                "total": 0,
+                "done": 0,
+                "in_progress": 0,
+                "todo": 0,
+                "progress_pct": 0,
+                "all_done": False,
+            }
+
+        cursor = await self._db.execute(
+            "SELECT status, COUNT(*) as cnt FROM task_graphs "
+            "WHERE project_id = ? GROUP BY status",
+            (self._current_project_id,),
+        )
+        rows = await cursor.fetchall()
+
+        counts: dict[str, int] = {}
+        total = 0
+        for row in rows:
+            counts[row[0]] = row[1]
+            total += row[1]
+
+        done = counts.get("done", 0)
+        in_progress = counts.get("in_progress", 0)
+        todo = counts.get("todo", 0)
+        progress_pct = int((done / total) * 100) if total > 0 else 0
+        all_done = total > 0 and done == total
+
+        progress = {
+            "project_id": self._current_project_id,
+            "total": total,
+            "done": done,
+            "in_progress": in_progress,
+            "todo": todo,
+            "progress_pct": progress_pct,
+            "all_done": all_done,
+        }
+
+        # Broadcast progress to frontend
+        if self._ws_hub is not None:
+            await self._ws_hub.broadcast(
+                "tower",
+                {"type": "progress", **progress},
+            )
+
+        return progress
+
+    async def _on_leader_output(self, data: dict[str, Any]) -> None:
+        """Capture PTY output from the Leader session for monitoring.
+
+        Only captures output from the current Leader session. Stores
+        recent lines for the Tower to inspect and broadcasts a summary
+        event so the frontend can show activity indicators.
+        """
+        session_id = data.get("session_id")
+        if session_id != self._current_session_id:
+            return
+
+        raw = data.get("data", b"")
+        text = raw.decode("utf-8", errors="replace") if isinstance(raw, bytes) else str(raw)
+
+        # Store output lines (ring buffer)
+        lines = text.splitlines()
+        self._leader_output_lines.extend(lines)
+        if len(self._leader_output_lines) > self._max_output_lines:
+            self._leader_output_lines = self._leader_output_lines[-self._max_output_lines :]
+
+        # Broadcast a lightweight activity event for the Tower UI
+        if self._ws_hub is not None:
+            # Only broadcast non-empty, visible text
+            stripped = text.strip()
+            if stripped:
+                await self._ws_hub.broadcast(
+                    "tower",
+                    {
+                        "type": "leader_activity",
+                        "session_id": session_id,
+                        "preview": stripped[:200],
+                    },
+                )
 
     async def _on_session_status_changed(self, data: dict[str, Any]) -> None:
         """Monitor Leader session status changes for error detection."""

--- a/tests/unit/test_tower_controller.py
+++ b/tests/unit/test_tower_controller.py
@@ -84,10 +84,20 @@ class TestTowerState:
         tower._state = TowerState.MANAGING
         tower._current_goal = "test"
         tower._current_project_id = "proj-1"
+        tower._leader_output_lines = ["line1", "line2"]
         await tower.reset()
         assert tower.state == TowerState.IDLE
         assert tower.current_goal is None
         assert tower.current_project_id is None
+        assert tower._leader_output_lines == []
+
+    async def test_get_status_includes_output_line_count(self, tower: TowerController) -> None:
+        status = tower.get_status()
+        assert status["output_line_count"] == 0
+
+        tower._leader_output_lines = ["a", "b", "c"]
+        status = tower.get_status()
+        assert status["output_line_count"] == 3
 
 
 @patch("atc.tower.controller.start_leader", new_callable=AsyncMock, return_value="session-123")
@@ -134,9 +144,7 @@ class TestSubmitGoal:
         tower = TowerController(db, event_bus)
 
         states: list[str] = []
-        event_bus.subscribe(
-            "tower_state_changed", lambda d: states.append(d["new_state"])
-        )
+        event_bus.subscribe("tower_state_changed", lambda d: states.append(d["new_state"]))
 
         await tower.submit_goal(project.id, "Test goal")
 
@@ -285,3 +293,294 @@ class TestWebSocketBroadcast:
         states_broadcast = [c[0][1]["new_state"] for c in calls if "new_state" in c[0][1]]
         assert "planning" in states_broadcast
         assert "managing" in states_broadcast
+
+
+@patch(
+    "atc.tower.controller.send_leader_message",
+    new_callable=AsyncMock,
+)
+@patch("atc.tower.controller.start_leader", new_callable=AsyncMock, return_value="sess-1")
+@pytest.mark.asyncio
+class TestSendMessage:
+    async def test_send_message_success(
+        self, mock_start: AsyncMock, mock_send: AsyncMock, db, event_bus: EventBus
+    ) -> None:
+        project = await create_project(db, "test-proj")
+        await create_leader(db, project.id)
+        tower = TowerController(db, event_bus)
+
+        await tower.submit_goal(project.id, "Test goal")
+        await tower.send_message("Do the thing")
+
+        mock_send.assert_called_once_with(
+            db,
+            project.id,
+            "Do the thing",
+            event_bus=event_bus,
+        )
+
+    async def test_send_message_not_managing_raises(
+        self, mock_start: AsyncMock, mock_send: AsyncMock, db, event_bus: EventBus
+    ) -> None:
+        tower = TowerController(db, event_bus)
+        with pytest.raises(ValueError, match="not managing"):
+            await tower.send_message("Hello")
+
+    async def test_send_message_broadcasts_to_ws(
+        self, mock_start: AsyncMock, mock_send: AsyncMock, db, event_bus: EventBus
+    ) -> None:
+        ws_hub = AsyncMock()
+        project = await create_project(db, "test-proj")
+        await create_leader(db, project.id)
+        tower = TowerController(db, event_bus, ws_hub=ws_hub)
+
+        await tower.submit_goal(project.id, "Test goal")
+        ws_hub.broadcast.reset_mock()
+
+        await tower.send_message("Do something")
+
+        # Find the message_sent broadcast
+        msg_calls = [
+            c
+            for c in ws_hub.broadcast.call_args_list
+            if c[0][0] == "tower" and c[0][1].get("type") == "message_sent"
+        ]
+        assert len(msg_calls) == 1
+        assert msg_calls[0][0][1]["message"] == "Do something"
+
+
+@patch("atc.tower.controller.start_leader", new_callable=AsyncMock, return_value="sess-1")
+@pytest.mark.asyncio
+class TestGetProgress:
+    async def test_progress_no_active_goal(
+        self, mock_start: AsyncMock, db, event_bus: EventBus
+    ) -> None:
+        tower = TowerController(db, event_bus)
+        progress = await tower.get_progress()
+        assert progress["total"] == 0
+        assert progress["all_done"] is False
+
+    async def test_progress_with_tasks(
+        self, mock_start: AsyncMock, db, event_bus: EventBus
+    ) -> None:
+        import uuid
+
+        project = await create_project(db, "test-proj")
+        await create_leader(db, project.id)
+        tower = TowerController(db, event_bus)
+
+        await tower.submit_goal(project.id, "Build it")
+
+        # Insert some task_graph rows
+        for status in ["done", "done", "in_progress", "todo"]:
+            await db.execute(
+                "INSERT INTO task_graphs (id, project_id, title, status, "
+                "created_at, updated_at) VALUES (?, ?, ?, ?, datetime('now'), datetime('now'))",
+                (str(uuid.uuid4()), project.id, f"Task-{status}", status),
+            )
+        await db.commit()
+
+        progress = await tower.get_progress()
+        assert progress["total"] == 4
+        assert progress["done"] == 2
+        assert progress["in_progress"] == 1
+        assert progress["todo"] == 1
+        assert progress["progress_pct"] == 50
+        assert progress["all_done"] is False
+
+    async def test_progress_all_done(self, mock_start: AsyncMock, db, event_bus: EventBus) -> None:
+        import uuid
+
+        project = await create_project(db, "test-proj")
+        await create_leader(db, project.id)
+        tower = TowerController(db, event_bus)
+
+        await tower.submit_goal(project.id, "Build it")
+
+        # Insert all-done tasks
+        for _ in range(3):
+            await db.execute(
+                "INSERT INTO task_graphs (id, project_id, title, status, "
+                "created_at, updated_at) VALUES "
+                "(?, ?, ?, 'done', datetime('now'), datetime('now'))",
+                (str(uuid.uuid4()), project.id, "Done task"),
+            )
+        await db.commit()
+
+        progress = await tower.get_progress()
+        assert progress["all_done"] is True
+        assert progress["progress_pct"] == 100
+
+    async def test_progress_broadcasts_to_ws(
+        self, mock_start: AsyncMock, db, event_bus: EventBus
+    ) -> None:
+        ws_hub = AsyncMock()
+        project = await create_project(db, "test-proj")
+        await create_leader(db, project.id)
+        tower = TowerController(db, event_bus, ws_hub=ws_hub)
+
+        await tower.submit_goal(project.id, "Build it")
+        ws_hub.broadcast.reset_mock()
+
+        await tower.get_progress()
+
+        progress_calls = [
+            c
+            for c in ws_hub.broadcast.call_args_list
+            if c[0][0] == "tower" and c[0][1].get("type") == "progress"
+        ]
+        assert len(progress_calls) == 1
+
+
+@patch("atc.tower.controller.start_leader", new_callable=AsyncMock, return_value="sess-1")
+@pytest.mark.asyncio
+class TestLeaderOutput:
+    async def test_captures_leader_output(
+        self, mock_start: AsyncMock, db, event_bus: EventBus
+    ) -> None:
+        project = await create_project(db, "test-proj")
+        await create_leader(db, project.id)
+        tower = TowerController(db, event_bus)
+
+        await tower.submit_goal(project.id, "Test goal")
+
+        # Simulate PTY output from leader session
+        await event_bus.publish(
+            "pty_output",
+            {"session_id": "sess-1", "data": b"Working on task 1\n"},
+        )
+
+        assert len(tower._leader_output_lines) == 1
+        assert "Working on task 1" in tower._leader_output_lines[0]
+
+    async def test_ignores_other_session_output(
+        self, mock_start: AsyncMock, db, event_bus: EventBus
+    ) -> None:
+        project = await create_project(db, "test-proj")
+        await create_leader(db, project.id)
+        tower = TowerController(db, event_bus)
+
+        await tower.submit_goal(project.id, "Test goal")
+
+        # Output from a different session should be ignored
+        await event_bus.publish(
+            "pty_output",
+            {"session_id": "other-session", "data": b"Not for Tower\n"},
+        )
+
+        assert len(tower._leader_output_lines) == 0
+
+    async def test_output_ring_buffer(self, mock_start: AsyncMock, db, event_bus: EventBus) -> None:
+        project = await create_project(db, "test-proj")
+        await create_leader(db, project.id)
+        tower = TowerController(db, event_bus)
+        tower._max_output_lines = 5
+
+        await tower.submit_goal(project.id, "Test goal")
+
+        # Send more lines than the buffer size
+        for i in range(10):
+            await event_bus.publish(
+                "pty_output",
+                {"session_id": "sess-1", "data": f"Line {i}\n".encode()},
+            )
+
+        assert len(tower._leader_output_lines) == 5
+        assert "Line 9" in tower._leader_output_lines[-1]
+
+    async def test_output_broadcasts_activity_to_ws(
+        self, mock_start: AsyncMock, db, event_bus: EventBus
+    ) -> None:
+        ws_hub = AsyncMock()
+        project = await create_project(db, "test-proj")
+        await create_leader(db, project.id)
+        tower = TowerController(db, event_bus, ws_hub=ws_hub)
+
+        await tower.submit_goal(project.id, "Test goal")
+        ws_hub.broadcast.reset_mock()
+
+        await event_bus.publish(
+            "pty_output",
+            {"session_id": "sess-1", "data": b"Thinking about it...\n"},
+        )
+
+        activity_calls = [
+            c
+            for c in ws_hub.broadcast.call_args_list
+            if c[0][0] == "tower" and c[0][1].get("type") == "leader_activity"
+        ]
+        assert len(activity_calls) == 1
+        assert "Thinking about it" in activity_calls[0][0][1]["preview"]
+
+    async def test_output_handles_string_data(
+        self, mock_start: AsyncMock, db, event_bus: EventBus
+    ) -> None:
+        project = await create_project(db, "test-proj")
+        await create_leader(db, project.id)
+        tower = TowerController(db, event_bus)
+
+        await tower.submit_goal(project.id, "Test goal")
+
+        # String data (not bytes) should also work
+        await event_bus.publish(
+            "pty_output",
+            {"session_id": "sess-1", "data": "String output\n"},
+        )
+
+        assert len(tower._leader_output_lines) == 1
+
+    async def test_mark_complete_clears_output(
+        self, mock_start: AsyncMock, db, event_bus: EventBus
+    ) -> None:
+        project = await create_project(db, "test-proj")
+        await create_leader(db, project.id)
+        tower = TowerController(db, event_bus)
+
+        await tower.submit_goal(project.id, "Test goal")
+
+        await event_bus.publish(
+            "pty_output",
+            {"session_id": "sess-1", "data": b"Some output\n"},
+        )
+        assert len(tower._leader_output_lines) > 0
+
+        await tower.mark_complete()
+        assert tower._leader_output_lines == []
+
+    async def test_cancel_clears_output(
+        self, mock_start: AsyncMock, db, event_bus: EventBus
+    ) -> None:
+        with patch("atc.tower.controller.stop_leader", new_callable=AsyncMock):
+            project = await create_project(db, "test-proj")
+            await create_leader(db, project.id)
+            tower = TowerController(db, event_bus)
+
+            await tower.submit_goal(project.id, "Test goal")
+            tower._leader_output_lines = ["line1", "line2"]
+
+            await tower.cancel_goal()
+            assert tower._leader_output_lines == []
+
+    async def test_empty_output_not_broadcast(
+        self, mock_start: AsyncMock, db, event_bus: EventBus
+    ) -> None:
+        ws_hub = AsyncMock()
+        project = await create_project(db, "test-proj")
+        await create_leader(db, project.id)
+        tower = TowerController(db, event_bus, ws_hub=ws_hub)
+
+        await tower.submit_goal(project.id, "Test goal")
+        ws_hub.broadcast.reset_mock()
+
+        # Empty/whitespace-only output should not trigger broadcast
+        await event_bus.publish(
+            "pty_output",
+            {"session_id": "sess-1", "data": b"   \n  \n"},
+        )
+
+        activity_calls = [
+            c
+            for c in ws_hub.broadcast.call_args_list
+            if c[0][0] == "tower" and c[0][1].get("type") == "leader_activity"
+        ]
+        assert len(activity_calls) == 0


### PR DESCRIPTION
## Summary
- Add **Tower → Leader message sending** via `POST /tower/message` — Tower types instructions into Leader's Claude Code terminal
- Add **Leader output monitoring** — Tower captures PTY output from Leader session, maintains ring buffer, broadcasts activity events to frontend
- Add **Task progress tracking** via `GET /tower/progress` — Tower queries Leader's task graph completion status and broadcasts progress to UI
- Add **Goal completion** via `POST /tower/complete` — user can mark the current goal as done
- Add **TowerPanel message input bar** — below the terminal when Tower is managing, allows sending instructions to Leader
- Add **progress indicator** in Tower bar showing done/total tasks with percentage

## Architecture
Full orchestration loop:
```
User → Tower.submit_goal() → start_leader() → Leader running in tmux
User → Tower.send_message() → send_leader_message() → Leader receives instruction
Leader PTY output → Tower._on_leader_output() → WebSocket broadcast → UI activity indicator
Tower.get_progress() → task_graphs query → WebSocket broadcast → UI progress bar
User → Tower.mark_complete() → Tower idle
```

## Testing Done

### Backend unit tests (34 pass)
```
$ pytest tests/unit/test_tower_controller.py -x -q
..................................
34 passed in 0.42s
```

New test classes:
- `TestSendMessage` — success, not-managing error, WebSocket broadcast
- `TestGetProgress` — no active goal, with tasks, all done, WS broadcast
- `TestLeaderOutput` — capture, ignore other sessions, ring buffer, activity broadcast, string data, clear on complete/cancel, empty output filtering

### Frontend component tests (8 pass)
```
$ npx vitest run src/components/tower/__tests__/TowerPanel.test.tsx
Test Files  1 passed (1)
     Tests  8 passed (8)
```

### Full test suite (462 pass)
```
$ pytest tests/unit/ -x -q
462 passed in 17.58s
```

### Lint clean
```
$ ruff check src/atc/tower/controller.py src/atc/api/routers/tower.py tests/unit/test_tower_controller.py
All checks passed!
```

## Files changed (8 files, +759/-21)
- `src/atc/tower/controller.py` — send_message, get_progress, _on_leader_output, output buffer
- `src/atc/api/routers/tower.py` — POST /message, POST /complete, GET /progress endpoints
- `frontend/src/components/tower/TowerPanel.tsx` — message input bar, progress indicator, complete button
- `frontend/src/components/tower/TowerPanel.css` — message form + progress styles
- `frontend/src/context/AppContext.tsx` — tower progress + leader_activity event handlers
- `frontend/src/types/index.ts` — TowerProgress type, leader_activity_preview field
- `tests/unit/test_tower_controller.py` — 16 new tests
- `frontend/src/components/tower/__tests__/TowerPanel.test.tsx` — 8 new tests (new file)