### PR TITLE
feat: add Makefile for simplified dev setup and workflow

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,34 @@
+.PHONY: setup dev test lint format clean help
+
+VENV := .venv
+PYTHON := $(VENV)/bin/python
+PIP := $(VENV)/bin/pip
+
+help: ## Show this help
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "  \033[36m%-15s\033[0m %s\n", $$1, $$2}'
+
+setup: ## Create venv, install all deps, set up pre-commit
+	python3.12 -m venv $(VENV)
+	$(PIP) install -e ".[dev]"
+	cd frontend && npm install
+	$(VENV)/bin/pre-commit install
+
+dev: ## Run backend + frontend dev servers
+	./scripts/dev.sh
+
+test: ## Run backend and frontend tests
+	$(PYTHON) -m pytest tests/
+	cd frontend && npm run test
+
+lint: ## Run all linters (ruff, mypy, eslint)
+	$(VENV)/bin/ruff check src/ tests/
+	$(VENV)/bin/mypy src/
+	cd frontend && npm run lint
+
+format: ## Auto-format Python and frontend code
+	$(VENV)/bin/ruff format src/ tests/
+	cd frontend && npm run format
+
+clean: ## Remove build artifacts and venv
+	rm -rf $(VENV) frontend/node_modules dist/ build/ *.egg-info
+	find . -type d -name __pycache__ -exec rm -rf {} + 2>/dev/null || true


### PR DESCRIPTION
## Summary
- Adds a Makefile with targets: `setup`, `dev`, `test`, `lint`, `format`, `clean`, and `help`
- `make setup && make dev` is all that's needed to get a dev environment running
- Replaces the multi-step manual setup process with a single command

## Targets
| Target | Description |
|--------|-------------|
| `make setup` | Creates venv, pip installs deps, npm installs frontend, sets up pre-commit |
| `make dev` | Runs `scripts/dev.sh` (backend + frontend) |
| `make test` | Runs pytest + vitest |
| `make lint` | Runs ruff, mypy, eslint |
| `make format` | Runs ruff format + prettier |
| `make clean` | Removes venv, node_modules, build artifacts |
| `make help` | Shows available targets |

## Test plan
- [ ] Run `make setup` on a fresh clone
- [ ] Run `make dev` and verify backend/frontend start
- [ ] Run `make test` and verify tests execute
- [ ] Run `make lint` and verify linters run

Generated with [Claude Code](https://claude.com/claude-code)