### PR TITLE
Remove Start/Del buttons from task cards

### DIFF
--- a/frontend/src/components/leader/TaskBoard.css
+++ b/frontend/src/components/leader/TaskBoard.css
@@ -97,12 +97,6 @@
   line-height: 1.4;
 }
 
-.task-board__card-actions {
-  display: flex;
-  gap: var(--space-1);
-  margin-top: var(--space-2);
-}
-
 /* Create form */
 .task-board__create-form {
   display: flex;
@@ -176,9 +170,4 @@
   color: var(--color-text-muted);
   display: block;
   margin-top: 2px;
-}
-
-.task-board__table-actions {
-  display: flex;
-  gap: var(--space-1);
 }

--- a/frontend/src/components/leader/TaskBoard.tsx
+++ b/frontend/src/components/leader/TaskBoard.tsx
@@ -39,33 +39,12 @@ export default function TaskBoard({
     await onRefresh();
   }, [projectId, newTitle, onRefresh]);
 
-  const handleStatusChange = useCallback(
-    async (taskGraphId: string, newStatus: string) => {
-      await api.patch(`/task-graphs/${taskGraphId}/status`, {
-        status: newStatus,
-      });
-      await onRefresh();
-    },
-    [onRefresh],
-  );
-
-  const handleDelete = useCallback(
-    async (taskGraphId: string) => {
-      await api.delete(`/task-graphs/${taskGraphId}`);
-      await onRefresh();
-    },
-    [onRefresh],
-  );
-
   return (
     <div className="task-board" data-testid="task-board">
       <div className="task-board__header">
         <h3>Tasks</h3>
         <div className="task-board__controls">
-          <div
-            className="task-board__view-toggle"
-            data-testid="view-toggle"
-          >
+          <div className="task-board__view-toggle" data-testid="view-toggle">
             <button
               className={`btn btn-sm ${viewMode === "kanban" ? "btn-primary" : ""}`}
               onClick={() => setViewMode("kanban")}
@@ -130,17 +109,9 @@ export default function TaskBoard({
       {taskGraphs.length === 0 && !creating ? (
         <p className="task-board__empty">No tasks yet.</p>
       ) : viewMode === "kanban" ? (
-        <KanbanView
-          taskGraphs={taskGraphs}
-          onStatusChange={handleStatusChange}
-          onDelete={handleDelete}
-        />
+        <KanbanView taskGraphs={taskGraphs} />
       ) : (
-        <TableView
-          taskGraphs={taskGraphs}
-          onStatusChange={handleStatusChange}
-          onDelete={handleDelete}
-        />
+        <TableView taskGraphs={taskGraphs} />
       )}
     </div>
   );
@@ -152,11 +123,9 @@ export default function TaskBoard({
 
 interface ViewProps {
   taskGraphs: TaskGraph[];
-  onStatusChange: (id: string, status: string) => Promise<void>;
-  onDelete: (id: string) => Promise<void>;
 }
 
-function KanbanView({ taskGraphs, onStatusChange, onDelete }: ViewProps) {
+function KanbanView({ taskGraphs }: ViewProps) {
   return (
     <div className="task-board__grid" data-testid="kanban-view">
       {COLUMNS.map((col) => {
@@ -168,12 +137,7 @@ function KanbanView({ taskGraphs, onStatusChange, onDelete }: ViewProps) {
               <span className="task-board__col-count">{colTasks.length}</span>
             </h4>
             {colTasks.map((task) => (
-              <TaskCard
-                key={task.id}
-                task={task}
-                onStatusChange={onStatusChange}
-                onDelete={onDelete}
-              />
+              <TaskCard key={task.id} task={task} />
             ))}
           </div>
         );
@@ -186,7 +150,7 @@ function KanbanView({ taskGraphs, onStatusChange, onDelete }: ViewProps) {
 // Table View
 // ---------------------------------------------------------------------------
 
-function TableView({ taskGraphs, onStatusChange, onDelete }: ViewProps) {
+function TableView({ taskGraphs }: ViewProps) {
   return (
     <div className="task-board__table-wrap" data-testid="table-view">
       <table className="task-board__table">
@@ -195,7 +159,6 @@ function TableView({ taskGraphs, onStatusChange, onDelete }: ViewProps) {
             <th>Title</th>
             <th>Status</th>
             <th>Assignee</th>
-            <th>Actions</th>
           </tr>
         </thead>
         <tbody>
@@ -221,40 +184,6 @@ function TableView({ taskGraphs, onStatusChange, onDelete }: ViewProps) {
                   <span className="task-board__unassigned">—</span>
                 )}
               </td>
-              <td>
-                <div className="task-board__table-actions">
-                  {task.status !== "in_progress" && (
-                    <button
-                      className="btn btn-sm"
-                      onClick={() => void onStatusChange(task.id, "in_progress")}
-                    >
-                      Start
-                    </button>
-                  )}
-                  {task.status !== "done" && (
-                    <button
-                      className="btn btn-sm"
-                      onClick={() => void onStatusChange(task.id, "done")}
-                    >
-                      Done
-                    </button>
-                  )}
-                  {task.status === "done" && (
-                    <button
-                      className="btn btn-sm"
-                      onClick={() => void onStatusChange(task.id, "todo")}
-                    >
-                      Reopen
-                    </button>
-                  )}
-                  <button
-                    className="btn btn-sm btn-danger"
-                    onClick={() => void onDelete(task.id)}
-                  >
-                    Del
-                  </button>
-                </div>
-              </td>
             </tr>
           ))}
         </tbody>
@@ -267,13 +196,7 @@ function TableView({ taskGraphs, onStatusChange, onDelete }: ViewProps) {
 // Task Card (Kanban)
 // ---------------------------------------------------------------------------
 
-interface TaskCardProps {
-  task: TaskGraph;
-  onStatusChange: (id: string, status: string) => Promise<void>;
-  onDelete: (id: string) => Promise<void>;
-}
-
-function TaskCard({ task, onStatusChange, onDelete }: TaskCardProps) {
+function TaskCard({ task }: { task: TaskGraph }) {
   return (
     <div className="task-board__card" data-testid="task-card">
       <div className="task-board__card-title">{task.title}</div>
@@ -292,38 +215,6 @@ function TaskCard({ task, onStatusChange, onDelete }: TaskCardProps) {
             : task.description}
         </p>
       )}
-      <div className="task-board__card-actions">
-        {task.status === "todo" && (
-          <button
-            className="btn btn-sm"
-            onClick={() => void onStatusChange(task.id, "in_progress")}
-          >
-            Start
-          </button>
-        )}
-        {task.status === "in_progress" && (
-          <button
-            className="btn btn-sm"
-            onClick={() => void onStatusChange(task.id, "done")}
-          >
-            Done
-          </button>
-        )}
-        {task.status === "done" && (
-          <button
-            className="btn btn-sm"
-            onClick={() => void onStatusChange(task.id, "todo")}
-          >
-            Reopen
-          </button>
-        )}
-        <button
-          className="btn btn-sm btn-danger"
-          onClick={() => void onDelete(task.id)}
-        >
-          Del
-        </button>
-      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Remove all action buttons (Start, Done, Reopen, Del) from kanban task cards and table view rows
- Task lifecycle is managed by the Leader and Aces via the API — the kanban board is a read-only view
- Keep the `+ Add` button so users can still create tasks for the Leader to work on
- Clean up unused CSS rules (`.task-board__card-actions`, `.task-board__table-actions`) and dead code (`handleStatusChange`, `handleDelete`, `ViewProps` callback props)

## Test plan
- [ ] Verify kanban cards no longer show Start/Done/Reopen/Del buttons
- [ ] Verify table view rows no longer show the Actions column
- [ ] Verify the `+ Add` button still works to create new tasks
- [ ] Verify tasks still display title, status badge, assignee, and description correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)