### PR TITLE
Add heartbeat protocol for Leader/Ace health monitoring

### DIFF
--- a/frontend/src/components/ace/AceList.tsx
+++ b/frontend/src/components/ace/AceList.tsx
@@ -1,8 +1,10 @@
 import { useState } from "react";
 import { api } from "../../utils/api";
 import StatusBadge from "../common/StatusBadge";
+import HealthIndicator from "../common/HealthIndicator";
 import ConfirmPopover from "../common/ConfirmPopover";
 import AceTerminal from "./AceTerminal";
+import { useAppContext } from "../../context/AppContext";
 import type { Session } from "../../types";
 import "./AceList.css";
 
@@ -19,6 +21,7 @@ export default function AceList({
   onRefresh,
   compact = false,
 }: AceListProps) {
+  const { state } = useAppContext();
   const [newName, setNewName] = useState("");
   const [creating, setCreating] = useState(false);
   const [selectedId, setSelectedId] = useState<string | null>(null);
@@ -102,6 +105,7 @@ export default function AceList({
                 <div className="ace-list__mini-header">
                   <span className="ace-list__mini-name">{session.name}</span>
                   <StatusBadge status={session.status} size="sm" />
+                  <HealthIndicator health={state.heartbeats[session.id]?.health} />
                 </div>
                 <div className="ace-list__mini-terminal">
                   <AceTerminal key={session.id} session={session} />
@@ -170,6 +174,7 @@ export default function AceList({
               >
                 <span>{session.name}</span>
                 <StatusBadge status={session.status} size="sm" />
+                <HealthIndicator health={state.heartbeats[session.id]?.health} />
               </button>
               <div className="ace-list__tab-actions">
                 {!isRunning(session) ? (

--- a/frontend/src/components/common/HealthIndicator.css
+++ b/frontend/src/components/common/HealthIndicator.css
@@ -1,0 +1,29 @@
+.health-indicator {
+  display: inline-flex;
+  align-items: center;
+  margin-left: 4px;
+}
+
+.health-indicator__dot {
+  display: inline-block;
+  border-radius: 50%;
+}
+
+.health-indicator--sm .health-indicator__dot {
+  width: 6px;
+  height: 6px;
+}
+
+.health-indicator--md .health-indicator__dot {
+  width: 8px;
+  height: 8px;
+}
+
+.health-indicator__dot--pulse {
+  animation: health-pulse 2s ease-in-out infinite;
+}
+
+@keyframes health-pulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.4; }
+}

--- a/frontend/src/components/common/HealthIndicator.tsx
+++ b/frontend/src/components/common/HealthIndicator.tsx
@@ -1,0 +1,41 @@
+import "./HealthIndicator.css";
+
+interface HealthIndicatorProps {
+  health: "alive" | "stale" | "stopped" | undefined;
+  size?: "sm" | "md";
+}
+
+const healthColors: Record<string, string> = {
+  alive: "var(--color-status-green)",
+  stale: "var(--color-status-amber)",
+  stopped: "var(--color-status-red)",
+};
+
+const healthLabels: Record<string, string> = {
+  alive: "healthy",
+  stale: "stale",
+  stopped: "stopped",
+};
+
+export default function HealthIndicator({
+  health,
+  size = "sm",
+}: HealthIndicatorProps) {
+  if (!health) return null;
+
+  const color = healthColors[health] ?? "var(--color-text-muted)";
+  const label = healthLabels[health] ?? health;
+
+  return (
+    <span
+      className={`health-indicator health-indicator--${size}`}
+      data-testid="health-indicator"
+      title={`Heartbeat: ${label}`}
+    >
+      <span
+        className={`health-indicator__dot ${health === "alive" ? "health-indicator__dot--pulse" : ""}`}
+        style={{ background: color }}
+      />
+    </span>
+  );
+}

--- a/frontend/src/components/common/__tests__/HealthIndicator.test.tsx
+++ b/frontend/src/components/common/__tests__/HealthIndicator.test.tsx
@@ -1,0 +1,50 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import HealthIndicator from "../HealthIndicator";
+
+describe("HealthIndicator", () => {
+  it("renders nothing when health is undefined", () => {
+    const { container } = render(<HealthIndicator health={undefined} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("renders a dot for alive health", () => {
+    render(<HealthIndicator health="alive" />);
+    const indicator = screen.getByTestId("health-indicator");
+    expect(indicator).toBeTruthy();
+    const dot = indicator.querySelector(".health-indicator__dot");
+    expect(dot?.className).toContain("health-indicator__dot--pulse");
+  });
+
+  it("renders without pulse for stale health", () => {
+    render(<HealthIndicator health="stale" />);
+    const indicator = screen.getByTestId("health-indicator");
+    const dot = indicator.querySelector(".health-indicator__dot");
+    expect(dot?.className).not.toContain("health-indicator__dot--pulse");
+  });
+
+  it("renders without pulse for stopped health", () => {
+    render(<HealthIndicator health="stopped" />);
+    const indicator = screen.getByTestId("health-indicator");
+    const dot = indicator.querySelector(".health-indicator__dot");
+    expect(dot?.className).not.toContain("health-indicator__dot--pulse");
+  });
+
+  it("supports sm size", () => {
+    render(<HealthIndicator health="alive" size="sm" />);
+    const indicator = screen.getByTestId("health-indicator");
+    expect(indicator.className).toContain("health-indicator--sm");
+  });
+
+  it("supports md size", () => {
+    render(<HealthIndicator health="alive" size="md" />);
+    const indicator = screen.getByTestId("health-indicator");
+    expect(indicator.className).toContain("health-indicator--md");
+  });
+
+  it("has title attribute with health info", () => {
+    render(<HealthIndicator health="stale" />);
+    const indicator = screen.getByTestId("health-indicator");
+    expect(indicator.getAttribute("title")).toBe("Heartbeat: stale");
+  });
+});

--- a/frontend/src/context/AppContext.tsx
+++ b/frontend/src/context/AppContext.tsx
@@ -11,6 +11,7 @@ import type {
   Project,
   Leader,
   Session,
+  SessionHeartbeat,
   Notification,
   FailureLog,
   Task,
@@ -56,6 +57,7 @@ const initialState: AppState = {
   failureLogs: [],
   usage: { today_cost: 0, month_cost: 0, today_tokens: 0, month_tokens: 0 },
   github: {},
+  heartbeats: {},
   selectedProjectId: null,
   selectedSessionId: null,
 };
@@ -83,7 +85,9 @@ type Action =
   | { type: "SET_FAILURE_LOGS"; payload: FailureLog[] }
   | { type: "ADD_FAILURE_LOG"; payload: FailureLog }
   | { type: "RESOLVE_FAILURE_LOG"; payload: string }
-  | { type: "SET_TOWER_PROGRESS"; payload: TowerProgress };
+  | { type: "SET_TOWER_PROGRESS"; payload: TowerProgress }
+  | { type: "SET_HEARTBEATS"; payload: Record<string, SessionHeartbeat> }
+  | { type: "UPDATE_HEARTBEAT"; payload: SessionHeartbeat };
 
 function reducer(state: AppState, action: Action): AppState {
   switch (action.type) {
@@ -146,6 +150,16 @@ function reducer(state: AppState, action: Action): AppState {
       };
     case "SET_TOWER_PROGRESS":
       return { ...state, towerProgress: action.payload };
+    case "SET_HEARTBEATS":
+      return { ...state, heartbeats: action.payload };
+    case "UPDATE_HEARTBEAT":
+      return {
+        ...state,
+        heartbeats: {
+          ...state.heartbeats,
+          [action.payload.session_id]: action.payload,
+        },
+      };
   }
 }
 
@@ -212,6 +226,14 @@ export function AppProvider({ children }: AppProviderProps) {
         if (r.status === "fulfilled") taskGraphs[projects[i]!.id] = r.value;
       }
       dispatch({ type: "SET_TASK_GRAPHS", payload: taskGraphs });
+
+      // Fetch heartbeats
+      const heartbeatList = await api.get<SessionHeartbeat[]>("/heartbeat");
+      const heartbeats: Record<string, SessionHeartbeat> = {};
+      for (const hb of heartbeatList) {
+        heartbeats[hb.session_id] = hb;
+      }
+      dispatch({ type: "SET_HEARTBEATS", payload: heartbeats });
 
       // Fetch failure logs
       const failureLogs = await api.get<FailureLog[]>("/failure-logs?limit=200");
@@ -282,6 +304,24 @@ export function AppProvider({ children }: AppProviderProps) {
           },
         });
       }
+    } else if (msg.channel === "heartbeat") {
+      const data = msg.data as {
+        session_id: string;
+        health: "alive" | "stale" | "stopped";
+        last_heartbeat_at?: string;
+      };
+      if (data.session_id) {
+        dispatch({
+          type: "UPDATE_HEARTBEAT",
+          payload: {
+            session_id: data.session_id,
+            health: data.health,
+            last_heartbeat_at: data.last_heartbeat_at ?? new Date().toISOString(),
+            registered_at: "",
+            updated_at: new Date().toISOString(),
+          },
+        });
+      }
     } else if (msg.channel === "failure_logs") {
       const data = msg.data as Record<string, unknown>;
       if (data.new) {
@@ -294,7 +334,7 @@ export function AppProvider({ children }: AppProviderProps) {
   }, []);
 
   useWebSocket({
-    channels: ["state", "failure_logs", "tower"],
+    channels: ["state", "failure_logs", "tower", "heartbeat"],
     onMessage: handleWsMessage,
   });
 

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -165,6 +165,14 @@ export interface FailureLog {
   created_at: string;
 }
 
+export interface SessionHeartbeat {
+  session_id: string;
+  health: "alive" | "stale" | "stopped";
+  last_heartbeat_at: string;
+  registered_at: string;
+  updated_at: string;
+}
+
 export interface AppState {
   projects: Project[];
   leaders: Record<string, Leader>;
@@ -179,6 +187,7 @@ export interface AppState {
   failureLogs: FailureLog[];
   usage: UsageSummary;
   github: Record<string, GitHubSummary>;
+  heartbeats: Record<string, SessionHeartbeat>;
   selectedProjectId: string | null;
   selectedSessionId: string | null;
 }

--- a/src/atc/agents/deploy.py
+++ b/src/atc/agents/deploy.py
@@ -365,6 +365,9 @@ _POST_TOOL_USE_BODY = """
 curl -sf -X PATCH "$ATC_API/api/aces/$SESSION_ID/status" \
   -H "Content-Type: application/json" \
   -d '{{"status": "working"}}' >/dev/null 2>&1 || true
+
+# Send heartbeat
+curl -sf -X POST "$ATC_API/api/heartbeat/$SESSION_ID" >/dev/null 2>&1 || true
 """
 
 _STOP_HOOK_BODY = """

--- a/src/atc/api/app.py
+++ b/src/atc/api/app.py
@@ -134,7 +134,43 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
     event_bus.subscribe("session_status_changed", _on_session_status_changed)
     event_bus.subscribe("session_destroyed", _on_session_destroyed)
 
-    # 6. Reconnect sessions that were active at last shutdown
+    # 6. Start heartbeat monitor
+    from atc.core.heartbeat import HeartbeatMonitor
+
+    hb_cfg = settings.heartbeat
+    heartbeat_monitor = HeartbeatMonitor(
+        db,
+        event_bus,
+        ws_hub=ws_hub,
+        check_interval=hb_cfg.check_interval_seconds,
+        stale_threshold=hb_cfg.stale_threshold_seconds,
+    )
+    if hb_cfg.enabled:
+        await heartbeat_monitor.start()
+    app.state.heartbeat_monitor = heartbeat_monitor
+
+    # Auto-register heartbeat when sessions are created
+    async def _on_session_created_hb(data: dict[str, Any]) -> None:
+        session_id = data.get("session_id", "")
+        if session_id:
+            await heartbeat_monitor.register(session_id)
+
+    # Auto-deregister heartbeat when sessions are destroyed (clean shutdown)
+    async def _on_session_destroyed_hb(data: dict[str, Any]) -> None:
+        session_id = data.get("session_id", "")
+        if session_id:
+            await heartbeat_monitor.deregister(session_id)
+
+    event_bus.subscribe("session_created", _on_session_created_hb)
+    event_bus.subscribe("session_destroyed", _on_session_destroyed_hb)
+
+    # Wire WebSocket heartbeat piggyback
+    async def _on_ws_heartbeat(session_id: str) -> None:
+        await heartbeat_monitor.handle_heartbeat(session_id)
+
+    ws_hub.on_heartbeat(_on_ws_heartbeat)
+
+    # 7. Reconnect sessions that were active at last shutdown
     from atc.session.reconnect import reconnect_all
 
     try:
@@ -150,6 +186,7 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
 
     # Shutdown
     logger.info("ATC shutting down")
+    await heartbeat_monitor.stop()
     await pty_pool.stop()
     await event_bus.stop()
     await db.close()
@@ -172,6 +209,7 @@ def create_app(settings: Settings | None = None) -> FastAPI:
     from atc.api.routers import (
         aces,
         failure_logs,
+        heartbeat,
         leader,
         projects,
         task_graphs,
@@ -190,6 +228,7 @@ def create_app(settings: Settings | None = None) -> FastAPI:
     app.include_router(usage.router, prefix="/api/usage", tags=["usage"])
     app.include_router(settings_router.router, prefix="/api/settings", tags=["settings"])
     app.include_router(failure_logs.router, prefix="/api", tags=["failure_logs"])
+    app.include_router(heartbeat.router, prefix="/api", tags=["heartbeat"])
 
     @app.get("/api/health")
     async def health() -> dict[str, object]:

--- a/src/atc/api/routers/heartbeat.py
+++ b/src/atc/api/routers/heartbeat.py
@@ -1,0 +1,73 @@
+"""Heartbeat REST endpoints.
+
+Routes:
+  POST   /api/heartbeat/{session_id}        -> record heartbeat
+  GET    /api/heartbeat                      -> list all heartbeats
+  GET    /api/heartbeat/{session_id}         -> get single heartbeat
+"""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, HTTPException, Request
+from pydantic import BaseModel
+
+from atc.state import db as db_ops
+
+router = APIRouter()
+
+
+class HeartbeatResponse(BaseModel):
+    session_id: str
+    health: str
+    last_heartbeat_at: str
+    registered_at: str
+    updated_at: str
+
+
+@router.post("/heartbeat/{session_id}")
+async def record_heartbeat(session_id: str, request: Request) -> dict[str, str]:
+    """Record a heartbeat from an agent session (called by hooks)."""
+    monitor = getattr(request.app.state, "heartbeat_monitor", None)
+    if monitor is None:
+        # Fallback: write directly to DB
+        db = request.app.state.db
+        recorded = await db_ops.record_heartbeat(db, session_id)
+        if not recorded:
+            await db_ops.register_heartbeat(db, session_id)
+        return {"status": "ok"}
+
+    await monitor.handle_heartbeat(session_id)
+    return {"status": "ok"}
+
+
+@router.get("/heartbeat", response_model=list[HeartbeatResponse])
+async def list_heartbeats(request: Request) -> list[HeartbeatResponse]:
+    """List all heartbeat records."""
+    db = request.app.state.db
+    heartbeats = await db_ops.list_heartbeats(db)
+    return [
+        HeartbeatResponse(
+            session_id=hb.session_id,
+            health=hb.health,
+            last_heartbeat_at=hb.last_heartbeat_at,
+            registered_at=hb.registered_at,
+            updated_at=hb.updated_at,
+        )
+        for hb in heartbeats
+    ]
+
+
+@router.get("/heartbeat/{session_id}", response_model=HeartbeatResponse)
+async def get_heartbeat(session_id: str, request: Request) -> HeartbeatResponse:
+    """Get heartbeat for a specific session."""
+    db = request.app.state.db
+    hb = await db_ops.get_heartbeat(db, session_id)
+    if hb is None:
+        raise HTTPException(status_code=404, detail=f"No heartbeat for session {session_id}")
+    return HeartbeatResponse(
+        session_id=hb.session_id,
+        health=hb.health,
+        last_heartbeat_at=hb.last_heartbeat_at,
+        registered_at=hb.registered_at,
+        updated_at=hb.updated_at,
+    )

--- a/src/atc/api/ws/hub.py
+++ b/src/atc/api/ws/hub.py
@@ -33,6 +33,7 @@ class WsHub:
     def __init__(self) -> None:
         self._clients: dict[WebSocket, set[str]] = {}
         self._input_callback: Any | None = None
+        self._heartbeat_callback: Any | None = None
 
     @property
     def client_count(self) -> int:
@@ -44,6 +45,13 @@ class WsHub:
         Callback signature: ``async def cb(channel: str, data: str) -> None``
         """
         self._input_callback = callback
+
+    def on_heartbeat(self, callback: Any) -> None:
+        """Register a callback for heartbeat pings from agents.
+
+        Callback signature: ``async def cb(session_id: str) -> None``
+        """
+        self._heartbeat_callback = callback
 
     async def connect(self, ws: WebSocket) -> None:
         """Accept a new WebSocket connection."""
@@ -96,6 +104,13 @@ class WsHub:
 
                 if channel == "subscribe" and isinstance(data, list):
                     self.subscribe(ws, data)
+                elif channel == "heartbeat" and isinstance(data, dict) and self._heartbeat_callback:
+                    session_id = data.get("session_id", "")
+                    if session_id:
+                        try:
+                            await self._heartbeat_callback(session_id)
+                        except Exception:
+                            logger.exception("Heartbeat callback error for %s", session_id)
                 elif (
                     channel
                     and channel.startswith("terminal:")

--- a/src/atc/config.py
+++ b/src/atc/config.py
@@ -43,6 +43,13 @@ class CostTrackerConfig(BaseModel):
     poll_interval_seconds: int = 30
 
 
+class HeartbeatConfig(BaseModel):
+    enabled: bool = True
+    interval_seconds: int = 30
+    check_interval_seconds: int = 60
+    stale_threshold_seconds: int = 120
+
+
 class LoggingConfig(BaseModel):
     level: str = "INFO"
 
@@ -66,6 +73,7 @@ class Settings(BaseSettings):
     github: GitHubConfig = GitHubConfig()
     budget: BudgetConfig = BudgetConfig()
     cost_tracker: CostTrackerConfig = CostTrackerConfig()
+    heartbeat: HeartbeatConfig = HeartbeatConfig()
     logging: LoggingConfig = LoggingConfig()
     agent_provider: AgentProviderConfig = AgentProviderConfig()
 

--- a/src/atc/core/heartbeat.py
+++ b/src/atc/core/heartbeat.py
@@ -1,0 +1,166 @@
+"""Heartbeat monitor — detects stale agent sessions.
+
+The monitor runs a background loop that checks all registered heartbeats
+every ``check_interval`` seconds.  If a session has not sent a heartbeat
+within ``stale_threshold`` seconds, its health is transitioned to ``stale``.
+
+Health values:
+    alive   — heartbeat received within the threshold
+    stale   — no heartbeat for > stale_threshold seconds
+    stopped — session was cleanly deregistered (or manually marked)
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import logging
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING
+
+from atc.state import db as db_ops
+
+if TYPE_CHECKING:
+    import aiosqlite
+
+    from atc.api.ws.hub import WsHub
+    from atc.core.events import EventBus
+
+logger = logging.getLogger(__name__)
+
+
+class HeartbeatMonitor:
+    """Background monitor that marks sessions stale when heartbeats stop."""
+
+    def __init__(
+        self,
+        db: aiosqlite.Connection,
+        event_bus: EventBus,
+        *,
+        ws_hub: WsHub | None = None,
+        check_interval: float = 60.0,
+        stale_threshold: float = 120.0,
+    ) -> None:
+        self._db = db
+        self._event_bus = event_bus
+        self._ws_hub = ws_hub
+        self._check_interval = check_interval
+        self._stale_threshold = stale_threshold
+        self._task: asyncio.Task[None] | None = None
+
+    async def start(self) -> None:
+        """Start the background monitor loop."""
+        if self._task is not None:
+            return
+        self._task = asyncio.create_task(self._monitor_loop())
+        logger.info(
+            "Heartbeat monitor started (check=%ds, stale=%ds)",
+            self._check_interval,
+            self._stale_threshold,
+        )
+
+    async def stop(self) -> None:
+        """Stop the background monitor loop."""
+        if self._task is not None:
+            self._task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await self._task
+            self._task = None
+            logger.info("Heartbeat monitor stopped")
+
+    async def _monitor_loop(self) -> None:
+        """Periodically check heartbeats and mark stale sessions."""
+        while True:
+            try:
+                await self._check_heartbeats()
+            except Exception:
+                logger.exception("Heartbeat check failed")
+            await asyncio.sleep(self._check_interval)
+
+    async def _check_heartbeats(self) -> None:
+        """Scan all heartbeat records and transition stale ones."""
+        heartbeats = await db_ops.list_heartbeats(self._db)
+        now = datetime.now(UTC)
+
+        for hb in heartbeats:
+            if hb.health == "stopped":
+                continue
+
+            last = datetime.fromisoformat(hb.last_heartbeat_at)
+            age = (now - last).total_seconds()
+
+            if age > self._stale_threshold and hb.health != "stale":
+                await db_ops.update_heartbeat_health(
+                    self._db, hb.session_id, "stale"
+                )
+                logger.warning(
+                    "Session %s marked stale (no heartbeat for %.0fs)",
+                    hb.session_id,
+                    age,
+                )
+                await self._event_bus.publish(
+                    "session_heartbeat_stale",
+                    {"session_id": hb.session_id, "age_seconds": age},
+                )
+                if self._ws_hub:
+                    await self._ws_hub.broadcast(
+                        "heartbeat",
+                        {
+                            "session_id": hb.session_id,
+                            "health": "stale",
+                            "last_heartbeat_at": hb.last_heartbeat_at,
+                        },
+                    )
+            elif age <= self._stale_threshold and hb.health == "stale":
+                # Recovered — mark alive again
+                await db_ops.update_heartbeat_health(
+                    self._db, hb.session_id, "alive"
+                )
+                logger.info("Session %s heartbeat recovered", hb.session_id)
+                if self._ws_hub:
+                    await self._ws_hub.broadcast(
+                        "heartbeat",
+                        {
+                            "session_id": hb.session_id,
+                            "health": "alive",
+                            "last_heartbeat_at": hb.last_heartbeat_at,
+                        },
+                    )
+
+    async def handle_heartbeat(self, session_id: str) -> bool:
+        """Process an incoming heartbeat from a session.
+
+        Auto-registers the session if not already tracked.
+        Returns True if recorded successfully.
+        """
+        recorded = await db_ops.record_heartbeat(self._db, session_id)
+        if not recorded:
+            await db_ops.register_heartbeat(self._db, session_id)
+            recorded = True
+
+        if self._ws_hub:
+            now = datetime.now(UTC).isoformat()
+            await self._ws_hub.broadcast(
+                "heartbeat",
+                {
+                    "session_id": session_id,
+                    "health": "alive",
+                    "last_heartbeat_at": now,
+                },
+            )
+        return recorded
+
+    async def register(self, session_id: str) -> None:
+        """Register a session for heartbeat tracking."""
+        await db_ops.register_heartbeat(self._db, session_id)
+        logger.info("Session %s registered for heartbeat", session_id)
+
+    async def deregister(self, session_id: str) -> None:
+        """Cleanly deregister a session (expected shutdown)."""
+        await db_ops.deregister_heartbeat(self._db, session_id)
+        logger.info("Session %s deregistered from heartbeat", session_id)
+        if self._ws_hub:
+            await self._ws_hub.broadcast(
+                "heartbeat",
+                {"session_id": session_id, "health": "stopped"},
+            )

--- a/src/atc/state/db.py
+++ b/src/atc/state/db.py
@@ -19,7 +19,7 @@ from typing import TYPE_CHECKING, Any
 
 import aiosqlite
 
-from atc.state.models import Leader, Project, Session, TaskGraph
+from atc.state.models import Leader, Project, Session, SessionHeartbeat, TaskGraph
 
 if TYPE_CHECKING:
     from collections.abc import AsyncIterator, Generator
@@ -319,6 +319,14 @@ CREATE TABLE IF NOT EXISTS task_graphs (
     dependencies    TEXT,
     created_at      TEXT NOT NULL,
     updated_at      TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS session_heartbeats (
+    session_id          TEXT PRIMARY KEY REFERENCES sessions(id) ON DELETE CASCADE,
+    health              TEXT NOT NULL DEFAULT 'alive',
+    last_heartbeat_at   TEXT NOT NULL,
+    registered_at       TEXT NOT NULL,
+    updated_at          TEXT NOT NULL
 );
 
 CREATE TABLE IF NOT EXISTS context_entries (
@@ -795,6 +803,106 @@ async def delete_task_graph(
     cursor = await db.execute(
         "DELETE FROM task_graphs WHERE id = ?",
         (task_graph_id,),
+    )
+    await db.commit()
+    return cursor.rowcount > 0
+
+
+# ---------------------------------------------------------------------------
+# Heartbeat CRUD
+# ---------------------------------------------------------------------------
+
+
+async def register_heartbeat(
+    db: aiosqlite.Connection,
+    session_id: str,
+) -> SessionHeartbeat:
+    """Register a session for heartbeat tracking (upsert)."""
+    now = _now()
+    await db.execute(
+        """INSERT INTO session_heartbeats
+           (session_id, health, last_heartbeat_at, registered_at, updated_at)
+           VALUES (?, 'alive', ?, ?, ?)
+           ON CONFLICT(session_id) DO UPDATE SET
+             health = 'alive',
+             last_heartbeat_at = excluded.last_heartbeat_at,
+             updated_at = excluded.updated_at""",
+        (session_id, now, now, now),
+    )
+    await db.commit()
+    return SessionHeartbeat(
+        session_id=session_id,
+        health="alive",
+        last_heartbeat_at=now,
+        registered_at=now,
+        updated_at=now,
+    )
+
+
+async def record_heartbeat(
+    db: aiosqlite.Connection,
+    session_id: str,
+) -> bool:
+    """Record a heartbeat ping. Returns True if session was registered."""
+    now = _now()
+    cursor = await db.execute(
+        """UPDATE session_heartbeats
+           SET last_heartbeat_at = ?, health = 'alive', updated_at = ?
+           WHERE session_id = ?""",
+        (now, now, session_id),
+    )
+    await db.commit()
+    return cursor.rowcount > 0
+
+
+async def get_heartbeat(
+    db: aiosqlite.Connection,
+    session_id: str,
+) -> SessionHeartbeat | None:
+    """Fetch heartbeat record for a session."""
+    cursor = await db.execute(
+        "SELECT * FROM session_heartbeats WHERE session_id = ?",
+        (session_id,),
+    )
+    row = await cursor.fetchone()
+    if row is None:
+        return None
+    return SessionHeartbeat(**dict(row))
+
+
+async def list_heartbeats(
+    db: aiosqlite.Connection,
+) -> list[SessionHeartbeat]:
+    """Return all heartbeat records."""
+    cursor = await db.execute(
+        "SELECT * FROM session_heartbeats ORDER BY last_heartbeat_at DESC",
+    )
+    rows = await cursor.fetchall()
+    return [SessionHeartbeat(**dict(r)) for r in rows]
+
+
+async def update_heartbeat_health(
+    db: aiosqlite.Connection,
+    session_id: str,
+    health: str,
+) -> None:
+    """Update the health status of a heartbeat record."""
+    now = _now()
+    await db.execute(
+        "UPDATE session_heartbeats SET health = ?, updated_at = ? WHERE session_id = ?",
+        (health, now, session_id),
+    )
+    await db.commit()
+
+
+async def deregister_heartbeat(
+    db: aiosqlite.Connection,
+    session_id: str,
+) -> bool:
+    """Remove heartbeat tracking for a session. Returns True if removed."""
+    cursor = await db.execute(
+        "DELETE FROM session_heartbeats WHERE session_id = ?",
+        (session_id,),
     )
     await db.commit()
     return cursor.rowcount > 0

--- a/src/atc/state/models.py
+++ b/src/atc/state/models.py
@@ -187,6 +187,15 @@ class TaskGraph:
 
 
 @dataclass
+class SessionHeartbeat:
+    session_id: str
+    health: str  # alive|stale|stopped
+    last_heartbeat_at: str
+    registered_at: str
+    updated_at: str
+
+
+@dataclass
 class ContextEntry:
     id: str
     project_id: str

--- a/tests/unit/test_heartbeat.py
+++ b/tests/unit/test_heartbeat.py
@@ -1,0 +1,283 @@
+"""Tests for the heartbeat protocol — DB CRUD, monitor, and API integration."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from atc.core.events import EventBus
+from atc.core.heartbeat import HeartbeatMonitor
+from atc.state.db import (
+    _SCHEMA_SQL,
+    create_project,
+    create_session,
+    deregister_heartbeat,
+    get_connection,
+    get_heartbeat,
+    list_heartbeats,
+    record_heartbeat,
+    register_heartbeat,
+    run_migrations,
+    update_heartbeat_health,
+)
+
+
+@pytest.fixture
+async def db():
+    """In-memory database with schema applied."""
+    await run_migrations(":memory:")
+    async with get_connection(":memory:") as conn:
+        await conn.executescript(_SCHEMA_SQL)
+        await conn.commit()
+        yield conn
+
+
+@pytest.fixture
+def event_bus() -> EventBus:
+    return EventBus()
+
+
+@pytest.fixture
+def ws_hub() -> MagicMock:
+    hub = MagicMock()
+    hub.broadcast = AsyncMock()
+    return hub
+
+
+# ---------------------------------------------------------------------------
+# DB CRUD tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+class TestHeartbeatCRUD:
+    async def test_register_heartbeat(self, db) -> None:
+        project = await create_project(db, "test-proj")
+        session = await create_session(db, project.id, "ace", "ace-1")
+
+        hb = await register_heartbeat(db, session.id)
+        assert hb.session_id == session.id
+        assert hb.health == "alive"
+        assert hb.last_heartbeat_at != ""
+        assert hb.registered_at != ""
+
+    async def test_register_heartbeat_upsert(self, db) -> None:
+        project = await create_project(db, "test-proj")
+        session = await create_session(db, project.id, "ace", "ace-1")
+
+        hb1 = await register_heartbeat(db, session.id)
+        await update_heartbeat_health(db, session.id, "stale")
+        hb2 = await register_heartbeat(db, session.id)
+
+        assert hb2.health == "alive"
+        assert hb2.last_heartbeat_at >= hb1.last_heartbeat_at
+
+    async def test_record_heartbeat(self, db) -> None:
+        project = await create_project(db, "test-proj")
+        session = await create_session(db, project.id, "ace", "ace-1")
+        await register_heartbeat(db, session.id)
+
+        result = await record_heartbeat(db, session.id)
+        assert result is True
+
+    async def test_record_heartbeat_unregistered(self, db) -> None:
+        result = await record_heartbeat(db, "nonexistent")
+        assert result is False
+
+    async def test_get_heartbeat(self, db) -> None:
+        project = await create_project(db, "test-proj")
+        session = await create_session(db, project.id, "ace", "ace-1")
+        await register_heartbeat(db, session.id)
+
+        hb = await get_heartbeat(db, session.id)
+        assert hb is not None
+        assert hb.session_id == session.id
+        assert hb.health == "alive"
+
+    async def test_get_heartbeat_missing(self, db) -> None:
+        hb = await get_heartbeat(db, "nonexistent")
+        assert hb is None
+
+    async def test_list_heartbeats(self, db) -> None:
+        project = await create_project(db, "test-proj")
+        s1 = await create_session(db, project.id, "ace", "ace-1")
+        s2 = await create_session(db, project.id, "ace", "ace-2")
+        await register_heartbeat(db, s1.id)
+        await register_heartbeat(db, s2.id)
+
+        heartbeats = await list_heartbeats(db)
+        assert len(heartbeats) == 2
+
+    async def test_update_heartbeat_health(self, db) -> None:
+        project = await create_project(db, "test-proj")
+        session = await create_session(db, project.id, "ace", "ace-1")
+        await register_heartbeat(db, session.id)
+
+        await update_heartbeat_health(db, session.id, "stale")
+        hb = await get_heartbeat(db, session.id)
+        assert hb is not None
+        assert hb.health == "stale"
+
+    async def test_deregister_heartbeat(self, db) -> None:
+        project = await create_project(db, "test-proj")
+        session = await create_session(db, project.id, "ace", "ace-1")
+        await register_heartbeat(db, session.id)
+
+        removed = await deregister_heartbeat(db, session.id)
+        assert removed is True
+
+        hb = await get_heartbeat(db, session.id)
+        assert hb is None
+
+    async def test_deregister_heartbeat_missing(self, db) -> None:
+        removed = await deregister_heartbeat(db, "nonexistent")
+        assert removed is False
+
+    async def test_cascade_delete(self, db) -> None:
+        """Heartbeat row is deleted when session is deleted."""
+        project = await create_project(db, "test-proj")
+        session = await create_session(db, project.id, "ace", "ace-1")
+        await register_heartbeat(db, session.id)
+
+        await db.execute("DELETE FROM sessions WHERE id = ?", (session.id,))
+        await db.commit()
+
+        hb = await get_heartbeat(db, session.id)
+        assert hb is None
+
+
+# ---------------------------------------------------------------------------
+# Monitor tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+class TestHeartbeatMonitor:
+    async def test_start_stop(self, db, event_bus) -> None:
+        monitor = HeartbeatMonitor(db, event_bus, check_interval=0.1, stale_threshold=1.0)
+        await monitor.start()
+        assert monitor._task is not None
+        await monitor.stop()
+        assert monitor._task is None
+
+    async def test_handle_heartbeat_auto_registers(self, db, event_bus) -> None:
+        monitor = HeartbeatMonitor(db, event_bus)
+
+        project = await create_project(db, "test-proj")
+        session = await create_session(db, project.id, "ace", "ace-1")
+
+        result = await monitor.handle_heartbeat(session.id)
+        assert result is True
+
+        hb = await get_heartbeat(db, session.id)
+        assert hb is not None
+        assert hb.health == "alive"
+
+    async def test_handle_heartbeat_updates_existing(self, db, event_bus) -> None:
+        monitor = HeartbeatMonitor(db, event_bus)
+
+        project = await create_project(db, "test-proj")
+        session = await create_session(db, project.id, "ace", "ace-1")
+        await register_heartbeat(db, session.id)
+
+        result = await monitor.handle_heartbeat(session.id)
+        assert result is True
+
+    async def test_handle_heartbeat_broadcasts(self, db, event_bus, ws_hub) -> None:
+        monitor = HeartbeatMonitor(db, event_bus, ws_hub=ws_hub)
+
+        project = await create_project(db, "test-proj")
+        session = await create_session(db, project.id, "ace", "ace-1")
+
+        await monitor.handle_heartbeat(session.id)
+        ws_hub.broadcast.assert_called()
+        call_args = ws_hub.broadcast.call_args
+        assert call_args[0][0] == "heartbeat"
+        assert call_args[0][1]["health"] == "alive"
+
+    async def test_mark_stale(self, db, event_bus, ws_hub) -> None:
+        """Sessions with old heartbeats are marked stale."""
+        monitor = HeartbeatMonitor(
+            db, event_bus, ws_hub=ws_hub, check_interval=0.1, stale_threshold=0.0
+        )
+
+        project = await create_project(db, "test-proj")
+        session = await create_session(db, project.id, "ace", "ace-1")
+        await register_heartbeat(db, session.id)
+
+        # Set the heartbeat timestamp to the past
+        old_time = (datetime.now(UTC) - timedelta(seconds=300)).isoformat()
+        await db.execute(
+            "UPDATE session_heartbeats SET last_heartbeat_at = ? WHERE session_id = ?",
+            (old_time, session.id),
+        )
+        await db.commit()
+
+        await monitor._check_heartbeats()
+
+        hb = await get_heartbeat(db, session.id)
+        assert hb is not None
+        assert hb.health == "stale"
+
+    async def test_skip_stopped(self, db, event_bus) -> None:
+        """Stopped sessions are not checked."""
+        monitor = HeartbeatMonitor(db, event_bus, stale_threshold=0.0)
+
+        project = await create_project(db, "test-proj")
+        session = await create_session(db, project.id, "ace", "ace-1")
+        await register_heartbeat(db, session.id)
+        await update_heartbeat_health(db, session.id, "stopped")
+
+        old_time = (datetime.now(UTC) - timedelta(seconds=300)).isoformat()
+        await db.execute(
+            "UPDATE session_heartbeats SET last_heartbeat_at = ? WHERE session_id = ?",
+            (old_time, session.id),
+        )
+        await db.commit()
+
+        await monitor._check_heartbeats()
+
+        hb = await get_heartbeat(db, session.id)
+        assert hb is not None
+        assert hb.health == "stopped"  # not changed to stale
+
+    async def test_register_deregister(self, db, event_bus, ws_hub) -> None:
+        monitor = HeartbeatMonitor(db, event_bus, ws_hub=ws_hub)
+
+        project = await create_project(db, "test-proj")
+        session = await create_session(db, project.id, "ace", "ace-1")
+
+        await monitor.register(session.id)
+        hb = await get_heartbeat(db, session.id)
+        assert hb is not None
+
+        await monitor.deregister(session.id)
+        hb = await get_heartbeat(db, session.id)
+        assert hb is None
+
+        # Broadcast called for deregister
+        ws_hub.broadcast.assert_called()
+
+    async def test_stale_publishes_event(self, db, event_bus) -> None:
+        received = []
+        event_bus.subscribe("session_heartbeat_stale", lambda d: received.append(d))
+
+        monitor = HeartbeatMonitor(db, event_bus, stale_threshold=0.0)
+
+        project = await create_project(db, "test-proj")
+        session = await create_session(db, project.id, "ace", "ace-1")
+        await register_heartbeat(db, session.id)
+
+        old_time = (datetime.now(UTC) - timedelta(seconds=300)).isoformat()
+        await db.execute(
+            "UPDATE session_heartbeats SET last_heartbeat_at = ? WHERE session_id = ?",
+            (old_time, session.id),
+        )
+        await db.commit()
+
+        await monitor._check_heartbeats()
+
+        assert len(received) == 1
+        assert received[0]["session_id"] == session.id


### PR DESCRIPTION
## Summary
- Adds periodic heartbeat tracking for agent sessions with `session_heartbeats` DB table (session_id, health: alive/stale/stopped, timestamps)
- `HeartbeatMonitor` background loop checks every 60s, marks sessions stale after 2min of no heartbeat
- REST API (`POST/GET /api/heartbeat/{session_id}`), WebSocket heartbeat channel, and PostToolUse hook integration
- Frontend `HealthIndicator` component shows green pulse (alive), amber (stale), red (stopped) next to each session
- Auto-registers on session creation, auto-deregisters on clean shutdown — only alerts on unexpected heartbeat loss

## Test plan
- [x] 19 backend unit tests covering CRUD, monitor stale detection, event publishing, WS broadcast
- [x] 7 frontend component tests for HealthIndicator rendering states
- [x] All 488 existing backend tests pass
- [x] All 171 existing frontend tests pass
- [ ] Manual verification: create sessions, observe green pulse, stop session, verify amber→red transition

🤖 Generated with [Claude Code](https://claude.com/claude-code)