### PR TITLE
feat: add feature flags system for phased rollout

### DIFF
--- a/frontend/src/components/settings/FeatureFlagsPanel.css
+++ b/frontend/src/components/settings/FeatureFlagsPanel.css
@@ -1,0 +1,46 @@
+.feature-flags__empty {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: var(--space-3);
+}
+
+.feature-flags__list {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+}
+
+.feature-flags__item {
+  padding: var(--space-3);
+  border: 1px solid var(--color-border-subtle);
+  border-radius: var(--radius-md);
+}
+
+.feature-flags__toggle {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  cursor: pointer;
+}
+
+.feature-flags__name {
+  font-weight: 500;
+  font-size: var(--text-sm);
+}
+
+.feature-flags__description {
+  margin-top: var(--space-1);
+  font-size: var(--text-xs);
+  color: var(--color-text-secondary);
+}
+
+.feature-flags__key {
+  display: inline-block;
+  margin-top: var(--space-1);
+  font-size: var(--text-xs);
+  color: var(--color-text-muted);
+  background: var(--color-bg-subtle);
+  padding: 1px 6px;
+  border-radius: var(--radius-sm);
+}

--- a/frontend/src/components/settings/FeatureFlagsPanel.tsx
+++ b/frontend/src/components/settings/FeatureFlagsPanel.tsx
@@ -1,0 +1,118 @@
+import { useCallback, useState } from "react";
+import { useFeatureFlags } from "../../hooks/useFeatureFlags";
+import { api } from "../../utils/api";
+import type { FeatureFlag } from "../../types";
+import "./FeatureFlagsPanel.css";
+
+const DEFAULT_FLAGS: { key: string; name: string; description: string }[] = [
+  {
+    key: "remote_aces",
+    name: "Remote Aces",
+    description: "Enable remote ace sessions on external machines.",
+  },
+  {
+    key: "tower_memory",
+    name: "Tower Memory",
+    description: "Persistent memory for the Tower controller.",
+  },
+  {
+    key: "cdp_view",
+    name: "CDP View",
+    description: "Chrome DevTools Protocol live view for sessions.",
+  },
+];
+
+export function FeatureFlagsPanel() {
+  const { flags, loading, error, toggleFlag, refetch } = useFeatureFlags();
+  const [seeding, setSeeding] = useState(false);
+
+  const handleToggle = useCallback(
+    async (flag: FeatureFlag) => {
+      await toggleFlag(flag.key, !flag.enabled);
+    },
+    [toggleFlag],
+  );
+
+  const handleSeedDefaults = useCallback(async () => {
+    setSeeding(true);
+    try {
+      const existing = new Set(flags.map((f) => f.key));
+      for (const def of DEFAULT_FLAGS) {
+        if (!existing.has(def.key)) {
+          await api.post("/feature-flags", {
+            key: def.key,
+            name: def.name,
+            description: def.description,
+            enabled: false,
+          });
+        }
+      }
+      await refetch();
+    } finally {
+      setSeeding(false);
+    }
+  }, [flags, refetch]);
+
+  return (
+    <section
+      className="panel settings-page__section"
+      data-testid="feature-flags-section"
+    >
+      <h2>Feature Flags</h2>
+      <p className="settings-page__description">
+        Toggle experimental features on or off. Disabled flags hide incomplete
+        functionality from the UI.
+      </p>
+
+      {error && (
+        <p className="settings-page__error" data-testid="feature-flags-error">
+          {error}
+        </p>
+      )}
+
+      {loading && flags.length === 0 && (
+        <p className="settings-page__description">Loading...</p>
+      )}
+
+      {!loading && flags.length === 0 && (
+        <div className="feature-flags__empty">
+          <p className="settings-page__description">
+            No feature flags configured.
+          </p>
+          <button
+            className="btn"
+            onClick={handleSeedDefaults}
+            disabled={seeding}
+            data-testid="seed-flags-btn"
+          >
+            {seeding ? "Creating..." : "Create Default Flags"}
+          </button>
+        </div>
+      )}
+
+      {flags.length > 0 && (
+        <div className="feature-flags__list">
+          {flags.map((flag) => (
+            <div key={flag.id} className="feature-flags__item">
+              <label className="feature-flags__toggle">
+                <input
+                  type="checkbox"
+                  checked={flag.enabled}
+                  onChange={() => handleToggle(flag)}
+                  data-testid={`feature-flag-toggle-${flag.key}`}
+                />
+                <span className="feature-flags__name">{flag.name}</span>
+              </label>
+              {flag.description && (
+                <p className="feature-flags__description">
+                  {flag.description}
+                </p>
+              )}
+              <code className="feature-flags__key">{flag.key}</code>
+            </div>
+          ))}
+        </div>
+      )}
+    </section>
+  );
+}

--- a/frontend/src/hooks/useFeatureFlags.ts
+++ b/frontend/src/hooks/useFeatureFlags.ts
@@ -1,0 +1,73 @@
+import { useCallback, useEffect, useState } from "react";
+import { api } from "../utils/api";
+import type { FeatureFlag } from "../types";
+
+/**
+ * Hook to manage feature flags.
+ *
+ * Usage:
+ *   const { flags, isEnabled, toggleFlag } = useFeatureFlags();
+ *   if (isEnabled("remote_aces")) { ... }
+ */
+export function useFeatureFlags() {
+  const [flags, setFlags] = useState<FeatureFlag[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchFlags = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const data = await api.get<FeatureFlag[]>("/feature-flags");
+      setFlags(data);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Failed to load feature flags");
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  const toggleFlag = useCallback(async (key: string, enabled: boolean) => {
+    try {
+      const updated = await api.put<FeatureFlag>(`/feature-flags/${key}`, {
+        enabled,
+      });
+      setFlags((prev) => prev.map((f) => (f.key === key ? updated : f)));
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Failed to update flag");
+    }
+  }, []);
+
+  const isEnabled = useCallback(
+    (key: string): boolean => {
+      const flag = flags.find((f) => f.key === key);
+      return flag?.enabled ?? false;
+    },
+    [flags],
+  );
+
+  useEffect(() => {
+    fetchFlags();
+  }, [fetchFlags]);
+
+  return { flags, loading, error, toggleFlag, isEnabled, refetch: fetchFlags };
+}
+
+/**
+ * Convenience hook to check a single feature flag.
+ *
+ * Usage:
+ *   const enabled = useFeatureFlag("remote_aces");
+ */
+export function useFeatureFlag(key: string): boolean {
+  const [enabled, setEnabled] = useState(false);
+
+  useEffect(() => {
+    api
+      .get<FeatureFlag>(`/feature-flags/${key}`)
+      .then((flag) => setEnabled(flag.enabled))
+      .catch(() => setEnabled(false));
+  }, [key]);
+
+  return enabled;
+}

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -5,6 +5,7 @@ import { api } from "../utils/api";
 import { hasConsent, setConsent, sendReport } from "../utils/sentry";
 import type { AgentProviderConfig, AppEvent, ProviderInfo } from "../types";
 import type { UseUpdaterReturn } from "../hooks/useUpdater";
+import { FeatureFlagsPanel } from "../components/settings/FeatureFlagsPanel";
 import "./SettingsPage.css";
 
 const APP_VERSION = __APP_VERSION__;
@@ -380,6 +381,8 @@ export default function SettingsPage() {
             <span className="settings-page__value">Dark</span>
           </div>
         </section>
+
+        <FeatureFlagsPanel />
 
         <section
           className="panel settings-page__section"

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -184,6 +184,17 @@ export interface AppEvent {
   created_at: string;
 }
 
+export interface FeatureFlag {
+  id: string;
+  key: string;
+  name: string;
+  description: string | null;
+  enabled: boolean;
+  metadata: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
 export interface AppState {
   projects: Project[];
   leaders: Record<string, Leader>;

--- a/src/atc/api/app.py
+++ b/src/atc/api/app.py
@@ -225,6 +225,7 @@ def create_app(settings: Settings | None = None) -> FastAPI:
     from atc.api.routers import (
         aces,
         failure_logs,
+        feature_flags,
         heartbeat,
         leader,
         projects,
@@ -245,6 +246,7 @@ def create_app(settings: Settings | None = None) -> FastAPI:
     app.include_router(settings_router.router, prefix="/api/settings", tags=["settings"])
     app.include_router(failure_logs.router, prefix="/api", tags=["failure_logs"])
     app.include_router(heartbeat.router, prefix="/api", tags=["heartbeat"])
+    app.include_router(feature_flags.router, prefix="/api/feature-flags", tags=["feature_flags"])
 
     @app.get("/api/health")
     async def health() -> dict[str, object]:

--- a/src/atc/api/routers/feature_flags.py
+++ b/src/atc/api/routers/feature_flags.py
@@ -1,0 +1,119 @@
+"""Feature flags REST endpoints.
+
+Routes:
+  GET    /api/feature-flags           -> list all flags
+  GET    /api/feature-flags/{key}     -> get flag by key
+  POST   /api/feature-flags           -> create a new flag
+  PUT    /api/feature-flags/{key}     -> update a flag (toggle, rename, etc.)
+  DELETE /api/feature-flags/{key}     -> delete a flag
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from fastapi import APIRouter, HTTPException, Request
+from pydantic import BaseModel
+
+from atc.state import db as db_ops
+
+router = APIRouter()
+
+
+async def _get_db(request: Request):  # noqa: ANN202
+    return request.app.state.db
+
+
+class FeatureFlagResponse(BaseModel):
+    id: str
+    key: str
+    name: str
+    description: str | None = None
+    enabled: bool
+    metadata: str | None = None
+    created_at: str
+    updated_at: str
+
+
+class CreateFlagRequest(BaseModel):
+    key: str
+    name: str
+    description: str | None = None
+    enabled: bool = False
+    metadata: str | None = None
+
+
+class UpdateFlagRequest(BaseModel):
+    enabled: bool | None = None
+    name: str | None = None
+    description: str | None = None
+    metadata: str | None = None
+
+
+@router.get("", response_model=list[FeatureFlagResponse])
+async def list_feature_flags(request: Request) -> list[FeatureFlagResponse]:
+    db = await _get_db(request)
+    flags = await db_ops.list_feature_flags(db)
+    return [FeatureFlagResponse(**f.__dict__) for f in flags]
+
+
+@router.get("/{key}", response_model=FeatureFlagResponse)
+async def get_feature_flag(key: str, request: Request) -> FeatureFlagResponse:
+    db = await _get_db(request)
+    flag = await db_ops.get_feature_flag(db, key)
+    if flag is None:
+        raise HTTPException(status_code=404, detail=f"Feature flag '{key}' not found")
+    return FeatureFlagResponse(**flag.__dict__)
+
+
+@router.post("", response_model=FeatureFlagResponse, status_code=201)
+async def create_feature_flag(
+    body: CreateFlagRequest,
+    request: Request,
+) -> FeatureFlagResponse:
+    db = await _get_db(request)
+    existing = await db_ops.get_feature_flag(db, body.key)
+    if existing is not None:
+        raise HTTPException(
+            status_code=409,
+            detail=f"Feature flag '{body.key}' already exists",
+        )
+    flag = await db_ops.create_feature_flag(
+        db,
+        key=body.key,
+        name=body.name,
+        description=body.description,
+        enabled=body.enabled,
+        metadata=body.metadata,
+    )
+    return FeatureFlagResponse(**flag.__dict__)
+
+
+@router.put("/{key}", response_model=FeatureFlagResponse)
+async def update_feature_flag(
+    key: str,
+    body: UpdateFlagRequest,
+    request: Request,
+) -> FeatureFlagResponse:
+    db = await _get_db(request)
+    kwargs: dict[str, Any] = {}
+    if body.enabled is not None:
+        kwargs["enabled"] = body.enabled
+    if body.name is not None:
+        kwargs["name"] = body.name
+    if body.description is not None:
+        kwargs["description"] = body.description
+    if body.metadata is not None:
+        kwargs["metadata"] = body.metadata
+    flag = await db_ops.update_feature_flag(db, key, **kwargs)  # type: ignore[arg-type]
+    if flag is None:
+        raise HTTPException(status_code=404, detail=f"Feature flag '{key}' not found")
+    return FeatureFlagResponse(**flag.__dict__)
+
+
+@router.delete("/{key}", status_code=204)
+async def delete_feature_flag(key: str, request: Request) -> None:
+    db = await _get_db(request)
+    deleted = await db_ops.delete_feature_flag(db, key)
+    if not deleted:
+        raise HTTPException(status_code=404, detail=f"Feature flag '{key}' not found")

--- a/src/atc/state/db.py
+++ b/src/atc/state/db.py
@@ -19,7 +19,14 @@ from typing import TYPE_CHECKING, Any
 
 import aiosqlite
 
-from atc.state.models import Leader, Project, Session, SessionHeartbeat, TaskGraph
+from atc.state.models import (
+    FeatureFlag,
+    Leader,
+    Project,
+    Session,
+    SessionHeartbeat,
+    TaskGraph,
+)
 
 if TYPE_CHECKING:
     from collections.abc import AsyncIterator, Generator
@@ -357,6 +364,19 @@ CREATE INDEX IF NOT EXISTS idx_app_events_created_at ON app_events(created_at);
 CREATE INDEX IF NOT EXISTS idx_app_events_level ON app_events(level);
 CREATE INDEX IF NOT EXISTS idx_app_events_category ON app_events(category);
 CREATE INDEX IF NOT EXISTS idx_app_events_project_id ON app_events(project_id);
+
+CREATE TABLE IF NOT EXISTS feature_flags (
+    id          TEXT PRIMARY KEY,
+    key         TEXT NOT NULL UNIQUE,
+    name        TEXT NOT NULL,
+    description TEXT,
+    enabled     INTEGER NOT NULL DEFAULT 0,
+    metadata    TEXT,
+    created_at  TEXT NOT NULL,
+    updated_at  TEXT NOT NULL
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_feature_flags_key ON feature_flags(key);
 """
 
 
@@ -922,3 +942,128 @@ async def deregister_heartbeat(
     )
     await db.commit()
     return cursor.rowcount > 0
+
+# ---------------------------------------------------------------------------
+# Feature flag helpers
+# ---------------------------------------------------------------------------
+
+
+def _flag_from_row(row: aiosqlite.Row) -> FeatureFlag:
+    """Convert a DB row to a FeatureFlag dataclass."""
+    d = dict(row)
+    d["enabled"] = bool(d.get("enabled", 0))
+    return FeatureFlag(**d)
+
+
+async def create_feature_flag(
+    db: aiosqlite.Connection,
+    key: str,
+    name: str,
+    *,
+    description: str | None = None,
+    enabled: bool = False,
+    metadata: str | None = None,
+) -> FeatureFlag:
+    """Insert a new feature flag."""
+    now = _now()
+    flag = FeatureFlag(
+        id=_uuid(),
+        key=key,
+        name=name,
+        description=description,
+        enabled=enabled,
+        metadata=metadata,
+        created_at=now,
+        updated_at=now,
+    )
+    await db.execute(
+        """INSERT INTO feature_flags
+           (id, key, name, description, enabled, metadata, created_at, updated_at)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?)""",
+        (
+            flag.id,
+            flag.key,
+            flag.name,
+            flag.description,
+            int(flag.enabled),
+            flag.metadata,
+            flag.created_at,
+            flag.updated_at,
+        ),
+    )
+    await db.commit()
+    return flag
+
+
+async def get_feature_flag(db: aiosqlite.Connection, key: str) -> FeatureFlag | None:
+    """Fetch a feature flag by its unique key."""
+    cursor = await db.execute("SELECT * FROM feature_flags WHERE key = ?", (key,))
+    row = await cursor.fetchone()
+    if row is None:
+        return None
+    return _flag_from_row(row)
+
+
+async def list_feature_flags(db: aiosqlite.Connection) -> list[FeatureFlag]:
+    """Return all feature flags ordered by creation time."""
+    cursor = await db.execute("SELECT * FROM feature_flags ORDER BY created_at ASC")
+    rows = await cursor.fetchall()
+    return [_flag_from_row(r) for r in rows]
+
+
+async def update_feature_flag(
+    db: aiosqlite.Connection,
+    key: str,
+    *,
+    enabled: bool | None = None,
+    name: str | None = None,
+    description: str | None = ...,  # type: ignore[assignment]
+    metadata: str | None = ...,  # type: ignore[assignment]
+) -> FeatureFlag | None:
+    """Update a feature flag. Returns None if not found."""
+    existing = await get_feature_flag(db, key)
+    if existing is None:
+        return None
+
+    sets: list[str] = []
+    params: list[Any] = []
+    if enabled is not None:
+        sets.append("enabled = ?")
+        params.append(int(enabled))
+    if name is not None:
+        sets.append("name = ?")
+        params.append(name)
+    if description is not ...:
+        sets.append("description = ?")
+        params.append(description)
+    if metadata is not ...:
+        sets.append("metadata = ?")
+        params.append(metadata)
+
+    if not sets:
+        return existing
+
+    sets.append("updated_at = ?")
+    params.append(_now())
+    params.append(key)
+
+    await db.execute(
+        f"UPDATE feature_flags SET {', '.join(sets)} WHERE key = ?",
+        params,
+    )
+    await db.commit()
+    return await get_feature_flag(db, key)
+
+
+async def delete_feature_flag(db: aiosqlite.Connection, key: str) -> bool:
+    """Delete a feature flag by key. Returns True if deleted."""
+    cursor = await db.execute("DELETE FROM feature_flags WHERE key = ?", (key,))
+    await db.commit()
+    return cursor.rowcount > 0
+
+
+async def is_feature_enabled(db: aiosqlite.Connection, key: str) -> bool:
+    """Check if a feature flag is enabled. Returns False if flag doesn't exist."""
+    flag = await get_feature_flag(db, key)
+    return flag.enabled if flag is not None else False
+

--- a/src/atc/state/migrations/versions/007_feature_flags.sql
+++ b/src/atc/state/migrations/versions/007_feature_flags.sql
@@ -1,0 +1,14 @@
+-- Feature flags for phased rollout of experimental features.
+
+CREATE TABLE IF NOT EXISTS feature_flags (
+    id          TEXT PRIMARY KEY,
+    key         TEXT NOT NULL UNIQUE,
+    name        TEXT NOT NULL,
+    description TEXT,
+    enabled     INTEGER NOT NULL DEFAULT 0,
+    metadata    TEXT,
+    created_at  TEXT NOT NULL,
+    updated_at  TEXT NOT NULL
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_feature_flags_key ON feature_flags(key);

--- a/src/atc/state/models.py
+++ b/src/atc/state/models.py
@@ -218,3 +218,15 @@ class ContextEntry:
     updated_by: str = ""
     created_at: str = ""
     updated_at: str = ""
+
+
+@dataclass
+class FeatureFlag:
+    id: str
+    key: str  # unique slug e.g. 'remote_aces', 'tower_memory'
+    name: str  # human-readable display name
+    description: str | None = None
+    enabled: bool = False
+    metadata: str | None = None  # optional JSON
+    created_at: str = ""
+    updated_at: str = ""


### PR DESCRIPTION
## Summary
- Add `feature_flags` table (key, enabled, metadata) with migration 007
- Python CRUD helpers + `is_feature_enabled(key)` utility in `db.py`
- REST API: `GET/POST/PUT/DELETE /api/feature-flags`
- React `useFeatureFlags()` hook (list, toggle, isEnabled) and `useFeatureFlag(key)` convenience hook
- Developer panel in Settings page to toggle flags with checkbox UI
- "Create Default Flags" button seeds `remote_aces`, `tower_memory`, `cdp_view`

## Testing Done
- All 576 backend tests pass (`pytest tests/ -q`)
- All 186 frontend tests pass (`npm run test -- --run`)
- Python imports verified: `from atc.api.app import create_app` works
- TypeScript compiles cleanly (no new TS errors introduced)

> Note: Pre-commit hooks (mypy, detect-secrets) have pre-existing failures across the codebase (45 mypy errors in 21 files, missing .secrets.baseline). These are not introduced by this PR.