### PR TITLE
feat: replace Tower bottom panel with full terminal console

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,7 +1,6 @@
-import { BrowserRouter, Routes, Route, Navigate, Outlet, useLocation } from "react-router-dom";
+import { BrowserRouter, Routes, Route, Navigate, Outlet } from "react-router-dom";
 import { AppProvider } from "./context/AppContext";
 import TowerBar from "./components/tower/TowerBar";
-import TowerPanel from "./components/tower/TowerPanel";
 import UpdateBanner from "./components/common/UpdateBanner";
 import { useUpdater } from "./hooks/useUpdater";
 import Dashboard from "./pages/Dashboard";
@@ -9,12 +8,7 @@ import ProjectView from "./pages/ProjectView";
 import SettingsPage from "./pages/SettingsPage";
 import UsagePage from "./pages/UsagePage";
 
-/** Pages where the Tower panel should NOT appear */
-const HIDE_TOWER_PATHS = ["/settings", "/usage"];
-
 function Layout() {
-  const { pathname } = useLocation();
-  const showTower = !HIDE_TOWER_PATHS.includes(pathname);
   const updater = useUpdater();
 
   return (
@@ -33,7 +27,6 @@ function Layout() {
       <main style={{ flex: 1, overflow: "auto", minHeight: 0 }}>
         <Outlet context={updater} />
       </main>
-      {showTower && <TowerPanel />}
     </>
   );
 }

--- a/frontend/src/components/tower/TowerConsole.css
+++ b/frontend/src/components/tower/TowerConsole.css
@@ -1,0 +1,89 @@
+.tower-console {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+  flex: 1;
+  min-height: 0;
+}
+
+.tower-console__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  flex-shrink: 0;
+}
+
+.tower-console__header h3 {
+  font-size: var(--text-sm);
+  color: var(--color-text-secondary);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.tower-console__controls {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+}
+
+.tower-console__progress {
+  font-size: var(--text-xs);
+  font-family: var(--font-mono);
+  color: var(--color-text-muted);
+  white-space: nowrap;
+}
+
+.tower-console__start-form {
+  margin-top: var(--space-1);
+  flex-shrink: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+
+.tower-console__goal {
+  font-size: var(--text-sm);
+  color: var(--color-text-secondary);
+  padding: var(--space-2) 0;
+  flex-shrink: 0;
+}
+
+.tower-console__terminal {
+  flex: 1;
+  min-height: 200px;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  overflow: hidden;
+  background: #0d1117;
+}
+
+.tower-console__input {
+  display: flex;
+  gap: var(--space-2);
+  flex-shrink: 0;
+}
+
+.tower-console__input input {
+  flex: 1;
+  padding: var(--space-2) var(--space-3);
+  font-size: var(--text-sm);
+  font-family: var(--font-mono);
+  color: var(--color-text);
+  background: var(--color-bg);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  outline: none;
+}
+
+.tower-console__input input:focus {
+  border-color: var(--color-accent);
+}
+
+.tower-console__error {
+  padding: var(--space-3);
+  font-size: var(--text-sm);
+  color: var(--color-status-red);
+  background: var(--color-bg-surface);
+  border: 1px solid var(--color-status-red);
+  border-radius: var(--radius-md);
+}

--- a/frontend/src/components/tower/TowerConsole.tsx
+++ b/frontend/src/components/tower/TowerConsole.tsx
@@ -1,0 +1,235 @@
+import { useState, useRef } from "react";
+import { useAppContext } from "../../context/AppContext";
+import { useTerminal } from "../../hooks/useTerminal";
+import { api } from "../../utils/api";
+import StatusBadge from "../common/StatusBadge";
+import "./TowerConsole.css";
+
+/**
+ * Full interactive terminal panel for the Tower Claude session.
+ * Identical in UX to LeaderConsole — the user chats with Tower
+ * directly via a real terminal, and Tower relays instructions
+ * to Leaders across projects.
+ *
+ * Idle: Start button + optional goal input.
+ * Running: Full PTY terminal + message input bar.
+ */
+export default function TowerConsole() {
+  const { state } = useAppContext();
+  const { towerDetail, towerProgress, brainStatus, projects } = state;
+
+  const [goal, setGoal] = useState("");
+  const [projectId, setProjectId] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [message, setMessage] = useState("");
+  const messageInputRef = useRef<HTMLInputElement>(null);
+
+  const isRunning =
+    towerDetail.state === "planning" || towerDetail.state === "managing";
+  const isIdle =
+    towerDetail.state === "idle" ||
+    towerDetail.state === "complete" ||
+    towerDetail.state === "error";
+
+  const terminalChannel = towerDetail.current_session_id
+    ? `terminal:${towerDetail.current_session_id}`
+    : undefined;
+
+  const { attachRef } = useTerminal({
+    channel: terminalChannel,
+    enabled: isRunning && !!terminalChannel,
+  });
+
+  // Default to first active project
+  if (!projectId && projects.length > 0) {
+    const active = projects.find((p) => p.status === "active");
+    if (active) setProjectId(active.id);
+  }
+
+  async function handleStart() {
+    if (!projectId) return;
+    setLoading(true);
+    try {
+      await api.post("/tower/goal", {
+        project_id: projectId,
+        goal: goal.trim() || null,
+      });
+      setGoal("");
+    } catch (err) {
+      console.error("Failed to start Tower:", err);
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  async function handleStop() {
+    setLoading(true);
+    try {
+      await api.post("/tower/cancel");
+    } catch (err) {
+      console.error("Failed to stop Tower:", err);
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  async function handleComplete() {
+    try {
+      await api.post("/tower/complete");
+    } catch (err) {
+      console.error("Failed to mark Tower goal complete:", err);
+    }
+  }
+
+  async function handleSendMessage(e: React.FormEvent) {
+    e.preventDefault();
+    if (!message.trim()) return;
+    try {
+      await api.post("/tower/message", { message: message.trim() });
+      setMessage("");
+      messageInputRef.current?.focus();
+    } catch (err) {
+      console.error("Failed to send message:", err);
+    }
+  }
+
+  const statusLabel = brainStatus.status ?? towerDetail.state;
+
+  return (
+    <div className="tower-console" data-testid="tower-console">
+      {/* Header */}
+      <div className="tower-console__header">
+        <h3>Tower</h3>
+        <div className="tower-console__controls">
+          <StatusBadge status={statusLabel} size="sm" />
+          {isRunning && towerProgress.total > 0 && (
+            <span
+              className="tower-console__progress"
+              data-testid="tower-console-progress"
+            >
+              {towerProgress.done}/{towerProgress.total}
+            </span>
+          )}
+          {!isRunning ? (
+            <button
+              className="btn btn-primary btn-sm"
+              onClick={handleStart}
+              disabled={loading || !projectId}
+              data-testid="tower-console-start"
+            >
+              {loading ? "Starting..." : "Start"}
+            </button>
+          ) : (
+            <>
+              <button
+                className="btn btn-sm"
+                onClick={handleComplete}
+                data-testid="tower-console-complete"
+              >
+                Complete
+              </button>
+              <button
+                className="btn btn-danger btn-sm"
+                onClick={handleStop}
+                disabled={loading}
+                data-testid="tower-console-stop"
+              >
+                Stop
+              </button>
+            </>
+          )}
+        </div>
+      </div>
+
+      {/* Idle: goal form */}
+      {isIdle && (
+        <div className="tower-console__start-form">
+          <div className="form-group">
+            <label htmlFor="tower-project">Project</label>
+            <select
+              id="tower-project"
+              value={projectId}
+              onChange={(e) => setProjectId(e.target.value)}
+              data-testid="tower-console-project"
+            >
+              <option value="" disabled>
+                Select project...
+              </option>
+              {projects
+                .filter((p) => p.status === "active")
+                .map((p) => (
+                  <option key={p.id} value={p.id}>
+                    {p.name}
+                  </option>
+                ))}
+            </select>
+          </div>
+          <div className="form-group">
+            <label htmlFor="tower-goal">Goal (optional)</label>
+            <input
+              id="tower-goal"
+              type="text"
+              value={goal}
+              onChange={(e) => setGoal(e.target.value)}
+              placeholder="Describe a goal for Tower..."
+              onKeyDown={(e) => {
+                if (e.key === "Enter" && projectId) handleStart();
+              }}
+              data-testid="tower-console-goal"
+            />
+          </div>
+        </div>
+      )}
+
+      {/* Current goal display */}
+      {towerDetail.current_goal && (
+        <p className="tower-console__goal" data-testid="tower-console-current-goal">
+          {towerDetail.current_goal}
+        </p>
+      )}
+
+      {/* Error state */}
+      {towerDetail.state === "error" && (
+        <div className="tower-console__error">
+          Tower encountered an error.
+          {towerDetail.current_goal && (
+            <> Goal: <strong>{towerDetail.current_goal}</strong></>
+          )}
+        </div>
+      )}
+
+      {/* Running: terminal + message input */}
+      {isRunning && (
+        <>
+          <div
+            className="tower-console__terminal"
+            ref={attachRef}
+            data-testid="tower-console-terminal"
+          />
+
+          <form
+            className="tower-console__input"
+            onSubmit={handleSendMessage}
+          >
+            <input
+              ref={messageInputRef}
+              type="text"
+              value={message}
+              onChange={(e) => setMessage(e.target.value)}
+              placeholder="Send message to Tower..."
+              data-testid="tower-console-message"
+            />
+            <button
+              type="submit"
+              className="btn btn-sm btn-primary"
+              disabled={!message.trim()}
+              data-testid="tower-console-send"
+            >
+              Send
+            </button>
+          </form>
+        </>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/tower/__tests__/TowerConsole.test.tsx
+++ b/frontend/src/components/tower/__tests__/TowerConsole.test.tsx
@@ -1,0 +1,74 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import TowerConsole from "../TowerConsole";
+import { renderWithProviders } from "../../../test/helpers";
+
+// Mock useTerminal since it requires WebSocket/xterm
+vi.mock("../../../hooks/useTerminal", () => ({
+  useTerminal: () => ({
+    attachRef: vi.fn(),
+    fit: vi.fn(),
+  }),
+}));
+
+beforeEach(() => {
+  vi.spyOn(globalThis, "fetch").mockResolvedValue(
+    new Response(JSON.stringify([]), { status: 200 }),
+  );
+});
+
+describe("TowerConsole", () => {
+  it("renders the tower console", () => {
+    renderWithProviders(<TowerConsole />);
+    expect(screen.getByTestId("tower-console")).toBeInTheDocument();
+  });
+
+  it("shows Tower label in the header", () => {
+    renderWithProviders(<TowerConsole />);
+    expect(screen.getByText("Tower")).toBeInTheDocument();
+  });
+
+  it("shows Start button when idle", () => {
+    renderWithProviders(<TowerConsole />);
+    expect(screen.getByTestId("tower-console-start")).toBeInTheDocument();
+    expect(screen.getByTestId("tower-console-start")).toHaveTextContent("Start");
+  });
+
+  it("shows goal input and project select when idle", () => {
+    renderWithProviders(<TowerConsole />);
+    expect(screen.getByTestId("tower-console-goal")).toBeInTheDocument();
+    expect(screen.getByTestId("tower-console-project")).toBeInTheDocument();
+  });
+
+  it("shows status badge", () => {
+    renderWithProviders(<TowerConsole />);
+    // The status badge should render with the brain status
+    expect(screen.getByText("idle")).toBeInTheDocument();
+  });
+
+  it("does not show terminal when idle", () => {
+    renderWithProviders(<TowerConsole />);
+    expect(screen.queryByTestId("tower-console-terminal")).not.toBeInTheDocument();
+  });
+
+  it("does not show message input when idle", () => {
+    renderWithProviders(<TowerConsole />);
+    expect(screen.queryByTestId("tower-console-message")).not.toBeInTheDocument();
+  });
+
+  it("allows typing a goal", async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<TowerConsole />);
+
+    const goalInput = screen.getByTestId("tower-console-goal");
+    await user.type(goalInput, "Build a new feature");
+    expect(goalInput).toHaveValue("Build a new feature");
+  });
+
+  it("disables Start when no project is selected", () => {
+    renderWithProviders(<TowerConsole />);
+    // No projects available, so no project is selected
+    expect(screen.getByTestId("tower-console-start")).toBeDisabled();
+  });
+});

--- a/frontend/src/pages/Dashboard.css
+++ b/frontend/src/pages/Dashboard.css
@@ -5,6 +5,28 @@
   width: 100%;
 }
 
+/* Two-column layout: projects on left, Tower console on right */
+.dashboard--two-col {
+  display: grid;
+  grid-template-columns: 1fr 420px;
+  gap: var(--space-6);
+  max-width: none;
+  height: 100%;
+  overflow: hidden;
+}
+
+.dashboard--two-col .dashboard__main {
+  overflow: auto;
+  min-height: 0;
+}
+
+.dashboard--two-col .dashboard__tower {
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+  overflow: hidden;
+}
+
 .dashboard__header {
   display: flex;
   align-items: center;

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -4,6 +4,7 @@ import { useAppContext } from "../context/AppContext";
 import StatusBadge from "../components/common/StatusBadge";
 import TimeAgo from "../components/common/TimeAgo";
 import CreateProjectModal from "../components/common/CreateProjectModal";
+import TowerConsole from "../components/tower/TowerConsole";
 import "./Dashboard.css";
 
 export default function Dashboard() {
@@ -15,139 +16,147 @@ export default function Dashboard() {
   const activeProjects = projects.filter((p) => p.status === "active");
 
   return (
-    <div className="dashboard" data-testid="dashboard-page">
-      <div className="dashboard__header">
-        <h1>Dashboard</h1>
-        <button
-          className="btn btn-primary"
-          onClick={() => setShowCreate(true)}
-        >
-          + New Project
-        </button>
-      </div>
+    <div className="dashboard dashboard--two-col" data-testid="dashboard-page">
+      {/* Left column: metrics + projects */}
+      <div className="dashboard__main">
+        <div className="dashboard__header">
+          <h1>Dashboard</h1>
+          <button
+            className="btn btn-primary"
+            onClick={() => setShowCreate(true)}
+          >
+            + New Project
+          </button>
+        </div>
 
-      <div className="dashboard__grid">
-        {/* Cost summary card */}
-        <div className="panel dashboard__card">
-          <h3 className="dashboard__card-title">Cost</h3>
-          <div className="dashboard__stat">
-            <span className="dashboard__stat-value">
-              ${usage.today_cost.toFixed(2)}
-            </span>
-            <span className="dashboard__stat-label">today</span>
+        <div className="dashboard__grid">
+          {/* Cost summary card */}
+          <div className="panel dashboard__card">
+            <h3 className="dashboard__card-title">Cost</h3>
+            <div className="dashboard__stat">
+              <span className="dashboard__stat-value">
+                ${usage.today_cost.toFixed(2)}
+              </span>
+              <span className="dashboard__stat-label">today</span>
+            </div>
+            <div className="dashboard__stat">
+              <span className="dashboard__stat-value">
+                ${usage.month_cost.toFixed(2)}
+              </span>
+              <span className="dashboard__stat-label">this month</span>
+            </div>
           </div>
-          <div className="dashboard__stat">
-            <span className="dashboard__stat-value">
-              ${usage.month_cost.toFixed(2)}
-            </span>
-            <span className="dashboard__stat-label">this month</span>
+
+          {/* Token summary card */}
+          <div className="panel dashboard__card">
+            <h3 className="dashboard__card-title">Tokens</h3>
+            <div className="dashboard__stat">
+              <span className="dashboard__stat-value">
+                {formatTokens(usage.today_tokens)}
+              </span>
+              <span className="dashboard__stat-label">today</span>
+            </div>
+            <div className="dashboard__stat">
+              <span className="dashboard__stat-value">
+                {formatTokens(usage.month_tokens)}
+              </span>
+              <span className="dashboard__stat-label">this month</span>
+            </div>
+          </div>
+
+          {/* Sessions card */}
+          <div className="panel dashboard__card">
+            <h3 className="dashboard__card-title">Sessions</h3>
+            <div className="dashboard__stat">
+              <span className="dashboard__stat-value">{sessions.length}</span>
+              <span className="dashboard__stat-label">total</span>
+            </div>
+            <div className="dashboard__stat">
+              <span className="dashboard__stat-value">
+                {sessions.filter((s) => s.status === "working").length}
+              </span>
+              <span className="dashboard__stat-label">active</span>
+            </div>
+          </div>
+
+          {/* Notifications card */}
+          <div className="panel dashboard__card">
+            <h3 className="dashboard__card-title">Notifications</h3>
+            <div className="dashboard__stat">
+              <span className="dashboard__stat-value">
+                {notifications.filter((n) => !n.read).length}
+              </span>
+              <span className="dashboard__stat-label">unread</span>
+            </div>
+            <div className="dashboard__stat">
+              <span className="dashboard__stat-value">
+                {notifications.length}
+              </span>
+              <span className="dashboard__stat-label">total</span>
+            </div>
           </div>
         </div>
 
-        {/* Token summary card */}
-        <div className="panel dashboard__card">
-          <h3 className="dashboard__card-title">Tokens</h3>
-          <div className="dashboard__stat">
-            <span className="dashboard__stat-value">
-              {formatTokens(usage.today_tokens)}
-            </span>
-            <span className="dashboard__stat-label">today</span>
-          </div>
-          <div className="dashboard__stat">
-            <span className="dashboard__stat-value">
-              {formatTokens(usage.month_tokens)}
-            </span>
-            <span className="dashboard__stat-label">this month</span>
-          </div>
-        </div>
-
-        {/* Sessions card */}
-        <div className="panel dashboard__card">
-          <h3 className="dashboard__card-title">Sessions</h3>
-          <div className="dashboard__stat">
-            <span className="dashboard__stat-value">{sessions.length}</span>
-            <span className="dashboard__stat-label">total</span>
-          </div>
-          <div className="dashboard__stat">
-            <span className="dashboard__stat-value">
-              {sessions.filter((s) => s.status === "working").length}
-            </span>
-            <span className="dashboard__stat-label">active</span>
-          </div>
-        </div>
-
-        {/* Notifications card */}
-        <div className="panel dashboard__card">
-          <h3 className="dashboard__card-title">Notifications</h3>
-          <div className="dashboard__stat">
-            <span className="dashboard__stat-value">
-              {notifications.filter((n) => !n.read).length}
-            </span>
-            <span className="dashboard__stat-label">unread</span>
-          </div>
-          <div className="dashboard__stat">
-            <span className="dashboard__stat-value">
-              {notifications.length}
-            </span>
-            <span className="dashboard__stat-label">total</span>
-          </div>
-        </div>
-      </div>
-
-      {/* Project cards */}
-      <section className="dashboard__projects">
-        <h2>Projects</h2>
-        {activeProjects.length === 0 ? (
-          <div className="dashboard__empty">
-            <p>No active projects.</p>
-            <button
-              className="btn btn-primary"
-              onClick={() => setShowCreate(true)}
-              style={{ marginTop: "var(--space-3)" }}
-            >
-              Create your first project
-            </button>
-          </div>
-        ) : (
-          <div className="dashboard__project-grid">
-            {activeProjects.map((project) => (
+        {/* Project cards */}
+        <section className="dashboard__projects">
+          <h2>Projects</h2>
+          {activeProjects.length === 0 ? (
+            <div className="dashboard__empty">
+              <p>No active projects.</p>
               <button
-                key={project.id}
-                className="panel dashboard__project-card"
-                onClick={() => navigate(`/projects/${project.id}`)}
+                className="btn btn-primary"
+                onClick={() => setShowCreate(true)}
+                style={{ marginTop: "var(--space-3)" }}
               >
-                <div className="dashboard__project-header">
-                  <h3>{project.name}</h3>
-                  <StatusBadge status={project.status} size="sm" />
-                </div>
-                {project.description && (
-                  <p className="dashboard__project-desc">
-                    {project.description}
-                  </p>
-                )}
-                <div className="dashboard__project-meta">
-                  <span>
-                    {
-                      sessions.filter((s) => s.project_id === project.id)
-                        .length
-                    }{" "}
-                    sessions
-                  </span>
-                  <TimeAgo datetime={project.updated_at} />
-                </div>
+                Create your first project
               </button>
-            ))}
-          </div>
-        )}
-      </section>
+            </div>
+          ) : (
+            <div className="dashboard__project-grid">
+              {activeProjects.map((project) => (
+                <button
+                  key={project.id}
+                  className="panel dashboard__project-card"
+                  onClick={() => navigate(`/projects/${project.id}`)}
+                >
+                  <div className="dashboard__project-header">
+                    <h3>{project.name}</h3>
+                    <StatusBadge status={project.status} size="sm" />
+                  </div>
+                  {project.description && (
+                    <p className="dashboard__project-desc">
+                      {project.description}
+                    </p>
+                  )}
+                  <div className="dashboard__project-meta">
+                    <span>
+                      {
+                        sessions.filter((s) => s.project_id === project.id)
+                          .length
+                      }{" "}
+                      sessions
+                    </span>
+                    <TimeAgo datetime={project.updated_at} />
+                  </div>
+                </button>
+              ))}
+            </div>
+          )}
+        </section>
 
-      <CreateProjectModal
-        open={showCreate}
-        onClose={() => setShowCreate(false)}
-        onCreated={() => {
-          void fetchAll();
-        }}
-      />
+        <CreateProjectModal
+          open={showCreate}
+          onClose={() => setShowCreate(false)}
+          onCreated={() => {
+            void fetchAll();
+          }}
+        />
+      </div>
+
+      {/* Right column: Tower terminal */}
+      <div className="dashboard__tower panel">
+        <TowerConsole />
+      </div>
     </div>
   );
 }

--- a/frontend/src/pages/__tests__/Dashboard.test.tsx
+++ b/frontend/src/pages/__tests__/Dashboard.test.tsx
@@ -3,6 +3,14 @@ import { screen } from "@testing-library/react";
 import Dashboard from "../Dashboard";
 import { renderWithProviders } from "../../test/helpers";
 
+// Mock useTerminal since TowerConsole uses it
+vi.mock("../../hooks/useTerminal", () => ({
+  useTerminal: () => ({
+    attachRef: vi.fn(),
+    fit: vi.fn(),
+  }),
+}));
+
 beforeEach(() => {
   vi.spyOn(globalThis, "fetch").mockResolvedValue(
     new Response(JSON.stringify([]), { status: 200 }),
@@ -41,5 +49,10 @@ describe("Dashboard", () => {
   it("shows the Projects heading", () => {
     renderWithProviders(<Dashboard />);
     expect(screen.getByText("Projects")).toBeInTheDocument();
+  });
+
+  it("renders TowerConsole in the dashboard", () => {
+    renderWithProviders(<Dashboard />);
+    expect(screen.getByTestId("tower-console")).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary
- **New TowerConsole component** — Full interactive terminal panel for the Tower Claude session, modeled after LeaderConsole. Shows status badge, start/stop controls, goal input (when idle), PTY terminal + message input (when running).
- **Dashboard 2-column layout** — Projects and metrics on the left, TowerConsole on the right (420px). Tower is now the primary interaction surface on the Dashboard.
- **Removed TowerPanel from global Layout** — The old collapsed bottom bar with "describe a goal" input is replaced by the embedded TowerConsole on the Dashboard page.

## Changes
| File | Change |
|------|--------|
| `frontend/src/components/tower/TowerConsole.tsx` | New full terminal console component |
| `frontend/src/components/tower/TowerConsole.css` | Styling matching LeaderConsole patterns |
| `frontend/src/components/tower/__tests__/TowerConsole.test.tsx` | Unit tests (9 tests) |
| `frontend/src/pages/Dashboard.tsx` | 2-column layout with TowerConsole |
| `frontend/src/pages/Dashboard.css` | Grid layout for two-column mode |
| `frontend/src/pages/__tests__/Dashboard.test.tsx` | Updated tests + TowerConsole presence test |
| `frontend/src/App.tsx` | Removed TowerPanel from Layout |

## Test plan
- [x] All 174 frontend tests pass (18 test files)
- [x] No new TypeScript errors introduced
- [ ] Manual: Dashboard shows 2-column layout with Tower terminal on right
- [ ] Manual: Tower Start/Stop/Complete controls work
- [ ] Manual: Terminal displays PTY output when Tower is running
- [ ] Manual: Message input sends instructions to Tower


🤖 Generated with [Claude Code](https://claude.com/claude-code)