### PR TITLE
fix: resolve pre-existing TypeScript errors in SettingsPage and AppContext test

### DIFF
--- a/frontend/src/context/__tests__/AppContext.test.tsx
+++ b/frontend/src/context/__tests__/AppContext.test.tsx
@@ -47,6 +47,7 @@ function TestConsumer() {
                 description: null,
                 repo_path: null,
                 github_repo: null,
+                agent_provider: "claude_code",
                 status: "active",
                 created_at: "2024-01-01T00:00:00Z",
                 updated_at: "2024-01-01T00:00:00Z",

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -253,17 +253,6 @@ export default function SettingsPage() {
     e.target.value = "";
   }
 
-  function onRestoreFileSelected(
-    e: React.ChangeEvent<HTMLInputElement>,
-    projectId: string,
-  ) {
-    const file = e.target.files?.[0];
-    if (file) {
-      setRestoreConfirm({ file, projectId });
-    }
-    e.target.value = "";
-  }
-
   function confirmRestore() {
     if (!restoreConfirm) return;
     handleImportFile(restoreConfirm.file, restoreConfirm.projectId);
@@ -945,7 +934,7 @@ function fileToBase64(file: File): Promise<string> {
     reader.onload = () => {
       const result = reader.result as string;
       // Strip data URL prefix (e.g. "data:application/zip;base64,")
-      const b64 = result.includes(",") ? result.split(",")[1] : result;
+      const b64 = result.includes(",") ? result.split(",")[1] ?? result : result;
       resolve(b64);
     };
     reader.onerror = reject;

--- a/frontend/src/pages/__tests__/SettingsPage.test.tsx
+++ b/frontend/src/pages/__tests__/SettingsPage.test.tsx
@@ -106,7 +106,7 @@ describe("SettingsPage", () => {
     });
     // Verify no calls to export endpoints
     const exportCalls = fetchSpy.mock.calls.filter(
-      (call) =>
+      (call: unknown[]) =>
         typeof call[0] === "string" &&
         (call[0].includes("/settings/export") ||
           call[0].includes("/settings/export-all")),


### PR DESCRIPTION
## Summary
- Add missing `agent_provider` field to Project test fixture in `AppContext.test.tsx` (TS2353)
- Type the `call` parameter in `SettingsPage.test.tsx` filter callback (TS7006)
- Remove unused `onRestoreFileSelected` function from `SettingsPage.tsx` (TS6133)
- Handle potential `undefined` from `string.split()` in `fileToBase64` (TS2345)

## Test plan
- [x] `npx tsc --noEmit` passes with zero errors
- [x] All 19 tests in affected test files pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)