### PR TITLE
feat: domain-specific error types with frontend mapping

### DIFF
--- a/frontend/src/components/common/ApiErrorBanner.tsx
+++ b/frontend/src/components/common/ApiErrorBanner.tsx
@@ -1,0 +1,152 @@
+/**
+ * Inline error banner that maps ATC domain error codes to actionable UI.
+ *
+ * Usage:
+ *   <ApiErrorBanner error={apiError} onRetry={refetch} onDismiss={clearError} />
+ *
+ * Renders contextual actions based on error code:
+ *   - session_stale  → "Reconnect" button
+ *   - github_rate_limited → retry countdown timer
+ *   - github_auth_failed → "Re-authenticate" button
+ *   - everything else → dismissable message
+ */
+
+import { useEffect, useState } from "react";
+import { ApiError } from "../../utils/api";
+import { getErrorAction, getErrorTitle } from "../../utils/errors";
+
+interface Props {
+  error: ApiError | Error | null;
+  /** Called when the user clicks Retry / Reconnect. */
+  onRetry?: () => void;
+  /** Called when the user dismisses the banner. */
+  onDismiss?: () => void;
+}
+
+export default function ApiErrorBanner({ error, onRetry, onDismiss }: Props) {
+  const [countdown, setCountdown] = useState<number | null>(null);
+
+  const code = error instanceof ApiError ? error.code : null;
+  const extra = error instanceof ApiError ? error.extra : {};
+  const action = code ? getErrorAction(code, extra) : { type: "dismiss" as const };
+  const retryAfter = action.type === "retry" ? action.retryAfter : undefined;
+
+  // Auto-retry countdown for rate-limited errors
+  useEffect(() => {
+    if (action.type !== "retry" || !retryAfter) return;
+    setCountdown(retryAfter);
+    const interval = setInterval(() => {
+      setCountdown((prev) => {
+        if (prev === null || prev <= 1) {
+          clearInterval(interval);
+          onRetry?.();
+          return null;
+        }
+        return prev - 1;
+      });
+    }, 1000);
+    return () => clearInterval(interval);
+  }, [action.type, retryAfter, onRetry]);
+
+  if (!error) return null;
+
+  const title = code ? getErrorTitle(code) : "Error";
+  const message = error.message;
+
+  return (
+    <div style={styles.banner} role="alert">
+      <div style={styles.content}>
+        <strong style={styles.title}>{title}</strong>
+        <span style={styles.message}>{message}</span>
+      </div>
+      <div style={styles.actions}>
+        {action.type === "reconnect" && (
+          <button style={styles.actionBtn} onClick={onRetry}>
+            Reconnect
+          </button>
+        )}
+        {action.type === "retry" && (
+          <button
+            style={styles.actionBtn}
+            onClick={onRetry}
+            disabled={countdown !== null}
+          >
+            {countdown !== null ? `Retry in ${countdown}s` : "Retry"}
+          </button>
+        )}
+        {action.type === "relogin" && (
+          <button
+            style={styles.actionBtn}
+            onClick={() => {
+              window.location.href = "/settings";
+            }}
+          >
+            Re-authenticate
+          </button>
+        )}
+        {onDismiss && (
+          <button style={styles.dismissBtn} onClick={onDismiss} aria-label="Dismiss">
+            &times;
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}
+
+const styles: Record<string, React.CSSProperties> = {
+  banner: {
+    display: "flex",
+    alignItems: "center",
+    justifyContent: "space-between",
+    gap: "0.75rem",
+    padding: "0.625rem 1rem",
+    borderRadius: 6,
+    background: "var(--color-bg-raised, #1a1a1a)",
+    border: "1px solid var(--color-status-red, #ef4444)",
+    fontSize: "0.8125rem",
+  },
+  content: {
+    display: "flex",
+    flexDirection: "column" as const,
+    gap: "0.125rem",
+    minWidth: 0,
+  },
+  title: {
+    color: "var(--color-status-red, #ef4444)",
+    fontSize: "0.8125rem",
+  },
+  message: {
+    color: "var(--color-text-secondary, #999)",
+    fontSize: "0.75rem",
+    overflow: "hidden",
+    textOverflow: "ellipsis",
+    whiteSpace: "nowrap" as const,
+  },
+  actions: {
+    display: "flex",
+    alignItems: "center",
+    gap: "0.5rem",
+    flexShrink: 0,
+  },
+  actionBtn: {
+    padding: "0.25rem 0.75rem",
+    fontSize: "0.75rem",
+    borderRadius: 4,
+    border: "1px solid var(--color-accent, #3b82f6)",
+    background: "var(--color-accent, #3b82f6)",
+    color: "#fff",
+    cursor: "pointer",
+    whiteSpace: "nowrap" as const,
+  },
+  dismissBtn: {
+    padding: "0.125rem 0.375rem",
+    fontSize: "1rem",
+    lineHeight: 1,
+    borderRadius: 4,
+    border: "none",
+    background: "transparent",
+    color: "var(--color-text-secondary, #999)",
+    cursor: "pointer",
+  },
+};

--- a/frontend/src/utils/api.ts
+++ b/frontend/src/utils/api.ts
@@ -9,12 +9,39 @@ const BASE = "/api";
 const REQUEST_TIMEOUT_MS = 30_000;
 
 export class ApiError extends Error {
+  /** Machine-readable error code from the backend (e.g. ``session_stale``). */
+  public code: string | null;
+  /** Extra context from the backend (e.g. ``retry_after``). */
+  public extra: Record<string, unknown>;
+
   constructor(
     public status: number,
     message: string,
+    code: string | null = null,
+    extra: Record<string, unknown> = {},
   ) {
     super(message);
     this.name = "ApiError";
+    this.code = code;
+    this.extra = extra;
+  }
+}
+
+/** Try to parse a structured ATC error body and throw an enriched ApiError. */
+function throwIfStructured(status: number, text: string): void {
+  try {
+    const parsed = JSON.parse(text);
+    if (parsed?.error?.code) {
+      throw new ApiError(
+        status,
+        parsed.error.message ?? text,
+        parsed.error.code,
+        parsed.error.extra ?? {},
+      );
+    }
+  } catch (e) {
+    if (e instanceof ApiError) throw e;
+    // Not structured JSON — caller will throw a plain ApiError
   }
 }
 
@@ -36,6 +63,7 @@ async function request<T>(
     });
     if (!res.ok) {
       const text = await res.text().catch(() => res.statusText);
+      throwIfStructured(res.status, text);
       throw new ApiError(res.status, text);
     }
     if (res.status === 204) return undefined as T;
@@ -83,6 +111,7 @@ export const api = {
     });
     if (!res.ok) {
       const text = await res.text().catch(() => res.statusText);
+      throwIfStructured(res.status, text);
       throw new ApiError(res.status, text);
     }
     return res.blob();

--- a/frontend/src/utils/errors.ts
+++ b/frontend/src/utils/errors.ts
@@ -1,0 +1,123 @@
+/**
+ * Domain error types and mapping for ATC frontend.
+ *
+ * The backend returns structured JSON errors:
+ *   { error: { code: string, message: string, extra?: Record<string, unknown> } }
+ *
+ * This module parses those responses and maps error codes to user-facing
+ * actions (reconnect, retry, re-login, etc.).
+ */
+
+// ---------------------------------------------------------------------------
+// Error codes (mirrors backend atc.core.errors)
+// ---------------------------------------------------------------------------
+
+export const ErrorCode = {
+  // Agent / session
+  SESSION_NOT_FOUND: "session_not_found",
+  SESSION_STALE: "session_stale",
+  CREATION_FAILED: "creation_failed",
+
+  // Budget
+  BUDGET_LIMIT_EXCEEDED: "budget_limit_exceeded",
+  NO_BUDGET_SET: "no_budget_set",
+
+  // GitHub
+  GITHUB_RATE_LIMITED: "github_rate_limited",
+  GITHUB_AUTH_FAILED: "github_auth_failed",
+} as const;
+
+export type ErrorCodeValue = (typeof ErrorCode)[keyof typeof ErrorCode];
+
+// ---------------------------------------------------------------------------
+// Structured error envelope
+// ---------------------------------------------------------------------------
+
+export interface ATCErrorBody {
+  error: {
+    code: string;
+    message: string;
+    extra?: Record<string, unknown>;
+  };
+}
+
+/** Action the UI should present to the user. */
+export type ErrorAction =
+  | { type: "reconnect"; sessionId?: string }
+  | { type: "retry"; retryAfter?: number }
+  | { type: "relogin" }
+  | { type: "dismiss" };
+
+// ---------------------------------------------------------------------------
+// Parsing
+// ---------------------------------------------------------------------------
+
+/**
+ * Try to parse a structured ATC error from an API response body string.
+ * Returns `null` if the body isn't in the expected format.
+ */
+export function parseATCError(body: string): ATCErrorBody | null {
+  try {
+    const parsed = JSON.parse(body);
+    if (parsed?.error?.code && parsed?.error?.message) {
+      return parsed as ATCErrorBody;
+    }
+  } catch {
+    // Not JSON — fall through
+  }
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// Code → action mapping
+// ---------------------------------------------------------------------------
+
+/**
+ * Map an error code to the recommended UI action.
+ */
+export function getErrorAction(
+  code: string,
+  extra?: Record<string, unknown>,
+): ErrorAction {
+  switch (code) {
+    case ErrorCode.SESSION_STALE:
+      return {
+        type: "reconnect",
+        sessionId: extra?.session_id as string | undefined,
+      };
+
+    case ErrorCode.GITHUB_RATE_LIMITED:
+      return {
+        type: "retry",
+        retryAfter: (extra?.retry_after as number) ?? 60,
+      };
+
+    case ErrorCode.GITHUB_AUTH_FAILED:
+      return { type: "relogin" };
+
+    case ErrorCode.BUDGET_LIMIT_EXCEEDED:
+      return { type: "dismiss" };
+
+    default:
+      return { type: "dismiss" };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Human-readable labels
+// ---------------------------------------------------------------------------
+
+const ERROR_TITLES: Record<string, string> = {
+  [ErrorCode.SESSION_NOT_FOUND]: "Session Not Found",
+  [ErrorCode.SESSION_STALE]: "Session Out of Sync",
+  [ErrorCode.CREATION_FAILED]: "Session Creation Failed",
+  [ErrorCode.BUDGET_LIMIT_EXCEEDED]: "Budget Limit Exceeded",
+  [ErrorCode.NO_BUDGET_SET]: "No Budget Configured",
+  [ErrorCode.GITHUB_RATE_LIMITED]: "GitHub Rate Limited",
+  [ErrorCode.GITHUB_AUTH_FAILED]: "GitHub Auth Failed",
+};
+
+/** Get a human-friendly title for an error code. Falls back to the code itself. */
+export function getErrorTitle(code: string): string {
+  return ERROR_TITLES[code] ?? code;
+}

--- a/src/atc/api/app.py
+++ b/src/atc/api/app.py
@@ -7,11 +7,13 @@ from contextlib import asynccontextmanager
 from typing import TYPE_CHECKING, Any
 
 import uvicorn
-from fastapi import FastAPI, WebSocket
+from fastapi import FastAPI, Request, WebSocket
+from fastapi.responses import JSONResponse
 
 from atc import __version__
 from atc.api.ws.hub import WsHub
 from atc.config import Settings, load_settings
+from atc.core.errors import ATCError
 from atc.core.events import EventBus
 from atc.state.db import run_migrations
 from atc.terminal.pty_stream import PtyStreamPool
@@ -167,6 +169,11 @@ def create_app(settings: Settings | None = None) -> FastAPI:
         lifespan=lifespan,
     )
     app.state.settings = settings
+
+    # Register domain error handler — serializes ATCError subclasses to JSON
+    @app.exception_handler(ATCError)
+    async def _atc_error_handler(request: Request, exc: ATCError) -> JSONResponse:
+        return JSONResponse(status_code=exc.status_code, content=exc.to_dict())
 
     # Register routers
     from atc.api.routers import (

--- a/src/atc/api/routers/aces.py
+++ b/src/atc/api/routers/aces.py
@@ -20,6 +20,7 @@ from pydantic import BaseModel
 
 from atc.agents.deploy import AceDeploySpec, deploy_ace_files
 from atc.agents.factory import get_launch_command
+from atc.core.errors import CreationFailedError, SessionNotFoundError, SessionStaleError
 from atc.session import ace as ace_ops
 from atc.session.state_machine import InvalidTransitionError
 from atc.state import db as db_ops
@@ -151,7 +152,7 @@ async def create_ace(project_id: str, body: CreateAceRequest, request: Request) 
     )
     session = await db_ops.get_session(db, session_id)
     if session is None:
-        raise HTTPException(status_code=500, detail="Session creation failed")
+        raise CreationFailedError(f"Session creation failed for project {project_id}")
     return _session_to_response(session)
 
 
@@ -162,9 +163,9 @@ async def start_ace(session_id: str, body: StartAceRequest, request: Request) ->
     try:
         await ace_ops.start_ace(db, session_id, instruction=body.instruction, event_bus=event_bus)
     except ValueError as e:
-        raise HTTPException(status_code=404, detail=str(e)) from None
+        raise SessionNotFoundError(str(e)) from None
     except InvalidTransitionError as e:
-        raise HTTPException(status_code=409, detail=str(e)) from None
+        raise SessionStaleError(str(e)) from None
     return {"status": "started"}
 
 
@@ -175,9 +176,9 @@ async def stop_ace(session_id: str, request: Request) -> dict[str, str]:
     try:
         await ace_ops.stop_ace(db, session_id, event_bus=event_bus)
     except ValueError as e:
-        raise HTTPException(status_code=404, detail=str(e)) from None
+        raise SessionNotFoundError(str(e)) from None
     except InvalidTransitionError as e:
-        raise HTTPException(status_code=409, detail=str(e)) from None
+        raise SessionStaleError(str(e)) from None
     return {"status": "stopped"}
 
 
@@ -195,7 +196,7 @@ async def update_ace_status(
 
     session = await db_ops.get_session(db, session_id)
     if session is None:
-        raise HTTPException(status_code=404, detail=f"Session {session_id} not found")
+        raise SessionNotFoundError(f"Session {session_id} not found")
 
     try:
         target = SessionStatus(body.status)
@@ -210,7 +211,7 @@ async def update_ace_status(
         await transition(session.id, current, target, event_bus)
         await db_ops.update_session_status(db, session.id, target.value)
     except InvalidTransitionError as exc:
-        raise HTTPException(status_code=409, detail=str(exc)) from None
+        raise SessionStaleError(str(exc)) from None
 
     return {"status": target.value}
 
@@ -230,7 +231,7 @@ async def notify_ace(
 
     session = await db_ops.get_session(db, session_id)
     if session is None:
-        raise HTTPException(status_code=404, detail=f"Session {session_id} not found")
+        raise SessionNotFoundError(f"Session {session_id} not found")
 
     now = datetime.now(UTC).isoformat()
     await db.execute(
@@ -268,10 +269,10 @@ async def message_ace(
 
     session = await db_ops.get_session(db, session_id)
     if session is None:
-        raise HTTPException(status_code=404, detail=f"Session {session_id} not found")
+        raise SessionNotFoundError(f"Session {session_id} not found")
 
     if session.tmux_pane is None:
-        raise HTTPException(status_code=409, detail="Session has no tmux pane")
+        raise SessionStaleError("Session has no tmux pane")
 
     from atc.session.ace import _send_keys
     from atc.session.state_machine import SessionStatus, transition
@@ -295,4 +296,4 @@ async def delete_ace(session_id: str, request: Request) -> None:
     try:
         await ace_ops.destroy_ace(db, session_id, event_bus=event_bus)
     except ValueError as e:
-        raise HTTPException(status_code=404, detail=str(e)) from None
+        raise SessionNotFoundError(str(e)) from None

--- a/src/atc/core/errors.py
+++ b/src/atc/core/errors.py
@@ -1,0 +1,156 @@
+"""Domain-specific error types for ATC.
+
+Each error carries a machine-readable ``code`` that the frontend maps to
+appropriate UI (reconnect button, retry timer, re-login prompt, etc.).
+
+Hierarchy
+---------
+ATCError (base)
+├── AgentError
+│   ├── SessionNotFoundError
+│   ├── SessionStaleError
+│   └── CreationFailedError
+├── BudgetError
+│   ├── LimitExceededError
+│   └── NoBudgetSetError
+└── GitHubError
+    ├── RateLimitedError
+    └── AuthFailedError
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+class ATCError(Exception):
+    """Base error for all ATC domain exceptions.
+
+    Attributes:
+        code: Machine-readable error code (e.g. ``session_not_found``).
+        status_code: Suggested HTTP status code for API responses.
+        detail: Human-readable message.
+        extra: Optional dict of additional context for the frontend.
+    """
+
+    code: str = "internal_error"
+    status_code: int = 500
+
+    def __init__(
+        self,
+        detail: str | None = None,
+        *,
+        extra: dict[str, Any] | None = None,
+    ) -> None:
+        self.detail = detail or self.__class__.__doc__ or self.code
+        self.extra: dict[str, Any] = extra or {}
+        super().__init__(self.detail)
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize to the structured JSON envelope the frontend expects."""
+        payload: dict[str, Any] = {
+            "error": {
+                "code": self.code,
+                "message": self.detail,
+            },
+        }
+        if self.extra:
+            payload["error"]["extra"] = self.extra
+        return payload
+
+
+# ---------------------------------------------------------------------------
+# Agent / session errors
+# ---------------------------------------------------------------------------
+
+
+class AgentError(ATCError):
+    """Base for agent/session-related errors."""
+
+    code = "agent_error"
+    status_code = 500
+
+
+class SessionNotFoundError(AgentError):
+    """The requested session does not exist."""
+
+    code = "session_not_found"
+    status_code = 404
+
+
+class SessionStaleError(AgentError):
+    """The session's state has changed since the client last fetched it."""
+
+    code = "session_stale"
+    status_code = 409
+
+
+class CreationFailedError(AgentError):
+    """Failed to create an agent session."""
+
+    code = "creation_failed"
+    status_code = 500
+
+
+# ---------------------------------------------------------------------------
+# Budget errors
+# ---------------------------------------------------------------------------
+
+
+class BudgetError(ATCError):
+    """Base for budget-related errors."""
+
+    code = "budget_error"
+    status_code = 402
+
+
+class LimitExceededError(BudgetError):
+    """The budget limit has been exceeded."""
+
+    code = "budget_limit_exceeded"
+    status_code = 402
+
+
+class NoBudgetSetError(BudgetError):
+    """No budget has been configured for this project."""
+
+    code = "no_budget_set"
+    status_code = 404
+
+
+# ---------------------------------------------------------------------------
+# GitHub errors
+# ---------------------------------------------------------------------------
+
+
+class GitHubError(ATCError):
+    """Base for GitHub integration errors."""
+
+    code = "github_error"
+    status_code = 502
+
+
+class RateLimitedError(GitHubError):
+    """GitHub API rate limit has been hit."""
+
+    code = "github_rate_limited"
+    status_code = 429
+
+    def __init__(
+        self,
+        detail: str | None = None,
+        *,
+        retry_after: int | None = None,
+        extra: dict[str, Any] | None = None,
+    ) -> None:
+        merged: dict[str, Any] = dict(extra or {})
+        if retry_after is not None:
+            merged["retry_after"] = retry_after
+        super().__init__(detail, extra=merged)
+
+
+class AuthFailedError(GitHubError):
+    """GitHub authentication failed or token expired."""
+
+    code = "github_auth_failed"
+    status_code = 401

--- a/tests/unit/test_domain_errors.py
+++ b/tests/unit/test_domain_errors.py
@@ -1,0 +1,155 @@
+"""Unit tests for domain error classes and FastAPI exception handler."""
+
+from __future__ import annotations
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from atc.core.errors import (
+    ATCError,
+    AuthFailedError,
+    BudgetError,
+    CreationFailedError,
+    GitHubError,
+    LimitExceededError,
+    NoBudgetSetError,
+    RateLimitedError,
+    SessionNotFoundError,
+    SessionStaleError,
+)
+
+
+class TestErrorHierarchy:
+    def test_base_defaults(self) -> None:
+        err = ATCError()
+        assert err.code == "internal_error"
+        assert err.status_code == 500
+        assert err.extra == {}
+
+    def test_custom_detail(self) -> None:
+        err = ATCError("something broke", extra={"key": "val"})
+        assert str(err) == "something broke"
+        assert err.detail == "something broke"
+        assert err.extra == {"key": "val"}
+
+    def test_session_not_found(self) -> None:
+        err = SessionNotFoundError("sess-123 missing")
+        assert err.code == "session_not_found"
+        assert err.status_code == 404
+        assert "sess-123" in err.detail
+
+    def test_session_stale(self) -> None:
+        err = SessionStaleError("state changed")
+        assert err.code == "session_stale"
+        assert err.status_code == 409
+
+    def test_creation_failed(self) -> None:
+        err = CreationFailedError()
+        assert err.code == "creation_failed"
+        assert err.status_code == 500
+
+    def test_budget_limit_exceeded(self) -> None:
+        err = LimitExceededError("over budget")
+        assert err.code == "budget_limit_exceeded"
+        assert err.status_code == 402
+        assert isinstance(err, BudgetError)
+        assert isinstance(err, ATCError)
+
+    def test_no_budget_set(self) -> None:
+        err = NoBudgetSetError()
+        assert err.code == "no_budget_set"
+        assert err.status_code == 404
+
+    def test_rate_limited_with_retry_after(self) -> None:
+        err = RateLimitedError("slow down", retry_after=60)
+        assert err.code == "github_rate_limited"
+        assert err.status_code == 429
+        assert err.extra["retry_after"] == 60
+        assert isinstance(err, GitHubError)
+
+    def test_auth_failed(self) -> None:
+        err = AuthFailedError("token expired")
+        assert err.code == "github_auth_failed"
+        assert err.status_code == 401
+
+
+class TestToDict:
+    def test_minimal(self) -> None:
+        d = SessionNotFoundError("gone").to_dict()
+        assert d == {"error": {"code": "session_not_found", "message": "gone"}}
+
+    def test_with_extra(self) -> None:
+        err = RateLimitedError("slow", retry_after=30)
+        d = err.to_dict()
+        assert d["error"]["extra"]["retry_after"] == 30
+
+
+@pytest.fixture()
+def app_with_handler() -> FastAPI:
+    """Minimal FastAPI app with the ATCError handler registered."""
+    from fastapi.responses import JSONResponse
+
+    app = FastAPI()
+
+    @app.exception_handler(ATCError)
+    async def handler(request: object, exc: ATCError) -> JSONResponse:
+        return JSONResponse(status_code=exc.status_code, content=exc.to_dict())
+
+    @app.get("/not-found")
+    async def not_found() -> None:
+        raise SessionNotFoundError("sess-abc")
+
+    @app.get("/stale")
+    async def stale() -> None:
+        raise SessionStaleError("state changed")
+
+    @app.get("/rate-limited")
+    async def rate_limited() -> None:
+        raise RateLimitedError("GitHub API limit", retry_after=120)
+
+    @app.get("/auth-failed")
+    async def auth_failed() -> None:
+        raise AuthFailedError("bad token")
+
+    @app.get("/budget")
+    async def budget() -> None:
+        raise LimitExceededError("over $100 limit")
+
+    return app
+
+
+class TestExceptionHandler:
+    def test_session_not_found_returns_404(self, app_with_handler: FastAPI) -> None:
+        client = TestClient(app_with_handler)
+        resp = client.get("/not-found")
+        assert resp.status_code == 404
+        body = resp.json()
+        assert body["error"]["code"] == "session_not_found"
+        assert "sess-abc" in body["error"]["message"]
+
+    def test_session_stale_returns_409(self, app_with_handler: FastAPI) -> None:
+        client = TestClient(app_with_handler)
+        resp = client.get("/stale")
+        assert resp.status_code == 409
+        assert resp.json()["error"]["code"] == "session_stale"
+
+    def test_rate_limited_returns_429(self, app_with_handler: FastAPI) -> None:
+        client = TestClient(app_with_handler)
+        resp = client.get("/rate-limited")
+        assert resp.status_code == 429
+        body = resp.json()
+        assert body["error"]["code"] == "github_rate_limited"
+        assert body["error"]["extra"]["retry_after"] == 120
+
+    def test_auth_failed_returns_401(self, app_with_handler: FastAPI) -> None:
+        client = TestClient(app_with_handler)
+        resp = client.get("/auth-failed")
+        assert resp.status_code == 401
+        assert resp.json()["error"]["code"] == "github_auth_failed"
+
+    def test_budget_returns_402(self, app_with_handler: FastAPI) -> None:
+        client = TestClient(app_with_handler)
+        resp = client.get("/budget")
+        assert resp.status_code == 402
+        assert resp.json()["error"]["code"] == "budget_limit_exceeded"


### PR DESCRIPTION
## Summary
- Add domain error hierarchy in `src/atc/core/errors.py`: `ATCError` base with `AgentError` (SessionNotFound, SessionStale, CreationFailed), `BudgetError` (LimitExceeded, NoBudgetSet), `GitHubError` (RateLimited, AuthFailed)
- Register FastAPI exception handler that serializes domain errors to structured JSON: `{ error: { code, message, extra? } }`
- Update `aces.py` router to raise domain errors instead of generic `HTTPException` for session operations
- Enhance frontend `ApiError` class with `code` and `extra` fields; add `throwIfStructured()` parser to `api.ts`
- New `frontend/src/utils/errors.ts` with error code constants, code→action mapping, and human-readable titles
- New `ApiErrorBanner` React component that renders contextual actions: session stale → reconnect button, rate limited → retry countdown, auth failed → re-authenticate

## Test plan
- [x] 16 new unit tests for error classes, serialization, and FastAPI handler integration
- [x] All 485 existing backend tests pass
- [x] All 164 frontend tests pass
- [x] TypeScript type-check clean (no new errors)
- [ ] Manual: trigger a session-not-found error and verify structured JSON response
- [ ] Manual: render `<ApiErrorBanner>` with different error codes to verify UI actions

🤖 Generated with [Claude Code](https://claude.com/claude-code)