### PR TITLE
fix: stale tower session + auto-start race on Stop

### DIFF
--- a/frontend/src/components/leader/LeaderConsole.tsx
+++ b/frontend/src/components/leader/LeaderConsole.tsx
@@ -26,6 +26,7 @@ export default function LeaderConsole({
   const [message, setMessage] = useState("");
   const [error, setError] = useState<string | null>(null);
   const autoStarted = useRef(false);
+  const userStopped = useRef(false);
 
   const isClaudeCode = project?.agent_provider === "claude_code";
 
@@ -43,15 +44,17 @@ export default function LeaderConsole({
     enabled: (isRunning || (isClaudeCode && !!terminalChannel)) && !!terminalChannel,
   });
 
-  // Auto-start for claude_code provider when viewing a project
+  // Auto-start for claude_code provider when viewing a project.
+  // Respects userStopped ref to prevent re-starting after manual Stop.
   useEffect(() => {
-    if (isClaudeCode && isIdle && !loading && !autoStarted.current && leader) {
+    if (isClaudeCode && isIdle && !loading && !autoStarted.current && !userStopped.current && leader) {
       autoStarted.current = true;
       void handleStart();
     }
   }, [isClaudeCode, isIdle, loading, leader]); // eslint-disable-line react-hooks/exhaustive-deps
 
   async function handleStart() {
+    userStopped.current = false;
     setLoading(true);
     setError(null);
     try {
@@ -91,6 +94,9 @@ export default function LeaderConsole({
   }
 
   async function handleStop() {
+    // Set userStopped BEFORE any state changes to prevent the auto-start
+    // useEffect from firing during the async gap or re-render.
+    userStopped.current = true;
     setLoading(true);
     try {
       await api.post(`/projects/${projectId}/leader/stop`);
@@ -106,6 +112,7 @@ export default function LeaderConsole({
       await onRefresh();
     } catch (err) {
       console.error("Failed to stop leader:", err);
+      userStopped.current = false;
     } finally {
       setLoading(false);
     }

--- a/frontend/src/components/tower/TowerConsole.tsx
+++ b/frontend/src/components/tower/TowerConsole.tsx
@@ -22,6 +22,7 @@ export default function TowerConsole() {
   const [message, setMessage] = useState("");
   const messageInputRef = useRef<HTMLInputElement>(null);
   const autoStarted = useRef(false);
+  const userStopped = useRef(false);
 
   const isRunning =
     towerDetail.state === "planning" || towerDetail.state === "managing";
@@ -48,9 +49,10 @@ export default function TowerConsole() {
     if (activeProject) setProjectId(activeProject.id);
   }
 
-  // Auto-start for claude_code provider on app load
+  // Auto-start for claude_code provider on app load.
+  // Respects userStopped ref to prevent re-starting after manual Stop.
   useEffect(() => {
-    if (isClaudeCode && isIdle && !loading && !autoStarted.current && projectId) {
+    if (isClaudeCode && isIdle && !loading && !autoStarted.current && !userStopped.current && projectId) {
       autoStarted.current = true;
       void handleStart();
     }
@@ -58,6 +60,7 @@ export default function TowerConsole() {
 
   async function handleStart() {
     if (!projectId) return;
+    userStopped.current = false;
     setLoading(true);
     try {
       if (isClaudeCode) {
@@ -93,10 +96,12 @@ export default function TowerConsole() {
   }
 
   async function handleStop() {
+    // Set userStopped BEFORE any state changes to prevent the auto-start
+    // useEffect from firing during the async gap or re-render.
+    userStopped.current = true;
     setLoading(true);
     try {
       await api.post("/tower/stop");
-      autoStarted.current = true;
       dispatch({
         type: "SET_TOWER_DETAIL",
         payload: {
@@ -108,6 +113,7 @@ export default function TowerConsole() {
       });
     } catch (err) {
       console.error("Failed to stop Tower:", err);
+      userStopped.current = false;
     } finally {
       setLoading(false);
     }

--- a/frontend/src/components/tower/TowerPanel.tsx
+++ b/frontend/src/components/tower/TowerPanel.tsx
@@ -29,6 +29,7 @@ export default function TowerPanel() {
   const [starting, setStarting] = useState(false);
   const messageInputRef = useRef<HTMLInputElement>(null);
   const autoStarted = useRef(false);
+  const userStopped = useRef(false);
 
   const isRunning =
     towerDetail.state === "planning" || towerDetail.state === "managing";
@@ -63,13 +64,15 @@ export default function TowerPanel() {
     enabled: (isRunning || (isClaudeCode && !!terminalChannel)) && !!terminalChannel,
   });
 
-  // Auto-start Tower session for claude_code provider
+  // Auto-start Tower session for claude_code provider.
+  // Respects userStopped ref to prevent re-starting after manual Stop.
   useEffect(() => {
     if (
       isClaudeCode &&
       isIdle &&
       !starting &&
       !autoStarted.current &&
+      !userStopped.current &&
       resolvedProjectId
     ) {
       autoStarted.current = true;
@@ -96,6 +99,7 @@ export default function TowerPanel() {
 
   const handleStart = useCallback(async () => {
     if (!resolvedProjectId) return;
+    userStopped.current = false;
     setStarting(true);
     try {
       const res = await api.post<{ session_id?: string }>(
@@ -120,9 +124,11 @@ export default function TowerPanel() {
   }, [resolvedProjectId, dispatch]);
 
   const handleStop = useCallback(async () => {
+    // Set userStopped BEFORE any state changes to prevent the auto-start
+    // useEffect from firing during the async gap or re-render.
+    userStopped.current = true;
     try {
       await api.post("/tower/stop");
-      autoStarted.current = false;
       dispatch({
         type: "SET_TOWER_DETAIL",
         payload: {
@@ -134,6 +140,7 @@ export default function TowerPanel() {
       });
     } catch (err) {
       console.error("Failed to stop tower:", err);
+      userStopped.current = false;
     }
   }, [dispatch]);
 

--- a/src/atc/tower/session.py
+++ b/src/atc/tower/session.py
@@ -17,6 +17,7 @@ from atc.session.ace import (
     ATC_TMUX_SESSION,
     _ensure_tmux_session,
     _kill_pane,
+    _pane_is_alive,
     _send_keys,
     _spawn_pane,
 )
@@ -46,11 +47,31 @@ async def start_tower_session(
     project = await db_ops.get_project(conn, project_id)
     name = f"tower-{project.name}" if project else f"tower-{project_id[:8]}"
 
-    # Check for existing tower session
+    # Check for existing tower session — validate tmux pane is actually alive
     existing = await db_ops.list_sessions(conn, project_id=project_id, session_type="tower")
     for sess in existing:
-        if sess.status not in (SessionStatus.ERROR.value, SessionStatus.DISCONNECTED.value):
+        if sess.status in (SessionStatus.ERROR.value, SessionStatus.DISCONNECTED.value):
+            continue
+        # Verify the tmux pane is still alive; stale sessions from a previous
+        # app run may have a non-terminal DB status but a dead pane.
+        if sess.tmux_pane and await _pane_is_alive(sess.tmux_pane):
             return sess.id
+        # Pane is dead or missing — mark session as disconnected so we create fresh
+        logger.warning(
+            "Tower session %s has dead/missing tmux pane %s — discarding",
+            sess.id,
+            sess.tmux_pane,
+        )
+        await db_ops.update_session_status(conn, sess.id, SessionStatus.DISCONNECTED.value)
+        if event_bus:
+            await event_bus.publish(
+                "session_status_changed",
+                {
+                    "session_id": sess.id,
+                    "previous_status": sess.status,
+                    "new_status": SessionStatus.DISCONNECTED.value,
+                },
+            )
 
     session = await db_ops.create_session(
         conn,


### PR DESCRIPTION
## Summary
- **Backend**: `start_tower_session` now validates the tmux pane is alive (`_pane_is_alive()`) before reusing an existing session. Stale sessions from a previous app run — where the DB shows IDLE but the tmux pane is dead — are marked DISCONNECTED and a fresh Claude Code session is spawned instead.
- **Frontend**: Fixes the "Starting..." flash when clicking Stop on Tower/Leader. Replaces the fragile `autoStarted` ref pattern with a `userStopped` ref that is set **synchronously before** any async work or state dispatch in `handleStop()`. The auto-start `useEffect` checks `!userStopped.current`, which prevents it from firing during the re-render triggered by the idle state change. Applied consistently to `TowerPanel`, `TowerConsole`, and `LeaderConsole`.

## Test plan
- [ ] Start app with a stale tower session in DB (from previous run) — should spawn fresh Claude Code, not reuse dead pane
- [ ] Click Stop on Tower — should not briefly show "Starting..." before settling on "Start"
- [ ] Click Stop then manually click Start — should start normally (userStopped resets)
- [ ] Auto-start on initial app load still works for claude_code provider
- [ ] Leader Stop button has same fix — no "Starting..." flash

🤖 Generated with [Claude Code](https://claude.com/claude-code)