### PR TITLE
Fix Makefile to use python3 instead of hardcoded python3.12

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ help: ## Show this help
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "  \033[36m%-15s\033[0m %s\n", $$1, $$2}'
 
 setup: ## Create venv, install all deps, set up pre-commit
-	python3.12 -m venv $(VENV)
+	python3 -m venv $(VENV)
 	$(PIP) install -e ".[dev]"
 	cd frontend && npm install
 	$(VENV)/bin/pre-commit install

--- a/README.md
+++ b/README.md
@@ -17,18 +17,8 @@ A hierarchical AI orchestration platform that manages multiple Claude Code sessi
 
 git clone <repo-url>
 cd atc
-
-# Backend
-python3.12 -m venv .venv
-source .venv/bin/activate
-pip install -e ".[dev]"
-pre-commit install
-
-# Frontend
-cd frontend && npm install && cd ..
-
-# Run
-./scripts/dev.sh
+make setup
+make dev
 ```
 
 Open http://127.0.0.1:5173
@@ -40,10 +30,8 @@ See [docs/setup/windows-wsl2.md](docs/setup/windows-wsl2.md) for detailed instru
 ```bash
 # Inside WSL2 (Ubuntu)
 cd ~ && git clone <repo-url> && cd atc
-python3.12 -m venv .venv && source .venv/bin/activate
-pip install -e ".[dev]"
-cd frontend && npm install && cd ..
-./scripts/dev.sh
+make setup
+make dev
 ```
 
 Open http://localhost:5173 in any Windows browser.
@@ -52,7 +40,7 @@ Open http://localhost:5173 in any Windows browser.
 
 | Dependency | macOS | Linux | WSL2 |
 |---|---|---|---|
-| Python 3.12+ | `brew install python@3.12` | `apt install python3.12` | `apt install python3.12` |
+| Python 3.12+ | `brew install python` | `apt install python3` | `apt install python3` |
 | Node.js 20+ | `brew install node` | `apt install nodejs` | `apt install nodejs` |
 | tmux | `brew install tmux` | `apt install tmux` | pre-installed |
 | gh CLI | `brew install gh` | `apt install gh` | `apt install gh` |


### PR DESCRIPTION
## Summary
- Changed `make setup` to use `python3` instead of `python3.12`, so it works on any system with Python 3.x installed
- Simplified README quick-start instructions (macOS/Linux and WSL2) to use `make setup && make dev`
- Updated Prerequisites table to reference generic `python3` install packages

## Test plan
- [ ] Run `make setup` on a system without python3.12 (e.g. python3.13) and verify venv creation succeeds
- [ ] Run `make dev` after setup and verify the dev server starts

🤖 Generated with [Claude Code](https://claude.com/claude-code)