### PR TITLE
fix: surface tmux errors to UI for Leader/Ace creation

### DIFF
--- a/frontend/src/components/ace/AceList.css
+++ b/frontend/src/components/ace/AceList.css
@@ -25,6 +25,15 @@
   border-radius: var(--radius-sm);
 }
 
+.ace-list__error {
+  font-size: var(--text-sm);
+  color: var(--color-danger, #f85149);
+  background: var(--color-danger-muted, rgba(248, 81, 73, 0.1));
+  border: 1px solid var(--color-danger, #f85149);
+  border-radius: var(--radius-md);
+  padding: var(--space-2) var(--space-3);
+}
+
 .ace-list__create {
   display: flex;
   gap: var(--space-2);

--- a/frontend/src/components/ace/AceList.tsx
+++ b/frontend/src/components/ace/AceList.tsx
@@ -26,6 +26,7 @@ export default function AceList({
   const [creating, setCreating] = useState(false);
   const [selectedId, setSelectedId] = useState<string | null>(null);
   const [loadingId, setLoadingId] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
 
   const selectedSession = sessions.find((s) => s.id === selectedId);
 
@@ -33,6 +34,7 @@ export default function AceList({
     e.preventDefault();
     if (!newName.trim()) return;
     setCreating(true);
+    setError(null);
     try {
       const created = await api.post<Session>(`/projects/${projectId}/aces`, {
         name: newName.trim(),
@@ -41,6 +43,8 @@ export default function AceList({
       setSelectedId(created.id);
       onRefresh();
     } catch (err) {
+      const msg = err instanceof Error ? err.message : "Failed to create ace";
+      setError(msg);
       console.error("Failed to create ace:", err);
     } finally {
       setCreating(false);
@@ -96,6 +100,12 @@ export default function AceList({
           <span className="ace-list__count">{sessions.length}</span>
         </div>
 
+        {error && (
+          <div className="ace-list__error" role="alert">
+            {error}
+          </div>
+        )}
+
         {sessions.length === 0 ? (
           <p className="ace-list__empty">No aces yet.</p>
         ) : (
@@ -141,6 +151,12 @@ export default function AceList({
         <h3>Aces</h3>
         <span className="ace-list__count">{sessions.length}</span>
       </div>
+
+      {error && (
+        <div className="ace-list__error" role="alert">
+          {error}
+        </div>
+      )}
 
       {/* Create new ace */}
       <form className="ace-list__create" onSubmit={handleCreate}>

--- a/frontend/src/components/leader/LeaderConsole.css
+++ b/frontend/src/components/leader/LeaderConsole.css
@@ -26,6 +26,15 @@
   gap: var(--space-2);
 }
 
+.leader-console__error {
+  font-size: var(--text-sm);
+  color: var(--color-danger, #f85149);
+  background: var(--color-danger-muted, rgba(248, 81, 73, 0.1));
+  border: 1px solid var(--color-danger, #f85149);
+  border-radius: var(--radius-md);
+  padding: var(--space-2) var(--space-3);
+}
+
 .leader-console__start-form {
   margin-top: var(--space-1);
   flex-shrink: 0;

--- a/frontend/src/components/leader/LeaderConsole.tsx
+++ b/frontend/src/components/leader/LeaderConsole.tsx
@@ -22,6 +22,7 @@ export default function LeaderConsole({
   const [goal, setGoal] = useState("");
   const [loading, setLoading] = useState(false);
   const [message, setMessage] = useState("");
+  const [error, setError] = useState<string | null>(null);
 
   const isRunning =
     leader?.status === "planning" || leader?.status === "managing";
@@ -37,6 +38,7 @@ export default function LeaderConsole({
 
   async function handleStart() {
     setLoading(true);
+    setError(null);
     try {
       await api.post(`/projects/${projectId}/leader/start`, {
         goal: goal.trim() || null,
@@ -44,6 +46,8 @@ export default function LeaderConsole({
       setGoal("");
       await onRefresh();
     } catch (err) {
+      const msg = err instanceof Error ? err.message : "Failed to start leader";
+      setError(msg);
       console.error("Failed to start leader:", err);
     } finally {
       setLoading(false);
@@ -111,6 +115,12 @@ export default function LeaderConsole({
           )}
         </div>
       </div>
+
+      {error && (
+        <div className="leader-console__error" role="alert">
+          {error}
+        </div>
+      )}
 
       {!isRunning && (
         <div className="leader-console__start-form">

--- a/src/atc/api/routers/aces.py
+++ b/src/atc/api/routers/aces.py
@@ -140,16 +140,19 @@ async def create_ace(project_id: str, body: CreateAceRequest, request: Request) 
 
     launch_cmd = get_launch_command(project.agent_provider)
 
-    session_id = await ace_ops.create_ace(
-        db,
-        project_id,
-        body.name,
-        task_id=body.task_id,
-        host=body.host,
-        event_bus=event_bus,
-        working_dir=working_dir,
-        launch_command=launch_cmd,
-    )
+    try:
+        session_id = await ace_ops.create_ace(
+            db,
+            project_id,
+            body.name,
+            task_id=body.task_id,
+            host=body.host,
+            event_bus=event_bus,
+            working_dir=working_dir,
+            launch_command=launch_cmd,
+        )
+    except RuntimeError as exc:
+        raise CreationFailedError(str(exc)) from None
     session = await db_ops.get_session(db, session_id)
     if session is None:
         raise CreationFailedError(f"Session creation failed for project {project_id}")

--- a/src/atc/api/routers/projects.py
+++ b/src/atc/api/routers/projects.py
@@ -17,6 +17,7 @@ import logging
 from fastapi import APIRouter, HTTPException, Request
 from pydantic import BaseModel
 
+from atc.core.errors import CreationFailedError
 from atc.leader import leader as leader_ops
 from atc.state import db as db_ops
 
@@ -167,7 +168,12 @@ async def start_leader(
 ) -> dict[str, str]:
     db = await _get_db(request)
     event_bus = await _get_event_bus(request)
-    session_id = await leader_ops.start_leader(db, project_id, goal=body.goal, event_bus=event_bus)
+    try:
+        session_id = await leader_ops.start_leader(
+            db, project_id, goal=body.goal, event_bus=event_bus,
+        )
+    except RuntimeError as exc:
+        raise CreationFailedError(str(exc)) from None
     return {"status": "started", "session_id": session_id}
 
 

--- a/src/atc/leader/leader.py
+++ b/src/atc/leader/leader.py
@@ -141,7 +141,7 @@ async def start_leader(
 
         await transition(session.id, SessionStatus.CONNECTING, SessionStatus.IDLE, event_bus)
         await db_ops.update_session_status(conn, session.id, SessionStatus.IDLE.value)
-    except Exception:
+    except Exception as exc:
         logger.exception("Failed to spawn leader pane for project %s", project_id)
         await db_ops.update_session_status(conn, session.id, SessionStatus.ERROR.value)
         if event_bus:
@@ -153,7 +153,7 @@ async def start_leader(
                     "new_status": SessionStatus.ERROR.value,
                 },
             )
-        return session.id
+        raise RuntimeError(str(exc)) from exc
 
     # Link session to leader row
     await conn.execute(

--- a/src/atc/session/ace.py
+++ b/src/atc/session/ace.py
@@ -280,7 +280,7 @@ async def create_ace(
         # Step 4a: success → idle
         await transition(session.id, SessionStatus.CONNECTING, SessionStatus.IDLE, event_bus)
         await db_ops.update_session_status(conn, session.id, SessionStatus.IDLE.value)
-    except Exception:
+    except Exception as exc:
         # Step 4b: failure → error
         logger.exception("Failed to spawn tmux pane for session %s", session.id)
         await db_ops.update_session_status(conn, session.id, SessionStatus.ERROR.value)
@@ -293,6 +293,7 @@ async def create_ace(
                     "new_status": SessionStatus.ERROR.value,
                 },
             )
+        raise RuntimeError(str(exc)) from exc
 
     return session.id
 

--- a/tests/integration/test_creation_reliability.py
+++ b/tests/integration/test_creation_reliability.py
@@ -116,13 +116,13 @@ class TestDBFirstCreation:
             "atc.session.ace._spawn_pane",
             new_callable=AsyncMock,
             side_effect=RuntimeError("tmux not available"),
-        ):
-            session_id = await create_ace(conn, project.id, "test-ace", event_bus=event_bus)
+        ), pytest.raises(RuntimeError, match="tmux not available"):
+            await create_ace(conn, project.id, "test-ace", event_bus=event_bus)
 
         # Session must exist with error status — no ghost session
-        session = await db_ops.get_session(conn, session_id)
-        assert session is not None
-        assert session.status == SessionStatus.ERROR.value
+        sessions = await db_ops.list_sessions(conn, project_id=project.id, session_type="ace")
+        assert len(sessions) == 1
+        assert sessions[0].status == SessionStatus.ERROR.value
 
     @pytest.mark.asyncio
     @patch("atc.session.ace._spawn_pane", new_callable=AsyncMock)


### PR DESCRIPTION
## Summary
- **Backend**: `create_ace()` and `start_leader()` now re-raise `RuntimeError` after recording the error status in DB, instead of silently returning success. API routes catch `RuntimeError` and raise `CreationFailedError` (HTTP 500 with structured error body).
- **Frontend**: `LeaderConsole` and `AceList` display error messages in a styled error banner when creation fails, instead of only `console.error`-ing.
- **Test**: Updated `test_session_moves_to_error_on_failure` to expect the exception while still verifying the DB row exists with error status.

## Test plan
- [ ] Verify existing unit/integration tests pass (567 pass, 2 pre-existing failures unrelated to this change)
- [ ] Manually trigger "no space for new pane" by shrinking tmux window — error should appear in Leader/Ace panel
- [ ] Verify normal Leader/Ace creation still works when tmux has space

🤖 Generated with [Claude Code](https://claude.com/claude-code)