### PR TITLE
feat: add structured app event logging with log viewer UI

### DIFF
--- a/frontend/src/pages/SettingsPage.css
+++ b/frontend/src/pages/SettingsPage.css
@@ -140,8 +140,12 @@
 }
 
 @keyframes progress-indeterminate {
-  0% { transform: translateX(-100%); }
-  100% { transform: translateX(400%); }
+  0% {
+    transform: translateX(-100%);
+  }
+  100% {
+    transform: translateX(400%);
+  }
 }
 
 .settings-page__success {
@@ -219,4 +223,129 @@
   gap: var(--space-2);
   justify-content: flex-end;
   margin-top: var(--space-4);
+}
+
+/* Log Viewer */
+.settings-page__logs-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: var(--space-2);
+}
+.settings-page__logs-header h2 {
+  margin-bottom: 0;
+}
+.settings-page__logs-actions {
+  display: flex;
+  gap: var(--space-2);
+}
+.settings-page__logs-filters {
+  display: flex;
+  gap: var(--space-3);
+  margin-bottom: var(--space-3);
+}
+.form-group--inline {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+}
+.form-group--inline label {
+  font-size: var(--text-sm);
+  color: var(--color-text-secondary);
+  white-space: nowrap;
+}
+.settings-page__logs-table-wrap {
+  max-height: 420px;
+  overflow-y: auto;
+  border: 1px solid var(--color-border-subtle);
+  border-radius: 6px;
+}
+.settings-page__logs-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: var(--text-sm);
+}
+.settings-page__logs-table thead {
+  position: sticky;
+  top: 0;
+  background: var(--color-bg-secondary, var(--color-bg));
+  z-index: 1;
+}
+.settings-page__logs-table th {
+  text-align: left;
+  padding: var(--space-2) var(--space-3);
+  font-weight: 600;
+  color: var(--color-text-secondary);
+  border-bottom: 1px solid var(--color-border-subtle);
+}
+.settings-page__logs-table td {
+  padding: var(--space-2) var(--space-3);
+  border-bottom: 1px solid var(--color-border-subtle);
+  vertical-align: top;
+}
+.settings-page__logs-table tbody tr:last-child td {
+  border-bottom: none;
+}
+.settings-page__log-time {
+  white-space: nowrap;
+  color: var(--color-text-secondary);
+  font-family: var(--font-mono);
+  font-size: 0.75rem;
+}
+.settings-page__log-badge {
+  display: inline-block;
+  padding: 1px 6px;
+  border-radius: 4px;
+  font-size: 0.7rem;
+  font-weight: 600;
+  text-transform: uppercase;
+}
+.settings-page__log-badge--debug {
+  background: rgba(100, 100, 100, 0.2);
+  color: var(--color-text-secondary);
+}
+.settings-page__log-badge--info {
+  background: rgba(59, 130, 246, 0.15);
+  color: rgb(96, 165, 250);
+}
+.settings-page__log-badge--warning {
+  background: rgba(245, 158, 11, 0.15);
+  color: rgb(251, 191, 36);
+}
+.settings-page__log-badge--error {
+  background: rgba(239, 68, 68, 0.15);
+  color: rgb(248, 113, 113);
+}
+.settings-page__log-badge--critical {
+  background: rgba(239, 68, 68, 0.25);
+  color: rgb(252, 165, 165);
+}
+.settings-page__log-row--error td,
+.settings-page__log-row--critical td {
+  background: rgba(239, 68, 68, 0.04);
+}
+.settings-page__log-message {
+  word-break: break-word;
+  max-width: 400px;
+}
+.settings-page__log-detail {
+  margin-top: var(--space-1);
+}
+.settings-page__log-detail summary {
+  cursor: pointer;
+  font-size: 0.7rem;
+  color: var(--color-text-secondary);
+}
+.settings-page__log-detail pre {
+  margin-top: var(--space-1);
+  padding: var(--space-2);
+  background: var(--color-bg);
+  border-radius: 4px;
+  font-size: 0.7rem;
+  overflow-x: auto;
+  max-height: 200px;
+}
+.btn-sm {
+  padding: 4px 10px;
+  font-size: var(--text-sm);
 }

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -1,9 +1,9 @@
-import { useState, useRef, useEffect } from "react";
+import { useState, useRef, useEffect, useCallback } from "react";
 import { useOutletContext } from "react-router-dom";
 import { useAppContext } from "../context/AppContext";
 import { api } from "../utils/api";
 import { hasConsent, setConsent, sendReport } from "../utils/sentry";
-import type { AgentProviderConfig, ProviderInfo } from "../types";
+import type { AgentProviderConfig, AppEvent, ProviderInfo } from "../types";
 import type { UseUpdaterReturn } from "../hooks/useUpdater";
 import "./SettingsPage.css";
 
@@ -61,6 +61,14 @@ export default function SettingsPage() {
     "idle",
   );
 
+  const [logEvents, setLogEvents] = useState<AppEvent[]>([]);
+  const [logLoading, setLogLoading] = useState(false);
+  const [logError, setLogError] = useState("");
+  const [logLevelFilter, setLogLevelFilter] = useState("");
+  const [logCategoryFilter, setLogCategoryFilter] = useState("");
+  const [logExporting, setLogExporting] = useState(false);
+  const [logTotal, setLogTotal] = useState(0);
+
   useEffect(() => {
     api.get<AgentProviderConfig>("/settings/agent-provider").then(setProviderConfig).catch(() => {});
     api.get<ProviderInfo[]>("/settings/providers").then(setProviders).catch(() => {});
@@ -71,6 +79,51 @@ export default function SettingsPage() {
       .then(setSentryStatus)
       .catch(() => {});
   }, []);
+
+  const fetchLogs = useCallback(async () => {
+    setLogLoading(true);
+    setLogError("");
+    try {
+      const params = new URLSearchParams();
+      if (logLevelFilter) params.set("level", logLevelFilter);
+      if (logCategoryFilter) params.set("category", logCategoryFilter);
+      params.set("limit", "200");
+      const qs = params.toString();
+      const [events, countRes] = await Promise.all([
+        api.get<AppEvent[]>(`/app-events?${qs}`),
+        api.get<{ count: number }>(`/app-events/count?${qs}`),
+      ]);
+      setLogEvents(events);
+      setLogTotal(countRes.count);
+    } catch (e) {
+      setLogError(e instanceof Error ? e.message : "Failed to load logs");
+    } finally {
+      setLogLoading(false);
+    }
+  }, [logLevelFilter, logCategoryFilter]);
+
+  useEffect(() => {
+    fetchLogs();
+  }, [fetchLogs]);
+
+  async function handleExportLogs() {
+    setLogExporting(true);
+    try {
+      const params = new URLSearchParams();
+      if (logLevelFilter) params.set("level", logLevelFilter);
+      if (logCategoryFilter) params.set("category", logCategoryFilter);
+      const qs = params.toString();
+      const blob = await api.postBlob(`/app-events/export?${qs}`);
+      downloadBlob(
+        blob,
+        `atc-logs-${new Date().toISOString().slice(0, 10)}.zip`,
+      );
+    } catch (e) {
+      setLogError(e instanceof Error ? e.message : "Export failed");
+    } finally {
+      setLogExporting(false);
+    }
+  }
 
   async function handleProviderChange(newDefault: string) {
     setProviderSaving(true);
@@ -249,23 +302,37 @@ export default function SettingsPage() {
               <button
                 className="btn"
                 onClick={() => updater.checkForUpdates()}
-                disabled={updater.status === "checking" || updater.status === "downloading"}
+                disabled={
+                  updater.status === "checking" ||
+                  updater.status === "downloading"
+                }
                 data-testid="check-updates-btn"
               >
-                {updater.status === "checking" ? "Checking..." : "Check for Updates"}
+                {updater.status === "checking"
+                  ? "Checking..."
+                  : "Check for Updates"}
               </button>
               {updater.status === "available" && updater.updateInfo && (
-                <span className="settings-page__success" data-testid="update-available">
+                <span
+                  className="settings-page__success"
+                  data-testid="update-available"
+                >
                   v{updater.updateInfo.version} available!
                 </span>
               )}
               {updater.status === "idle" && (
-                <span className="settings-page__up-to-date" data-testid="up-to-date">
+                <span
+                  className="settings-page__up-to-date"
+                  data-testid="up-to-date"
+                >
                   Up to date
                 </span>
               )}
               {updater.error && (
-                <span className="settings-page__error" data-testid="update-error">
+                <span
+                  className="settings-page__error"
+                  data-testid="update-error"
+                >
                   {updater.error}
                 </span>
               )}
@@ -677,6 +744,131 @@ export default function SettingsPage() {
             </p>
           )}
         </section>
+
+        {/* Log Viewer */}
+        <section
+          className="panel settings-page__section"
+          data-testid="log-viewer-section"
+        >
+          <div className="settings-page__logs-header">
+            <h2>App Event Logs</h2>
+            <div className="settings-page__logs-actions">
+              <button
+                className="btn btn-sm"
+                onClick={fetchLogs}
+                disabled={logLoading}
+                data-testid="log-refresh-btn"
+              >
+                Refresh
+              </button>
+              <button
+                className="btn btn-sm"
+                onClick={handleExportLogs}
+                disabled={logExporting}
+                data-testid="log-export-btn"
+              >
+                {logExporting ? "Exporting..." : "Export Zip"}
+              </button>
+            </div>
+          </div>
+          <p className="settings-page__description">
+            Structured app events for debugging. Showing {logEvents.length} of{" "}
+            {logTotal} total.
+          </p>
+          <div className="settings-page__logs-filters">
+            <div className="form-group form-group--inline">
+              <label htmlFor="log-level-filter">Level</label>
+              <select
+                id="log-level-filter"
+                data-testid="log-level-filter"
+                value={logLevelFilter}
+                onChange={(e) => setLogLevelFilter(e.target.value)}
+              >
+                <option value="">All</option>
+                <option value="debug">Debug</option>
+                <option value="info">Info</option>
+                <option value="warning">Warning</option>
+                <option value="error">Error</option>
+                <option value="critical">Critical</option>
+              </select>
+            </div>
+            <div className="form-group form-group--inline">
+              <label htmlFor="log-category-filter">Category</label>
+              <select
+                id="log-category-filter"
+                data-testid="log-category-filter"
+                value={logCategoryFilter}
+                onChange={(e) => setLogCategoryFilter(e.target.value)}
+              >
+                <option value="">All</option>
+                <option value="session">Session</option>
+                <option value="task">Task</option>
+                <option value="error">Error</option>
+                <option value="cost">Cost</option>
+                <option value="system">System</option>
+              </select>
+            </div>
+          </div>
+          {logError && (
+            <p className="settings-page__error" data-testid="log-error">
+              {logError}
+            </p>
+          )}
+          {logLoading && logEvents.length === 0 ? (
+            <div className="settings-page__progress">
+              <div className="settings-page__progress-bar">
+                <div className="settings-page__progress-fill settings-page__progress-fill--indeterminate" />
+              </div>
+            </div>
+          ) : logEvents.length === 0 ? (
+            <p className="settings-page__description">No events found.</p>
+          ) : (
+            <div className="settings-page__logs-table-wrap">
+              <table
+                className="settings-page__logs-table"
+                data-testid="log-table"
+              >
+                <thead>
+                  <tr>
+                    <th>Time</th>
+                    <th>Level</th>
+                    <th>Category</th>
+                    <th>Message</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {logEvents.map((evt) => (
+                    <tr
+                      key={evt.id}
+                      className={`settings-page__log-row settings-page__log-row--${evt.level}`}
+                    >
+                      <td className="settings-page__log-time">
+                        {formatLogTime(evt.created_at)}
+                      </td>
+                      <td>
+                        <span
+                          className={`settings-page__log-badge settings-page__log-badge--${evt.level}`}
+                        >
+                          {evt.level}
+                        </span>
+                      </td>
+                      <td>{evt.category}</td>
+                      <td className="settings-page__log-message">
+                        {evt.message}
+                        {evt.detail && (
+                          <details className="settings-page__log-detail">
+                            <summary>detail</summary>
+                            <pre>{JSON.stringify(evt.detail, null, 2)}</pre>
+                          </details>
+                        )}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )}
+        </section>
       </div>
 
       {/* Restore Confirmation Dialog */}
@@ -717,6 +909,21 @@ export default function SettingsPage() {
 // ---------------------------------------------------------------------------
 // Utilities
 // ---------------------------------------------------------------------------
+
+function formatLogTime(iso: string): string {
+  try {
+    const d = new Date(iso);
+    return d.toLocaleString(undefined, {
+      month: "short",
+      day: "numeric",
+      hour: "2-digit",
+      minute: "2-digit",
+      second: "2-digit",
+    });
+  } catch {
+    return iso;
+  }
+}
 
 function downloadBlob(blob: Blob, filename: string) {
   const url = URL.createObjectURL(blob);

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -173,6 +173,17 @@ export interface SessionHeartbeat {
   updated_at: string;
 }
 
+export interface AppEvent {
+  id: string;
+  level: "debug" | "info" | "warning" | "error" | "critical";
+  category: "session" | "task" | "error" | "cost" | "system";
+  message: string;
+  detail: Record<string, unknown> | null;
+  project_id: string | null;
+  session_id: string | null;
+  created_at: string;
+}
+
 export interface AppState {
   projects: Project[];
   leaders: Record<string, Leader>;

--- a/src/atc/api/app.py
+++ b/src/atc/api/app.py
@@ -58,6 +58,11 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
 
     set_ws_hub(ws_hub)
 
+    # Wire app event broadcasting
+    from atc.core import app_events as _app_events_mod
+
+    _app_events_mod.set_ws_hub(ws_hub)
+
     # 4b. Start Tower controller
     from atc.tower.controller import TowerController
 

--- a/src/atc/api/routers/app_events.py
+++ b/src/atc/api/routers/app_events.py
@@ -1,0 +1,98 @@
+"""App event log REST endpoints.
+
+Routes:
+  GET    /api/app-events           -> list/filter app events
+  GET    /api/app-events/count     -> count matching events
+  POST   /api/app-events/export    -> export events as downloadable zip
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import zipfile
+from datetime import UTC, datetime
+from typing import Any
+
+from fastapi import APIRouter, Query, Request
+from fastapi.responses import StreamingResponse
+from pydantic import BaseModel
+
+from atc.core.app_events import count_events, export_events_json, list_events
+
+router = APIRouter()
+
+
+class AppEventResponse(BaseModel):
+    id: str
+    level: str
+    category: str
+    message: str
+    detail: dict[str, Any] | None = None
+    project_id: str | None = None
+    session_id: str | None = None
+    created_at: str
+
+
+class EventCountResponse(BaseModel):
+    count: int
+
+
+async def _get_db(request: Request) -> Any:
+    return request.app.state.db
+
+
+@router.get("/app-events/count", response_model=EventCountResponse)
+async def get_event_count(
+    request: Request,
+    level: str | None = Query(None),
+    category: str | None = Query(None),
+    project_id: str | None = Query(None),
+) -> EventCountResponse:
+    db = await _get_db(request)
+    total = await count_events(db, level=level, category=category, project_id=project_id)
+    return EventCountResponse(count=total)
+
+
+@router.get("/app-events", response_model=list[AppEventResponse])
+async def get_app_events(
+    request: Request,
+    level: str | None = Query(None),
+    category: str | None = Query(None),
+    project_id: str | None = Query(None),
+    limit: int = Query(200, ge=1, le=1000),
+    offset: int = Query(0, ge=0),
+) -> list[AppEventResponse]:
+    db = await _get_db(request)
+    events = await list_events(
+        db,
+        level=level,
+        category=category,
+        project_id=project_id,
+        limit=limit,
+        offset=offset,
+    )
+    return [AppEventResponse(**e) for e in events]
+
+
+@router.post("/app-events/export")
+async def export_app_events(
+    request: Request,
+    level: str | None = Query(None),
+    category: str | None = Query(None),
+    project_id: str | None = Query(None),
+) -> StreamingResponse:
+    db = await _get_db(request)
+    events = await export_events_json(db, level=level, category=category, project_id=project_id)
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w", zipfile.ZIP_DEFLATED) as zf:
+        payload = json.dumps(events, indent=2, default=str)
+        zf.writestr("app_events.json", payload)
+    buf.seek(0)
+    date_str = datetime.now(UTC).strftime("%Y-%m-%d")
+    filename = f"atc-logs-{date_str}.zip"
+    return StreamingResponse(
+        buf,
+        media_type="application/zip",
+        headers={"Content-Disposition": f'attachment; filename="{filename}"'},
+    )

--- a/src/atc/core/app_events.py
+++ b/src/atc/core/app_events.py
@@ -1,0 +1,170 @@
+"""Structured app-level event logging.
+
+Records queryable events (session lifecycle, task completion, errors, cost
+changes) to the ``app_events`` SQLite table.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import json
+import logging
+import uuid
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    import aiosqlite
+
+    from atc.api.ws.hub import WsHub
+
+logger = logging.getLogger(__name__)
+
+_ws_hub: WsHub | None = None
+
+
+def set_ws_hub(hub: WsHub) -> None:
+    """Wire the WebSocket hub for real-time event broadcasting."""
+    global _ws_hub  # noqa: PLW0603
+    _ws_hub = hub
+
+
+async def log_event(
+    db: aiosqlite.Connection,
+    *,
+    level: str,
+    category: str,
+    message: str,
+    detail: dict[str, Any] | None = None,
+    project_id: str | None = None,
+    session_id: str | None = None,
+) -> str:
+    """Insert an app event and return its id."""
+    event_id = str(uuid.uuid4())
+    now = datetime.now(UTC).isoformat()
+
+    await db.execute(
+        """INSERT INTO app_events
+           (id, level, category, message, detail, project_id, session_id, created_at)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?)""",
+        (
+            event_id,
+            level,
+            category,
+            message,
+            json.dumps(detail) if detail else None,
+            project_id,
+            session_id,
+            now,
+        ),
+    )
+    await db.commit()
+
+    py_level = getattr(logging, level.upper(), logging.INFO)
+    logger.log(py_level, "[%s] %s (id=%s)", category, message, event_id)
+
+    if _ws_hub is not None:
+        try:
+            await _ws_hub.broadcast(
+                "app_events",
+                {
+                    "new": {
+                        "id": event_id,
+                        "level": level,
+                        "category": category,
+                        "message": message,
+                        "detail": detail,
+                        "project_id": project_id,
+                        "session_id": session_id,
+                        "created_at": now,
+                    },
+                },
+            )
+        except Exception:
+            logger.debug("Failed to broadcast app event via WebSocket")
+
+    return event_id
+
+
+async def list_events(
+    db: aiosqlite.Connection,
+    *,
+    level: str | None = None,
+    category: str | None = None,
+    project_id: str | None = None,
+    limit: int = 200,
+    offset: int = 0,
+) -> list[dict[str, Any]]:
+    """Query app events with optional filters."""
+    clauses: list[str] = []
+    params: list[Any] = []
+
+    if level:
+        clauses.append("level = ?")
+        params.append(level)
+    if category:
+        clauses.append("category = ?")
+        params.append(category)
+    if project_id:
+        clauses.append("project_id = ?")
+        params.append(project_id)
+
+    where = " WHERE " + " AND ".join(clauses) if clauses else ""
+    params.extend([limit, offset])
+
+    cursor = await db.execute(
+        f"SELECT * FROM app_events{where} ORDER BY created_at DESC LIMIT ? OFFSET ?",
+        params,
+    )
+    rows = await cursor.fetchall()
+    results = []
+    for r in rows:
+        d = dict(r)
+        if d.get("detail"):
+            with contextlib.suppress(json.JSONDecodeError, TypeError):
+                d["detail"] = json.loads(d["detail"])
+        results.append(d)
+    return results
+
+
+async def count_events(
+    db: aiosqlite.Connection,
+    *,
+    level: str | None = None,
+    category: str | None = None,
+    project_id: str | None = None,
+) -> int:
+    """Return count of matching events."""
+    clauses: list[str] = []
+    params: list[Any] = []
+
+    if level:
+        clauses.append("level = ?")
+        params.append(level)
+    if category:
+        clauses.append("category = ?")
+        params.append(category)
+    if project_id:
+        clauses.append("project_id = ?")
+        params.append(project_id)
+
+    where = " WHERE " + " AND ".join(clauses) if clauses else ""
+
+    cursor = await db.execute(
+        f"SELECT COUNT(*) FROM app_events{where}",
+        params,
+    )
+    row = await cursor.fetchone()
+    return row[0] if row else 0
+
+
+async def export_events_json(
+    db: aiosqlite.Connection,
+    *,
+    level: str | None = None,
+    category: str | None = None,
+    project_id: str | None = None,
+    limit: int = 10000,
+) -> list[dict[str, Any]]:
+    """Export events as a list of dicts (for zip packaging)."""
+    return await list_events(db, level=level, category=category, project_id=project_id, limit=limit)

--- a/src/atc/state/db.py
+++ b/src/atc/state/db.py
@@ -341,6 +341,22 @@ CREATE TABLE IF NOT EXISTS context_entries (
     updated_at  TEXT NOT NULL,
     UNIQUE(project_id, key)
 );
+
+CREATE TABLE IF NOT EXISTS app_events (
+    id          TEXT PRIMARY KEY,
+    level       TEXT NOT NULL,
+    category    TEXT NOT NULL,
+    message     TEXT NOT NULL,
+    detail      TEXT,
+    project_id  TEXT,
+    session_id  TEXT,
+    created_at  TEXT NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_app_events_created_at ON app_events(created_at);
+CREATE INDEX IF NOT EXISTS idx_app_events_level ON app_events(level);
+CREATE INDEX IF NOT EXISTS idx_app_events_category ON app_events(category);
+CREATE INDEX IF NOT EXISTS idx_app_events_project_id ON app_events(project_id);
 """
 
 

--- a/src/atc/state/migrations/versions/005_app_events.sql
+++ b/src/atc/state/migrations/versions/005_app_events.sql
@@ -1,0 +1,16 @@
+-- Structured app-level event logging table
+CREATE TABLE IF NOT EXISTS app_events (
+    id          TEXT PRIMARY KEY,
+    level       TEXT NOT NULL,           -- debug|info|warning|error|critical
+    category    TEXT NOT NULL,           -- session|task|error|cost|system
+    message     TEXT NOT NULL,
+    detail      TEXT,                    -- JSON: arbitrary event-specific data
+    project_id  TEXT,
+    session_id  TEXT,
+    created_at  TEXT NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_app_events_created_at ON app_events(created_at);
+CREATE INDEX IF NOT EXISTS idx_app_events_level ON app_events(level);
+CREATE INDEX IF NOT EXISTS idx_app_events_category ON app_events(category);
+CREATE INDEX IF NOT EXISTS idx_app_events_project_id ON app_events(project_id);

--- a/src/atc/state/models.py
+++ b/src/atc/state/models.py
@@ -196,6 +196,18 @@ class SessionHeartbeat:
 
 
 @dataclass
+class AppEvent:
+    id: str
+    level: str  # debug|info|warning|error|critical
+    category: str  # session|task|error|cost|system
+    message: str
+    created_at: str = ""
+    detail: str | None = None  # JSON
+    project_id: str | None = None
+    session_id: str | None = None
+
+
+@dataclass
 class ContextEntry:
     id: str
     project_id: str

--- a/tests/unit/test_app_events.py
+++ b/tests/unit/test_app_events.py
@@ -1,0 +1,95 @@
+"""Unit tests for structured app event logging."""
+
+from __future__ import annotations
+
+import pytest
+
+from atc.core.app_events import count_events, list_events, log_event
+from atc.state.db import _SCHEMA_SQL, get_connection, run_migrations
+
+
+@pytest.fixture
+async def db():
+    await run_migrations(":memory:")
+    async with get_connection(":memory:") as conn:
+        await conn.executescript(_SCHEMA_SQL)
+        await conn.commit()
+        yield conn
+
+
+@pytest.mark.asyncio
+class TestAppEvents:
+    async def test_log_and_list(self, db) -> None:
+        event_id = await log_event(
+            db,
+            level="info",
+            category="session",
+            message="Session started",
+            detail={"session_id": "s1"},
+            project_id="p1",
+        )
+        assert event_id
+        events = await list_events(db)
+        assert len(events) == 1
+        assert events[0]["id"] == event_id
+        assert events[0]["level"] == "info"
+        assert events[0]["category"] == "session"
+        assert events[0]["detail"] == {"session_id": "s1"}
+
+    async def test_list_empty(self, db) -> None:
+        assert await list_events(db) == []
+
+    async def test_filter_by_level(self, db) -> None:
+        await log_event(db, level="info", category="session", message="m1")
+        await log_event(db, level="error", category="error", message="m2")
+        info = await list_events(db, level="info")
+        assert len(info) == 1
+        assert info[0]["level"] == "info"
+
+    async def test_filter_by_category(self, db) -> None:
+        await log_event(db, level="info", category="session", message="m1")
+        await log_event(db, level="info", category="task", message="m2")
+        tasks = await list_events(db, category="task")
+        assert len(tasks) == 1
+
+    async def test_filter_by_project(self, db) -> None:
+        await log_event(db, level="info", category="session", message="m1", project_id="p1")
+        await log_event(db, level="info", category="session", message="m2", project_id="p2")
+        results = await list_events(db, project_id="p1")
+        assert len(results) == 1
+
+    async def test_count(self, db) -> None:
+        for i in range(5):
+            await log_event(db, level="info", category="session", message=f"m{i}")
+        assert await count_events(db) == 5
+
+    async def test_limit_and_offset(self, db) -> None:
+        for i in range(10):
+            await log_event(db, level="info", category="session", message=f"m{i}")
+        page1 = await list_events(db, limit=3, offset=0)
+        page2 = await list_events(db, limit=3, offset=3)
+        assert len(page1) == 3
+        assert len(page2) == 3
+        assert page1[0]["id"] != page2[0]["id"]
+
+    async def test_ordering_newest_first(self, db) -> None:
+        await log_event(db, level="info", category="session", message="first")
+        await log_event(db, level="info", category="session", message="second")
+        events = await list_events(db)
+        assert events[0]["message"] == "second"
+
+    async def test_detail_deserialized(self, db) -> None:
+        await log_event(
+            db,
+            level="info",
+            category="system",
+            message="m1",
+            detail={"key": "value", "nested": {"a": 1}},
+        )
+        results = await list_events(db)
+        assert results[0]["detail"] == {"key": "value", "nested": {"a": 1}}
+
+    async def test_null_detail(self, db) -> None:
+        await log_event(db, level="info", category="system", message="m1")
+        results = await list_events(db)
+        assert results[0]["detail"] is None


### PR DESCRIPTION
## Summary
- Add `app_events` SQLite table with migration (`005_app_events.sql`) for structured event logging (session lifecycle, task completion, errors, cost changes)
- New `atc.core.app_events` module with `log_event()`, `list_events()`, `count_events()`, `export_events_json()` — includes real-time WebSocket broadcasting
- REST API endpoints: `GET /api/app-events` (filter/paginate), `GET /api/app-events/count`, `POST /api/app-events/export` (downloadable zip)
- Log viewer UI in Settings page with level/category filters, color-coded badges, expandable detail, and zip export button
- 10 unit tests covering filtering, pagination, ordering, and serialization

## Test plan
- [x] All 10 unit tests pass (`tests/unit/test_app_events.py`)
- [ ] Verify log viewer renders on Settings page
- [ ] Test level/category filter dropdowns
- [ ] Test export button downloads a zip file
- [ ] Confirm events appear in real-time via WebSocket

🤖 Generated with [Claude Code](https://claude.com/claude-code)