### PR TITLE
fix: persist Tower panel across Dashboard and project pages

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,4 +1,4 @@
-import { BrowserRouter, Routes, Route, Navigate, Outlet } from "react-router-dom";
+import { BrowserRouter, Routes, Route, Navigate, Outlet, useLocation } from "react-router-dom";
 import { AppProvider } from "./context/AppContext";
 import TowerBar from "./components/tower/TowerBar";
 import TowerPanel from "./components/tower/TowerPanel";
@@ -7,14 +7,20 @@ import ProjectView from "./pages/ProjectView";
 import SettingsPage from "./pages/SettingsPage";
 import UsagePage from "./pages/UsagePage";
 
+/** Pages where the Tower panel should NOT appear */
+const HIDE_TOWER_PATHS = ["/settings", "/usage"];
+
 function Layout() {
+  const { pathname } = useLocation();
+  const showTower = !HIDE_TOWER_PATHS.includes(pathname);
+
   return (
     <>
       <TowerBar />
       <main style={{ flex: 1, overflow: "auto", minHeight: 0 }}>
         <Outlet />
       </main>
-      <TowerPanel />
+      {showTower && <TowerPanel />}
     </>
   );
 }

--- a/frontend/src/pages/ProjectView.tsx
+++ b/frontend/src/pages/ProjectView.tsx
@@ -1,7 +1,6 @@
 import { useParams } from "react-router-dom";
 import { useAppContext } from "../context/AppContext";
 import StatusBadge from "../components/common/StatusBadge";
-import TowerBanner from "../components/tower/TowerBanner";
 import LeaderConsole from "../components/leader/LeaderConsole";
 import TaskBoard from "../components/leader/TaskBoard";
 import AceList from "../components/ace/AceList";
@@ -10,7 +9,7 @@ import "./ProjectView.css";
 export default function ProjectView() {
   const { id } = useParams<{ id: string }>();
   const { state, fetchAll } = useAppContext();
-  const { projects, sessions, leaders, taskGraphs, brainStatus } = state;
+  const { projects, sessions, leaders, taskGraphs } = state;
 
   const project = projects.find((p) => p.id === id);
   const projectSessions = sessions.filter((s) => s.project_id === id);
@@ -39,9 +38,6 @@ export default function ProjectView() {
           <p className="project-view__desc">{project.description}</p>
         )}
       </div>
-
-      {/* Tower Banner — full width, minimizable */}
-      <TowerBanner towerStatus={brainStatus} />
 
       {/* Main 60/40 layout */}
       <div className="project-view__layout">

--- a/frontend/src/pages/__tests__/ProjectView.test.tsx
+++ b/frontend/src/pages/__tests__/ProjectView.test.tsx
@@ -52,11 +52,11 @@ describe("ProjectView", () => {
     expect(screen.getByText("Project not found.")).toBeInTheDocument();
   });
 
-  it("renders tower banner", () => {
+  it("renders without tower banner (Tower is in shell Layout)", () => {
     renderProjectView();
-    // Tower banner is always rendered (even for not-found view shows project-view wrapper)
-    // For a valid project, tower banner should be present
+    // TowerBanner was removed — Tower panel lives in the shell Layout now
     expect(screen.getByTestId("project-view")).toBeInTheDocument();
+    expect(screen.queryByTestId("tower-banner")).not.toBeInTheDocument();
   });
 
   it("contains the task board section", () => {


### PR DESCRIPTION
## Summary
- Remove duplicate TowerBanner from ProjectView — the persistent TowerPanel in the shell Layout already covers Tower functionality
- Hide TowerPanel on Settings and Usage pages (not relevant there)
- Update ProjectView test to verify TowerBanner is no longer rendered

## What changed
- **App.tsx**: Add `useLocation` to conditionally hide TowerPanel on `/settings` and `/usage` routes
- **ProjectView.tsx**: Remove TowerBanner import and usage (Layout TowerPanel provides consistent behavior)
- **ProjectView.test.tsx**: Update test name and assertion to reflect removal

## Test plan
- [x] All 164 frontend tests pass (`npx vitest run`)
- [x] No new TypeScript errors (`tsc --noEmit`)
- [ ] Manual: navigate Dashboard → project page → verify Tower panel persists and is expandable
- [ ] Manual: navigate to Settings/Usage → verify Tower panel is hidden

Generated with [Claude Code](https://claude.com/claude-code)