### PR TITLE
feat: persistent Tower terminal panel across all pages

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,6 +1,7 @@
 import { BrowserRouter, Routes, Route, Navigate, Outlet } from "react-router-dom";
 import { AppProvider } from "./context/AppContext";
 import TowerBar from "./components/tower/TowerBar";
+import TowerPanel from "./components/tower/TowerPanel";
 import UpdateBanner from "./components/common/UpdateBanner";
 import { useUpdater } from "./hooks/useUpdater";
 import Dashboard from "./pages/Dashboard";
@@ -27,6 +28,7 @@ function Layout() {
       <main style={{ flex: 1, overflow: "auto", minHeight: 0 }}>
         <Outlet context={updater} />
       </main>
+      <TowerPanel />
     </>
   );
 }

--- a/frontend/src/components/tower/TowerPanel.css
+++ b/frontend/src/components/tower/TowerPanel.css
@@ -55,6 +55,17 @@
   flex-shrink: 0;
 }
 
+.tower-panel__context {
+  font-size: var(--text-xs);
+  color: var(--color-accent);
+  font-family: var(--font-mono);
+  flex-shrink: 0;
+  max-width: 160px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 .tower-panel__ticker {
   flex: 1;
   font-size: var(--text-xs);
@@ -85,46 +96,6 @@
   height: 280px;
 }
 
-/* Goal form — shown when idle */
-.tower-panel__goal-form {
-  display: flex;
-  align-items: center;
-  gap: var(--space-2);
-  padding: var(--space-3);
-}
-
-.tower-panel__project-select {
-  padding: var(--space-1) var(--space-2);
-  font-size: var(--text-sm);
-  font-family: var(--font-sans);
-  color: var(--color-text);
-  background: var(--color-bg);
-  border: 1px solid var(--color-border);
-  border-radius: var(--radius-md);
-  outline: none;
-  min-width: 140px;
-}
-
-.tower-panel__project-select:focus {
-  border-color: var(--color-accent);
-}
-
-.tower-panel__goal-input {
-  flex: 1;
-  padding: var(--space-1) var(--space-3);
-  font-size: var(--text-sm);
-  font-family: var(--font-sans);
-  color: var(--color-text);
-  background: var(--color-bg);
-  border: 1px solid var(--color-border);
-  border-radius: var(--radius-md);
-  outline: none;
-}
-
-.tower-panel__goal-input:focus {
-  border-color: var(--color-accent);
-}
-
 /* Terminal area */
 .tower-panel__terminal {
   flex: 1;
@@ -132,33 +103,41 @@
   padding: var(--space-1) var(--space-2);
 }
 
-/* Message input bar — below terminal when managing */
-.tower-panel__message-form {
+/* Unified input bar at bottom -- terminal-style */
+.tower-panel__input-bar {
   display: flex;
   align-items: center;
   gap: var(--space-2);
   padding: var(--space-2) var(--space-3);
   border-top: 1px solid var(--color-border-subtle);
   flex-shrink: 0;
+  background: var(--color-bg);
 }
 
-.tower-panel__message-input {
+.tower-panel__prompt {
+  font-family: var(--font-mono);
+  font-size: var(--text-sm);
+  color: var(--color-accent);
+  flex-shrink: 0;
+  user-select: none;
+}
+
+.tower-panel__input {
   flex: 1;
-  padding: var(--space-1) var(--space-3);
+  padding: var(--space-1) var(--space-2);
   font-size: var(--text-sm);
   font-family: var(--font-mono);
   color: var(--color-text);
-  background: var(--color-bg);
-  border: 1px solid var(--color-border);
-  border-radius: var(--radius-md);
+  background: transparent;
+  border: none;
   outline: none;
 }
 
-.tower-panel__message-input:focus {
-  border-color: var(--color-accent);
+.tower-panel__input::placeholder {
+  color: var(--color-text-muted);
 }
 
-.tower-panel__message-input:disabled {
+.tower-panel__input:disabled {
   opacity: 0.6;
 }
 

--- a/frontend/src/components/tower/TowerPanel.tsx
+++ b/frontend/src/components/tower/TowerPanel.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useCallback, useRef } from "react";
+import { useLocation } from "react-router-dom";
 import { useAppContext } from "../../context/AppContext";
 import { useTerminal } from "../../hooks/useTerminal";
 import { api } from "../../utils/api";
@@ -8,24 +9,26 @@ import "./TowerPanel.css";
  * Persistent bottom panel for Tower — lives in the shell layout,
  * persists across all pages. Think VS Code integrated terminal.
  *
- * Minimized: single-line ticker showing latest Tower activity.
- * Expanded + idle: goal input form.
- * Expanded + running: full PTY terminal + message input bar.
+ * Context-aware: automatically infers the active project from the
+ * current route (e.g. /projects/:id). No project dropdown needed.
  *
- * The message input bar allows the user to send instructions to the
- * Leader through Tower. This is the top of the chain of command —
- * Tower is the user's interface to the entire hierarchy.
+ * Minimized: single-line ticker showing latest Tower activity.
+ * Expanded + idle: terminal-style input at bottom.
+ * Expanded + running: full PTY terminal + message input bar.
  */
 export default function TowerPanel() {
   const { state } = useAppContext();
   const { towerDetail, towerProgress, brainStatus, projects } = state;
 
+  const location = useLocation();
+  const routeProjectId = useRouteProjectId();
+
   const [expanded, setExpanded] = useState(false);
-  const [goal, setGoal] = useState("");
-  const [projectId, setProjectId] = useState("");
+  const [input, setInput] = useState("");
   const [submitting, setSubmitting] = useState(false);
   const [message, setMessage] = useState("");
   const [sending, setSending] = useState(false);
+  const inputRef = useRef<HTMLInputElement>(null);
   const messageInputRef = useRef<HTMLInputElement>(null);
 
   const isRunning =
@@ -47,7 +50,6 @@ export default function TowerPanel() {
   // Re-fit terminal when panel expands
   useEffect(() => {
     if (expanded && isRunning) {
-      // Delay to let CSS transition finish
       const timer = setTimeout(() => fit(), 200);
       return () => clearTimeout(timer);
     }
@@ -60,32 +62,43 @@ export default function TowerPanel() {
     }
   }, [isRunning]);
 
-  // Default to first active project
+  // Focus input when expanded and idle
   useEffect(() => {
-    if (!projectId && projects.length > 0) {
-      const active = projects.find((p) => p.status === "active");
-      if (active) setProjectId(active.id);
+    if (expanded && isIdle) {
+      inputRef.current?.focus();
     }
-  }, [projectId, projects]);
+  }, [expanded, isIdle]);
+
+  // Derive the active project from the route
+  const contextProject = routeProjectId
+    ? projects.find((p) => p.id === routeProjectId)
+    : null;
+
+  // Determine which project ID to use: route context, or first active project
+  const resolvedProjectId =
+    routeProjectId ??
+    (projects.find((p) => p.status === "active")?.id || "");
+
+  const contextLabel = deriveContextLabel(location.pathname, contextProject?.name);
 
   const handleSubmitGoal = useCallback(
     async (e: React.FormEvent) => {
       e.preventDefault();
-      if (!goal.trim() || !projectId) return;
+      if (!input.trim() || !resolvedProjectId) return;
       setSubmitting(true);
       try {
         await api.post("/tower/goal", {
-          project_id: projectId,
-          goal: goal.trim(),
+          project_id: resolvedProjectId,
+          goal: input.trim(),
         });
-        setGoal("");
+        setInput("");
       } catch (err) {
         console.error("Failed to set tower goal:", err);
       } finally {
         setSubmitting(false);
       }
     },
-    [goal, projectId],
+    [input, resolvedProjectId],
   );
 
   const handleCancel = useCallback(async () => {
@@ -133,7 +146,7 @@ export default function TowerPanel() {
       className={`tower-panel ${expanded ? "tower-panel--expanded" : ""}`}
       data-testid="tower-panel"
     >
-      {/* Minimized bar — always visible */}
+      {/* Minimized bar -- always visible */}
       <div className="tower-panel__bar">
         <button
           className="tower-panel__toggle"
@@ -148,6 +161,14 @@ export default function TowerPanel() {
         </button>
 
         <TowerStateDot state={towerDetail.state} />
+
+        <span
+          className="tower-panel__context"
+          title={contextLabel}
+          data-testid="tower-panel-context"
+        >
+          {contextLabel}
+        </span>
 
         <span className="tower-panel__ticker" title={tickerText}>
           {tickerText}
@@ -186,86 +207,80 @@ export default function TowerPanel() {
       {/* Expanded content */}
       {expanded && (
         <div className="tower-panel__content" data-testid="tower-panel-content">
-          {isIdle && (
-            <form
-              className="tower-panel__goal-form"
-              onSubmit={handleSubmitGoal}
-            >
-              <select
-                className="tower-panel__project-select"
-                value={projectId}
-                onChange={(e) => setProjectId(e.target.value)}
-                data-testid="tower-panel-project"
-              >
-                <option value="" disabled>
-                  Select project...
-                </option>
-                {projects
-                  .filter((p) => p.status === "active")
-                  .map((p) => (
-                    <option key={p.id} value={p.id}>
-                      {p.name}
-                    </option>
-                  ))}
-              </select>
-              <input
-                type="text"
-                className="tower-panel__goal-input"
-                value={goal}
-                onChange={(e) => setGoal(e.target.value)}
-                placeholder="Describe a goal for Tower..."
-                data-testid="tower-panel-goal"
-              />
-              <button
-                type="submit"
-                className="btn btn-primary btn-sm"
-                disabled={submitting || !goal.trim() || !projectId}
-                data-testid="tower-panel-start"
-              >
-                {submitting ? "Starting..." : "Start"}
-              </button>
-            </form>
-          )}
-
+          {/* Terminal area -- always present when running */}
           {isRunning && (
-            <>
-              <div
-                className="tower-panel__terminal"
-                ref={attachRef}
-                data-testid="tower-panel-terminal"
-              />
-              <form
-                className="tower-panel__message-form"
-                onSubmit={handleSendMessage}
-                data-testid="tower-panel-message-form"
-              >
-                <input
-                  ref={messageInputRef}
-                  type="text"
-                  className="tower-panel__message-input"
-                  value={message}
-                  onChange={(e) => setMessage(e.target.value)}
-                  placeholder="Send instruction to Leader..."
-                  disabled={sending}
-                  data-testid="tower-panel-message"
-                />
-                <button
-                  type="submit"
-                  className="btn btn-primary btn-sm"
-                  disabled={sending || !message.trim()}
-                  data-testid="tower-panel-send"
-                >
-                  {sending ? "Sending..." : "Send"}
-                </button>
-              </form>
-            </>
+            <div
+              className="tower-panel__terminal"
+              ref={attachRef}
+              data-testid="tower-panel-terminal"
+            />
           )}
 
+          {/* Error state */}
           {towerDetail.state === "error" && towerDetail.current_goal && (
             <div className="tower-panel__error">
               Tower encountered an error while processing:{" "}
               <strong>{towerDetail.current_goal}</strong>
             </div>
+          )}
+
+          {/* Input bar -- always at the bottom */}
+          {isRunning ? (
+            <form
+              className="tower-panel__input-bar"
+              onSubmit={handleSendMessage}
+              data-testid="tower-panel-message-form"
+            >
+              <span className="tower-panel__prompt">&gt;</span>
+              <input
+                ref={messageInputRef}
+                type="text"
+                className="tower-panel__input"
+                value={message}
+                onChange={(e) => setMessage(e.target.value)}
+                placeholder="Send message to Tower..."
+                disabled={sending}
+                data-testid="tower-panel-message"
+              />
+              <button
+                type="submit"
+                className="btn btn-primary btn-sm"
+                disabled={sending || !message.trim()}
+                data-testid="tower-panel-send"
+              >
+                {sending ? "..." : "Send"}
+              </button>
+            </form>
+          ) : (
+            <form
+              className="tower-panel__input-bar"
+              onSubmit={handleSubmitGoal}
+              data-testid="tower-panel-goal-form"
+            >
+              <span className="tower-panel__prompt">&gt;</span>
+              <input
+                ref={inputRef}
+                type="text"
+                className="tower-panel__input"
+                value={input}
+                onChange={(e) => setInput(e.target.value)}
+                placeholder={
+                  resolvedProjectId
+                    ? "Describe a goal for Tower..."
+                    : "No active projects"
+                }
+                disabled={submitting || !resolvedProjectId}
+                data-testid="tower-panel-goal"
+              />
+              <button
+                type="submit"
+                className="btn btn-primary btn-sm"
+                disabled={submitting || !input.trim() || !resolvedProjectId}
+                data-testid="tower-panel-start"
+              >
+                {submitting ? "..." : "Start"}
+              </button>
+            </form>
           )}
         </div>
       )}
@@ -288,4 +303,31 @@ function TowerStateDot({ state }: { state: string }) {
       title={`Tower: ${state}`}
     />
   );
+}
+
+/** Extract project ID from /projects/:id route */
+function useRouteProjectId(): string | undefined {
+  const location = useLocation();
+  const match = location.pathname.match(/^\/projects\/([^/]+)/);
+  return match?.[1];
+}
+
+/** Derive a human-readable context label from the current route */
+function deriveContextLabel(
+  pathname: string,
+  projectName: string | undefined,
+): string {
+  if (pathname.startsWith("/projects/") && projectName) {
+    return projectName;
+  }
+  if (pathname === "/dashboard" || pathname === "/") {
+    return "Dashboard";
+  }
+  if (pathname === "/settings") {
+    return "Settings";
+  }
+  if (pathname === "/usage") {
+    return "Usage";
+  }
+  return "ATC";
 }

--- a/frontend/src/components/tower/__tests__/TowerPanel.test.tsx
+++ b/frontend/src/components/tower/__tests__/TowerPanel.test.tsx
@@ -42,14 +42,26 @@ describe("TowerPanel", () => {
     expect(screen.getByTestId("tower-panel-content")).toBeInTheDocument();
   });
 
-  it("shows goal form when expanded and idle", async () => {
+  it("shows terminal-style goal input when expanded and idle", async () => {
     const user = userEvent.setup();
     renderWithProviders(<TowerPanel />);
 
     await user.click(screen.getByTestId("tower-panel-toggle"));
     expect(screen.getByTestId("tower-panel-goal")).toBeInTheDocument();
-    expect(screen.getByTestId("tower-panel-project")).toBeInTheDocument();
     expect(screen.getByTestId("tower-panel-start")).toBeInTheDocument();
+  });
+
+  it("does not show a project dropdown", async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<TowerPanel />);
+
+    await user.click(screen.getByTestId("tower-panel-toggle"));
+    expect(screen.queryByTestId("tower-panel-project")).not.toBeInTheDocument();
+  });
+
+  it("shows context label in the bar", () => {
+    renderWithProviders(<TowerPanel />);
+    expect(screen.getByTestId("tower-panel-context")).toBeInTheDocument();
   });
 
   it("shows Idle in ticker when no goal is set", () => {
@@ -77,5 +89,13 @@ describe("TowerPanel", () => {
     // Collapse
     await user.click(screen.getByTestId("tower-panel-toggle"));
     expect(screen.queryByTestId("tower-panel-content")).not.toBeInTheDocument();
+  });
+
+  it("shows prompt character in input bar", async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<TowerPanel />);
+
+    await user.click(screen.getByTestId("tower-panel-toggle"));
+    expect(screen.getByText(">")).toBeInTheDocument();
   });
 });

--- a/frontend/src/pages/Dashboard.css
+++ b/frontend/src/pages/Dashboard.css
@@ -5,28 +5,6 @@
   width: 100%;
 }
 
-/* Two-column layout: projects on left, Tower console on right */
-.dashboard--two-col {
-  display: grid;
-  grid-template-columns: 1fr 420px;
-  gap: var(--space-6);
-  max-width: none;
-  height: 100%;
-  overflow: hidden;
-}
-
-.dashboard--two-col .dashboard__main {
-  overflow: auto;
-  min-height: 0;
-}
-
-.dashboard--two-col .dashboard__tower {
-  display: flex;
-  flex-direction: column;
-  min-height: 0;
-  overflow: hidden;
-}
-
 .dashboard__header {
   display: flex;
   align-items: center;

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -4,7 +4,6 @@ import { useAppContext } from "../context/AppContext";
 import StatusBadge from "../components/common/StatusBadge";
 import TimeAgo from "../components/common/TimeAgo";
 import CreateProjectModal from "../components/common/CreateProjectModal";
-import TowerConsole from "../components/tower/TowerConsole";
 import "./Dashboard.css";
 
 export default function Dashboard() {
@@ -16,147 +15,139 @@ export default function Dashboard() {
   const activeProjects = projects.filter((p) => p.status === "active");
 
   return (
-    <div className="dashboard dashboard--two-col" data-testid="dashboard-page">
-      {/* Left column: metrics + projects */}
-      <div className="dashboard__main">
-        <div className="dashboard__header">
-          <h1>Dashboard</h1>
-          <button
-            className="btn btn-primary"
-            onClick={() => setShowCreate(true)}
-          >
-            + New Project
-          </button>
-        </div>
+    <div className="dashboard" data-testid="dashboard-page">
+      <div className="dashboard__header">
+        <h1>Dashboard</h1>
+        <button
+          className="btn btn-primary"
+          onClick={() => setShowCreate(true)}
+        >
+          + New Project
+        </button>
+      </div>
 
-        <div className="dashboard__grid">
-          {/* Cost summary card */}
-          <div className="panel dashboard__card">
-            <h3 className="dashboard__card-title">Cost</h3>
-            <div className="dashboard__stat">
-              <span className="dashboard__stat-value">
-                ${usage.today_cost.toFixed(2)}
-              </span>
-              <span className="dashboard__stat-label">today</span>
-            </div>
-            <div className="dashboard__stat">
-              <span className="dashboard__stat-value">
-                ${usage.month_cost.toFixed(2)}
-              </span>
-              <span className="dashboard__stat-label">this month</span>
-            </div>
+      <div className="dashboard__grid">
+        {/* Cost summary card */}
+        <div className="panel dashboard__card">
+          <h3 className="dashboard__card-title">Cost</h3>
+          <div className="dashboard__stat">
+            <span className="dashboard__stat-value">
+              ${usage.today_cost.toFixed(2)}
+            </span>
+            <span className="dashboard__stat-label">today</span>
           </div>
-
-          {/* Token summary card */}
-          <div className="panel dashboard__card">
-            <h3 className="dashboard__card-title">Tokens</h3>
-            <div className="dashboard__stat">
-              <span className="dashboard__stat-value">
-                {formatTokens(usage.today_tokens)}
-              </span>
-              <span className="dashboard__stat-label">today</span>
-            </div>
-            <div className="dashboard__stat">
-              <span className="dashboard__stat-value">
-                {formatTokens(usage.month_tokens)}
-              </span>
-              <span className="dashboard__stat-label">this month</span>
-            </div>
-          </div>
-
-          {/* Sessions card */}
-          <div className="panel dashboard__card">
-            <h3 className="dashboard__card-title">Sessions</h3>
-            <div className="dashboard__stat">
-              <span className="dashboard__stat-value">{sessions.length}</span>
-              <span className="dashboard__stat-label">total</span>
-            </div>
-            <div className="dashboard__stat">
-              <span className="dashboard__stat-value">
-                {sessions.filter((s) => s.status === "working").length}
-              </span>
-              <span className="dashboard__stat-label">active</span>
-            </div>
-          </div>
-
-          {/* Notifications card */}
-          <div className="panel dashboard__card">
-            <h3 className="dashboard__card-title">Notifications</h3>
-            <div className="dashboard__stat">
-              <span className="dashboard__stat-value">
-                {notifications.filter((n) => !n.read).length}
-              </span>
-              <span className="dashboard__stat-label">unread</span>
-            </div>
-            <div className="dashboard__stat">
-              <span className="dashboard__stat-value">
-                {notifications.length}
-              </span>
-              <span className="dashboard__stat-label">total</span>
-            </div>
+          <div className="dashboard__stat">
+            <span className="dashboard__stat-value">
+              ${usage.month_cost.toFixed(2)}
+            </span>
+            <span className="dashboard__stat-label">this month</span>
           </div>
         </div>
 
-        {/* Project cards */}
-        <section className="dashboard__projects">
-          <h2>Projects</h2>
-          {activeProjects.length === 0 ? (
-            <div className="dashboard__empty">
-              <p>No active projects.</p>
+        {/* Token summary card */}
+        <div className="panel dashboard__card">
+          <h3 className="dashboard__card-title">Tokens</h3>
+          <div className="dashboard__stat">
+            <span className="dashboard__stat-value">
+              {formatTokens(usage.today_tokens)}
+            </span>
+            <span className="dashboard__stat-label">today</span>
+          </div>
+          <div className="dashboard__stat">
+            <span className="dashboard__stat-value">
+              {formatTokens(usage.month_tokens)}
+            </span>
+            <span className="dashboard__stat-label">this month</span>
+          </div>
+        </div>
+
+        {/* Sessions card */}
+        <div className="panel dashboard__card">
+          <h3 className="dashboard__card-title">Sessions</h3>
+          <div className="dashboard__stat">
+            <span className="dashboard__stat-value">{sessions.length}</span>
+            <span className="dashboard__stat-label">total</span>
+          </div>
+          <div className="dashboard__stat">
+            <span className="dashboard__stat-value">
+              {sessions.filter((s) => s.status === "working").length}
+            </span>
+            <span className="dashboard__stat-label">active</span>
+          </div>
+        </div>
+
+        {/* Notifications card */}
+        <div className="panel dashboard__card">
+          <h3 className="dashboard__card-title">Notifications</h3>
+          <div className="dashboard__stat">
+            <span className="dashboard__stat-value">
+              {notifications.filter((n) => !n.read).length}
+            </span>
+            <span className="dashboard__stat-label">unread</span>
+          </div>
+          <div className="dashboard__stat">
+            <span className="dashboard__stat-value">
+              {notifications.length}
+            </span>
+            <span className="dashboard__stat-label">total</span>
+          </div>
+        </div>
+      </div>
+
+      {/* Project cards */}
+      <section className="dashboard__projects">
+        <h2>Projects</h2>
+        {activeProjects.length === 0 ? (
+          <div className="dashboard__empty">
+            <p>No active projects.</p>
+            <button
+              className="btn btn-primary"
+              onClick={() => setShowCreate(true)}
+              style={{ marginTop: "var(--space-3)" }}
+            >
+              Create your first project
+            </button>
+          </div>
+        ) : (
+          <div className="dashboard__project-grid">
+            {activeProjects.map((project) => (
               <button
-                className="btn btn-primary"
-                onClick={() => setShowCreate(true)}
-                style={{ marginTop: "var(--space-3)" }}
+                key={project.id}
+                className="panel dashboard__project-card"
+                onClick={() => navigate(`/projects/${project.id}`)}
               >
-                Create your first project
+                <div className="dashboard__project-header">
+                  <h3>{project.name}</h3>
+                  <StatusBadge status={project.status} size="sm" />
+                </div>
+                {project.description && (
+                  <p className="dashboard__project-desc">
+                    {project.description}
+                  </p>
+                )}
+                <div className="dashboard__project-meta">
+                  <span>
+                    {
+                      sessions.filter((s) => s.project_id === project.id)
+                        .length
+                    }{" "}
+                    sessions
+                  </span>
+                  <TimeAgo datetime={project.updated_at} />
+                </div>
               </button>
-            </div>
-          ) : (
-            <div className="dashboard__project-grid">
-              {activeProjects.map((project) => (
-                <button
-                  key={project.id}
-                  className="panel dashboard__project-card"
-                  onClick={() => navigate(`/projects/${project.id}`)}
-                >
-                  <div className="dashboard__project-header">
-                    <h3>{project.name}</h3>
-                    <StatusBadge status={project.status} size="sm" />
-                  </div>
-                  {project.description && (
-                    <p className="dashboard__project-desc">
-                      {project.description}
-                    </p>
-                  )}
-                  <div className="dashboard__project-meta">
-                    <span>
-                      {
-                        sessions.filter((s) => s.project_id === project.id)
-                          .length
-                      }{" "}
-                      sessions
-                    </span>
-                    <TimeAgo datetime={project.updated_at} />
-                  </div>
-                </button>
-              ))}
-            </div>
-          )}
-        </section>
+            ))}
+          </div>
+        )}
+      </section>
 
-        <CreateProjectModal
-          open={showCreate}
-          onClose={() => setShowCreate(false)}
-          onCreated={() => {
-            void fetchAll();
-          }}
-        />
-      </div>
-
-      {/* Right column: Tower terminal */}
-      <div className="dashboard__tower panel">
-        <TowerConsole />
-      </div>
+      <CreateProjectModal
+        open={showCreate}
+        onClose={() => setShowCreate(false)}
+        onCreated={() => {
+          void fetchAll();
+        }}
+      />
     </div>
   );
 }

--- a/frontend/src/pages/__tests__/Dashboard.test.tsx
+++ b/frontend/src/pages/__tests__/Dashboard.test.tsx
@@ -3,14 +3,6 @@ import { screen } from "@testing-library/react";
 import Dashboard from "../Dashboard";
 import { renderWithProviders } from "../../test/helpers";
 
-// Mock useTerminal since TowerConsole uses it
-vi.mock("../../hooks/useTerminal", () => ({
-  useTerminal: () => ({
-    attachRef: vi.fn(),
-    fit: vi.fn(),
-  }),
-}));
-
 beforeEach(() => {
   vi.spyOn(globalThis, "fetch").mockResolvedValue(
     new Response(JSON.stringify([]), { status: 200 }),
@@ -51,8 +43,8 @@ describe("Dashboard", () => {
     expect(screen.getByText("Projects")).toBeInTheDocument();
   });
 
-  it("renders TowerConsole in the dashboard", () => {
+  it("does not render TowerConsole inline (Tower is now persistent in layout)", () => {
     renderWithProviders(<Dashboard />);
-    expect(screen.getByTestId("tower-console")).toBeInTheDocument();
+    expect(screen.queryByTestId("tower-console")).not.toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary

- Move Tower from a Dashboard-only right sidebar to a persistent bottom panel (like VS Code integrated terminal) available on every page
- Tower is now context-aware — automatically infers the active project from the current route (e.g. `/projects/:id`) instead of requiring a dropdown selector
- Remove the project dropdown selector entirely — Tower resolves context from navigation
- Terminal-style UI: input bar at bottom with `>` prompt character, streaming terminal output above

## Changes

- **`TowerPanel.tsx`** — Rewritten with `useLocation()` route-based context detection (`useRouteProjectId`), context label display, terminal-style input bar, removed project `<select>` dropdown
- **`TowerPanel.css`** — New `.tower-panel__input-bar`, `.tower-panel__prompt`, `.tower-panel__input`, `.tower-panel__context` styles for terminal-style UI
- **`App.tsx`** — Added `<TowerPanel />` to Layout component so it persists across all routes
- **`Dashboard.tsx`** — Removed `TowerConsole` import and right-column layout; simplified to single-column
- **`Dashboard.css`** — Removed two-column grid layout (`dashboard--two-col`, `dashboard__tower`)
- **Tests updated** — `TowerPanel.test.tsx` updated for new UI (no dropdown, context label, prompt char); `Dashboard.test.tsx` updated to verify TowerConsole is no longer inline

## Testing Done

```
$ npx vitest run
 Test Files  20 passed (20)
      Tests  189 passed (189)
```

Build passes (only pre-existing TS errors in unrelated files).