### PR TITLE
fix: split Tower and Leader into independent sessions

### DIFF
--- a/frontend/src/components/ace/AceTerminal.tsx
+++ b/frontend/src/components/ace/AceTerminal.tsx
@@ -14,11 +14,15 @@ export default function AceTerminal({ session }: AceTerminalProps) {
   const isActive =
     session.status === "working" ||
     session.status === "waiting" ||
-    session.status === "idle";
+    session.status === "idle" ||
+    session.status === "connecting";
+
+  // Keep terminal enabled even for error state so past output remains visible
+  const showTerminal = isActive || session.status === "error";
 
   const { attachRef } = useTerminal({
     channel: `terminal:${session.id}`,
-    enabled: isActive,
+    enabled: showTerminal,
   });
 
   async function handleSendMessage(e: React.FormEvent) {

--- a/frontend/src/components/tower/TowerPanel.tsx
+++ b/frontend/src/components/tower/TowerPanel.tsx
@@ -3,33 +3,33 @@ import { useLocation } from "react-router-dom";
 import { useAppContext } from "../../context/AppContext";
 import { useTerminal } from "../../hooks/useTerminal";
 import { api } from "../../utils/api";
+import ConfirmPopover from "../common/ConfirmPopover";
 import "./TowerPanel.css";
 
 /**
  * Persistent bottom panel for Tower — lives in the shell layout,
  * persists across all pages. Think VS Code integrated terminal.
  *
- * Context-aware: automatically infers the active project from the
- * current route (e.g. /projects/:id). No project dropdown needed.
+ * For claude_code provider: auto-starts Tower's own Claude Code session
+ * on mount (no goal form). Tower has its own independent terminal session,
+ * separate from the Leader session.
  *
  * Minimized: single-line ticker showing latest Tower activity.
- * Expanded + idle: terminal-style input at bottom.
  * Expanded + running: full PTY terminal + message input bar.
  */
 export default function TowerPanel() {
-  const { state } = useAppContext();
+  const { state, dispatch } = useAppContext();
   const { towerDetail, towerProgress, brainStatus, projects } = state;
 
   const location = useLocation();
   const routeProjectId = useRouteProjectId();
 
   const [expanded, setExpanded] = useState(false);
-  const [input, setInput] = useState("");
-  const [submitting, setSubmitting] = useState(false);
   const [message, setMessage] = useState("");
   const [sending, setSending] = useState(false);
-  const inputRef = useRef<HTMLInputElement>(null);
+  const [starting, setStarting] = useState(false);
   const messageInputRef = useRef<HTMLInputElement>(null);
+  const autoStarted = useRef(false);
 
   const isRunning =
     towerDetail.state === "planning" || towerDetail.state === "managing";
@@ -37,37 +37,6 @@ export default function TowerPanel() {
     towerDetail.state === "idle" ||
     towerDetail.state === "complete" ||
     towerDetail.state === "error";
-
-  const terminalChannel = towerDetail.current_session_id
-    ? `terminal:${towerDetail.current_session_id}`
-    : undefined;
-
-  const { attachRef, fit } = useTerminal({
-    channel: terminalChannel,
-    enabled: isRunning && !!terminalChannel,
-  });
-
-  // Re-fit terminal when panel expands
-  useEffect(() => {
-    if (expanded && isRunning) {
-      const timer = setTimeout(() => fit(), 200);
-      return () => clearTimeout(timer);
-    }
-  }, [expanded, isRunning, fit]);
-
-  // Auto-expand when Tower starts running
-  useEffect(() => {
-    if (isRunning) {
-      setExpanded(true);
-    }
-  }, [isRunning]);
-
-  // Focus input when expanded and idle
-  useEffect(() => {
-    if (expanded && isIdle) {
-      inputRef.current?.focus();
-    }
-  }, [expanded, isIdle]);
 
   // Derive the active project from the route
   const contextProject = routeProjectId
@@ -79,35 +48,95 @@ export default function TowerPanel() {
     routeProjectId ??
     (projects.find((p) => p.status === "active")?.id || "");
 
+  const resolvedProject = resolvedProjectId
+    ? projects.find((p) => p.id === resolvedProjectId)
+    : null;
+
+  const isClaudeCode = resolvedProject?.agent_provider === "claude_code";
+
+  // Tower's own terminal channel (NOT the Leader's)
+  const terminalChannel = towerDetail.current_session_id
+    ? `terminal:${towerDetail.current_session_id}`
+    : undefined;
+
+  const { attachRef, fit } = useTerminal({
+    channel: terminalChannel,
+    enabled: (isRunning || (isClaudeCode && !!terminalChannel)) && !!terminalChannel,
+  });
+
+  // Auto-start Tower session for claude_code provider
+  useEffect(() => {
+    if (
+      isClaudeCode &&
+      isIdle &&
+      !starting &&
+      !autoStarted.current &&
+      resolvedProjectId
+    ) {
+      autoStarted.current = true;
+      void handleStart();
+    }
+  }, [isClaudeCode, isIdle, starting, resolvedProjectId]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  // Re-fit terminal when panel expands
+  useEffect(() => {
+    if (expanded && (isRunning || (isClaudeCode && !!terminalChannel))) {
+      const timer = setTimeout(() => fit(), 200);
+      return () => clearTimeout(timer);
+    }
+  }, [expanded, isRunning, isClaudeCode, terminalChannel, fit]);
+
+  // Auto-expand when Tower starts running
+  useEffect(() => {
+    if (isRunning) {
+      setExpanded(true);
+    }
+  }, [isRunning]);
+
   const contextLabel = deriveContextLabel(location.pathname, contextProject?.name);
 
-  const handleSubmitGoal = useCallback(
-    async (e: React.FormEvent) => {
-      e.preventDefault();
-      if (!input.trim() || !resolvedProjectId) return;
-      setSubmitting(true);
-      try {
-        await api.post("/tower/goal", {
-          project_id: resolvedProjectId,
-          goal: input.trim(),
-        });
-        setInput("");
-      } catch (err) {
-        console.error("Failed to set tower goal:", err);
-      } finally {
-        setSubmitting(false);
-      }
-    },
-    [input, resolvedProjectId],
-  );
-
-  const handleCancel = useCallback(async () => {
+  const handleStart = useCallback(async () => {
+    if (!resolvedProjectId) return;
+    setStarting(true);
     try {
-      await api.post("/tower/cancel");
+      const res = await api.post<{ session_id?: string }>(
+        "/tower/start",
+        { project_id: resolvedProjectId },
+      );
+      if (res.session_id) {
+        dispatch({
+          type: "SET_TOWER_DETAIL",
+          payload: {
+            current_session_id: res.session_id,
+            current_project_id: resolvedProjectId,
+          },
+        });
+      }
+      setExpanded(true);
     } catch (err) {
-      console.error("Failed to cancel tower goal:", err);
+      console.error("Failed to start tower session:", err);
+    } finally {
+      setStarting(false);
     }
-  }, []);
+  }, [resolvedProjectId, dispatch]);
+
+  const handleStop = useCallback(async () => {
+    try {
+      await api.post("/tower/stop");
+      autoStarted.current = false;
+      dispatch({
+        type: "SET_TOWER_DETAIL",
+        payload: {
+          state: "idle",
+          current_session_id: null,
+          leader_session_id: null,
+          current_goal: null,
+        },
+      });
+    } catch (err) {
+      console.error("Failed to stop tower:", err);
+    }
+  }, [dispatch]);
 
   const handleSendMessage = useCallback(
     async (e: React.FormEvent) => {
@@ -119,7 +148,7 @@ export default function TowerPanel() {
         setMessage("");
         messageInputRef.current?.focus();
       } catch (err) {
-        console.error("Failed to send message to Leader:", err);
+        console.error("Failed to send message to Tower:", err);
       } finally {
         setSending(false);
       }
@@ -127,19 +156,13 @@ export default function TowerPanel() {
     [message],
   );
 
-  const handleMarkComplete = useCallback(async () => {
-    try {
-      await api.post("/tower/complete");
-    } catch (err) {
-      console.error("Failed to mark Tower goal complete:", err);
-    }
-  }, []);
-
   const tickerText =
     brainStatus.message ||
     (towerDetail.current_goal
       ? `Goal: ${towerDetail.current_goal}`
       : "Idle");
+
+  const showTerminal = isRunning || (isClaudeCode && !!terminalChannel);
 
   return (
     <div
@@ -183,23 +206,30 @@ export default function TowerPanel() {
               {towerProgress.done}/{towerProgress.total} tasks ({towerProgress.progress_pct}%)
             </span>
           )}
-          {isRunning && (
-            <>
-              <button
-                className="btn btn-sm"
-                onClick={handleMarkComplete}
-                data-testid="tower-panel-complete"
-              >
-                Complete
-              </button>
+          {!showTerminal && !isClaudeCode && (
+            <button
+              className="btn btn-primary btn-sm"
+              onClick={handleStart}
+              disabled={starting || !resolvedProjectId}
+              data-testid="tower-panel-start"
+            >
+              {starting ? "Starting..." : "Start"}
+            </button>
+          )}
+          {showTerminal && (
+            <ConfirmPopover
+              message="Stop the Tower session?"
+              confirmLabel="Stop"
+              onConfirm={handleStop}
+              variant="danger"
+            >
               <button
                 className="btn btn-danger btn-sm"
-                onClick={handleCancel}
-                data-testid="tower-panel-cancel"
+                data-testid="tower-panel-stop"
               >
-                Cancel
+                Stop
               </button>
-            </>
+            </ConfirmPopover>
           )}
         </div>
       </div>
@@ -207,13 +237,18 @@ export default function TowerPanel() {
       {/* Expanded content */}
       {expanded && (
         <div className="tower-panel__content" data-testid="tower-panel-content">
-          {/* Terminal area -- always present when running */}
-          {isRunning && (
+          {/* Terminal area */}
+          {showTerminal && (
             <div
               className="tower-panel__terminal"
               ref={attachRef}
               data-testid="tower-panel-terminal"
             />
+          )}
+
+          {/* Loading state for auto-start */}
+          {isClaudeCode && !showTerminal && starting && (
+            <div className="tower-panel__loading">Starting Tower terminal...</div>
           )}
 
           {/* Error state */}
@@ -224,8 +259,8 @@ export default function TowerPanel() {
             </div>
           )}
 
-          {/* Input bar -- always at the bottom */}
-          {isRunning ? (
+          {/* Message input bar — always at the bottom when terminal is showing */}
+          {showTerminal && (
             <form
               className="tower-panel__input-bar"
               onSubmit={handleSendMessage}
@@ -249,36 +284,6 @@ export default function TowerPanel() {
                 data-testid="tower-panel-send"
               >
                 {sending ? "..." : "Send"}
-              </button>
-            </form>
-          ) : (
-            <form
-              className="tower-panel__input-bar"
-              onSubmit={handleSubmitGoal}
-              data-testid="tower-panel-goal-form"
-            >
-              <span className="tower-panel__prompt">&gt;</span>
-              <input
-                ref={inputRef}
-                type="text"
-                className="tower-panel__input"
-                value={input}
-                onChange={(e) => setInput(e.target.value)}
-                placeholder={
-                  resolvedProjectId
-                    ? "Describe a goal for Tower..."
-                    : "No active projects"
-                }
-                disabled={submitting || !resolvedProjectId}
-                data-testid="tower-panel-goal"
-              />
-              <button
-                type="submit"
-                className="btn btn-primary btn-sm"
-                disabled={submitting || !input.trim() || !resolvedProjectId}
-                data-testid="tower-panel-start"
-              >
-                {submitting ? "..." : "Start"}
               </button>
             </form>
           )}

--- a/frontend/src/context/AppContext.tsx
+++ b/frontend/src/context/AppContext.tsx
@@ -42,6 +42,7 @@ const initialState: AppState = {
     current_goal: null,
     current_project_id: null,
     current_session_id: null,
+    leader_session_id: null,
     leader_activity_preview: null,
   },
   towerProgress: {
@@ -255,6 +256,7 @@ export function AppProvider({ children }: AppProviderProps) {
         current_goal: string | null;
         current_project_id: string | null;
         current_session_id: string | null;
+        leader_session_id: string | null;
       }>("/tower/status");
       dispatch({
         type: "SET_TOWER_DETAIL",
@@ -263,6 +265,7 @@ export function AppProvider({ children }: AppProviderProps) {
           current_goal: towerStatus.current_goal,
           current_project_id: towerStatus.current_project_id,
           current_session_id: towerStatus.current_session_id,
+          leader_session_id: towerStatus.leader_session_id ?? null,
           leader_activity_preview: null,
         },
       });
@@ -294,11 +297,18 @@ export function AppProvider({ children }: AppProviderProps) {
             current_project_id: (data.project_id as string) ?? null,
           },
         });
-      } else if (data.type === "leader_status") {
+      } else if (data.type === "tower_session") {
         dispatch({
           type: "SET_TOWER_DETAIL",
           payload: {
             current_session_id: (data.session_id as string) ?? null,
+          },
+        });
+      } else if (data.type === "leader_status") {
+        dispatch({
+          type: "SET_TOWER_DETAIL",
+          payload: {
+            leader_session_id: (data.session_id as string) ?? null,
           },
         });
       } else if (data.type === "progress") {

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -41,7 +41,7 @@ export interface Leader {
 export interface Session {
   id: string;
   project_id: string;
-  session_type: "ace" | "manager";
+  session_type: "ace" | "manager" | "tower";
   name: string;
   status:
     | "idle"
@@ -138,6 +138,7 @@ export interface TowerDetail {
   current_goal: string | null;
   current_project_id: string | null;
   current_session_id: string | null;
+  leader_session_id: string | null;
   leader_activity_preview: string | null;
 }
 

--- a/src/atc/agents/deploy.py
+++ b/src/atc/agents/deploy.py
@@ -335,7 +335,7 @@ def _build_settings(
     *,
     model: str,
     allowed_commands: list[str],
-    hooks: dict[str, list[dict[str, str]]],
+    hooks: dict[str, list[dict[str, Any]]],
 ) -> dict[str, Any]:
     """Build the .claude/settings.json content."""
     return {
@@ -412,24 +412,43 @@ def _manager_hook_scripts(spec: ManagerDeploySpec) -> list[HookConfig]:
     ]
 
 
-def _ace_hooks(spec: AceDeploySpec) -> dict[str, list[dict[str, str]]]:
+def _ace_hooks(spec: AceDeploySpec) -> dict[str, list[dict[str, Any]]]:
     """Build the hooks section for .claude/settings.json (Ace)."""
     hooks_dir = f"/tmp/atc-agents/{spec.session_id}/.claude/hooks"
     return _hooks_dict(hooks_dir)
 
 
-def _manager_hooks(spec: ManagerDeploySpec) -> dict[str, list[dict[str, str]]]:
+def _manager_hooks(spec: ManagerDeploySpec) -> dict[str, list[dict[str, Any]]]:
     """Build the hooks section for .claude/settings.json (Manager)."""
     hooks_dir = f"/tmp/atc-agents/{spec.leader_id}/.claude/hooks"
     return _hooks_dict(hooks_dir)
 
 
-def _hooks_dict(hooks_dir: str) -> dict[str, list[dict[str, str]]]:
-    """Build a hooks dict pointing to shell scripts in the given directory."""
+def _hooks_dict(hooks_dir: str) -> dict[str, list[dict[str, Any]]]:
+    """Build a hooks dict pointing to shell scripts in the given directory.
+
+    Claude Code settings.json hooks format requires each entry to have a
+    ``matcher`` string and a ``hooks`` array of command objects.
+    """
     return {
-        "PostToolUse": [{"type": "command", "command": f"bash {hooks_dir}/PostToolUse.sh"}],
-        "Stop": [{"type": "command", "command": f"bash {hooks_dir}/Stop.sh"}],
-        "Notification": [{"type": "command", "command": f"bash {hooks_dir}/Notification.sh"}],
+        "PostToolUse": [
+            {
+                "matcher": "",
+                "hooks": [{"type": "command", "command": f"bash {hooks_dir}/PostToolUse.sh"}],
+            }
+        ],
+        "Stop": [
+            {
+                "matcher": "",
+                "hooks": [{"type": "command", "command": f"bash {hooks_dir}/Stop.sh"}],
+            }
+        ],
+        "Notification": [
+            {
+                "matcher": "",
+                "hooks": [{"type": "command", "command": f"bash {hooks_dir}/Notification.sh"}],
+            }
+        ],
     }
 
 

--- a/src/atc/api/routers/tower.py
+++ b/src/atc/api/routers/tower.py
@@ -2,10 +2,10 @@
 
 Routes:
   GET    /api/tower/status           → Tower status summary
+  POST   /api/tower/start            → start Tower's own Claude Code session
+  POST   /api/tower/stop             → stop Tower's session
   POST   /api/tower/goal             → submit new goal (creates Leader + context)
-  POST   /api/tower/message          → send message to current Leader
-  POST   /api/tower/cancel           → cancel current goal
-  POST   /api/tower/complete         → mark current goal as complete
+  POST   /api/tower/message          → send message to Tower's terminal
   GET    /api/tower/progress         → get Leader task graph progress
   GET    /api/tower/memory           → list tower memory entries
   DELETE /api/tower/memory/{key}     → forget a memory entry
@@ -19,6 +19,10 @@ from pydantic import BaseModel
 from atc.tower.controller import TowerBusyError, TowerController
 
 router = APIRouter()
+
+
+class StartRequest(BaseModel):
+    project_id: str
 
 
 class GoalRequest(BaseModel):
@@ -38,6 +42,7 @@ class TowerStatusResponse(BaseModel):
     current_goal: str | None
     current_project_id: str | None
     current_session_id: str | None
+    leader_session_id: str | None
     output_line_count: int
 
 
@@ -95,8 +100,41 @@ async def tower_status(request: Request) -> TowerStatusResponse:
         current_goal=controller_status["current_goal"],
         current_project_id=controller_status["current_project_id"],
         current_session_id=controller_status["current_session_id"],
+        leader_session_id=controller_status.get("leader_session_id"),
         output_line_count=controller_status.get("output_line_count", 0),
     )
+
+
+@router.post("/start")
+async def start_tower(body: StartRequest, request: Request) -> dict:
+    """Start Tower's own Claude Code session for a project.
+
+    This creates an independent terminal session for Tower, separate
+    from the Leader session.
+    """
+    db = await _get_db(request)
+    tower = _get_tower(request)
+
+    # Verify project exists
+    cursor = await db.execute("SELECT id FROM projects WHERE id = ?", (body.project_id,))
+    row = await cursor.fetchone()
+    if row is None:
+        raise HTTPException(status_code=404, detail=f"Project {body.project_id} not found")
+
+    try:
+        session_id = await tower.start_session(body.project_id)
+    except Exception as exc:
+        raise HTTPException(status_code=500, detail=str(exc)) from exc
+
+    return {"status": "started", "session_id": session_id, "project_id": body.project_id}
+
+
+@router.post("/stop")
+async def stop_tower(request: Request) -> dict:
+    """Stop Tower's Claude Code session and any active Leader."""
+    tower = _get_tower(request)
+    await tower.stop_session()
+    return {"status": "stopped"}
 
 
 @router.post("/goal")
@@ -127,11 +165,7 @@ async def submit_goal(body: GoalRequest, request: Request) -> dict:
 
 @router.post("/message")
 async def send_message(body: MessageRequest, request: Request) -> dict[str, str]:
-    """Send a message to the current Leader's terminal.
-
-    The Tower types this message into the Leader's Claude Code session,
-    allowing the user to communicate with the Leader through Tower.
-    """
+    """Send a message to Tower's Claude Code terminal."""
     tower = _get_tower(request)
 
     try:
@@ -140,33 +174,6 @@ async def send_message(body: MessageRequest, request: Request) -> dict[str, str]
         raise HTTPException(status_code=409, detail=str(exc)) from exc
 
     return {"status": "sent"}
-
-
-@router.post("/cancel")
-async def cancel_goal(request: Request) -> dict:
-    """Cancel the current goal and stop the Leader session."""
-    tower = _get_tower(request)
-
-    if tower.state.value == "idle":
-        raise HTTPException(status_code=409, detail="No active goal to cancel")
-
-    await tower.cancel_goal()
-    return {"status": "cancelled"}
-
-
-@router.post("/complete")
-async def mark_complete(request: Request) -> dict[str, str]:
-    """Mark the current goal as complete and return Tower to idle."""
-    tower = _get_tower(request)
-
-    if tower.state.value != "managing":
-        raise HTTPException(
-            status_code=409,
-            detail=f"Cannot complete — Tower is {tower.state.value}, not managing",
-        )
-
-    await tower.mark_complete()
-    return {"status": "completed"}
 
 
 @router.get("/progress", response_model=TowerProgressResponse)

--- a/src/atc/state/models.py
+++ b/src/atc/state/models.py
@@ -45,7 +45,7 @@ class Leader:
 class Session:
     id: str
     project_id: str
-    session_type: str  # ace|manager
+    session_type: str  # ace|manager|tower
     name: str
     status: str  # idle|connecting|working|paused|waiting|disconnected|error
     task_id: str | None = None

--- a/src/atc/tower/controller.py
+++ b/src/atc/tower/controller.py
@@ -23,7 +23,8 @@ import logging
 from typing import TYPE_CHECKING, Any
 
 from atc.leader.context_package import build_context_package
-from atc.leader.leader import send_leader_message, start_leader, stop_leader
+from atc.leader.leader import start_leader, stop_leader
+from atc.tower.session import send_tower_message, start_tower_session, stop_tower_session
 
 if TYPE_CHECKING:
     import aiosqlite
@@ -73,7 +74,10 @@ class TowerController:
         self._state = TowerState.IDLE
         self._current_goal: str | None = None
         self._current_project_id: str | None = None
+        # Tower's own Claude Code session (independent from Leader)
         self._current_session_id: str | None = None
+        # Leader's session (separate terminal stream)
+        self._leader_session_id: str | None = None
 
         # Track Leader output lines for monitoring
         self._leader_output_lines: list[str] = []
@@ -132,13 +136,85 @@ class TowerController:
                 },
             )
 
+    async def start_session(self, project_id: str) -> str:
+        """Start Tower's own Claude Code session (independent from Leader).
+
+        Returns the tower session id.  If a session already exists, returns
+        its id without spawning a new one.
+        """
+        self._current_project_id = project_id
+
+        session_id = await start_tower_session(
+            self._db,
+            project_id,
+            event_bus=self._event_bus,
+        )
+        self._current_session_id = session_id
+
+        # Transition to MANAGING so the frontend shows the terminal
+        if self._state in (TowerState.IDLE, TowerState.COMPLETE, TowerState.ERROR):
+            if self._state in (TowerState.COMPLETE, TowerState.ERROR):
+                self._state = TowerState.IDLE
+            await self._transition(TowerState.PLANNING)
+            await self._transition(TowerState.MANAGING)
+
+        # Broadcast tower session info so the frontend subscribes immediately
+        if self._ws_hub is not None:
+            await self._ws_hub.broadcast(
+                "tower",
+                {
+                    "type": "tower_session",
+                    "session_id": session_id,
+                    "status": "idle",
+                    "project_id": project_id,
+                },
+            )
+
+        return session_id
+
+    async def stop_session(self) -> None:
+        """Stop Tower's own Claude Code session."""
+        if self._current_session_id:
+            await stop_tower_session(
+                self._db,
+                self._current_session_id,
+                event_bus=self._event_bus,
+            )
+
+        # Also stop the Leader if running
+        if self._current_project_id and self._leader_session_id:
+            await stop_leader(
+                self._db,
+                self._current_project_id,
+                event_bus=self._event_bus,
+            )
+            self._leader_session_id = None
+
+        # Reset state
+        if self._state in (TowerState.MANAGING, TowerState.PLANNING):
+            await self._transition(TowerState.ERROR)
+
+        if self._state in (TowerState.ERROR, TowerState.COMPLETE):
+            self._state = TowerState.IDLE
+
+        self._current_goal = None
+        self._current_project_id = None
+        self._current_session_id = None
+        self._leader_output_lines.clear()
+
+        await self._event_bus.publish(
+            "tower_state_changed",
+            {"previous_state": "managing", "new_state": "idle", "project_id": None, "goal": None},
+        )
+
     async def submit_goal(self, project_id: str, goal: str) -> dict[str, Any]:
         """Process a new goal: build context, start Leader, begin monitoring.
 
         Returns a dict with status, project_id, session_id, and context_package.
         Raises if the tower is not idle (already processing a goal).
         """
-        if self._state not in (TowerState.IDLE, TowerState.COMPLETE, TowerState.ERROR):
+        allowed = (TowerState.IDLE, TowerState.COMPLETE, TowerState.ERROR, TowerState.MANAGING)
+        if self._state not in allowed:
             raise TowerBusyError(self._state, project_id)
 
         # Reset to idle first if coming from complete/error
@@ -149,9 +225,12 @@ class TowerController:
         self._current_goal = goal
 
         try:
-            # Phase 1: Planning — build the context package
-            await self._transition(TowerState.PLANNING)
+            # If not already managing (i.e. Tower session not yet started)
+            if self._state == TowerState.IDLE:
+                await self._transition(TowerState.PLANNING)
+                await self._transition(TowerState.MANAGING)
 
+            # Build the context package
             context_package = await build_context_package(self._db, project_id, goal)
 
             # Store context on the leader row
@@ -162,29 +241,23 @@ class TowerController:
             )
             await self._db.commit()
 
-            # Phase 2: Managing — start the Leader session
-            await self._transition(TowerState.MANAGING)
-
-            session_id = await start_leader(
+            # Start the Leader session (separate from Tower's session)
+            leader_session_id = await start_leader(
                 self._db,
                 project_id,
                 goal=goal,
                 event_bus=self._event_bus,
                 context_package=context_package,
             )
-            self._current_session_id = session_id
+            self._leader_session_id = leader_session_id
 
-            # Broadcast leader session info to frontend so the terminal
-            # panel can subscribe to the PTY WebSocket channel immediately.
-            # The initial connecting→idle transition fires BEFORE
-            # _current_session_id is set, so _on_session_status_changed
-            # misses it.  This explicit broadcast closes that gap.
+            # Broadcast leader session info so LeaderConsole can subscribe
             if self._ws_hub is not None:
                 await self._ws_hub.broadcast(
                     "tower",
                     {
                         "type": "leader_status",
-                        "session_id": session_id,
+                        "session_id": leader_session_id,
                         "status": "idle",
                         "project_id": project_id,
                     },
@@ -195,14 +268,15 @@ class TowerController:
                 {
                     "project_id": project_id,
                     "goal": goal,
-                    "session_id": session_id,
+                    "session_id": leader_session_id,
                 },
             )
 
             return {
                 "status": "accepted",
                 "project_id": project_id,
-                "session_id": session_id,
+                "session_id": self._current_session_id,
+                "leader_session_id": leader_session_id,
                 "context_package": context_package,
             }
 
@@ -215,34 +289,42 @@ class TowerController:
         """Mark the current goal as complete and return tower to idle."""
         await self._transition(TowerState.COMPLETE)
         self._current_goal = None
-        self._current_project_id = None
-        self._current_session_id = None
+        self._leader_session_id = None
         self._leader_output_lines.clear()
 
     async def cancel_goal(self) -> None:
-        """Cancel the current goal, stop the Leader, and return to idle."""
-        if self._current_project_id and self._state == TowerState.MANAGING:
+        """Cancel the current goal and stop the Leader.
+
+        If Tower has its own session, it stays in MANAGING. Otherwise
+        transitions back to idle.
+        """
+        if self._current_project_id and self._leader_session_id:
             await stop_leader(
                 self._db,
                 self._current_project_id,
                 event_bus=self._event_bus,
             )
+            self._leader_session_id = None
 
-        # Transition through error → idle for cancellation
-        if self._state == TowerState.MANAGING:
-            await self._transition(TowerState.ERROR)
+        self._current_goal = None
+        self._leader_output_lines.clear()
 
-        if self._state in (TowerState.ERROR, TowerState.COMPLETE):
-            self._state = TowerState.IDLE
-            self._current_goal = None
-            self._current_project_id = None
-            self._current_session_id = None
-            self._leader_output_lines.clear()
-
-            await self._event_bus.publish(
-                "tower_state_changed",
-                {"previous_state": "error", "new_state": "idle", "project_id": None, "goal": None},
-            )
+        # If Tower has no session of its own, return to idle
+        if not self._current_session_id:
+            if self._state == TowerState.MANAGING:
+                await self._transition(TowerState.ERROR)
+            if self._state in (TowerState.ERROR, TowerState.COMPLETE):
+                self._state = TowerState.IDLE
+                self._current_project_id = None
+                await self._event_bus.publish(
+                    "tower_state_changed",
+                    {
+                        "previous_state": "error",
+                        "new_state": "idle",
+                        "project_id": None,
+                        "goal": None,
+                    },
+                )
 
     async def reset(self) -> None:
         """Force-reset tower to idle state (e.g. after unrecoverable error)."""
@@ -250,6 +332,7 @@ class TowerController:
         self._current_goal = None
         self._current_project_id = None
         self._current_session_id = None
+        self._leader_session_id = None
         self._leader_output_lines.clear()
 
     def get_status(self) -> dict[str, Any]:
@@ -259,31 +342,28 @@ class TowerController:
             "current_goal": self._current_goal,
             "current_project_id": self._current_project_id,
             "current_session_id": self._current_session_id,
+            "leader_session_id": self._leader_session_id,
             "output_line_count": len(self._leader_output_lines),
         }
 
     async def send_message(self, message: str) -> None:
-        """Send a message to the current Leader's terminal.
+        """Send a message to Tower's own terminal.
 
-        This is the Tower → Leader communication channel. The message is
-        typed into the Leader's Claude Code terminal just like a human
-        would, triggering the Leader to process the instruction.
+        This types the message into Tower's Claude Code session.
 
-        Raises ``ValueError`` if no Leader is currently active.
+        Raises ``ValueError`` if no Tower session is active.
         """
-        if self._state != TowerState.MANAGING:
-            raise ValueError(f"Cannot send message — Tower is {self._state.value}, not managing")
-        if not self._current_project_id:
-            raise ValueError("No active project")
+        if not self._current_session_id:
+            raise ValueError("No active Tower session")
 
-        await send_leader_message(
+        await send_tower_message(
             self._db,
-            self._current_project_id,
+            self._current_session_id,
             message,
             event_bus=self._event_bus,
         )
 
-        logger.info("Tower sent message to Leader (project %s)", self._current_project_id)
+        logger.info("Sent message to Tower session (project %s)", self._current_project_id)
 
         if self._ws_hub is not None:
             await self._ws_hub.broadcast(
@@ -358,7 +438,7 @@ class TowerController:
         event so the frontend can show activity indicators.
         """
         session_id = data.get("session_id")
-        if session_id != self._current_session_id:
+        if session_id != self._leader_session_id:
             return
 
         raw = data.get("data", b"")
@@ -389,7 +469,7 @@ class TowerController:
         session_id = data.get("session_id")
         new_status = data.get("new_status")
 
-        if session_id != self._current_session_id:
+        if session_id != self._leader_session_id:
             return
 
         if new_status == "error" and self._state == TowerState.MANAGING:

--- a/src/atc/tower/session.py
+++ b/src/atc/tower/session.py
@@ -1,0 +1,145 @@
+"""Tower session lifecycle — start / stop / message.
+
+Tower gets its own independent Claude Code session (separate from Leader).
+Tower is the top-level controller that talks directly to the user through
+its terminal. Leader is a project-scoped agent that Tower delegates to.
+
+Uses the same tmux infrastructure as aces and leaders.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+from atc.agents.factory import get_launch_command
+from atc.session.ace import (
+    ATC_TMUX_SESSION,
+    _ensure_tmux_session,
+    _kill_pane,
+    _send_keys,
+    _spawn_pane,
+)
+from atc.session.state_machine import SessionStatus, transition
+from atc.state import db as db_ops
+
+if TYPE_CHECKING:
+    import aiosqlite
+
+    from atc.core.events import EventBus
+
+logger = logging.getLogger(__name__)
+
+
+async def start_tower_session(
+    conn: aiosqlite.Connection,
+    project_id: str,
+    *,
+    event_bus: EventBus | None = None,
+) -> str:
+    """Start Tower's own Claude Code session for a project.
+
+    Creates a session of type ``tower``, spawns a tmux pane running
+    ``claude``, and returns the session id.  This session is independent
+    of the Leader session.
+    """
+    project = await db_ops.get_project(conn, project_id)
+    name = f"tower-{project.name}" if project else f"tower-{project_id[:8]}"
+
+    # Check for existing tower session
+    existing = await db_ops.list_sessions(conn, project_id=project_id, session_type="tower")
+    for sess in existing:
+        if sess.status not in (SessionStatus.ERROR.value, SessionStatus.DISCONNECTED.value):
+            return sess.id
+
+    session = await db_ops.create_session(
+        conn,
+        project_id=project_id,
+        session_type="tower",
+        name=name,
+        status=SessionStatus.CONNECTING.value,
+    )
+
+    if event_bus:
+        await event_bus.publish(
+            "session_created",
+            {"session_id": session.id, "session_type": "tower", "project_id": project_id},
+        )
+
+    try:
+        provider = project.agent_provider if project else "claude_code"
+        launch_cmd = get_launch_command(provider)
+        working_dir = project.repo_path if project and project.repo_path else None
+
+        await _ensure_tmux_session(ATC_TMUX_SESSION)
+        pane_id = await _spawn_pane(
+            ATC_TMUX_SESSION,
+            launch_cmd,
+            working_dir=working_dir,
+        )
+        await db_ops.update_session_tmux(conn, session.id, ATC_TMUX_SESSION, pane_id)
+
+        await transition(session.id, SessionStatus.CONNECTING, SessionStatus.IDLE, event_bus)
+        await db_ops.update_session_status(conn, session.id, SessionStatus.IDLE.value)
+    except Exception as exc:
+        logger.exception("Failed to spawn tower pane for project %s", project_id)
+        await db_ops.update_session_status(conn, session.id, SessionStatus.ERROR.value)
+        if event_bus:
+            await event_bus.publish(
+                "session_status_changed",
+                {
+                    "session_id": session.id,
+                    "previous_status": SessionStatus.CONNECTING.value,
+                    "new_status": SessionStatus.ERROR.value,
+                },
+            )
+        raise RuntimeError(str(exc)) from exc
+
+    return session.id
+
+
+async def stop_tower_session(
+    conn: aiosqlite.Connection,
+    session_id: str,
+    *,
+    event_bus: EventBus | None = None,
+) -> None:
+    """Stop Tower's Claude Code session."""
+    session = await db_ops.get_session(conn, session_id)
+    if session is None:
+        return
+
+    if session.tmux_pane:
+        await _kill_pane(session.tmux_pane)
+
+    await db_ops.update_session_status(conn, session.id, SessionStatus.IDLE.value)
+
+    if event_bus:
+        await event_bus.publish(
+            "session_status_changed",
+            {
+                "session_id": session.id,
+                "previous_status": session.status,
+                "new_status": SessionStatus.IDLE.value,
+            },
+        )
+
+
+async def send_tower_message(
+    conn: aiosqlite.Connection,
+    session_id: str,
+    message: str,
+    *,
+    event_bus: EventBus | None = None,
+) -> None:
+    """Send a message to Tower's tmux pane."""
+    session = await db_ops.get_session(conn, session_id)
+    if session is None or session.tmux_pane is None:
+        raise ValueError("Tower session has no tmux pane")
+
+    current = SessionStatus(session.status)
+    if current in (SessionStatus.IDLE, SessionStatus.WAITING):
+        await transition(session.id, current, SessionStatus.WORKING, event_bus)
+        await db_ops.update_session_status(conn, session.id, SessionStatus.WORKING.value)
+
+    await _send_keys(session.tmux_pane, message)

--- a/tests/e2e/test_smoke.py
+++ b/tests/e2e/test_smoke.py
@@ -302,13 +302,14 @@ class TestTowerStatus:
     @patch("atc.leader.leader._send_keys", new_callable=AsyncMock)
     @patch("atc.leader.leader._spawn_pane", new_callable=AsyncMock, return_value="%1")
     @patch("atc.leader.leader._ensure_tmux_session", new_callable=AsyncMock)
-    def test_submit_goal_twice_returns_conflict(
+    def test_submit_goal_twice_while_managing_succeeds(
         self,
         mock_ensure: AsyncMock,
         mock_spawn: AsyncMock,
         mock_send: AsyncMock,
         client: TestClient,
     ) -> None:
+        """Tower in MANAGING state can accept new goals (delegates to Leader)."""
         resp = client.post("/api/projects", json={"name": "busy-proj"})
         project_id = resp.json()["id"]
 
@@ -322,39 +323,37 @@ class TestTowerStatus:
             "/api/tower/goal",
             json={"project_id": project_id, "goal": "Second goal"},
         )
-        assert resp.status_code == 409
+        assert resp.status_code == 200
 
+    @patch("atc.tower.session.stop_tower_session", new_callable=AsyncMock)
     @patch("atc.leader.leader._kill_pane", new_callable=AsyncMock)
     @patch("atc.leader.leader._send_keys", new_callable=AsyncMock)
     @patch("atc.leader.leader._spawn_pane", new_callable=AsyncMock, return_value="%1")
     @patch("atc.leader.leader._ensure_tmux_session", new_callable=AsyncMock)
-    def test_cancel_goal(
+    def test_stop_tower(
         self,
         mock_ensure: AsyncMock,
         mock_spawn: AsyncMock,
         mock_send: AsyncMock,
         mock_kill: AsyncMock,
+        mock_stop_tower: AsyncMock,
         client: TestClient,
     ) -> None:
-        resp = client.post("/api/projects", json={"name": "cancel-proj"})
+        resp = client.post("/api/projects", json={"name": "stop-proj"})
         project_id = resp.json()["id"]
 
         client.post(
             "/api/tower/goal",
-            json={"project_id": project_id, "goal": "Cancel me"},
+            json={"project_id": project_id, "goal": "Stop me"},
         )
 
-        resp = client.post("/api/tower/cancel")
+        resp = client.post("/api/tower/stop")
         assert resp.status_code == 200
-        assert resp.json()["status"] == "cancelled"
+        assert resp.json()["status"] == "stopped"
 
         # Tower should be idle again
         resp = client.get("/api/tower/status")
         assert resp.json()["state"] == "idle"
-
-    def test_cancel_no_active_goal(self, client: TestClient) -> None:
-        resp = client.post("/api/tower/cancel")
-        assert resp.status_code == 409
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_deploy.py
+++ b/tests/unit/test_deploy.py
@@ -135,6 +135,20 @@ class TestDeployAceFiles:
         assert "Stop" in settings["hooks"]
         assert "Notification" in settings["hooks"]
 
+    def test_hooks_use_correct_format(self, ace_spec: AceDeploySpec, staging_root: Path) -> None:
+        """Hooks must use matcher + hooks array format, not bare command objects."""
+        result = deploy_ace_files(ace_spec, staging_root=staging_root)
+        settings = json.loads(result.settings_path.read_text())
+        for event_name, entries in settings["hooks"].items():
+            assert isinstance(entries, list), f"{event_name} hooks must be a list"
+            for entry in entries:
+                assert "matcher" in entry, f"{event_name} entry missing 'matcher'"
+                assert "hooks" in entry, f"{event_name} entry missing 'hooks'"
+                assert isinstance(entry["hooks"], list), f"{event_name} 'hooks' must be a list"
+                for hook in entry["hooks"]:
+                    assert "type" in hook
+                    assert "command" in hook
+
     def test_creates_hook_scripts(self, ace_spec: AceDeploySpec, staging_root: Path) -> None:
         result = deploy_ace_files(ace_spec, staging_root=staging_root)
         hooks_dir = result.root / ".claude" / "hooks"

--- a/tests/unit/test_tower_controller.py
+++ b/tests/unit/test_tower_controller.py
@@ -53,6 +53,7 @@ class TestTowerState:
         assert status["current_goal"] is None
         assert status["current_project_id"] is None
         assert status["current_session_id"] is None
+        assert status["leader_session_id"] is None
 
     async def test_invalid_transition_raises(self, tower: TowerController) -> None:
         with pytest.raises(InvalidTowerTransitionError):
@@ -100,7 +101,7 @@ class TestTowerState:
         assert status["output_line_count"] == 3
 
 
-@patch("atc.tower.controller.start_leader", new_callable=AsyncMock, return_value="session-123")
+@patch("atc.tower.controller.start_leader", new_callable=AsyncMock, return_value="leader-sess-123")
 @pytest.mark.asyncio
 class TestSubmitGoal:
     async def test_submit_goal_success(
@@ -114,11 +115,13 @@ class TestSubmitGoal:
 
         assert result["status"] == "accepted"
         assert result["project_id"] == project.id
-        assert result["session_id"] == "session-123"
+        assert result["leader_session_id"] == "leader-sess-123"
         assert result["context_package"]["goal"] == "Build feature X"
         assert result["context_package"]["project_name"] == "test-proj"
         assert result["context_package"]["repo_path"] == "/tmp/repo"
         assert tower.state == TowerState.MANAGING
+        # Leader session tracked separately
+        assert tower._leader_session_id == "leader-sess-123"
 
     async def test_submit_goal_publishes_event(
         self, mock_start: AsyncMock, db, event_bus: EventBus
@@ -134,7 +137,7 @@ class TestSubmitGoal:
 
         assert len(captured) == 1
         assert captured[0]["goal"] == "Test goal"
-        assert captured[0]["session_id"] == "session-123"
+        assert captured[0]["session_id"] == "leader-sess-123"
 
     async def test_submit_goal_publishes_state_changes(
         self, mock_start: AsyncMock, db, event_bus: EventBus
@@ -159,19 +162,6 @@ class TestSubmitGoal:
             await tower.submit_goal("nonexistent-id", "Some goal")
         # Tower should be in error state after failure
         assert tower.state == TowerState.ERROR
-
-    async def test_submit_goal_while_busy(
-        self, mock_start: AsyncMock, db, event_bus: EventBus
-    ) -> None:
-        project = await create_project(db, "test-proj")
-        await create_leader(db, project.id)
-        tower = TowerController(db, event_bus)
-
-        await tower.submit_goal(project.id, "First goal")
-        assert tower.state == TowerState.MANAGING
-
-        with pytest.raises(TowerBusyError):
-            await tower.submit_goal(project.id, "Second goal")
 
     async def test_submit_goal_after_complete(
         self, mock_start: AsyncMock, db, event_bus: EventBus
@@ -203,7 +193,7 @@ class TestSubmitGoal:
 
 
 @patch("atc.tower.controller.stop_leader", new_callable=AsyncMock)
-@patch("atc.tower.controller.start_leader", new_callable=AsyncMock, return_value="session-123")
+@patch("atc.tower.controller.start_leader", new_callable=AsyncMock, return_value="leader-sess-123")
 @pytest.mark.asyncio
 class TestCancelGoal:
     async def test_cancel_active_goal(
@@ -216,10 +206,12 @@ class TestCancelGoal:
         await tower.submit_goal(project.id, "Cancel me")
         await tower.cancel_goal()
 
+        # Leader should be stopped but Tower stays in managing
         mock_stop.assert_called_once()
-        assert tower.state == TowerState.IDLE
+        assert tower.current_goal is None
+        assert tower._leader_session_id is None
 
-    async def test_cancel_resets_properties(
+    async def test_cancel_resets_goal_properties(
         self, mock_start: AsyncMock, mock_stop: AsyncMock, db, event_bus: EventBus
     ) -> None:
         project = await create_project(db, "test-proj")
@@ -230,13 +222,12 @@ class TestCancelGoal:
         await tower.cancel_goal()
 
         assert tower.current_goal is None
-        assert tower.current_project_id is None
-        assert tower.current_session_id is None
+        assert tower._leader_session_id is None
 
 
 @pytest.mark.asyncio
 class TestSessionMonitoring:
-    @patch("atc.tower.controller.start_leader", new_callable=AsyncMock, return_value="sess-1")
+    @patch("atc.tower.controller.start_leader", new_callable=AsyncMock, return_value="leader-sess-1")
     async def test_leader_error_transitions_tower(
         self, mock_start: AsyncMock, db, event_bus: EventBus
     ) -> None:
@@ -250,12 +241,12 @@ class TestSessionMonitoring:
         # Simulate leader session entering error state
         await event_bus.publish(
             "session_status_changed",
-            {"session_id": "sess-1", "new_status": "error"},
+            {"session_id": "leader-sess-1", "new_status": "error"},
         )
 
         assert tower.state == TowerState.ERROR
 
-    @patch("atc.tower.controller.start_leader", new_callable=AsyncMock, return_value="sess-1")
+    @patch("atc.tower.controller.start_leader", new_callable=AsyncMock, return_value="leader-sess-1")
     async def test_unrelated_session_error_ignored(
         self, mock_start: AsyncMock, db, event_bus: EventBus
     ) -> None:
@@ -276,7 +267,7 @@ class TestSessionMonitoring:
 
 @pytest.mark.asyncio
 class TestWebSocketBroadcast:
-    @patch("atc.tower.controller.start_leader", new_callable=AsyncMock, return_value="sess-1")
+    @patch("atc.tower.controller.start_leader", new_callable=AsyncMock, return_value="leader-sess-1")
     async def test_state_changes_broadcast_to_ws(
         self, mock_start: AsyncMock, db, event_bus: EventBus
     ) -> None:
@@ -296,45 +287,50 @@ class TestWebSocketBroadcast:
 
 
 @patch(
-    "atc.tower.controller.send_leader_message",
+    "atc.tower.controller.send_tower_message",
     new_callable=AsyncMock,
 )
-@patch("atc.tower.controller.start_leader", new_callable=AsyncMock, return_value="sess-1")
+@patch("atc.tower.controller.start_tower_session", new_callable=AsyncMock, return_value="tower-sess-1")
+@patch("atc.tower.controller.start_leader", new_callable=AsyncMock, return_value="leader-sess-1")
 @pytest.mark.asyncio
 class TestSendMessage:
     async def test_send_message_success(
-        self, mock_start: AsyncMock, mock_send: AsyncMock, db, event_bus: EventBus
+        self, mock_start_leader: AsyncMock, mock_start_tower: AsyncMock,
+        mock_send: AsyncMock, db, event_bus: EventBus
     ) -> None:
         project = await create_project(db, "test-proj")
         await create_leader(db, project.id)
         tower = TowerController(db, event_bus)
 
-        await tower.submit_goal(project.id, "Test goal")
+        # Start tower session first, then submit goal
+        await tower.start_session(project.id)
         await tower.send_message("Do the thing")
 
         mock_send.assert_called_once_with(
             db,
-            project.id,
+            "tower-sess-1",
             "Do the thing",
             event_bus=event_bus,
         )
 
-    async def test_send_message_not_managing_raises(
-        self, mock_start: AsyncMock, mock_send: AsyncMock, db, event_bus: EventBus
+    async def test_send_message_no_session_raises(
+        self, mock_start_leader: AsyncMock, mock_start_tower: AsyncMock,
+        mock_send: AsyncMock, db, event_bus: EventBus
     ) -> None:
         tower = TowerController(db, event_bus)
-        with pytest.raises(ValueError, match="not managing"):
+        with pytest.raises(ValueError, match="No active Tower session"):
             await tower.send_message("Hello")
 
     async def test_send_message_broadcasts_to_ws(
-        self, mock_start: AsyncMock, mock_send: AsyncMock, db, event_bus: EventBus
+        self, mock_start_leader: AsyncMock, mock_start_tower: AsyncMock,
+        mock_send: AsyncMock, db, event_bus: EventBus
     ) -> None:
         ws_hub = AsyncMock()
         project = await create_project(db, "test-proj")
         await create_leader(db, project.id)
         tower = TowerController(db, event_bus, ws_hub=ws_hub)
 
-        await tower.submit_goal(project.id, "Test goal")
+        await tower.start_session(project.id)
         ws_hub.broadcast.reset_mock()
 
         await tower.send_message("Do something")
@@ -349,7 +345,7 @@ class TestSendMessage:
         assert msg_calls[0][0][1]["message"] == "Do something"
 
 
-@patch("atc.tower.controller.start_leader", new_callable=AsyncMock, return_value="sess-1")
+@patch("atc.tower.controller.start_leader", new_callable=AsyncMock, return_value="leader-sess-1")
 @pytest.mark.asyncio
 class TestGetProgress:
     async def test_progress_no_active_goal(
@@ -432,7 +428,7 @@ class TestGetProgress:
         assert len(progress_calls) == 1
 
 
-@patch("atc.tower.controller.start_leader", new_callable=AsyncMock, return_value="sess-1")
+@patch("atc.tower.controller.start_leader", new_callable=AsyncMock, return_value="leader-sess-1")
 @pytest.mark.asyncio
 class TestLeaderOutput:
     async def test_captures_leader_output(
@@ -447,7 +443,7 @@ class TestLeaderOutput:
         # Simulate PTY output from leader session
         await event_bus.publish(
             "pty_output",
-            {"session_id": "sess-1", "data": b"Working on task 1\n"},
+            {"session_id": "leader-sess-1", "data": b"Working on task 1\n"},
         )
 
         assert len(tower._leader_output_lines) == 1
@@ -482,7 +478,7 @@ class TestLeaderOutput:
         for i in range(10):
             await event_bus.publish(
                 "pty_output",
-                {"session_id": "sess-1", "data": f"Line {i}\n".encode()},
+                {"session_id": "leader-sess-1", "data": f"Line {i}\n".encode()},
             )
 
         assert len(tower._leader_output_lines) == 5
@@ -501,7 +497,7 @@ class TestLeaderOutput:
 
         await event_bus.publish(
             "pty_output",
-            {"session_id": "sess-1", "data": b"Thinking about it...\n"},
+            {"session_id": "leader-sess-1", "data": b"Thinking about it...\n"},
         )
 
         activity_calls = [
@@ -524,7 +520,7 @@ class TestLeaderOutput:
         # String data (not bytes) should also work
         await event_bus.publish(
             "pty_output",
-            {"session_id": "sess-1", "data": "String output\n"},
+            {"session_id": "leader-sess-1", "data": "String output\n"},
         )
 
         assert len(tower._leader_output_lines) == 1
@@ -540,7 +536,7 @@ class TestLeaderOutput:
 
         await event_bus.publish(
             "pty_output",
-            {"session_id": "sess-1", "data": b"Some output\n"},
+            {"session_id": "leader-sess-1", "data": b"Some output\n"},
         )
         assert len(tower._leader_output_lines) > 0
 
@@ -575,7 +571,7 @@ class TestLeaderOutput:
         # Empty/whitespace-only output should not trigger broadcast
         await event_bus.publish(
             "pty_output",
-            {"session_id": "sess-1", "data": b"   \n  \n"},
+            {"session_id": "leader-sess-1", "data": b"   \n  \n"},
         )
 
         activity_calls = [


### PR DESCRIPTION
## Summary

- **Tower/Leader session split**: Tower now gets its own independent Claude Code session (separate tmux pane + PTY stream) instead of reusing the Leader's session. Tower controller tracks `_current_session_id` (Tower's own and  separately.
- **Tower auto-start**: For  provider, Tower auto-starts its own session on mount — no goal form needed. Goal form removed for claude_code.
- **Stop button**: Replaced Complete + Cancel buttons with a single Stop button (with ConfirmPopover), matching Leader's controls.
- **Ace terminal fix**: Terminal now stays enabled during  and  states so output is visible and the terminal isn't blank/unclickable.
- **Hooks format fix**: Claude Code settings.json hooks now use the correct  format instead of the broken flat  format.

## Files changed

| File | Change |
|------|--------|
|  | **New** — Tower session lifecycle (start/stop/message) |
|  | Track tower + leader sessions separately; add / |
|  | Add ,  endpoints; remove cancel/complete |
|  | Fix hooks format to use  +  array |
|  | Auto-start, remove goal form for claude_code, Stop button |
|  | Include connecting/error in terminal enabled states |
|  | Add tower session type,  |
|  | Handle  WS event, init  |

## Test plan

- [x] All 622 unit/e2e tests pass (3 pre-existing failures on main excluded)
- [x]  passes on all changed Python files
- [ ] Verify Tower panel auto-starts terminal for claude_code projects
- [ ] Verify Tower and Leader show different terminal output
- [ ] Verify Ace terminal shows content for error/connecting sessions
- [ ] Verify deployed settings.json hooks have correct format

🤖 Generated with [Claude Code](https://claude.com/claude-code)
EOF
)