### PR TITLE
Fix Leader and Tower auto-restart after manual Stop

### DIFF
--- a/frontend/src/components/leader/LeaderConsole.tsx
+++ b/frontend/src/components/leader/LeaderConsole.tsx
@@ -94,6 +94,7 @@ export default function LeaderConsole({
     setLoading(true);
     try {
       await api.post(`/projects/${projectId}/leader/stop`);
+      autoStarted.current = true;
       // Optimistically update leader status to idle
       if (leader) {
         const updatedLeaders = {

--- a/frontend/src/components/tower/TowerConsole.tsx
+++ b/frontend/src/components/tower/TowerConsole.tsx
@@ -96,7 +96,7 @@ export default function TowerConsole() {
     setLoading(true);
     try {
       await api.post("/tower/stop");
-      autoStarted.current = false;
+      autoStarted.current = true;
       dispatch({
         type: "SET_TOWER_DETAIL",
         payload: {


### PR DESCRIPTION
## Summary
- **TowerConsole**: `handleStop` was setting `autoStarted.current = false`, which reset the guard and caused the auto-start useEffect to immediately re-spawn the session after stopping
- **LeaderConsole**: `handleStop` was not setting `autoStarted.current` at all, leaving it vulnerable to re-triggering on component remount
- Fix: set `autoStarted.current = true` in both Stop handlers so auto-start only fires on initial mount, never after manual Stop

## Test plan
- [ ] Start a claude_code project, verify Leader auto-starts on mount
- [ ] Click Stop on Leader, confirm it stays stopped (no auto-restart)
- [ ] Start Tower, click Stop, confirm it stays stopped
- [ ] Refresh page — verify auto-start fires again on fresh mount

🤖 Generated with [Claude Code](https://claude.com/claude-code)