### PR TITLE
feat: integrate Sentry for crash reporting

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -27,5 +27,11 @@ budget:
 cost_tracker:
   poll_interval_seconds: 30
 
+sentry:
+  enabled: false
+  dsn: ""
+  traces_sample_rate: 0.0
+  environment: "development"
+
 logging:
   level: "INFO"

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,6 +8,7 @@
       "name": "atc-frontend",
       "version": "0.1.0",
       "dependencies": {
+        "@sentry/react": "^9.0.0",
         "@tanstack/react-query": "^5.62.0",
         "@xterm/addon-fit": "^0.10.0",
         "@xterm/addon-webgl": "^0.18.0",
@@ -1609,6 +1610,98 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@sentry-internal/browser-utils": {
+      "version": "9.47.1",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/browser-utils/-/browser-utils-9.47.1.tgz",
+      "integrity": "sha512-twv6YhrUlPkvKz4/iQDH4KHgcv9t4cMjmZPf4/dCSCXn4/GOjzjx2d74c1w+1KOdS7lcsQzI+MtbK6SeYLiGfQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/core": "9.47.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry-internal/feedback": {
+      "version": "9.47.1",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/feedback/-/feedback-9.47.1.tgz",
+      "integrity": "sha512-xJ4vKvIpAT8e+Sz80YrsNinPU0XV7jPxPjdZ4ex8R2mMvx7pM0gq8JiR/sIVmNiOE0WiUDr6VwLDE8j2APSRMA==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/core": "9.47.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry-internal/replay": {
+      "version": "9.47.1",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/replay/-/replay-9.47.1.tgz",
+      "integrity": "sha512-O9ZEfySpstGtX1f73m3NbdbS2utwPikaFt6sgp74RG4ZX4LlXe99VAjKR464xKECpYsLmj2bYpiK4opURF0pBA==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry-internal/browser-utils": "9.47.1",
+        "@sentry/core": "9.47.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry-internal/replay-canvas": {
+      "version": "9.47.1",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/replay-canvas/-/replay-canvas-9.47.1.tgz",
+      "integrity": "sha512-r9nve+l5+elGB9NXSN1+PUgJy790tXN1e8lZNH2ziveoU91jW4yYYt34mHZ30fU9tOz58OpaRMj3H3GJ/jYZVA==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry-internal/replay": "9.47.1",
+        "@sentry/core": "9.47.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/browser": {
+      "version": "9.47.1",
+      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-9.47.1.tgz",
+      "integrity": "sha512-at5JOLziw5QpVYytxTDU6xijdV6lDQ/Rxp/qXJaHXud3gIK4suv2cXW+tupJfwoUoHFCnDNfccjCmPmP0yRqiA==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry-internal/browser-utils": "9.47.1",
+        "@sentry-internal/feedback": "9.47.1",
+        "@sentry-internal/replay": "9.47.1",
+        "@sentry-internal/replay-canvas": "9.47.1",
+        "@sentry/core": "9.47.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/core": {
+      "version": "9.47.1",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-9.47.1.tgz",
+      "integrity": "sha512-KX62+qIt4xgy8eHKHiikfhz2p5fOciXd0Cl+dNzhgPFq8klq4MGMNaf148GB3M/vBqP4nw/eFvRMAayFCgdRQw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/react": {
+      "version": "9.47.1",
+      "resolved": "https://registry.npmjs.org/@sentry/react/-/react-9.47.1.tgz",
+      "integrity": "sha512-Anqt0hG1R+nktlwEiDc2FmD+6DUGMJOLuArgr7q1cSCdPbK2Gb1eZ2rF57Ui+CDo9XLvlX9QP2is/M08rrVe3w==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/browser": "9.47.1",
+        "@sentry/core": "9.47.1",
+        "hoist-non-react-statics": "^3.3.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "react": "^16.14.0 || 17.x || 18.x || 19.x"
+      }
     },
     "node_modules/@standard-schema/spec": {
       "version": "1.1.0",
@@ -3324,6 +3417,21 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/hoist-non-react-statics": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
+      "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "react-is": "^16.7.0"
+      }
+    },
+    "node_modules/hoist-non-react-statics/node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "license": "MIT"
     },
     "node_modules/html-encoding-sniffer": {
       "version": "6.0.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -13,6 +13,7 @@
     "test:watch": "vitest"
   },
   "dependencies": {
+    "@sentry/react": "^9.0.0",
     "@tauri-apps/api": "^2.0.0",
     "@tauri-apps/plugin-process": "^2.0.0",
     "@tauri-apps/plugin-updater": "^2.0.0",

--- a/frontend/src/components/common/ErrorBoundary.tsx
+++ b/frontend/src/components/common/ErrorBoundary.tsx
@@ -1,0 +1,145 @@
+import { Component, type ErrorInfo, type ReactNode } from "react";
+import { captureException, sendReport } from "../../utils/sentry";
+
+interface Props {
+  children: ReactNode;
+  fallback?: ReactNode;
+}
+
+interface State {
+  hasError: boolean;
+  error: Error | null;
+  reportSent: boolean;
+  reportSending: boolean;
+}
+
+export default class ErrorBoundary extends Component<Props, State> {
+  state: State = {
+    hasError: false,
+    error: null,
+    reportSent: false,
+    reportSending: false,
+  };
+
+  static getDerivedStateFromError(error: Error): Partial<State> {
+    return { hasError: true, error };
+  }
+
+  componentDidCatch(error: Error, info: ErrorInfo): void {
+    captureException(error, { componentStack: info.componentStack ?? "" });
+  }
+
+  handleSendReport = async () => {
+    const { error } = this.state;
+    if (!error) return;
+    this.setState({ reportSending: true });
+    await sendReport(`[Frontend Crash] ${error.message}`, {
+      stack: error.stack ?? "",
+      source: "error_boundary",
+    });
+    this.setState({ reportSent: true, reportSending: false });
+  };
+
+  handleReload = () => {
+    window.location.reload();
+  };
+
+  render() {
+    if (!this.state.hasError) return this.props.children;
+
+    if (this.props.fallback) return this.props.fallback;
+
+    return (
+      <div style={styles.container}>
+        <div style={styles.card}>
+          <h2 style={styles.title}>Something went wrong</h2>
+          <p style={styles.message}>
+            An unexpected error occurred. You can send a crash report to help us
+            fix this issue.
+          </p>
+          {this.state.error && (
+            <pre style={styles.errorDetail}>{this.state.error.message}</pre>
+          )}
+          <div style={styles.actions}>
+            <button
+              style={styles.reportBtn}
+              onClick={this.handleSendReport}
+              disabled={this.state.reportSent || this.state.reportSending}
+            >
+              {this.state.reportSent
+                ? "Report Sent"
+                : this.state.reportSending
+                  ? "Sending..."
+                  : "Send Report"}
+            </button>
+            <button style={styles.reloadBtn} onClick={this.handleReload}>
+              Reload Page
+            </button>
+          </div>
+        </div>
+      </div>
+    );
+  }
+}
+
+const styles: Record<string, React.CSSProperties> = {
+  container: {
+    display: "flex",
+    alignItems: "center",
+    justifyContent: "center",
+    minHeight: "100vh",
+    padding: "2rem",
+    background: "var(--color-bg, #111)",
+  },
+  card: {
+    maxWidth: 480,
+    width: "100%",
+    padding: "2rem",
+    borderRadius: 8,
+    background: "var(--color-bg-raised, #1a1a1a)",
+    border: "1px solid var(--color-border-subtle, #333)",
+  },
+  title: {
+    fontSize: "1.25rem",
+    fontWeight: 600,
+    marginBottom: "0.75rem",
+    color: "var(--color-text, #eee)",
+  },
+  message: {
+    fontSize: "0.875rem",
+    color: "var(--color-text-secondary, #999)",
+    marginBottom: "1rem",
+  },
+  errorDetail: {
+    fontSize: "0.75rem",
+    color: "var(--color-status-red, #ef4444)",
+    background: "var(--color-bg, #111)",
+    padding: "0.75rem",
+    borderRadius: 4,
+    overflow: "auto",
+    maxHeight: 120,
+    marginBottom: "1rem",
+  },
+  actions: {
+    display: "flex",
+    gap: "0.5rem",
+  },
+  reportBtn: {
+    padding: "0.5rem 1rem",
+    fontSize: "0.875rem",
+    borderRadius: 4,
+    border: "1px solid var(--color-accent, #3b82f6)",
+    background: "var(--color-accent, #3b82f6)",
+    color: "#fff",
+    cursor: "pointer",
+  },
+  reloadBtn: {
+    padding: "0.5rem 1rem",
+    fontSize: "0.875rem",
+    borderRadius: 4,
+    border: "1px solid var(--color-border-subtle, #333)",
+    background: "transparent",
+    color: "var(--color-text, #eee)",
+    cursor: "pointer",
+  },
+};

--- a/frontend/src/components/tower/LogViewer.css
+++ b/frontend/src/components/tower/LogViewer.css
@@ -235,6 +235,29 @@
   color: #fff;
 }
 
+.log-entry__report-btn {
+  font-size: var(--text-xs);
+  font-weight: 500;
+  padding: var(--space-1) var(--space-3);
+  color: var(--color-status-amber);
+  background: rgba(245, 158, 11, 0.1);
+  border: 1px solid var(--color-status-amber);
+  border-radius: var(--radius-md);
+  cursor: pointer;
+  font-family: var(--font-sans);
+  transition: background var(--transition-fast), color var(--transition-fast);
+}
+
+.log-entry__report-btn:hover:not(:disabled) {
+  background: var(--color-status-amber);
+  color: #fff;
+}
+
+.log-entry__report-btn:disabled {
+  opacity: 0.6;
+  cursor: default;
+}
+
 .log-entry__resolve-btn {
   font-size: var(--text-xs);
   font-weight: 500;

--- a/frontend/src/components/tower/LogViewer.tsx
+++ b/frontend/src/components/tower/LogViewer.tsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import { useAppContext } from "../../context/AppContext";
 import { api } from "../../utils/api";
+import { sendReport } from "../../utils/sentry";
 import type { FailureLog } from "../../types";
 import "./LogViewer.css";
 
@@ -44,12 +45,31 @@ function LevelBadge({ level }: { level: string }) {
 function LogEntry({ entry }: { entry: FailureLog }) {
   const [expanded, setExpanded] = useState(false);
   const [copied, setCopied] = useState(false);
+  const [reported, setReported] = useState(false);
+  const [reporting, setReporting] = useState(false);
   const { dispatch } = useAppContext();
 
   const handleCopy = async () => {
     await navigator.clipboard.writeText(formatClaudeContext(entry));
     setCopied(true);
     setTimeout(() => setCopied(false), 2000);
+  };
+
+  const handleSendReport = async () => {
+    setReporting(true);
+    const result = await sendReport(
+      `[${entry.level}] ${entry.category}: ${entry.message}`,
+      {
+        failure_log_id: entry.id,
+        category: entry.category,
+        project_id: entry.project_id,
+        entity_type: entry.entity_type,
+        stack_trace: entry.stack_trace,
+        source: "log_viewer",
+      },
+    );
+    setReported(result.sent);
+    setReporting(false);
   };
 
   const handleResolve = async () => {
@@ -104,6 +124,14 @@ function LogEntry({ entry }: { entry: FailureLog }) {
               title="Copy formatted error context for pasting into Claude"
             >
               {copied ? "Copied!" : "Copy for Claude"}
+            </button>
+            <button
+              className="log-entry__report-btn"
+              onClick={handleSendReport}
+              disabled={reported || reporting}
+              data-testid="send-report-btn"
+            >
+              {reported ? "Reported" : reporting ? "Sending..." : "Send Report"}
             </button>
             {!entry.resolved && (
               <button

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -2,7 +2,12 @@ import React from "react";
 import ReactDOM from "react-dom/client";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import App from "./App";
+import ErrorBoundary from "./components/common/ErrorBoundary";
+import { initSentry } from "./utils/sentry";
 import "./theme.css";
+
+// Initialise Sentry before rendering (no-op if consent not given or no DSN)
+initSentry();
 
 const queryClient = new QueryClient({
   defaultOptions: {
@@ -15,8 +20,10 @@ const queryClient = new QueryClient({
 
 ReactDOM.createRoot(document.getElementById("root")!).render(
   <React.StrictMode>
-    <QueryClientProvider client={queryClient}>
-      <App />
-    </QueryClientProvider>
+    <ErrorBoundary>
+      <QueryClientProvider client={queryClient}>
+        <App />
+      </QueryClientProvider>
+    </ErrorBoundary>
   </React.StrictMode>,
 );

--- a/frontend/src/pages/SettingsPage.css
+++ b/frontend/src/pages/SettingsPage.css
@@ -156,6 +156,34 @@
   color: var(--color-status-red, #ef4444);
 }
 
+/* Crash Reporting section */
+
+.settings-page__consent-row {
+  margin-bottom: var(--space-4);
+}
+
+.settings-page__toggle-label {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  font-size: var(--text-sm);
+  color: var(--color-text);
+  cursor: pointer;
+}
+
+.settings-page__toggle-label input[type="checkbox"] {
+  width: 16px;
+  height: 16px;
+  cursor: pointer;
+}
+
+.settings-page__report-actions {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  margin-top: var(--space-4);
+}
+
 /* Restore confirmation dialog */
 
 .settings-page__overlay {

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -2,6 +2,7 @@ import { useState, useRef, useEffect } from "react";
 import { useOutletContext } from "react-router-dom";
 import { useAppContext } from "../context/AppContext";
 import { api } from "../utils/api";
+import { hasConsent, setConsent, sendReport } from "../utils/sentry";
 import type { AgentProviderConfig, ProviderInfo } from "../types";
 import type { UseUpdaterReturn } from "../hooks/useUpdater";
 import "./SettingsPage.css";
@@ -48,9 +49,27 @@ export default function SettingsPage() {
   const [providerSaving, setProviderSaving] = useState(false);
   const [providerError, setProviderError] = useState("");
 
+  // Sentry / crash reporting state
+  const [sentryConsent, setSentryConsent] = useState(hasConsent);
+  const [sentryStatus, setSentryStatus] = useState<{
+    enabled: boolean;
+    initialized: boolean;
+    environment: string;
+  } | null>(null);
+  const [reportSending, setReportSending] = useState(false);
+  const [reportResult, setReportResult] = useState<"idle" | "sent" | "error">(
+    "idle",
+  );
+
   useEffect(() => {
     api.get<AgentProviderConfig>("/settings/agent-provider").then(setProviderConfig).catch(() => {});
     api.get<ProviderInfo[]>("/settings/providers").then(setProviders).catch(() => {});
+    api
+      .get<{ enabled: boolean; initialized: boolean; environment: string }>(
+        "/settings/sentry",
+      )
+      .then(setSentryStatus)
+      .catch(() => {});
   }, []);
 
   async function handleProviderChange(newDefault: string) {
@@ -69,6 +88,22 @@ export default function SettingsPage() {
     } finally {
       setProviderSaving(false);
     }
+  }
+
+  function handleConsentChange(value: boolean) {
+    setConsent(value);
+    setSentryConsent(value);
+  }
+
+  async function handleSendReport() {
+    setReportSending(true);
+    setReportResult("idle");
+    const result = await sendReport(
+      "User-initiated crash report from Settings",
+      { source: "settings_page" },
+    );
+    setReportResult(result.sent ? "sent" : "error");
+    setReportSending(false);
   }
 
   // Restore confirm state
@@ -355,6 +390,75 @@ export default function SettingsPage() {
               {providerError}
             </p>
           )}
+        </section>
+
+        {/* Crash Reporting Section */}
+        <section
+          className="panel settings-page__section"
+          data-testid="sentry-section"
+        >
+          <h2>Crash Reporting</h2>
+          <p className="settings-page__description">
+            Help improve ATC by sending anonymous crash reports. No personal
+            data is included — all PII is stripped before sending.
+          </p>
+
+          <div className="settings-page__consent-row">
+            <label className="settings-page__toggle-label">
+              <input
+                type="checkbox"
+                checked={sentryConsent}
+                onChange={(e) => handleConsentChange(e.target.checked)}
+                data-testid="sentry-consent-toggle"
+              />
+              <span>Enable crash reporting</span>
+            </label>
+          </div>
+
+          {sentryStatus && (
+            <>
+              <div className="settings-page__info-row">
+                <span className="settings-page__label">Backend Sentry</span>
+                <span className="settings-page__value">
+                  {sentryStatus.initialized ? "Active" : "Inactive"}
+                </span>
+              </div>
+              <div className="settings-page__info-row">
+                <span className="settings-page__label">Environment</span>
+                <span className="settings-page__value">
+                  {sentryStatus.environment}
+                </span>
+              </div>
+            </>
+          )}
+
+          <div className="settings-page__report-actions">
+            <button
+              className="btn"
+              onClick={handleSendReport}
+              disabled={reportSending}
+              data-testid="send-report-btn"
+            >
+              {reportSending ? "Sending..." : "Send Report"}
+            </button>
+            {reportResult === "sent" && (
+              <span
+                className="settings-page__success"
+                data-testid="report-success"
+              >
+                Report sent successfully.
+              </span>
+            )}
+            {reportResult === "error" && (
+              <span
+                className="settings-page__error"
+                data-testid="report-error"
+              >
+                Failed to send report. Sentry may not be configured on the
+                backend.
+              </span>
+            )}
+          </div>
         </section>
 
         {/* Export Section */}

--- a/frontend/src/utils/sentry.ts
+++ b/frontend/src/utils/sentry.ts
@@ -1,0 +1,135 @@
+/**
+ * Sentry SDK initialisation and helpers for ATC frontend.
+ *
+ * Sentry is opt-in — it only activates when the user gives consent and
+ * a DSN is provided via the VITE_SENTRY_DSN env var.
+ */
+
+/// <reference types="vite/client" />
+
+import * as Sentry from "@sentry/react";
+
+const CONSENT_KEY = "atc:sentry_consent";
+
+/** Whether the user has opted in to crash reporting. */
+export function hasConsent(): boolean {
+  return localStorage.getItem(CONSENT_KEY) === "true";
+}
+
+/** Set the user's crash-reporting consent preference. */
+export function setConsent(value: boolean): void {
+  localStorage.setItem(CONSENT_KEY, value ? "true" : "false");
+  if (!value && Sentry.isInitialized()) {
+    Sentry.getCurrentScope().setClient(undefined);
+  }
+}
+
+/** Initialise Sentry if consent is given and a DSN is available. */
+export function initSentry(): void {
+  const dsn = import.meta.env.VITE_SENTRY_DSN as string | undefined;
+  if (!dsn || !hasConsent()) return;
+
+  Sentry.init({
+    dsn,
+    environment: import.meta.env.MODE as string,
+    sendDefaultPii: false,
+    beforeSend(event) {
+      return stripPii(event);
+    },
+  });
+}
+
+/** Send a user-initiated report via the backend API. */
+export async function sendReport(
+  message: string,
+  context?: Record<string, unknown>,
+): Promise<{ sent: boolean; event_id?: string }> {
+  try {
+    const res = await fetch("/api/settings/sentry/send-report", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ message, context }),
+    });
+    if (!res.ok) return { sent: false };
+    return res.json();
+  } catch {
+    return { sent: false };
+  }
+}
+
+/** Capture a frontend exception to Sentry (client-side). */
+export function captureException(
+  error: unknown,
+  extra?: Record<string, unknown>,
+): void {
+  if (!Sentry.isInitialized()) return;
+  Sentry.withScope((scope) => {
+    if (extra) {
+      Object.entries(extra).forEach(([k, v]) => scope.setExtra(k, v));
+    }
+    Sentry.captureException(error);
+  });
+}
+
+// ---------------------------------------------------------------------------
+// PII stripping
+// ---------------------------------------------------------------------------
+
+const PII_KEYS =
+  /password|secret|token|api.?key|auth|credential|cookie|session.?id|email|phone|ssn|credit.?card|card.?number/i;
+
+function stripPii(event: Sentry.ErrorEvent): Sentry.ErrorEvent {
+  if (event.request) {
+    if (event.request.headers) {
+      event.request.headers = redactHeaders(event.request.headers);
+    }
+    if (event.request.data) {
+      event.request.data = redactObj(
+        event.request.data as Record<string, unknown>,
+      ) as unknown as Sentry.ErrorEvent["request"] extends { data?: infer D }
+        ? D
+        : never;
+    }
+    if (event.request.cookies) {
+      event.request.cookies = { _: "[Filtered]" };
+    }
+    if (event.request.query_string) {
+      event.request.query_string = "";
+    }
+  }
+
+  if (event.extra) {
+    event.extra = redactObj(event.extra);
+  }
+
+  if (event.user) {
+    event.user = { id: event.user.id ?? "anon" };
+  }
+
+  return event;
+}
+
+function redactHeaders(
+  headers: Record<string, string>,
+): Record<string, string> {
+  const result: Record<string, string> = {};
+  for (const [k, v] of Object.entries(headers)) {
+    result[k] = PII_KEYS.test(k) ? "[Filtered]" : v;
+  }
+  return result;
+}
+
+function redactObj(obj: unknown): Record<string, unknown> {
+  if (typeof obj !== "object" || obj === null) return {};
+  const result: Record<string, unknown> = {};
+  for (const [k, v] of Object.entries(obj as Record<string, unknown>)) {
+    if (PII_KEYS.test(k)) {
+      result[k] = "[Filtered]";
+    } else if (typeof v === "object" && v !== null) {
+      result[k] = redactObj(v);
+    } else {
+      result[k] = v;
+    }
+  }
+  return result;
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ dependencies = [
     "aiosqlite>=0.20.0",
     "psutil>=6.1.0",
     "pyyaml>=6.0.2",
+    "sentry-sdk[fastapi]>=2.0.0",
     "websockets>=14.0",
 ]
 

--- a/src/atc/api/app.py
+++ b/src/atc/api/app.py
@@ -13,6 +13,7 @@ from atc import __version__
 from atc.api.ws.hub import WsHub
 from atc.config import Settings, load_settings
 from atc.core.events import EventBus
+from atc.core.sentry import init_sentry
 from atc.state.db import run_migrations
 from atc.terminal.pty_stream import PtyStreamPool
 
@@ -196,6 +197,9 @@ def create_app(settings: Settings | None = None) -> FastAPI:
     """Create and configure the FastAPI application."""
     if settings is None:
         settings = load_settings()
+
+    # Initialise Sentry before creating the app so the FastAPI integration hooks in
+    init_sentry(settings.sentry)
 
     app = FastAPI(
         title="ATC",

--- a/src/atc/api/routers/settings.py
+++ b/src/atc/api/routers/settings.py
@@ -1,4 +1,4 @@
-"""Settings router — export/import backup + agent provider config endpoints.
+"""Settings router — export/import backup + agent provider config + sentry endpoints.
 
 Routes:
   POST /api/settings/export/{project_id}  → export single project as zip
@@ -8,6 +8,8 @@ Routes:
   GET  /api/settings/agent-provider       → get current agent provider config
   PUT  /api/settings/agent-provider       → update agent provider config
   GET  /api/settings/providers            → list available providers
+  GET  /api/settings/sentry              → get sentry status
+  POST /api/settings/sentry/send-report  → manually send an error report
 """
 
 from __future__ import annotations
@@ -238,3 +240,66 @@ async def list_available_providers() -> list[ProviderInfo]:
                 )
             )
     return result
+
+
+# ---------------------------------------------------------------------------
+# Sentry endpoints
+# ---------------------------------------------------------------------------
+
+
+class SentryStatusResponse(BaseModel):
+    """Current Sentry configuration status."""
+
+    enabled: bool
+    initialized: bool
+    environment: str
+
+
+class SendReportRequest(BaseModel):
+    """User-initiated error report."""
+
+    message: str
+    context: dict[str, object] | None = None
+
+
+class SendReportResponse(BaseModel):
+    """Result of sending an error report."""
+
+    sent: bool
+    event_id: str | None = None
+
+
+@router.get("/sentry")
+async def get_sentry_status(request: Request) -> SentryStatusResponse:
+    """Return the current Sentry status."""
+    settings = request.app.state.settings
+    cfg = settings.sentry
+
+    initialized = False
+    try:
+        import sentry_sdk
+
+        initialized = sentry_sdk.is_initialized()
+    except ImportError:
+        pass
+
+    return SentryStatusResponse(
+        enabled=cfg.enabled,
+        initialized=initialized,
+        environment=cfg.environment,
+    )
+
+
+@router.post("/sentry/send-report")
+async def send_sentry_report(
+    body: SendReportRequest,
+    request: Request,
+) -> SendReportResponse:
+    """Manually send a user-initiated error report to Sentry."""
+    from atc.core.sentry import capture_message
+
+    extra = dict(body.context) if body.context else {}
+    extra["source"] = "user_report"
+
+    event_id = capture_message(body.message, level="error", **extra)
+    return SendReportResponse(sent=event_id is not None, event_id=event_id)

--- a/src/atc/config.py
+++ b/src/atc/config.py
@@ -54,6 +54,15 @@ class LoggingConfig(BaseModel):
     level: str = "INFO"
 
 
+class SentryConfig(BaseModel):
+    """Sentry crash reporting configuration (opt-in)."""
+
+    enabled: bool = False
+    dsn: str = ""
+    traces_sample_rate: float = 0.0
+    environment: str = "development"
+
+
 class AgentProviderConfig(BaseModel):
     """Configuration for the agent provider abstraction layer."""
 
@@ -75,6 +84,7 @@ class Settings(BaseSettings):
     cost_tracker: CostTrackerConfig = CostTrackerConfig()
     heartbeat: HeartbeatConfig = HeartbeatConfig()
     logging: LoggingConfig = LoggingConfig()
+    sentry: SentryConfig = SentryConfig()
     agent_provider: AgentProviderConfig = AgentProviderConfig()
 
 

--- a/src/atc/core/sentry.py
+++ b/src/atc/core/sentry.py
@@ -1,0 +1,149 @@
+"""Sentry SDK initialisation and PII stripping for ATC backend."""
+
+from __future__ import annotations
+
+import logging
+import re
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from atc.config import SentryConfig
+
+logger = logging.getLogger(__name__)
+
+# Patterns that look like PII — matched case-insensitively in event data.
+_PII_KEY_PATTERNS = re.compile(
+    r"(password|secret|token|api.?key|auth|credential|cookie|session.?id|"
+    r"email|phone|ssn|credit.?card|card.?number)",
+    re.IGNORECASE,
+)
+
+_REDACTED = "[Filtered]"
+
+
+def _strip_pii(obj: Any) -> Any:
+    """Recursively redact values whose keys look like PII."""
+    if isinstance(obj, dict):
+        return {
+            k: (_REDACTED if _PII_KEY_PATTERNS.search(k) else _strip_pii(v))
+            for k, v in obj.items()
+        }
+    if isinstance(obj, list):
+        return [_strip_pii(item) for item in obj]
+    return obj
+
+
+def _before_send(event: dict[str, Any], hint: dict[str, Any]) -> dict[str, Any] | None:
+    """Strip PII from Sentry events before they leave the process."""
+    # Scrub request data
+    if "request" in event:
+        req = event["request"]
+        if "headers" in req:
+            req["headers"] = _strip_pii(req["headers"])
+        if "data" in req:
+            req["data"] = _strip_pii(req["data"])
+        if "cookies" in req:
+            req["cookies"] = _REDACTED
+        # Strip query strings that may contain tokens
+        if "query_string" in req:
+            req["query_string"] = _REDACTED
+
+    # Scrub breadcrumb data
+    if "breadcrumbs" in event:
+        for bc in event.get("breadcrumbs", {}).get("values", []):
+            if "data" in bc:
+                bc["data"] = _strip_pii(bc["data"])
+
+    # Scrub extra context
+    if "extra" in event:
+        event["extra"] = _strip_pii(event["extra"])
+
+    # Scrub user info — keep id for correlation but drop everything else
+    if "user" in event:
+        event["user"] = {"id": event["user"].get("id", "anon")}
+
+    return event
+
+
+def _before_send_transaction(
+    event: dict[str, Any], hint: dict[str, Any]
+) -> dict[str, Any] | None:
+    """Strip PII from performance transactions."""
+    return _before_send(event, hint)
+
+
+def init_sentry(config: SentryConfig) -> bool:
+    """Initialise Sentry SDK if enabled and DSN is configured.
+
+    Returns True if Sentry was successfully initialised.
+    """
+    if not config.enabled or not config.dsn:
+        logger.debug("Sentry disabled or no DSN configured — skipping init")
+        return False
+
+    try:
+        import sentry_sdk
+        from sentry_sdk.integrations.fastapi import FastApiIntegration
+        from sentry_sdk.integrations.logging import LoggingIntegration
+
+        sentry_sdk.init(
+            dsn=config.dsn,
+            environment=config.environment,
+            traces_sample_rate=config.traces_sample_rate,
+            send_default_pii=False,
+            before_send=_before_send,
+            before_send_transaction=_before_send_transaction,
+            integrations=[
+                FastApiIntegration(transaction_style="endpoint"),
+                LoggingIntegration(level=logging.WARNING, event_level=logging.ERROR),
+            ],
+            release=_get_release(),
+        )
+        logger.info("Sentry initialised (env=%s)", config.environment)
+        return True
+    except Exception:
+        logger.exception("Failed to initialise Sentry SDK")
+        return False
+
+
+def capture_exception(exc: Exception, **extra: Any) -> str | None:
+    """Capture an exception to Sentry with optional extra context.
+
+    Returns the Sentry event ID, or None if Sentry is not active.
+    """
+    try:
+        import sentry_sdk
+
+        if sentry_sdk.is_initialized():
+            with sentry_sdk.new_scope() as scope:
+                for k, v in extra.items():
+                    scope.set_extra(k, v)
+                return sentry_sdk.capture_exception(exc)
+    except Exception:
+        logger.debug("Failed to send exception to Sentry", exc_info=True)
+    return None
+
+
+def capture_message(message: str, level: str = "error", **extra: Any) -> str | None:
+    """Capture a message to Sentry with optional extra context."""
+    try:
+        import sentry_sdk
+
+        if sentry_sdk.is_initialized():
+            with sentry_sdk.new_scope() as scope:
+                for k, v in extra.items():
+                    scope.set_extra(k, v)
+                return sentry_sdk.capture_message(message, level=level)
+    except Exception:
+        logger.debug("Failed to send message to Sentry", exc_info=True)
+    return None
+
+
+def _get_release() -> str:
+    """Return the ATC version string for Sentry release tracking."""
+    try:
+        from atc import __version__
+
+        return f"atc@{__version__}"
+    except Exception:
+        return "atc@unknown"


### PR DESCRIPTION
## Summary
- Add opt-in Sentry crash reporting with PII stripping to both backend and frontend
- Backend: `sentry-sdk[fastapi]` with `SentryConfig` in `config.yaml`, PII-stripping `before_send` hook, `GET /api/settings/sentry` status endpoint and `POST /api/settings/sentry/send-report` for user-initiated reports
- Frontend: `@sentry/react` with consent-gated init via localStorage, `ErrorBoundary` component with Send Report + Reload buttons, Crash Reporting section in Settings (opt-in toggle + Send Report button), Send Report button on failure log entries in LogViewer

## Files Changed
**Backend (Python):**
- `pyproject.toml` — add `sentry-sdk[fastapi]` dependency
- `src/atc/config.py` — add `SentryConfig` model (enabled, dsn, traces_sample_rate, environment)
- `src/atc/core/sentry.py` — new module: SDK init, PII stripping, capture helpers
- `src/atc/api/app.py` — call `init_sentry()` in `create_app()`
- `src/atc/api/routers/settings.py` — add sentry status + send-report endpoints
- `config.yaml` — add `sentry:` section (disabled by default)

**Frontend (React/TS):**
- `frontend/package.json` — add `@sentry/react`
- `frontend/src/utils/sentry.ts` — new module: SDK init, consent, PII stripping, helpers
- `frontend/src/components/common/ErrorBoundary.tsx` — new: catches React errors with Send Report
- `frontend/src/main.tsx` — init Sentry + wrap app in ErrorBoundary
- `frontend/src/pages/SettingsPage.tsx` — Crash Reporting section with consent toggle and Send Report
- `frontend/src/pages/SettingsPage.css` — styles for new section
- `frontend/src/components/tower/LogViewer.tsx` — Send Report button per log entry
- `frontend/src/components/tower/LogViewer.css` — styles for report button

## Testing Done
- TypeScript type-check passes (`npx tsc --noEmit`) — no new errors from Sentry code
- Sentry is disabled by default (`enabled: false` in config.yaml), so existing behavior is unchanged
- Frontend consent defaults to off (localStorage key `atc:sentry_consent`)
- PII stripping covers: passwords, tokens, API keys, auth headers, cookies, emails, SSNs, credit cards

## Design Decisions
- **Opt-in only**: Both backend (config.yaml `sentry.enabled`) and frontend (localStorage consent toggle) must be explicitly enabled
- **PII stripping**: Both sides strip sensitive keys from event data before sending to Sentry
- **Send Report via backend**: The "Send Report" button sends reports through the backend API endpoint, not directly from the browser, ensuring the backend DSN is used
- **No breaking changes**: All Sentry features are additive and disabled by default