### PR TITLE
feat: in-app auto-updater via Tauri plugin

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -13,6 +13,9 @@
     "test:watch": "vitest"
   },
   "dependencies": {
+    "@tauri-apps/api": "^2.0.0",
+    "@tauri-apps/plugin-process": "^2.0.0",
+    "@tauri-apps/plugin-updater": "^2.0.0",
     "@tanstack/react-query": "^5.62.0",
     "@xterm/addon-fit": "^0.10.0",
     "@xterm/addon-webgl": "^0.18.0",

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -2,6 +2,8 @@ import { BrowserRouter, Routes, Route, Navigate, Outlet, useLocation } from "rea
 import { AppProvider } from "./context/AppContext";
 import TowerBar from "./components/tower/TowerBar";
 import TowerPanel from "./components/tower/TowerPanel";
+import UpdateBanner from "./components/common/UpdateBanner";
+import { useUpdater } from "./hooks/useUpdater";
 import Dashboard from "./pages/Dashboard";
 import ProjectView from "./pages/ProjectView";
 import SettingsPage from "./pages/SettingsPage";
@@ -13,12 +15,23 @@ const HIDE_TOWER_PATHS = ["/settings", "/usage"];
 function Layout() {
   const { pathname } = useLocation();
   const showTower = !HIDE_TOWER_PATHS.includes(pathname);
+  const updater = useUpdater();
 
   return (
     <>
+      {(updater.status === "available" || updater.status === "downloading") &&
+        updater.updateInfo && (
+          <UpdateBanner
+            updateInfo={updater.updateInfo}
+            status={updater.status}
+            progress={updater.progress}
+            onInstall={updater.downloadAndInstall}
+            onDismiss={updater.dismissUpdate}
+          />
+        )}
       <TowerBar />
       <main style={{ flex: 1, overflow: "auto", minHeight: 0 }}>
-        <Outlet />
+        <Outlet context={updater} />
       </main>
       {showTower && <TowerPanel />}
     </>

--- a/frontend/src/components/common/UpdateBanner.css
+++ b/frontend/src/components/common/UpdateBanner.css
@@ -1,0 +1,69 @@
+.update-banner {
+  background: var(--color-accent, #3b82f6);
+  color: #fff;
+  padding: var(--space-2) var(--space-4);
+  font-size: var(--text-sm);
+  z-index: 900;
+  flex-shrink: 0;
+}
+
+.update-banner__content {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--space-3);
+  max-width: 960px;
+  margin: 0 auto;
+}
+
+.update-banner__message {
+  font-weight: 500;
+}
+
+.update-banner__actions {
+  display: flex;
+  gap: var(--space-2);
+}
+
+.update-banner__btn {
+  border: none;
+  border-radius: 4px;
+  padding: 2px 10px;
+  font-size: var(--text-sm);
+  cursor: pointer;
+  font-weight: 500;
+}
+
+.update-banner__btn--install {
+  background: #fff;
+  color: var(--color-accent, #3b82f6);
+}
+
+.update-banner__btn--install:hover {
+  background: #e5e7eb;
+}
+
+.update-banner__btn--dismiss {
+  background: transparent;
+  color: #fff;
+  border: 1px solid rgba(255, 255, 255, 0.4);
+}
+
+.update-banner__btn--dismiss:hover {
+  border-color: #fff;
+}
+
+.update-banner__progress-bar {
+  width: 120px;
+  height: 4px;
+  background: rgba(255, 255, 255, 0.3);
+  border-radius: 2px;
+  overflow: hidden;
+}
+
+.update-banner__progress-fill {
+  height: 100%;
+  background: #fff;
+  border-radius: 2px;
+  transition: width 0.2s ease;
+}

--- a/frontend/src/components/common/UpdateBanner.tsx
+++ b/frontend/src/components/common/UpdateBanner.tsx
@@ -1,0 +1,56 @@
+import type { UpdateInfo } from "../../hooks/useUpdater";
+import "./UpdateBanner.css";
+
+interface UpdateBannerProps {
+  updateInfo: UpdateInfo;
+  status: "available" | "downloading";
+  progress: number;
+  onInstall: () => void;
+  onDismiss: () => void;
+}
+
+export default function UpdateBanner({
+  updateInfo,
+  status,
+  progress,
+  onInstall,
+  onDismiss,
+}: UpdateBannerProps) {
+  return (
+    <div className="update-banner" data-testid="update-banner">
+      <div className="update-banner__content">
+        <span className="update-banner__message">
+          {status === "downloading"
+            ? `Downloading v${updateInfo.version}... ${progress}%`
+            : `A new version is available: v${updateInfo.version}`}
+        </span>
+        {status === "available" && (
+          <div className="update-banner__actions">
+            <button
+              className="update-banner__btn update-banner__btn--install"
+              onClick={onInstall}
+              data-testid="update-install-btn"
+            >
+              Install & Restart
+            </button>
+            <button
+              className="update-banner__btn update-banner__btn--dismiss"
+              onClick={onDismiss}
+              data-testid="update-dismiss-btn"
+            >
+              Later
+            </button>
+          </div>
+        )}
+        {status === "downloading" && (
+          <div className="update-banner__progress-bar">
+            <div
+              className="update-banner__progress-fill"
+              style={{ width: `${progress}%` }}
+            />
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/common/__tests__/UpdateBanner.test.tsx
+++ b/frontend/src/components/common/__tests__/UpdateBanner.test.tsx
@@ -1,0 +1,47 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, it, expect, vi } from "vitest";
+import UpdateBanner from "../UpdateBanner";
+
+describe("UpdateBanner", () => {
+  const defaultProps = {
+    updateInfo: { version: "1.2.0" },
+    status: "available" as const,
+    progress: 0,
+    onInstall: vi.fn(),
+    onDismiss: vi.fn(),
+  };
+
+  it("shows version when update is available", () => {
+    render(<UpdateBanner {...defaultProps} />);
+    expect(screen.getByText(/v1\.2\.0/)).toBeInTheDocument();
+  });
+
+  it("shows Install & Restart button when available", () => {
+    render(<UpdateBanner {...defaultProps} />);
+    expect(screen.getByTestId("update-install-btn")).toBeInTheDocument();
+    expect(screen.getByTestId("update-dismiss-btn")).toBeInTheDocument();
+  });
+
+  it("calls onInstall when Install button clicked", async () => {
+    const onInstall = vi.fn();
+    render(<UpdateBanner {...defaultProps} onInstall={onInstall} />);
+    await userEvent.click(screen.getByTestId("update-install-btn"));
+    expect(onInstall).toHaveBeenCalledOnce();
+  });
+
+  it("calls onDismiss when Later button clicked", async () => {
+    const onDismiss = vi.fn();
+    render(<UpdateBanner {...defaultProps} onDismiss={onDismiss} />);
+    await userEvent.click(screen.getByTestId("update-dismiss-btn"));
+    expect(onDismiss).toHaveBeenCalledOnce();
+  });
+
+  it("shows download progress when downloading", () => {
+    render(
+      <UpdateBanner {...defaultProps} status="downloading" progress={42} />,
+    );
+    expect(screen.getByText(/42%/)).toBeInTheDocument();
+    expect(screen.queryByTestId("update-install-btn")).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/env.d.ts
+++ b/frontend/src/env.d.ts
@@ -1,0 +1,1 @@
+declare const __APP_VERSION__: string;

--- a/frontend/src/hooks/useUpdater.ts
+++ b/frontend/src/hooks/useUpdater.ts
@@ -1,0 +1,124 @@
+import { useState, useEffect, useCallback, useRef } from "react";
+
+/** How often to poll for updates (6 hours in ms) */
+const CHECK_INTERVAL_MS = 6 * 60 * 60 * 1000;
+
+export interface UpdateInfo {
+  version: string;
+  date?: string;
+  body?: string;
+}
+
+export type UpdateStatus =
+  | "idle"
+  | "checking"
+  | "available"
+  | "downloading"
+  | "error";
+
+export interface UseUpdaterReturn {
+  status: UpdateStatus;
+  updateInfo: UpdateInfo | null;
+  error: string | null;
+  progress: number;
+  checkForUpdates: () => Promise<void>;
+  downloadAndInstall: () => Promise<void>;
+  dismissUpdate: () => void;
+}
+
+/** Whether we're running inside a Tauri webview */
+function isTauri(): boolean {
+  return typeof window !== "undefined" && "__TAURI_INTERNALS__" in window;
+}
+
+export function useUpdater(): UseUpdaterReturn {
+  const [status, setStatus] = useState<UpdateStatus>("idle");
+  const [updateInfo, setUpdateInfo] = useState<UpdateInfo | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [progress, setProgress] = useState(0);
+  const updateRef = useRef<unknown>(null);
+
+  const checkForUpdates = useCallback(async () => {
+    if (!isTauri()) return;
+
+    setStatus("checking");
+    setError(null);
+    try {
+      const { check } = await import("@tauri-apps/plugin-updater");
+      const update = await check();
+      if (update) {
+        updateRef.current = update;
+        setUpdateInfo({
+          version: update.version,
+          date: update.date ?? undefined,
+          body: update.body ?? undefined,
+        });
+        setStatus("available");
+      } else {
+        setStatus("idle");
+      }
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Failed to check for updates");
+      setStatus("error");
+    }
+  }, []);
+
+  const downloadAndInstall = useCallback(async () => {
+    const update = updateRef.current as {
+      downloadAndInstall: (
+        cb?: (event: {
+          event: string;
+          data?: { contentLength?: number; chunkLength?: number };
+        }) => void,
+      ) => Promise<void>;
+    } | null;
+    if (!update) return;
+
+    setStatus("downloading");
+    setProgress(0);
+    try {
+      let totalBytes = 0;
+      let downloadedBytes = 0;
+      await update.downloadAndInstall((event) => {
+        if (event.event === "Started" && event.data?.contentLength) {
+          totalBytes = event.data.contentLength;
+        } else if (event.event === "Progress" && event.data?.chunkLength) {
+          downloadedBytes += event.data.chunkLength;
+          if (totalBytes > 0) {
+            setProgress(Math.round((downloadedBytes / totalBytes) * 100));
+          }
+        }
+      });
+      const { relaunch } = await import("@tauri-apps/plugin-process");
+      await relaunch();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Failed to install update");
+      setStatus("error");
+    }
+  }, []);
+
+  const dismissUpdate = useCallback(() => {
+    setStatus("idle");
+    setUpdateInfo(null);
+    updateRef.current = null;
+  }, []);
+
+  // Check on mount + every 6 hours
+  useEffect(() => {
+    if (!isTauri()) return;
+
+    checkForUpdates();
+    const interval = setInterval(checkForUpdates, CHECK_INTERVAL_MS);
+    return () => clearInterval(interval);
+  }, [checkForUpdates]);
+
+  return {
+    status,
+    updateInfo,
+    error,
+    progress,
+    checkForUpdates,
+    downloadAndInstall,
+    dismissUpdate,
+  };
+}

--- a/frontend/src/pages/SettingsPage.css
+++ b/frontend/src/pages/SettingsPage.css
@@ -65,6 +65,20 @@
   text-transform: capitalize;
 }
 
+/* About / Updates */
+
+.settings-page__update-actions {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  margin-top: var(--space-3);
+}
+
+.settings-page__up-to-date {
+  font-size: var(--text-sm);
+  color: var(--color-text-secondary);
+}
+
 /* Export / Import sections */
 
 .settings-page__description {

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -1,8 +1,12 @@
 import { useState, useRef, useEffect } from "react";
+import { useOutletContext } from "react-router-dom";
 import { useAppContext } from "../context/AppContext";
 import { api } from "../utils/api";
 import type { AgentProviderConfig, ProviderInfo } from "../types";
+import type { UseUpdaterReturn } from "../hooks/useUpdater";
 import "./SettingsPage.css";
+
+const APP_VERSION = __APP_VERSION__;
 
 const GITHUB_ORG_KEY = "atc:github_default_org";
 
@@ -19,6 +23,7 @@ interface ImportResult {
 
 export default function SettingsPage() {
   const { state } = useAppContext();
+  const updater = useOutletContext<UseUpdaterReturn | null>() ?? null;
   const [backendUrl] = useState("http://127.0.0.1:8420");
   const [githubOrg, setGithubOrg] = useState(
     () => localStorage.getItem(GITHUB_ORG_KEY) ?? "",
@@ -191,6 +196,46 @@ export default function SettingsPage() {
             <span className="settings-page__dot settings-page__dot--connected" />
             Connected
           </div>
+        </section>
+
+        <section
+          className="panel settings-page__section"
+          data-testid="about-section"
+        >
+          <h2>About</h2>
+          <div className="settings-page__info-row">
+            <span className="settings-page__label">Version</span>
+            <span className="settings-page__value" data-testid="app-version">
+              v{APP_VERSION}
+            </span>
+          </div>
+          {updater && (
+            <div className="settings-page__update-actions">
+              <button
+                className="btn"
+                onClick={() => updater.checkForUpdates()}
+                disabled={updater.status === "checking" || updater.status === "downloading"}
+                data-testid="check-updates-btn"
+              >
+                {updater.status === "checking" ? "Checking..." : "Check for Updates"}
+              </button>
+              {updater.status === "available" && updater.updateInfo && (
+                <span className="settings-page__success" data-testid="update-available">
+                  v{updater.updateInfo.version} available!
+                </span>
+              )}
+              {updater.status === "idle" && (
+                <span className="settings-page__up-to-date" data-testid="up-to-date">
+                  Up to date
+                </span>
+              )}
+              {updater.error && (
+                <span className="settings-page__error" data-testid="update-error">
+                  {updater.error}
+                </span>
+              )}
+            </div>
+          )}
         </section>
 
         <section className="panel settings-page__section">

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,8 +1,24 @@
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
+import { readFileSync } from "fs";
+import { resolve } from "path";
+
+function getAppVersion(): string {
+  try {
+    const tauriConf = JSON.parse(
+      readFileSync(resolve(__dirname, "../src-tauri/tauri.conf.json"), "utf-8"),
+    );
+    return tauriConf.version ?? "0.1.0";
+  } catch {
+    return "0.1.0";
+  }
+}
 
 export default defineConfig({
   plugins: [react()],
+  define: {
+    __APP_VERSION__: JSON.stringify(getAppVersion()),
+  },
   server: {
     port: 5173,
     proxy: {

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -3,6 +3,9 @@ import react from "@vitejs/plugin-react";
 
 export default defineConfig({
   plugins: [react()],
+  define: {
+    __APP_VERSION__: JSON.stringify("0.1.0"),
+  },
   test: {
     environment: "jsdom",
     globals: true,

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -5,3 +5,10 @@ edition = "2021"
 description = "ATC desktop shell"
 
 [dependencies]
+tauri = { version = "2", features = [] }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+
+[target.'cfg(any(target_os = "macos", windows, target_os = "linux"))'.dependencies]
+tauri-plugin-updater = "2"
+tauri-plugin-process = "2"

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "../gen/schemas/desktop-schema.json",
+  "identifier": "default",
+  "description": "Default capability for the ATC desktop shell",
+  "windows": ["main"],
+  "permissions": [
+    "core:default",
+    "updater:default",
+    "process:default"
+  ]
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,6 +1,17 @@
-// Tauri 2 desktop shell: sidecar spawn, health poll, port conflict resolution.
-// Stub — implementation follows in later tasks.
+// Tauri 2 desktop shell with auto-updater via tauri-plugin-updater.
 
-fn main() {
-    println!("ATC Tauri shell — not yet implemented");
+#[cfg_attr(mobile, tauri::mobile_entry_point)]
+pub fn run() {
+    tauri::Builder::default()
+        .setup(|app| {
+            #[cfg(desktop)]
+            {
+                app.handle()
+                    .plugin(tauri_plugin_updater::Builder::new().build())?;
+                app.handle().plugin(tauri_plugin_process::init())?;
+            }
+            Ok(())
+        })
+        .run(tauri::generate_context!())
+        .expect("error while running tauri application");
 }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -5,5 +5,16 @@
   "identifier": "com.atc.app",
   "build": {
     "frontendDist": "../frontend/dist"
+  },
+  "bundle": {
+    "createUpdaterArtifacts": true
+  },
+  "plugins": {
+    "updater": {
+      "pubkey": "",
+      "endpoints": [
+        "https://github.com/wowc8/atc/releases/latest/download/latest.json"
+      ]
+    }
   }
 }


### PR DESCRIPTION
## Summary
- Integrate `tauri-plugin-updater` and `tauri-plugin-process` in the Rust Tauri shell for auto-update capability
- Add `useUpdater` hook that checks for updates on launch and every 6 hours via GitHub Releases endpoint
- Add non-blocking `UpdateBanner` component at the top of the app when an update is available, with Install & Restart / Later actions and download progress
- Add About section to Settings page showing current version (`v0.1.0`) and a "Check for Updates" button
- Configure `tauri.conf.json` with updater plugin settings, bundle artifacts, and capabilities/permissions

## Test plan
- [x] All 169 existing tests pass (18 test files)
- [x] 5 new UpdateBanner tests pass (render, install click, dismiss click, download progress)
- [ ] Manual: verify banner appears when a newer release exists on GitHub
- [ ] Manual: verify "Check for Updates" button in Settings works
- [ ] Manual: verify version displayed matches `tauri.conf.json`
- [ ] Generate signing keys with `npm run tauri signer generate` and set `pubkey` in `tauri.conf.json` before release

🤖 Generated with [Claude Code](https://claude.com/claude-code)