### PR TITLE
fix: use tmux new-window for Tower/Leader/Ace session spawning

### DIFF
--- a/src/atc/agents/claude_provider.py
+++ b/src/atc/agents/claude_provider.py
@@ -32,7 +32,7 @@ _TMUX_CMD = "tmux"
 class ClaudeCodeProvider:
     """Agent provider using Claude Code in tmux panes.
 
-    Sessions are spawned as tmux split-window commands. Prompts are delivered
+    Sessions are spawned as tmux new-window commands. Prompts are delivered
     via ``tmux send-keys``. Status is tracked internally (future: via PTY
     monitor). Output streaming delegates to the terminal/pty_stream module.
 
@@ -82,13 +82,13 @@ class ClaudeCodeProvider:
 
         shell_cmd = f"{env_prefix}{' '.join(cmd_parts)}"
 
-        # Spawn in a new tmux pane
+        # Spawn in a new tmux window (avoids 'no space for new pane' in small terminals)
         tmux_args = [
             _TMUX_CMD,
-            "split-window",
-            "-h",
+            "new-window",
             "-t",
             self._tmux_session,
+            "-d",
             "-P",  # print pane info
             "-F",
             "#{pane_id}",
@@ -109,7 +109,7 @@ class ClaudeCodeProvider:
 
         if proc.returncode != 0:
             err = stderr.decode().strip()
-            raise ProviderError(self.name, f"tmux split-window failed: {err}")
+            raise ProviderError(self.name, f"tmux new-window failed: {err}")
 
         pane_id = stdout.decode().strip()
         tracked = _TrackedSession(

--- a/src/atc/agents/opencode_provider.py
+++ b/src/atc/agents/opencode_provider.py
@@ -406,10 +406,10 @@ class OpenCodeProvider:
 
         tmux_args = [
             _TMUX_CMD,
-            "split-window",
-            "-h",
+            "new-window",
             "-t",
             self._tmux_session,
+            "-d",
             "-P",
             "-F",
             "#{pane_id}",
@@ -430,6 +430,6 @@ class OpenCodeProvider:
 
         if proc.returncode != 0:
             err = stderr.decode().strip()
-            raise ProviderError(self.name, f"tmux split-window failed: {err}")
+            raise ProviderError(self.name, f"tmux new-window failed: {err}")
 
         return stdout.decode().strip()

--- a/src/atc/session/ace.py
+++ b/src/atc/session/ace.py
@@ -67,11 +67,16 @@ async def _tmux_run(*args: str) -> str:
 
 
 async def _ensure_tmux_session(session_name: str) -> None:
-    """Create the tmux session if it doesn't already exist."""
+    """Create the tmux session if it doesn't already exist.
+
+    Uses explicit dimensions (-x 200 -y 50) so panes work correctly even
+    when no real terminal is attached (e.g. PTY output streams to xterm.js
+    in the frontend).
+    """
     try:
         await _tmux_run("has-session", "-t", session_name)
     except RuntimeError:
-        await _tmux_run("new-session", "-d", "-s", session_name)
+        await _tmux_run("new-session", "-d", "-s", session_name, "-x", "200", "-y", "50")
 
 
 async def _spawn_pane(
@@ -80,8 +85,13 @@ async def _spawn_pane(
     *,
     working_dir: str | None = None,
 ) -> str:
-    """Split a new pane in *session_name* and return its pane id (e.g. ``%5``)."""
-    args = ["split-window", "-t", session_name, "-d", "-P", "-F", "#{pane_id}"]
+    """Create a new window in *session_name* and return its pane id (e.g. ``%5``).
+
+    Uses ``new-window`` instead of ``split-window`` to avoid the
+    'no space for new pane' error that occurs when the terminal is small
+    or headless (PTY output streams to the frontend xterm.js panel).
+    """
+    args = ["new-window", "-t", session_name, "-d", "-P", "-F", "#{pane_id}"]
     if working_dir:
         args.extend(["-c", working_dir])
     if command:

--- a/tests/e2e/test_ace_lifecycle.py
+++ b/tests/e2e/test_ace_lifecycle.py
@@ -31,7 +31,7 @@ def client(tmp_path: Path) -> TestClient:
 def _smart_tmux_mock(*args: str) -> str:
     """Mock _tmux_run that returns sensible values based on the tmux command."""
     cmd = args[0] if args else ""
-    if cmd == "split-window":
+    if cmd == "new-window":
         return "%1"
     if cmd == "display-message":
         return "0"  # alternate_on = False (TUI not active)

--- a/tests/unit/test_agent_provider.py
+++ b/tests/unit/test_agent_provider.py
@@ -385,11 +385,11 @@ class TestOpenCodeProvider:
     ) -> None:
         # First call: ensure_server_running API check (GET /session)
         # Second call: API request (curl for POST /session)
-        # Third call: tmux split-window
+        # Third call: tmux new-window
         calls = [
             _make_process(stdout=b'{"sessions": []}'),  # ensure_server GET /session
             _make_process(stdout=b'{"id": "w1", "status": "idle"}'),  # POST /session
-            _make_process(stdout=b"%50\n"),  # tmux split-window
+            _make_process(stdout=b"%50\n"),  # tmux new-window
         ]
         mock_exec.side_effect = calls
 
@@ -409,7 +409,7 @@ class TestOpenCodeProvider:
         mock_exec.side_effect = [
             _make_process(stdout=b'{"sessions": []}'),  # ensure_server
             _make_process(stdout=b"{}"),  # POST /session
-            _make_process(stdout=b"%50\n"),  # tmux split-window
+            _make_process(stdout=b"%50\n"),  # tmux new-window
         ]
         await provider.spawn_session("w1")
 
@@ -428,7 +428,7 @@ class TestOpenCodeProvider:
         mock_exec.side_effect = [
             _make_process(stdout=b'{"sessions": []}'),  # ensure_server
             _make_process(stdout=b"{}"),  # POST /session
-            _make_process(stdout=b"%50\n"),  # tmux split-window
+            _make_process(stdout=b"%50\n"),  # tmux new-window
         ]
         await provider.spawn_session("w1")
 


### PR DESCRIPTION
## Summary
- Replace `split-window` with `new-window` in all tmux session spawn points (`ace.py`, `claude_provider.py`, `opencode_provider.py`) to fix the "no space for new pane" error that occurs when the terminal is small or headless
- Add explicit dimensions (`-x 200 -y 50`) to `_ensure_tmux_session()` so panes work correctly when no real terminal is attached (PTY output streams to the frontend xterm.js panel)
- Update test mocks to recognize the new `new-window` command

This unblocks the Tower panel from spawning real Claude Code terminal sessions. The Tower to Leader to PTY to WebSocket pipeline was already fully wired (PR #39) but failed at the tmux spawn step.

## Test plan
- [x] All 333 existing tests pass (1 pre-existing failure in TestDeployedFileCleanup unrelated to this change)
- [x] TestSpawnPaneWorkingDir tests verify -c working_dir is passed correctly
- [x] TestAceLifecycle full lifecycle tests pass with updated mock
- [ ] Manual test: submit a goal in Tower panel, verify Claude Code session spawns and terminal output streams

Generated with [Claude Code](https://claude.com/claude-code)