### PR TITLE
feat: idempotent task assignments with state machine guards

### DIFF
--- a/src/atc/api/routers/task_graphs.py
+++ b/src/atc/api/routers/task_graphs.py
@@ -91,7 +91,8 @@ def _to_response(tg: Any) -> TaskGraphResponse:
     response_model=list[TaskGraphResponse],
 )
 async def list_task_graphs(
-    project_id: str, request: Request,
+    project_id: str,
+    request: Request,
 ) -> list[TaskGraphResponse]:
     db = await _get_db(request)
     project = await db_ops.get_project(db, project_id)
@@ -107,7 +108,9 @@ async def list_task_graphs(
     status_code=201,
 )
 async def create_task_graph(
-    project_id: str, body: CreateTaskGraphRequest, request: Request,
+    project_id: str,
+    body: CreateTaskGraphRequest,
+    request: Request,
 ) -> TaskGraphResponse:
     db = await _get_db(request)
     project = await db_ops.get_project(db, project_id)
@@ -133,13 +136,15 @@ async def create_task_graph(
     response_model=TaskGraphResponse,
 )
 async def get_task_graph(
-    task_graph_id: str, request: Request,
+    task_graph_id: str,
+    request: Request,
 ) -> TaskGraphResponse:
     db = await _get_db(request)
     tg = await db_ops.get_task_graph(db, task_graph_id)
     if tg is None:
         raise HTTPException(
-            status_code=404, detail=f"TaskGraph {task_graph_id} not found",
+            status_code=404,
+            detail=f"TaskGraph {task_graph_id} not found",
         )
     return _to_response(tg)
 
@@ -149,7 +154,9 @@ async def get_task_graph(
     response_model=TaskGraphResponse,
 )
 async def update_task_graph(
-    task_graph_id: str, body: UpdateTaskGraphRequest, request: Request,
+    task_graph_id: str,
+    body: UpdateTaskGraphRequest,
+    request: Request,
 ) -> TaskGraphResponse:
     db = await _get_db(request)
 
@@ -167,7 +174,8 @@ async def update_task_graph(
     tg = await db_ops.update_task_graph(db, task_graph_id, **kwargs)
     if tg is None:
         raise HTTPException(
-            status_code=404, detail=f"TaskGraph {task_graph_id} not found",
+            status_code=404,
+            detail=f"TaskGraph {task_graph_id} not found",
         )
     return _to_response(tg)
 
@@ -177,7 +185,9 @@ async def update_task_graph(
     response_model=TaskGraphResponse,
 )
 async def transition_task_graph_status(
-    task_graph_id: str, body: StatusTransitionRequest, request: Request,
+    task_graph_id: str,
+    body: StatusTransitionRequest,
+    request: Request,
 ) -> TaskGraphResponse:
     db = await _get_db(request)
     try:
@@ -186,18 +196,123 @@ async def transition_task_graph_status(
         raise HTTPException(status_code=422, detail=str(e)) from None
     if tg is None:
         raise HTTPException(
-            status_code=404, detail=f"TaskGraph {task_graph_id} not found",
+            status_code=404,
+            detail=f"TaskGraph {task_graph_id} not found",
         )
     return _to_response(tg)
 
 
 @router.delete("/task-graphs/{task_graph_id}", status_code=204)
 async def delete_task_graph(
-    task_graph_id: str, request: Request,
+    task_graph_id: str,
+    request: Request,
 ) -> None:
     db = await _get_db(request)
     deleted = await db_ops.delete_task_graph(db, task_graph_id)
     if not deleted:
         raise HTTPException(
-            status_code=404, detail=f"TaskGraph {task_graph_id} not found",
+            status_code=404,
+            detail=f"TaskGraph {task_graph_id} not found",
         )
+
+
+# ---------------------------------------------------------------------------
+# Task Assignment routes (idempotent assignments)
+# ---------------------------------------------------------------------------
+
+
+class AssignTaskRequest(BaseModel):
+    ace_session_id: str
+    assignment_id: str
+
+
+class TaskAssignmentResponse(BaseModel):
+    id: str
+    task_graph_id: str
+    ace_session_id: str
+    assignment_id: str
+    status: str
+    created_at: str
+    updated_at: str
+
+
+class AssignmentStatusRequest(BaseModel):
+    status: str
+
+
+def _to_assignment_response(a: Any) -> TaskAssignmentResponse:
+    return TaskAssignmentResponse(
+        id=a.id,
+        task_graph_id=a.task_graph_id,
+        ace_session_id=a.ace_session_id,
+        assignment_id=a.assignment_id,
+        status=a.status,
+        created_at=a.created_at,
+        updated_at=a.updated_at,
+    )
+
+
+@router.post(
+    "/task-graphs/{task_graph_id}/assign",
+    response_model=TaskAssignmentResponse,
+)
+async def assign_task(
+    task_graph_id: str,
+    body: AssignTaskRequest,
+    request: Request,
+) -> TaskAssignmentResponse:
+    """Idempotently assign an Ace to a task graph entry.
+
+    Returns 200 with the assignment record.  If the same assignment_id
+    was already used, the existing record is returned (no-op).
+    """
+    db = await _get_db(request)
+    try:
+        assignment, _created = await db_ops.assign_task(
+            db,
+            task_graph_id,
+            body.ace_session_id,
+            body.assignment_id,
+        )
+    except ValueError as e:
+        raise HTTPException(status_code=422, detail=str(e)) from None
+    return _to_assignment_response(assignment)
+
+
+@router.get(
+    "/task-graphs/{task_graph_id}/assignments",
+    response_model=list[TaskAssignmentResponse],
+)
+async def list_task_assignments(
+    task_graph_id: str,
+    request: Request,
+) -> list[TaskAssignmentResponse]:
+    db = await _get_db(request)
+    items = await db_ops.list_task_assignments(db, task_graph_id=task_graph_id)
+    return [_to_assignment_response(a) for a in items]
+
+
+@router.patch(
+    "/task-assignments/{assignment_id}/status",
+    response_model=TaskAssignmentResponse,
+)
+async def transition_assignment_status(
+    assignment_id: str,
+    body: AssignmentStatusRequest,
+    request: Request,
+) -> TaskAssignmentResponse:
+    db = await _get_db(request)
+    try:
+        assignment = await db_ops.update_task_assignment_status(
+            db,
+            assignment_id,
+            body.status,
+        )
+    except ValueError as e:
+        raise HTTPException(status_code=422, detail=str(e)) from None
+    if assignment is None:
+        raise HTTPException(
+            status_code=404,
+            detail=f"Assignment {assignment_id} not found",
+        )
+    return _to_assignment_response(assignment)

--- a/src/atc/leader/decomposer.py
+++ b/src/atc/leader/decomposer.py
@@ -132,7 +132,9 @@ async def decompose_goal(
 
         if dep_ids:
             updated = await db_ops.update_task_graph(
-                conn, tg.id, dependencies=dep_ids,
+                conn,
+                tg.id,
+                dependencies=dep_ids,
             )
             if updated is not None:
                 # Replace the entry in created list with updated version
@@ -196,14 +198,16 @@ def get_completion_status(task_graphs: list[TaskGraph]) -> dict[str, Any]:
         }
 
     done = sum(1 for tg in task_graphs if tg.status == "done")
-    in_progress = sum(1 for tg in task_graphs if tg.status == "in_progress")
+    in_progress = sum(1 for tg in task_graphs if tg.status in ("assigned", "in_progress", "review"))
     todo = sum(1 for tg in task_graphs if tg.status == "todo")
+    error = sum(1 for tg in task_graphs if tg.status == "error")
 
     return {
         "total": total,
         "done": done,
         "in_progress": in_progress,
         "todo": todo,
+        "error": error,
         "all_done": done == total,
         "progress_pct": round((done / total) * 100),
     }

--- a/src/atc/leader/orchestrator.py
+++ b/src/atc/leader/orchestrator.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 
 import contextlib
 import logging
+import uuid
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
 
@@ -41,6 +42,7 @@ class AceAssignment:
     ace_session_id: str
     task_graph_id: str
     task_title: str
+    assignment_id: str = ""  # idempotency key for assign_task
     status: str = "assigned"  # assigned|working|done|failed
     deployed_root: Path | None = None  # staging dir for cleanup
 
@@ -109,11 +111,20 @@ class LeaderOrchestrator:
     ) -> AceAssignment | None:
         """Spawn a single Ace session and assign it to a task graph entry.
 
+        Uses ``assign_task`` for idempotent, state-machine-guarded
+        assignment.  If the same ``assignment_id`` is used twice the
+        second call is a no-op.
+
         Deploys config files (CLAUDE.md, hooks) via ``deploy_ace_files``
         before launching the tmux pane so Claude Code reads the task
         instructions automatically.
         """
         ace_name = f"ace-{title[:30]}"
+
+        # Generate a deterministic assignment_id for idempotency.
+        # The leader_id + task_graph_id combination ensures that the
+        # same leader assigning the same task produces the same key.
+        idempotency_key = f"{self.leader_id}:{task_graph_id}"
 
         try:
             # Look up project metadata for the deploy spec
@@ -123,8 +134,6 @@ class LeaderOrchestrator:
             github_repo = project.github_repo if project else None
 
             # Generate a stable session id up-front so deploy can use it
-            import uuid
-
             session_id_preview = str(uuid.uuid4())
 
             # Deploy config files before launching the session
@@ -162,14 +171,31 @@ class LeaderOrchestrator:
             )
             return None
 
-        # Link the task_graph entry to this Ace
-        await db_ops.update_task_graph(
-            self.conn,
-            task_graph_id,
-            assigned_ace_id=session_id,
-        )
+        # Idempotent assignment — creates record + transitions task to 'assigned'
+        try:
+            db_assignment, created = await db_ops.assign_task(
+                self.conn,
+                task_graph_id,
+                session_id,
+                idempotency_key,
+            )
+        except ValueError as exc:
+            logger.warning(
+                "Cannot assign task '%s' (graph %s): %s",
+                title,
+                task_graph_id,
+                exc,
+            )
+            return None
 
-        # Transition the task to in_progress
+        if not created:
+            logger.info(
+                "Leader %s: assignment for task '%s' already exists (idempotent no-op)",
+                self.leader_id,
+                title,
+            )
+
+        # Transition the task to in_progress now that the Ace is running
         await db_ops.update_task_graph_status(
             self.conn,
             task_graph_id,
@@ -180,6 +206,7 @@ class LeaderOrchestrator:
             ace_session_id=session_id,
             task_graph_id=task_graph_id,
             task_title=title,
+            assignment_id=idempotency_key,
             status="assigned",
             deployed_root=deployed.root,
         )
@@ -201,6 +228,7 @@ class LeaderOrchestrator:
                     "session_id": session_id,
                     "task_graph_id": task_graph_id,
                     "task_title": title,
+                    "assignment_id": idempotency_key,
                 },
             )
 
@@ -227,6 +255,15 @@ class LeaderOrchestrator:
     async def mark_task_done(self, task_graph_id: str) -> None:
         """Mark a task graph entry as done and clean up its Ace session."""
         assignment = self.assignments.get(task_graph_id)
+
+        # Update the assignment record status
+        if assignment and assignment.assignment_id:
+            with contextlib.suppress(ValueError):
+                await db_ops.update_task_assignment_status(
+                    self.conn,
+                    assignment.assignment_id,
+                    "done",
+                )
 
         # Update task graph status
         await db_ops.update_task_graph_status(
@@ -276,7 +313,22 @@ class LeaderOrchestrator:
         """Handle a failed task — update status and clean up Ace."""
         assignment = self.assignments.get(task_graph_id)
 
-        # Transition back to todo so it can be retried
+        # Update the assignment record status
+        if assignment and assignment.assignment_id:
+            with contextlib.suppress(ValueError):
+                await db_ops.update_task_assignment_status(
+                    self.conn,
+                    assignment.assignment_id,
+                    "failed",
+                )
+
+        # Transition to error, then back to todo so it can be retried
+        with contextlib.suppress(ValueError):
+            await db_ops.update_task_graph_status(
+                self.conn,
+                task_graph_id,
+                "error",
+            )
         with contextlib.suppress(ValueError):
             await db_ops.update_task_graph_status(
                 self.conn,

--- a/src/atc/state/db.py
+++ b/src/atc/state/db.py
@@ -25,6 +25,7 @@ from atc.state.models import (
     Project,
     Session,
     SessionHeartbeat,
+    TaskAssignment,
     TaskGraph,
 )
 
@@ -377,6 +378,21 @@ CREATE TABLE IF NOT EXISTS feature_flags (
 );
 
 CREATE UNIQUE INDEX IF NOT EXISTS idx_feature_flags_key ON feature_flags(key);
+
+CREATE TABLE IF NOT EXISTS task_assignments (
+    id              TEXT PRIMARY KEY,
+    task_graph_id   TEXT NOT NULL REFERENCES task_graphs(id) ON DELETE CASCADE,
+    ace_session_id  TEXT NOT NULL,
+    assignment_id   TEXT NOT NULL UNIQUE,
+    status          TEXT NOT NULL DEFAULT 'assigned',
+    created_at      TEXT NOT NULL,
+    updated_at      TEXT NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_task_assignments_task_graph
+    ON task_assignments(task_graph_id);
+CREATE INDEX IF NOT EXISTS idx_task_assignments_ace_session
+    ON task_assignments(ace_session_id);
 """
 
 
@@ -665,12 +681,15 @@ def _row_to_session(row: aiosqlite.Row) -> Session:
 # TaskGraph CRUD
 # ---------------------------------------------------------------------------
 
-_VALID_TASK_GRAPH_STATUSES = {"todo", "in_progress", "done"}
+_VALID_TASK_GRAPH_STATUSES = {"todo", "assigned", "in_progress", "review", "done", "error"}
 
 _TASK_GRAPH_TRANSITIONS: dict[str, set[str]] = {
-    "todo": {"in_progress", "done"},
-    "in_progress": {"todo", "done"},
-    "done": {"todo", "in_progress"},
+    "todo": {"assigned"},
+    "assigned": {"in_progress", "todo", "error"},
+    "in_progress": {"review", "done", "error"},
+    "review": {"done", "in_progress", "error"},
+    "done": {"todo"},  # re-open for retry
+    "error": {"todo"},  # retry from scratch
 }
 
 
@@ -842,6 +861,195 @@ async def delete_task_graph(
     )
     await db.commit()
     return cursor.rowcount > 0
+
+
+# ---------------------------------------------------------------------------
+# TaskAssignment CRUD (idempotent assignments)
+# ---------------------------------------------------------------------------
+
+_VALID_ASSIGNMENT_STATUSES = {"assigned", "working", "done", "failed"}
+
+_ASSIGNMENT_TRANSITIONS: dict[str, set[str]] = {
+    "assigned": {"working", "failed"},
+    "working": {"done", "failed"},
+    "done": set(),
+    "failed": set(),
+}
+
+
+def _row_to_task_assignment(row: aiosqlite.Row) -> TaskAssignment:
+    d = dict(row)
+    return TaskAssignment(**d)
+
+
+async def assign_task(
+    db: aiosqlite.Connection,
+    task_graph_id: str,
+    ace_session_id: str,
+    assignment_id: str,
+) -> tuple[TaskAssignment, bool]:
+    """Idempotently assign an Ace to a task graph entry.
+
+    If an assignment with the same ``assignment_id`` already exists, returns
+    the existing record and ``False`` (no-op).  Otherwise creates the
+    assignment, transitions the task to ``assigned``, and returns the new
+    record with ``True``.
+
+    Raises ``ValueError`` if the task is not in a state that allows
+    assignment (i.e. not ``todo``).
+    """
+    # Check for existing assignment with same idempotency key
+    cursor = await db.execute(
+        "SELECT * FROM task_assignments WHERE assignment_id = ?",
+        (assignment_id,),
+    )
+    existing_row = await cursor.fetchone()
+    if existing_row is not None:
+        return _row_to_task_assignment(existing_row), False
+
+    # Validate the task exists and is in assignable state
+    task = await get_task_graph(db, task_graph_id)
+    if task is None:
+        raise ValueError(f"TaskGraph {task_graph_id} not found")
+
+    if task.status != "todo":
+        raise ValueError(
+            f"Cannot assign task in '{task.status}' state "
+            f"(must be 'todo'); task_graph_id={task_graph_id}"
+        )
+
+    # Check for an existing active assignment on this task (prevent double-assign)
+    cursor = await db.execute(
+        "SELECT * FROM task_assignments"
+        " WHERE task_graph_id = ? AND status IN ('assigned', 'working')",
+        (task_graph_id,),
+    )
+    active_row = await cursor.fetchone()
+    if active_row is not None:
+        active = _row_to_task_assignment(active_row)
+        if active.ace_session_id == ace_session_id:
+            # Same ace re-assigned — idempotent no-op
+            return active, False
+        raise ValueError(
+            f"Task {task_graph_id} already has an active assignment to ace {active.ace_session_id}"
+        )
+
+    now = _now()
+    assignment = TaskAssignment(
+        id=_uuid(),
+        task_graph_id=task_graph_id,
+        ace_session_id=ace_session_id,
+        assignment_id=assignment_id,
+        status="assigned",
+        created_at=now,
+        updated_at=now,
+    )
+
+    await db.execute(
+        """INSERT INTO task_assignments
+           (id, task_graph_id, ace_session_id, assignment_id, status, created_at, updated_at)
+           VALUES (?, ?, ?, ?, ?, ?, ?)""",
+        (
+            assignment.id,
+            assignment.task_graph_id,
+            assignment.ace_session_id,
+            assignment.assignment_id,
+            assignment.status,
+            assignment.created_at,
+            assignment.updated_at,
+        ),
+    )
+
+    # Transition the task_graph to 'assigned'
+    await db.execute(
+        "UPDATE task_graphs SET status = ?, assigned_ace_id = ?, updated_at = ? WHERE id = ?",
+        ("assigned", ace_session_id, now, task_graph_id),
+    )
+
+    await db.commit()
+    return assignment, True
+
+
+async def get_task_assignment(
+    db: aiosqlite.Connection,
+    assignment_id: str,
+) -> TaskAssignment | None:
+    """Fetch a task assignment by its idempotency key."""
+    cursor = await db.execute(
+        "SELECT * FROM task_assignments WHERE assignment_id = ?",
+        (assignment_id,),
+    )
+    row = await cursor.fetchone()
+    if row is None:
+        return None
+    return _row_to_task_assignment(row)
+
+
+async def get_task_assignment_by_id(
+    db: aiosqlite.Connection,
+    record_id: str,
+) -> TaskAssignment | None:
+    """Fetch a task assignment by its primary key."""
+    cursor = await db.execute(
+        "SELECT * FROM task_assignments WHERE id = ?",
+        (record_id,),
+    )
+    row = await cursor.fetchone()
+    if row is None:
+        return None
+    return _row_to_task_assignment(row)
+
+
+async def list_task_assignments(
+    db: aiosqlite.Connection,
+    *,
+    task_graph_id: str | None = None,
+    ace_session_id: str | None = None,
+) -> list[TaskAssignment]:
+    """List task assignments, optionally filtered."""
+    conditions: list[str] = []
+    params: list[str] = []
+
+    if task_graph_id is not None:
+        conditions.append("task_graph_id = ?")
+        params.append(task_graph_id)
+    if ace_session_id is not None:
+        conditions.append("ace_session_id = ?")
+        params.append(ace_session_id)
+
+    where = f" WHERE {' AND '.join(conditions)}" if conditions else ""
+    cursor = await db.execute(
+        f"SELECT * FROM task_assignments{where} ORDER BY created_at DESC",
+        params,
+    )
+    rows = await cursor.fetchall()
+    return [_row_to_task_assignment(r) for r in rows]
+
+
+async def update_task_assignment_status(
+    db: aiosqlite.Connection,
+    assignment_id: str,
+    new_status: str,
+) -> TaskAssignment | None:
+    """Transition a task assignment's status with validation."""
+    if new_status not in _VALID_ASSIGNMENT_STATUSES:
+        raise ValueError(f"Invalid assignment status: {new_status}")
+
+    existing = await get_task_assignment(db, assignment_id)
+    if existing is None:
+        return None
+
+    allowed = _ASSIGNMENT_TRANSITIONS.get(existing.status, set())
+    if new_status not in allowed:
+        raise ValueError(f"Cannot transition assignment from '{existing.status}' to '{new_status}'")
+
+    now = _now()
+    await db.execute(
+        "UPDATE task_assignments SET status = ?, updated_at = ? WHERE assignment_id = ?",
+        (new_status, now, assignment_id),
+    )
+    await db.commit()
+    return await get_task_assignment(db, assignment_id)
 
 
 # ---------------------------------------------------------------------------

--- a/src/atc/state/migrations/versions/006_task_assignments.sql
+++ b/src/atc/state/migrations/versions/006_task_assignments.sql
@@ -1,0 +1,20 @@
+-- Idempotent task assignments with state machine guards.
+--
+-- Creates a task_assignments table to track individual assignment attempts
+-- with an assignment_id for idempotency.  Duplicate assignment_ids are
+-- silently ignored (ON CONFLICT DO NOTHING at the application layer).
+
+CREATE TABLE IF NOT EXISTS task_assignments (
+    id              TEXT PRIMARY KEY,
+    task_graph_id   TEXT NOT NULL REFERENCES task_graphs(id) ON DELETE CASCADE,
+    ace_session_id  TEXT NOT NULL,
+    assignment_id   TEXT NOT NULL UNIQUE,
+    status          TEXT NOT NULL DEFAULT 'assigned',
+    created_at      TEXT NOT NULL,
+    updated_at      TEXT NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_task_assignments_task_graph
+    ON task_assignments(task_graph_id);
+CREATE INDEX IF NOT EXISTS idx_task_assignments_ace_session
+    ON task_assignments(ace_session_id);

--- a/src/atc/state/models.py
+++ b/src/atc/state/models.py
@@ -187,6 +187,23 @@ class TaskGraph:
 
 
 @dataclass
+class TaskAssignment:
+    """Tracks a single assignment of an Ace session to a task graph entry.
+
+    The ``assignment_id`` is a caller-supplied idempotency key.  Inserting
+    a duplicate ``assignment_id`` is a no-op.
+    """
+
+    id: str
+    task_graph_id: str
+    ace_session_id: str
+    assignment_id: str
+    status: str = "assigned"  # assigned|working|done|failed
+    created_at: str = ""
+    updated_at: str = ""
+
+
+@dataclass
 class SessionHeartbeat:
     session_id: str
     health: str  # alive|stale|stopped

--- a/tests/e2e/test_task_graph_api.py
+++ b/tests/e2e/test_task_graph_api.py
@@ -1,6 +1,6 @@
 """E2E tests for task graph REST API.
 
-Covers: CRUD operations, status transitions, error handling.
+Covers: CRUD operations, status transitions, idempotent assignments, error handling.
 """
 
 from __future__ import annotations
@@ -163,7 +163,7 @@ class TestTaskGraphCRUD:
 
 
 class TestTaskGraphStatusTransitions:
-    def test_todo_to_in_progress(self, client: TestClient) -> None:
+    def test_todo_to_assigned(self, client: TestClient) -> None:
         project_id = _create_project(client)
         create_resp = client.post(
             f"/api/projects/{project_id}/task-graphs",
@@ -172,12 +172,13 @@ class TestTaskGraphStatusTransitions:
         tg_id = create_resp.json()["id"]
         resp = client.patch(
             f"/api/task-graphs/{tg_id}/status",
-            json={"status": "in_progress"},
+            json={"status": "assigned"},
         )
         assert resp.status_code == 200
-        assert resp.json()["status"] == "in_progress"
+        assert resp.json()["status"] == "assigned"
 
     def test_full_lifecycle(self, client: TestClient) -> None:
+        """Test the full state machine: todo -> assigned -> in_progress -> review -> done."""
         project_id = _create_project(client)
         create_resp = client.post(
             f"/api/projects/{project_id}/task-graphs",
@@ -185,21 +186,43 @@ class TestTaskGraphStatusTransitions:
         )
         tg_id = create_resp.json()["id"]
 
-        # todo → in_progress
+        for status in ["assigned", "in_progress", "review", "done"]:
+            resp = client.patch(
+                f"/api/task-graphs/{tg_id}/status",
+                json={"status": status},
+            )
+            assert resp.status_code == 200, f"Failed transition to {status}"
+            assert resp.json()["status"] == status
+
+    def test_skip_review_lifecycle(self, client: TestClient) -> None:
+        """Test shortcut: todo -> assigned -> in_progress -> done (skip review)."""
+        project_id = _create_project(client)
+        create_resp = client.post(
+            f"/api/projects/{project_id}/task-graphs",
+            json={"title": "Skip review"},
+        )
+        tg_id = create_resp.json()["id"]
+
+        for status in ["assigned", "in_progress", "done"]:
+            resp = client.patch(
+                f"/api/task-graphs/{tg_id}/status",
+                json={"status": status},
+            )
+            assert resp.status_code == 200
+
+    def test_todo_to_in_progress_rejected(self, client: TestClient) -> None:
+        """Cannot skip 'assigned' step."""
+        project_id = _create_project(client)
+        create_resp = client.post(
+            f"/api/projects/{project_id}/task-graphs",
+            json={"title": "Skip assigned"},
+        )
+        tg_id = create_resp.json()["id"]
         resp = client.patch(
             f"/api/task-graphs/{tg_id}/status",
             json={"status": "in_progress"},
         )
-        assert resp.status_code == 200
-        assert resp.json()["status"] == "in_progress"
-
-        # in_progress → done
-        resp = client.patch(
-            f"/api/task-graphs/{tg_id}/status",
-            json={"status": "done"},
-        )
-        assert resp.status_code == 200
-        assert resp.json()["status"] == "done"
+        assert resp.status_code == 422
 
     def test_invalid_transition_same_status(self, client: TestClient) -> None:
         project_id = _create_project(client)
@@ -233,3 +256,155 @@ class TestTaskGraphStatusTransitions:
             json={"status": "done"},
         )
         assert resp.status_code == 404
+
+    def test_error_recovery_lifecycle(self, client: TestClient) -> None:
+        """Test error recovery: todo -> assigned -> in_progress -> error -> todo."""
+        project_id = _create_project(client)
+        create_resp = client.post(
+            f"/api/projects/{project_id}/task-graphs",
+            json={"title": "Error recovery"},
+        )
+        tg_id = create_resp.json()["id"]
+
+        for status in ["assigned", "in_progress", "error", "todo"]:
+            resp = client.patch(
+                f"/api/task-graphs/{tg_id}/status",
+                json={"status": status},
+            )
+            assert resp.status_code == 200
+
+
+class TestIdempotentAssignment:
+    def test_assign_task(self, client: TestClient) -> None:
+        project_id = _create_project(client)
+        create_resp = client.post(
+            f"/api/projects/{project_id}/task-graphs",
+            json={"title": "Assign me"},
+        )
+        tg_id = create_resp.json()["id"]
+
+        resp = client.post(
+            f"/api/task-graphs/{tg_id}/assign",
+            json={"ace_session_id": "ace-1", "assignment_id": "key-1"},
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["task_graph_id"] == tg_id
+        assert data["ace_session_id"] == "ace-1"
+        assert data["assignment_id"] == "key-1"
+        assert data["status"] == "assigned"
+
+        # Task should now be 'assigned'
+        tg_resp = client.get(f"/api/task-graphs/{tg_id}")
+        assert tg_resp.json()["status"] == "assigned"
+
+    def test_duplicate_assignment_is_noop(self, client: TestClient) -> None:
+        project_id = _create_project(client)
+        create_resp = client.post(
+            f"/api/projects/{project_id}/task-graphs",
+            json={"title": "Duplicate test"},
+        )
+        tg_id = create_resp.json()["id"]
+
+        resp1 = client.post(
+            f"/api/task-graphs/{tg_id}/assign",
+            json={"ace_session_id": "ace-1", "assignment_id": "key-dup"},
+        )
+        assert resp1.status_code == 200
+
+        # Same assignment_id again -- should return same record
+        resp2 = client.post(
+            f"/api/task-graphs/{tg_id}/assign",
+            json={"ace_session_id": "ace-1", "assignment_id": "key-dup"},
+        )
+        assert resp2.status_code == 200
+        assert resp2.json()["id"] == resp1.json()["id"]
+
+    def test_assign_non_todo_task_rejected(self, client: TestClient) -> None:
+        project_id = _create_project(client)
+        create_resp = client.post(
+            f"/api/projects/{project_id}/task-graphs",
+            json={"title": "Already assigned"},
+        )
+        tg_id = create_resp.json()["id"]
+
+        # First assignment succeeds
+        client.post(
+            f"/api/task-graphs/{tg_id}/assign",
+            json={"ace_session_id": "ace-1", "assignment_id": "key-1"},
+        )
+
+        # Second assignment with different key fails
+        resp = client.post(
+            f"/api/task-graphs/{tg_id}/assign",
+            json={"ace_session_id": "ace-2", "assignment_id": "key-2"},
+        )
+        assert resp.status_code == 422
+
+    def test_list_assignments(self, client: TestClient) -> None:
+        project_id = _create_project(client)
+        create_resp = client.post(
+            f"/api/projects/{project_id}/task-graphs",
+            json={"title": "List assignments"},
+        )
+        tg_id = create_resp.json()["id"]
+
+        client.post(
+            f"/api/task-graphs/{tg_id}/assign",
+            json={"ace_session_id": "ace-1", "assignment_id": "key-list"},
+        )
+
+        resp = client.get(f"/api/task-graphs/{tg_id}/assignments")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert len(data) == 1
+        assert data[0]["assignment_id"] == "key-list"
+
+    def test_assignment_status_transition(self, client: TestClient) -> None:
+        project_id = _create_project(client)
+        create_resp = client.post(
+            f"/api/projects/{project_id}/task-graphs",
+            json={"title": "Status transition"},
+        )
+        tg_id = create_resp.json()["id"]
+
+        client.post(
+            f"/api/task-graphs/{tg_id}/assign",
+            json={"ace_session_id": "ace-1", "assignment_id": "key-status"},
+        )
+
+        # assigned -> working
+        resp = client.patch(
+            "/api/task-assignments/key-status/status",
+            json={"status": "working"},
+        )
+        assert resp.status_code == 200
+        assert resp.json()["status"] == "working"
+
+        # working -> done
+        resp = client.patch(
+            "/api/task-assignments/key-status/status",
+            json={"status": "done"},
+        )
+        assert resp.status_code == 200
+        assert resp.json()["status"] == "done"
+
+    def test_assignment_invalid_transition(self, client: TestClient) -> None:
+        project_id = _create_project(client)
+        create_resp = client.post(
+            f"/api/projects/{project_id}/task-graphs",
+            json={"title": "Invalid transition"},
+        )
+        tg_id = create_resp.json()["id"]
+
+        client.post(
+            f"/api/task-graphs/{tg_id}/assign",
+            json={"ace_session_id": "ace-1", "assignment_id": "key-invalid"},
+        )
+
+        # assigned -> done (skip working) should fail
+        resp = client.patch(
+            "/api/task-assignments/key-invalid/status",
+            json={"status": "done"},
+        )
+        assert resp.status_code == 422

--- a/tests/unit/test_leader_orchestrator.py
+++ b/tests/unit/test_leader_orchestrator.py
@@ -15,7 +15,6 @@ from atc.state.db import (
     create_task_graph,
     get_connection,
     get_task_graph,
-    list_task_graphs,
     run_migrations,
 )
 
@@ -63,21 +62,28 @@ def orchestrator(db, event_bus, project_with_leader) -> LeaderOrchestrator:
 @pytest.mark.asyncio
 class TestSpawnAces:
     async def test_spawns_for_ready_tasks(
-        self, mock_create: AsyncMock, db, orchestrator: LeaderOrchestrator,
+        self,
+        mock_create: AsyncMock,
+        db,
+        orchestrator: LeaderOrchestrator,
     ) -> None:
-        project, _ = await create_project(db, "p2"), None
+        await create_project(db, "p2")
         # Use orchestrator's project_id
-        tg = await create_task_graph(db, orchestrator.project_id, "Login page")
+        await create_task_graph(db, orchestrator.project_id, "Login page")
 
         assignments = await orchestrator.spawn_aces_for_ready_tasks()
 
         assert len(assignments) == 1
         assert assignments[0].task_title == "Login page"
         assert assignments[0].ace_session_id == "ace-session-1"
+        assert assignments[0].assignment_id != ""  # idempotency key set
         mock_create.assert_called_once()
 
     async def test_uses_project_agent_provider(
-        self, mock_create: AsyncMock, db, orchestrator: LeaderOrchestrator,
+        self,
+        mock_create: AsyncMock,
+        db,
+        orchestrator: LeaderOrchestrator,
     ) -> None:
         """Ace sessions must use the project's configured agent_provider."""
         # Set project to use opencode
@@ -96,7 +102,10 @@ class TestSpawnAces:
         assert call_kwargs.kwargs.get("launch_command") == "opencode"
 
     async def test_default_provider_uses_claude(
-        self, mock_create: AsyncMock, db, orchestrator: LeaderOrchestrator,
+        self,
+        mock_create: AsyncMock,
+        db,
+        orchestrator: LeaderOrchestrator,
     ) -> None:
         """Default agent_provider (claude_code) uses the Claude launch command."""
         await create_task_graph(db, orchestrator.project_id, "Task B")
@@ -107,11 +116,16 @@ class TestSpawnAces:
         assert call_kwargs.kwargs.get("launch_command") == "claude --dangerously-skip-permissions"
 
     async def test_skips_tasks_with_unmet_deps(
-        self, mock_create: AsyncMock, db, orchestrator: LeaderOrchestrator,
+        self,
+        mock_create: AsyncMock,
+        db,
+        orchestrator: LeaderOrchestrator,
     ) -> None:
         tg1 = await create_task_graph(db, orchestrator.project_id, "Task A")
-        tg2 = await create_task_graph(
-            db, orchestrator.project_id, "Task B",
+        await create_task_graph(
+            db,
+            orchestrator.project_id,
+            "Task B",
             dependencies=[tg1.id],
         )
 
@@ -122,7 +136,10 @@ class TestSpawnAces:
         assert assignments[0].task_title == "Task A"
 
     async def test_respects_max_concurrent_limit(
-        self, mock_create: AsyncMock, db, orchestrator: LeaderOrchestrator,
+        self,
+        mock_create: AsyncMock,
+        db,
+        orchestrator: LeaderOrchestrator,
     ) -> None:
         orchestrator._max_concurrent_aces = 2
 
@@ -134,13 +151,19 @@ class TestSpawnAces:
         assert len(assignments) == 2
 
     async def test_no_tasks_returns_empty(
-        self, mock_create: AsyncMock, db, orchestrator: LeaderOrchestrator,
+        self,
+        mock_create: AsyncMock,
+        db,
+        orchestrator: LeaderOrchestrator,
     ) -> None:
         assignments = await orchestrator.spawn_aces_for_ready_tasks()
         assert assignments == []
 
     async def test_skip_already_assigned(
-        self, mock_create: AsyncMock, db, orchestrator: LeaderOrchestrator,
+        self,
+        mock_create: AsyncMock,
+        db,
+        orchestrator: LeaderOrchestrator,
     ) -> None:
         tg = await create_task_graph(db, orchestrator.project_id, "Task A")
 
@@ -155,7 +178,10 @@ class TestSpawnAces:
         assert len(assignments) == 0
 
     async def test_marks_task_in_progress(
-        self, mock_create: AsyncMock, db, orchestrator: LeaderOrchestrator,
+        self,
+        mock_create: AsyncMock,
+        db,
+        orchestrator: LeaderOrchestrator,
     ) -> None:
         tg = await create_task_graph(db, orchestrator.project_id, "Task A")
 
@@ -166,7 +192,10 @@ class TestSpawnAces:
         assert updated.status == "in_progress"
 
     async def test_assigns_ace_to_task_graph(
-        self, mock_create: AsyncMock, db, orchestrator: LeaderOrchestrator,
+        self,
+        mock_create: AsyncMock,
+        db,
+        orchestrator: LeaderOrchestrator,
     ) -> None:
         tg = await create_task_graph(db, orchestrator.project_id, "Task A")
 
@@ -177,10 +206,13 @@ class TestSpawnAces:
         assert updated.assigned_ace_id == "ace-session-1"
 
     async def test_publishes_ace_spawned_event(
-        self, mock_create: AsyncMock, db, orchestrator: LeaderOrchestrator,
+        self,
+        mock_create: AsyncMock,
+        db,
+        orchestrator: LeaderOrchestrator,
         event_bus: EventBus,
     ) -> None:
-        tg = await create_task_graph(db, orchestrator.project_id, "Task A")
+        await create_task_graph(db, orchestrator.project_id, "Task A")
 
         captured: list[dict] = []
         event_bus.subscribe("leader_ace_spawned", lambda d: captured.append(d))
@@ -190,9 +222,13 @@ class TestSpawnAces:
         assert len(captured) == 1
         assert captured[0]["task_title"] == "Task A"
         assert captured[0]["session_id"] == "ace-session-1"
+        assert "assignment_id" in captured[0]
 
     async def test_spawn_failure_does_not_crash(
-        self, mock_create: AsyncMock, db, orchestrator: LeaderOrchestrator,
+        self,
+        mock_create: AsyncMock,
+        db,
+        orchestrator: LeaderOrchestrator,
     ) -> None:
         mock_create.side_effect = RuntimeError("tmux failed")
         await create_task_graph(db, orchestrator.project_id, "Task A")
@@ -200,6 +236,23 @@ class TestSpawnAces:
         # Should not raise
         assignments = await orchestrator.spawn_aces_for_ready_tasks()
         assert len(assignments) == 0
+
+    async def test_idempotent_spawn_same_task(
+        self,
+        mock_create: AsyncMock,
+        db,
+        orchestrator: LeaderOrchestrator,
+    ) -> None:
+        """Spawning the same task twice with the same leader is idempotent."""
+        await create_task_graph(db, orchestrator.project_id, "Task A")
+
+        # First spawn
+        assignments1 = await orchestrator.spawn_aces_for_ready_tasks()
+        assert len(assignments1) == 1
+
+        # Second call -- task is already in self.assignments, so skipped
+        assignments2 = await orchestrator.spawn_aces_for_ready_tasks()
+        assert len(assignments2) == 0
 
 
 # ---------------------------------------------------------------------------
@@ -211,14 +264,21 @@ class TestSpawnAces:
 @pytest.mark.asyncio
 class TestSendInstruction:
     async def test_sends_instruction(
-        self, mock_start: AsyncMock, db, orchestrator: LeaderOrchestrator,
+        self,
+        mock_start: AsyncMock,
+        db,
+        orchestrator: LeaderOrchestrator,
     ) -> None:
         tg = await create_task_graph(db, orchestrator.project_id, "Task A")
 
         # Manually create session row for the Ace
         from atc.state import db as db_ops
+
         session = await db_ops.create_session(
-            db, orchestrator.project_id, "ace", "ace-task-a",
+            db,
+            orchestrator.project_id,
+            "ace",
+            "ace-task-a",
         )
 
         orchestrator.assignments[tg.id] = AceAssignment(
@@ -230,14 +290,18 @@ class TestSendInstruction:
         await orchestrator.send_instruction_to_ace(tg.id, "Build the login page")
 
         mock_start.assert_called_once_with(
-            db, session.id,
+            db,
+            session.id,
             instruction="Build the login page",
             event_bus=orchestrator.event_bus,
         )
         assert orchestrator.assignments[tg.id].status == "working"
 
     async def test_instruction_to_unknown_task_raises(
-        self, mock_start: AsyncMock, db, orchestrator: LeaderOrchestrator,
+        self,
+        mock_start: AsyncMock,
+        db,
+        orchestrator: LeaderOrchestrator,
     ) -> None:
         with pytest.raises(ValueError, match="No Ace assigned"):
             await orchestrator.send_instruction_to_ace("nonexistent", "Do something")
@@ -252,12 +316,17 @@ class TestSendInstruction:
 @pytest.mark.asyncio
 class TestMarkTaskDone:
     async def test_marks_done_and_destroys_ace(
-        self, mock_destroy: AsyncMock, db, orchestrator: LeaderOrchestrator,
+        self,
+        mock_destroy: AsyncMock,
+        db,
+        orchestrator: LeaderOrchestrator,
         event_bus: EventBus,
     ) -> None:
         tg = await create_task_graph(db, orchestrator.project_id, "Task A")
-        # Transition to in_progress first (required for done transition)
+        # Transition through the state machine: todo -> assigned -> in_progress
         from atc.state import db as db_ops
+
+        await db_ops.update_task_graph_status(db, tg.id, "assigned")
         await db_ops.update_task_graph_status(db, tg.id, "in_progress")
 
         orchestrator.assignments[tg.id] = AceAssignment(
@@ -280,10 +349,15 @@ class TestMarkTaskDone:
         assert len(captured) == 1
 
     async def test_done_without_assignment(
-        self, mock_destroy: AsyncMock, db, orchestrator: LeaderOrchestrator,
+        self,
+        mock_destroy: AsyncMock,
+        db,
+        orchestrator: LeaderOrchestrator,
     ) -> None:
         tg = await create_task_graph(db, orchestrator.project_id, "Task A")
         from atc.state import db as db_ops
+
+        await db_ops.update_task_graph_status(db, tg.id, "assigned")
         await db_ops.update_task_graph_status(db, tg.id, "in_progress")
 
         # Should not crash even without assignment
@@ -304,11 +378,16 @@ class TestMarkTaskDone:
 @pytest.mark.asyncio
 class TestMarkTaskFailed:
     async def test_resets_to_todo_and_destroys_ace(
-        self, mock_destroy: AsyncMock, db, orchestrator: LeaderOrchestrator,
+        self,
+        mock_destroy: AsyncMock,
+        db,
+        orchestrator: LeaderOrchestrator,
         event_bus: EventBus,
     ) -> None:
         tg = await create_task_graph(db, orchestrator.project_id, "Task A")
         from atc.state import db as db_ops
+
+        await db_ops.update_task_graph_status(db, tg.id, "assigned")
         await db_ops.update_task_graph_status(db, tg.id, "in_progress")
 
         orchestrator.assignments[tg.id] = AceAssignment(
@@ -325,7 +404,7 @@ class TestMarkTaskFailed:
 
         updated = await get_task_graph(db, tg.id)
         assert updated is not None
-        assert updated.status == "todo"  # Reset for retry
+        assert updated.status == "todo"  # Reset for retry (via error -> todo)
         assert tg.id not in orchestrator.assignments  # Assignment removed
         mock_destroy.assert_called_once()
         assert len(captured) == 1
@@ -342,13 +421,16 @@ class TestGetProgress:
     async def test_progress_with_tasks(self, db, orchestrator: LeaderOrchestrator) -> None:
         tg1 = await create_task_graph(db, orchestrator.project_id, "Done Task")
         from atc.state import db as db_ops
+
+        await db_ops.update_task_graph_status(db, tg1.id, "assigned")
         await db_ops.update_task_graph_status(db, tg1.id, "in_progress")
         await db_ops.update_task_graph_status(db, tg1.id, "done")
 
         tg2 = await create_task_graph(db, orchestrator.project_id, "In Progress")
+        await db_ops.update_task_graph_status(db, tg2.id, "assigned")
         await db_ops.update_task_graph_status(db, tg2.id, "in_progress")
 
-        tg3 = await create_task_graph(db, orchestrator.project_id, "Todo Task")
+        await create_task_graph(db, orchestrator.project_id, "Todo Task")
 
         progress = await orchestrator.get_progress()
 
@@ -375,19 +457,28 @@ class TestGetProgress:
 @pytest.mark.asyncio
 class TestCleanup:
     async def test_destroys_active_aces(
-        self, mock_destroy: AsyncMock, db, orchestrator: LeaderOrchestrator,
+        self,
+        mock_destroy: AsyncMock,
+        db,
+        orchestrator: LeaderOrchestrator,
     ) -> None:
         orchestrator.assignments["tg-1"] = AceAssignment(
-            ace_session_id="ace-1", task_graph_id="tg-1",
-            task_title="Task 1", status="working",
+            ace_session_id="ace-1",
+            task_graph_id="tg-1",
+            task_title="Task 1",
+            status="working",
         )
         orchestrator.assignments["tg-2"] = AceAssignment(
-            ace_session_id="ace-2", task_graph_id="tg-2",
-            task_title="Task 2", status="assigned",
+            ace_session_id="ace-2",
+            task_graph_id="tg-2",
+            task_title="Task 2",
+            status="assigned",
         )
         orchestrator.assignments["tg-3"] = AceAssignment(
-            ace_session_id="ace-3", task_graph_id="tg-3",
-            task_title="Task 3", status="done",
+            ace_session_id="ace-3",
+            task_graph_id="tg-3",
+            task_title="Task 3",
+            status="done",
         )
 
         await orchestrator.cleanup()
@@ -397,7 +488,10 @@ class TestCleanup:
         assert len(orchestrator.assignments) == 0
 
     async def test_cleanup_with_no_assignments(
-        self, mock_destroy: AsyncMock, db, orchestrator: LeaderOrchestrator,
+        self,
+        mock_destroy: AsyncMock,
+        db,
+        orchestrator: LeaderOrchestrator,
     ) -> None:
         await orchestrator.cleanup()
         mock_destroy.assert_not_called()
@@ -412,21 +506,30 @@ class TestCleanup:
 @pytest.mark.asyncio
 class TestSessionMonitoring:
     async def test_ace_error_triggers_task_failure(
-        self, mock_destroy: AsyncMock, db, orchestrator: LeaderOrchestrator,
+        self,
+        mock_destroy: AsyncMock,
+        db,
+        orchestrator: LeaderOrchestrator,
     ) -> None:
         tg = await create_task_graph(db, orchestrator.project_id, "Task A")
         from atc.state import db as db_ops
+
+        await db_ops.update_task_graph_status(db, tg.id, "assigned")
         await db_ops.update_task_graph_status(db, tg.id, "in_progress")
 
         orchestrator.assignments[tg.id] = AceAssignment(
-            ace_session_id="ace-1", task_graph_id=tg.id,
-            task_title="Task A", status="working",
+            ace_session_id="ace-1",
+            task_graph_id=tg.id,
+            task_title="Task A",
+            status="working",
         )
 
-        await orchestrator.on_session_status_changed({
-            "session_id": "ace-1",
-            "new_status": "error",
-        })
+        await orchestrator.on_session_status_changed(
+            {
+                "session_id": "ace-1",
+                "new_status": "error",
+            }
+        )
 
         assert tg.id not in orchestrator.assignments
         updated = await get_task_graph(db, tg.id)
@@ -434,57 +537,80 @@ class TestSessionMonitoring:
         assert updated.status == "todo"
 
     async def test_ace_disconnected_triggers_task_failure(
-        self, mock_destroy: AsyncMock, db, orchestrator: LeaderOrchestrator,
+        self,
+        mock_destroy: AsyncMock,
+        db,
+        orchestrator: LeaderOrchestrator,
     ) -> None:
         tg = await create_task_graph(db, orchestrator.project_id, "Task A")
         from atc.state import db as db_ops
+
+        await db_ops.update_task_graph_status(db, tg.id, "assigned")
         await db_ops.update_task_graph_status(db, tg.id, "in_progress")
 
         orchestrator.assignments[tg.id] = AceAssignment(
-            ace_session_id="ace-1", task_graph_id=tg.id,
-            task_title="Task A", status="working",
+            ace_session_id="ace-1",
+            task_graph_id=tg.id,
+            task_title="Task A",
+            status="working",
         )
 
-        await orchestrator.on_session_status_changed({
-            "session_id": "ace-1",
-            "new_status": "disconnected",
-        })
+        await orchestrator.on_session_status_changed(
+            {
+                "session_id": "ace-1",
+                "new_status": "disconnected",
+            }
+        )
 
         assert tg.id not in orchestrator.assignments
 
     async def test_unrelated_session_ignored(
-        self, mock_destroy: AsyncMock, db, orchestrator: LeaderOrchestrator,
+        self,
+        mock_destroy: AsyncMock,
+        db,
+        orchestrator: LeaderOrchestrator,
     ) -> None:
         tg = await create_task_graph(db, orchestrator.project_id, "Task A")
 
         orchestrator.assignments[tg.id] = AceAssignment(
-            ace_session_id="ace-1", task_graph_id=tg.id,
-            task_title="Task A", status="working",
+            ace_session_id="ace-1",
+            task_graph_id=tg.id,
+            task_title="Task A",
+            status="working",
         )
 
-        await orchestrator.on_session_status_changed({
-            "session_id": "other-session",
-            "new_status": "error",
-        })
+        await orchestrator.on_session_status_changed(
+            {
+                "session_id": "other-session",
+                "new_status": "error",
+            }
+        )
 
         # Assignment should be unchanged
         assert tg.id in orchestrator.assignments
         assert orchestrator.assignments[tg.id].status == "working"
 
     async def test_non_error_status_ignored(
-        self, mock_destroy: AsyncMock, db, orchestrator: LeaderOrchestrator,
+        self,
+        mock_destroy: AsyncMock,
+        db,
+        orchestrator: LeaderOrchestrator,
     ) -> None:
         tg = await create_task_graph(db, orchestrator.project_id, "Task A")
 
         orchestrator.assignments[tg.id] = AceAssignment(
-            ace_session_id="ace-1", task_graph_id=tg.id,
-            task_title="Task A", status="working",
+            ace_session_id="ace-1",
+            task_graph_id=tg.id,
+            task_title="Task A",
+            status="working",
         )
 
-        await orchestrator.on_session_status_changed({
-            "session_id": "ace-1",
-            "new_status": "waiting",
-        })
+        await orchestrator.on_session_status_changed(
+            {
+                "session_id": "ace-1",
+                "new_status": "waiting",
+            }
+        )
 
         # Should not trigger failure
         assert tg.id in orchestrator.assignments

--- a/tests/unit/test_task_graphs.py
+++ b/tests/unit/test_task_graphs.py
@@ -1,4 +1,4 @@
-"""Tests for task_graph CRUD operations and status transitions."""
+"""Tests for task_graph CRUD operations, status transitions, and idempotent assignments."""
 
 from __future__ import annotations
 
@@ -6,12 +6,16 @@ import pytest
 
 from atc.state.db import (
     _SCHEMA_SQL,
+    assign_task,
     create_project,
     create_task_graph,
     delete_task_graph,
     get_connection,
+    get_task_assignment,
     get_task_graph,
+    list_task_assignments,
     list_task_graphs,
+    update_task_assignment_status,
     update_task_graph,
     update_task_graph_status,
 )
@@ -158,16 +162,38 @@ class TestTaskGraphCRUD:
 
 @pytest.mark.asyncio
 class TestTaskGraphStatusTransitions:
-    async def test_todo_to_in_progress(self, db) -> None:
+    """Test the strict state machine: todo -> assigned -> in_progress -> review -> done."""
+
+    async def test_todo_to_assigned(self, db) -> None:
         project = await create_project(db, "p1")
         tg = await create_task_graph(db, project.id, "Task")
+        updated = await update_task_graph_status(db, tg.id, "assigned")
+        assert updated is not None
+        assert updated.status == "assigned"
+
+    async def test_assigned_to_in_progress(self, db) -> None:
+        project = await create_project(db, "p1")
+        tg = await create_task_graph(db, project.id, "Task")
+        await update_task_graph_status(db, tg.id, "assigned")
         updated = await update_task_graph_status(db, tg.id, "in_progress")
         assert updated is not None
         assert updated.status == "in_progress"
 
-    async def test_todo_to_done(self, db) -> None:
+    async def test_in_progress_to_review(self, db) -> None:
         project = await create_project(db, "p1")
         tg = await create_task_graph(db, project.id, "Task")
+        await update_task_graph_status(db, tg.id, "assigned")
+        await update_task_graph_status(db, tg.id, "in_progress")
+        updated = await update_task_graph_status(db, tg.id, "review")
+        assert updated is not None
+        assert updated.status == "review"
+
+    async def test_review_to_done(self, db) -> None:
+        project = await create_project(db, "p1")
+        tg = await create_task_graph(db, project.id, "Task")
+        await update_task_graph_status(db, tg.id, "assigned")
+        await update_task_graph_status(db, tg.id, "in_progress")
+        await update_task_graph_status(db, tg.id, "review")
         updated = await update_task_graph_status(db, tg.id, "done")
         assert updated is not None
         assert updated.status == "done"
@@ -175,34 +201,88 @@ class TestTaskGraphStatusTransitions:
     async def test_in_progress_to_done(self, db) -> None:
         project = await create_project(db, "p1")
         tg = await create_task_graph(db, project.id, "Task")
+        await update_task_graph_status(db, tg.id, "assigned")
         await update_task_graph_status(db, tg.id, "in_progress")
         updated = await update_task_graph_status(db, tg.id, "done")
         assert updated is not None
         assert updated.status == "done"
 
-    async def test_in_progress_to_todo(self, db) -> None:
+    async def test_in_progress_to_error(self, db) -> None:
         project = await create_project(db, "p1")
         tg = await create_task_graph(db, project.id, "Task")
+        await update_task_graph_status(db, tg.id, "assigned")
         await update_task_graph_status(db, tg.id, "in_progress")
+        updated = await update_task_graph_status(db, tg.id, "error")
+        assert updated is not None
+        assert updated.status == "error"
+
+    async def test_error_to_todo(self, db) -> None:
+        """Error state allows retry by transitioning back to todo."""
+        project = await create_project(db, "p1")
+        tg = await create_task_graph(db, project.id, "Task")
+        await update_task_graph_status(db, tg.id, "assigned")
+        await update_task_graph_status(db, tg.id, "in_progress")
+        await update_task_graph_status(db, tg.id, "error")
         updated = await update_task_graph_status(db, tg.id, "todo")
         assert updated is not None
         assert updated.status == "todo"
 
     async def test_done_to_todo(self, db) -> None:
+        """Completed tasks can be re-opened."""
         project = await create_project(db, "p1")
         tg = await create_task_graph(db, project.id, "Task")
+        await update_task_graph_status(db, tg.id, "assigned")
+        await update_task_graph_status(db, tg.id, "in_progress")
         await update_task_graph_status(db, tg.id, "done")
         updated = await update_task_graph_status(db, tg.id, "todo")
         assert updated is not None
         assert updated.status == "todo"
 
-    async def test_done_to_in_progress(self, db) -> None:
+    async def test_assigned_to_todo(self, db) -> None:
+        """Un-assigning sends task back to todo."""
         project = await create_project(db, "p1")
         tg = await create_task_graph(db, project.id, "Task")
-        await update_task_graph_status(db, tg.id, "done")
+        await update_task_graph_status(db, tg.id, "assigned")
+        updated = await update_task_graph_status(db, tg.id, "todo")
+        assert updated is not None
+        assert updated.status == "todo"
+
+    async def test_review_to_in_progress(self, db) -> None:
+        """Review can send task back to in_progress (revisions needed)."""
+        project = await create_project(db, "p1")
+        tg = await create_task_graph(db, project.id, "Task")
+        await update_task_graph_status(db, tg.id, "assigned")
+        await update_task_graph_status(db, tg.id, "in_progress")
+        await update_task_graph_status(db, tg.id, "review")
         updated = await update_task_graph_status(db, tg.id, "in_progress")
         assert updated is not None
         assert updated.status == "in_progress"
+
+    # --- Invalid transitions ---
+
+    async def test_todo_to_in_progress_rejected(self, db) -> None:
+        """Cannot skip 'assigned' -- must go todo -> assigned -> in_progress."""
+        project = await create_project(db, "p1")
+        tg = await create_task_graph(db, project.id, "Task")
+        with pytest.raises(ValueError, match="Cannot transition"):
+            await update_task_graph_status(db, tg.id, "in_progress")
+
+    async def test_todo_to_done_rejected(self, db) -> None:
+        """Cannot skip intermediate states."""
+        project = await create_project(db, "p1")
+        tg = await create_task_graph(db, project.id, "Task")
+        with pytest.raises(ValueError, match="Cannot transition"):
+            await update_task_graph_status(db, tg.id, "done")
+
+    async def test_done_to_in_progress_rejected(self, db) -> None:
+        """Done tasks cannot jump directly to in_progress."""
+        project = await create_project(db, "p1")
+        tg = await create_task_graph(db, project.id, "Task")
+        await update_task_graph_status(db, tg.id, "assigned")
+        await update_task_graph_status(db, tg.id, "in_progress")
+        await update_task_graph_status(db, tg.id, "done")
+        with pytest.raises(ValueError, match="Cannot transition"):
+            await update_task_graph_status(db, tg.id, "in_progress")
 
     async def test_invalid_status(self, db) -> None:
         project = await create_project(db, "p1")
@@ -227,3 +307,144 @@ class TestTaskGraphStatusTransitions:
         fetched = await get_task_graph(db, tg.id)
         assert fetched is not None
         assert fetched.dependencies == deps
+
+
+@pytest.mark.asyncio
+class TestIdempotentAssignment:
+    """Test idempotent task assignment via assign_task()."""
+
+    async def test_assign_creates_record_and_transitions(self, db) -> None:
+        project = await create_project(db, "p1")
+        tg = await create_task_graph(db, project.id, "Task A")
+
+        assignment, created = await assign_task(db, tg.id, "ace-1", "key-1")
+
+        assert created is True
+        assert assignment.task_graph_id == tg.id
+        assert assignment.ace_session_id == "ace-1"
+        assert assignment.assignment_id == "key-1"
+        assert assignment.status == "assigned"
+
+        # Task should now be 'assigned'
+        task = await get_task_graph(db, tg.id)
+        assert task is not None
+        assert task.status == "assigned"
+        assert task.assigned_ace_id == "ace-1"
+
+    async def test_duplicate_assignment_id_is_noop(self, db) -> None:
+        """Same assignment_id returns existing record without side effects."""
+        project = await create_project(db, "p1")
+        tg = await create_task_graph(db, project.id, "Task A")
+
+        first, created1 = await assign_task(db, tg.id, "ace-1", "key-1")
+        assert created1 is True
+
+        second, created2 = await assign_task(db, tg.id, "ace-1", "key-1")
+        assert created2 is False
+        assert second.id == first.id
+        assert second.assignment_id == "key-1"
+
+    async def test_assign_non_todo_task_rejected(self, db) -> None:
+        """Only tasks in 'todo' state can be assigned."""
+        project = await create_project(db, "p1")
+        tg = await create_task_graph(db, project.id, "Task A")
+
+        # Assign it first (moves to 'assigned')
+        await assign_task(db, tg.id, "ace-1", "key-1")
+
+        # Second assignment with different key should fail (task is 'assigned')
+        with pytest.raises(ValueError, match="Cannot assign task in 'assigned' state"):
+            await assign_task(db, tg.id, "ace-2", "key-2")
+
+    async def test_assign_already_assigned_same_ace_is_noop(self, db) -> None:
+        """If the same ace is already assigned, return existing (no error)."""
+        project = await create_project(db, "p1")
+        tg = await create_task_graph(db, project.id, "Task A")
+
+        await assign_task(db, tg.id, "ace-1", "key-1")
+
+        # Reset to todo manually for testing the active-assignment guard
+        await db.execute("UPDATE task_graphs SET status = 'todo' WHERE id = ?", (tg.id,))
+        await db.commit()
+
+        # Same ace, different key -- should detect active assignment and return it
+        assignment, created = await assign_task(db, tg.id, "ace-1", "key-2")
+        assert created is False
+
+    async def test_assign_already_assigned_different_ace_rejected(self, db) -> None:
+        """Cannot assign to a different ace while another is active."""
+        project = await create_project(db, "p1")
+        tg = await create_task_graph(db, project.id, "Task A")
+
+        await assign_task(db, tg.id, "ace-1", "key-1")
+
+        # Reset to todo manually for testing the active-assignment guard
+        await db.execute("UPDATE task_graphs SET status = 'todo' WHERE id = ?", (tg.id,))
+        await db.commit()
+
+        with pytest.raises(ValueError, match="already has an active assignment"):
+            await assign_task(db, tg.id, "ace-2", "key-2")
+
+    async def test_assign_nonexistent_task_raises(self, db) -> None:
+        with pytest.raises(ValueError, match="not found"):
+            await assign_task(db, "nonexistent", "ace-1", "key-1")
+
+    async def test_get_assignment_by_key(self, db) -> None:
+        project = await create_project(db, "p1")
+        tg = await create_task_graph(db, project.id, "Task A")
+        await assign_task(db, tg.id, "ace-1", "key-1")
+
+        assignment = await get_task_assignment(db, "key-1")
+        assert assignment is not None
+        assert assignment.ace_session_id == "ace-1"
+
+    async def test_get_assignment_nonexistent(self, db) -> None:
+        result = await get_task_assignment(db, "nonexistent")
+        assert result is None
+
+    async def test_list_assignments_by_task(self, db) -> None:
+        project = await create_project(db, "p1")
+        tg1 = await create_task_graph(db, project.id, "Task A")
+        tg2 = await create_task_graph(db, project.id, "Task B")
+
+        await assign_task(db, tg1.id, "ace-1", "key-1")
+        await assign_task(db, tg2.id, "ace-2", "key-2")
+
+        items = await list_task_assignments(db, task_graph_id=tg1.id)
+        assert len(items) == 1
+        assert items[0].task_graph_id == tg1.id
+
+    async def test_assignment_status_transitions(self, db) -> None:
+        project = await create_project(db, "p1")
+        tg = await create_task_graph(db, project.id, "Task A")
+        await assign_task(db, tg.id, "ace-1", "key-1")
+
+        updated = await update_task_assignment_status(db, "key-1", "working")
+        assert updated is not None
+        assert updated.status == "working"
+
+        updated = await update_task_assignment_status(db, "key-1", "done")
+        assert updated is not None
+        assert updated.status == "done"
+
+    async def test_assignment_invalid_transition(self, db) -> None:
+        project = await create_project(db, "p1")
+        tg = await create_task_graph(db, project.id, "Task A")
+        await assign_task(db, tg.id, "ace-1", "key-1")
+
+        # Cannot go from assigned -> done (must go through working)
+        with pytest.raises(ValueError, match="Cannot transition assignment"):
+            await update_task_assignment_status(db, "key-1", "done")
+
+    async def test_assignment_to_failed(self, db) -> None:
+        project = await create_project(db, "p1")
+        tg = await create_task_graph(db, project.id, "Task A")
+        await assign_task(db, tg.id, "ace-1", "key-1")
+
+        updated = await update_task_assignment_status(db, "key-1", "failed")
+        assert updated is not None
+        assert updated.status == "failed"
+
+    async def test_assignment_status_update_nonexistent(self, db) -> None:
+        result = await update_task_assignment_status(db, "nonexistent", "working")
+        assert result is None


### PR DESCRIPTION
## Summary
- Enforce strict task lifecycle state machine: `todo → assigned → in_progress → review → done` with error recovery paths (`error → todo`, `done → todo`)
- Add `task_assignments` table with unique `assignment_id` column for idempotent deduplication — re-assigning the same task to the same Ace is a no-op
- Guard against invalid transitions and double-assignments at the DB layer, preventing ghost tasks when messages are lost or duplicated
- Add REST API endpoints for task assignment management (`POST /assign`, `GET /assignments`, `PATCH /status`)

## Changes
- **Migration**: `006_task_assignments.sql` — new `task_assignments` table with indexes
- **Models**: `TaskAssignment` dataclass with assignment lifecycle states
- **DB layer**: `assign_task()`, `get/list/update_task_assignment*()` with state machine validation
- **Orchestrator**: Uses idempotent `assign_task()` with deterministic keys (`leader_id:task_graph_id`)
- **Decomposer**: Updated `get_completion_status()` for new states (`assigned`, `review`, `error`)
- **API**: 3 new endpoints for assignment CRUD
- **Tests**: 98 tests covering all transitions, idempotency, and edge cases

## Test plan
- [x] All 98 tests pass (unit + e2e)
- [x] ruff lint clean
- [x] ruff-format clean
- [ ] Verify mypy passes (133 pre-existing errors unrelated to this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)