### PR TITLE
Fix Tower launch, Start button after Stop, and duplicate terminal lines

### DIFF
--- a/frontend/src/components/tower/TowerConsole.tsx
+++ b/frontend/src/components/tower/TowerConsole.tsx
@@ -60,17 +60,30 @@ export default function TowerConsole() {
     if (!projectId) return;
     setLoading(true);
     try {
-      const res = await api.post<{ session_id?: string }>("/tower/goal", {
-        project_id: projectId,
-        goal: goal.trim() || null,
-      });
-      setGoal("");
-      // Update session_id immediately so the terminal can subscribe
-      if (res.session_id) {
-        dispatch({
-          type: "SET_TOWER_DETAIL",
-          payload: { current_session_id: res.session_id },
+      if (isClaudeCode) {
+        // For claude_code: start Tower's own Claude Code session
+        const res = await api.post<{ session_id?: string }>("/tower/start", {
+          project_id: projectId,
         });
+        if (res.session_id) {
+          dispatch({
+            type: "SET_TOWER_DETAIL",
+            payload: { current_session_id: res.session_id },
+          });
+        }
+      } else {
+        // For other providers: submit a goal to start the Leader
+        const res = await api.post<{ session_id?: string }>("/tower/goal", {
+          project_id: projectId,
+          goal: goal.trim() || null,
+        });
+        setGoal("");
+        if (res.session_id) {
+          dispatch({
+            type: "SET_TOWER_DETAIL",
+            payload: { current_session_id: res.session_id },
+          });
+        }
       }
     } catch (err) {
       console.error("Failed to start Tower:", err);
@@ -82,7 +95,17 @@ export default function TowerConsole() {
   async function handleStop() {
     setLoading(true);
     try {
-      await api.post("/tower/cancel");
+      await api.post("/tower/stop");
+      autoStarted.current = false;
+      dispatch({
+        type: "SET_TOWER_DETAIL",
+        payload: {
+          state: "idle",
+          current_session_id: null,
+          leader_session_id: null,
+          current_goal: null,
+        },
+      });
     } catch (err) {
       console.error("Failed to stop Tower:", err);
     } finally {

--- a/frontend/src/components/tower/TowerPanel.tsx
+++ b/frontend/src/components/tower/TowerPanel.tsx
@@ -198,7 +198,7 @@ export default function TowerPanel() {
               {towerProgress.done}/{towerProgress.total} tasks ({towerProgress.progress_pct}%)
             </span>
           )}
-          {!showTerminal && !isClaudeCode && (
+          {!showTerminal && (
             <button
               className="btn btn-primary btn-sm"
               onClick={handleStart}

--- a/frontend/src/hooks/useTerminal.ts
+++ b/frontend/src/hooks/useTerminal.ts
@@ -22,7 +22,6 @@ export function useTerminal({ channel, enabled = true }: UseTerminalOptions) {
   const containerRef = useRef<HTMLDivElement | null>(null);
   const wsRef = useRef<WebSocket | null>(null);
   const reconnectRef = useRef<ReturnType<typeof setTimeout>>(undefined);
-  const cleanedUpRef = useRef(false);
 
   // Create terminal once
   useEffect(() => {
@@ -77,14 +76,19 @@ export function useTerminal({ channel, enabled = true }: UseTerminalOptions) {
     return () => window.removeEventListener("resize", handleResize);
   }, [enabled]);
 
-  // WebSocket connection for terminal channel
+  // WebSocket connection for terminal channel.
+  // Uses a local `cancelled` variable (captured in the closure) instead of a
+  // shared ref so that React StrictMode double-mount cannot cause a stale
+  // onclose handler to schedule a spurious reconnect after the new effect has
+  // already started.  This prevents the duplicate-lines bug where two
+  // WebSocket connections subscribe to the same channel simultaneously.
   useEffect(() => {
     if (!enabled || !channel) return;
 
-    cleanedUpRef.current = false;
+    let cancelled = false;
 
     function connect() {
-      if (cleanedUpRef.current) return;
+      if (cancelled) return;
       const protocol = window.location.protocol === "https:" ? "wss:" : "ws:";
       const ws = new WebSocket(`${protocol}//${window.location.host}/ws`);
       wsRef.current = ws;
@@ -107,7 +111,7 @@ export function useTerminal({ channel, enabled = true }: UseTerminalOptions) {
       };
 
       ws.onclose = () => {
-        if (!cleanedUpRef.current) {
+        if (!cancelled) {
           reconnectRef.current = setTimeout(connect, 3000);
         }
       };
@@ -118,7 +122,7 @@ export function useTerminal({ channel, enabled = true }: UseTerminalOptions) {
     connect();
 
     return () => {
-      cleanedUpRef.current = true;
+      cancelled = true;
       clearTimeout(reconnectRef.current);
       wsRef.current?.close();
       wsRef.current = null;

--- a/src/atc/tower/session.py
+++ b/src/atc/tower/session.py
@@ -112,7 +112,7 @@ async def stop_tower_session(
     if session.tmux_pane:
         await _kill_pane(session.tmux_pane)
 
-    await db_ops.update_session_status(conn, session.id, SessionStatus.IDLE.value)
+    await db_ops.update_session_status(conn, session.id, SessionStatus.DISCONNECTED.value)
 
     if event_bus:
         await event_bus.publish(
@@ -120,7 +120,7 @@ async def stop_tower_session(
             {
                 "session_id": session.id,
                 "previous_status": session.status,
-                "new_status": SessionStatus.IDLE.value,
+                "new_status": SessionStatus.DISCONNECTED.value,
             },
         )
 


### PR DESCRIPTION
## Summary
- **Tower spawns bash instead of Claude Code**: `TowerConsole.handleStart` called `/tower/goal` (starts a Leader) instead of `/tower/start` (starts Tower's own Claude Code session). Fixed to call correct endpoint for `claude_code` provider.
- **No Start button after Stop**: `TowerConsole.handleStop` called `/tower/cancel` which doesn't exist as a route (404'd silently). Fixed to call `/tower/stop`. Also reset `autoStarted` ref and dispatch idle state. Removed `!isClaudeCode` guard on TowerPanel Start button so users have a manual fallback.
- **Stale session reuse**: `stop_tower_session` set status to IDLE, so the next `start_tower_session` returned the stale session (dead pane) instead of creating a fresh one. Changed to DISCONNECTED so stale sessions are skipped.
- **Duplicate terminal lines (Leader, Ace)**: The `useTerminal` hook's `cleanedUpRef` (shared React ref) had a race condition in StrictMode: old WebSocket `onclose` fires after the new effect sets `cleanedUpRef=false`, scheduling a spurious reconnect. Replaced with a local `cancelled` closure variable that is properly scoped to each effect invocation.

## Test plan
- [ ] Start ATC with a claude_code project — Tower terminal should show Claude Code prompt, not bash
- [ ] Click Stop on Tower panel — Start button should appear
- [ ] Click Start again — new Claude Code session should spawn
- [ ] Open Leader console — no duplicate output lines
- [ ] Open Ace terminal — no duplicate output lines
- [ ] Verify TowerConsole (non-panel view) start/stop cycle works

Generated with [Claude Code](https://claude.com/claude-code)