### PR TITLE
fix: Tower Send button fires REST API instead of silent WebSocket

### DIFF
--- a/frontend/src/components/tower/TowerConsole.css
+++ b/frontend/src/components/tower/TowerConsole.css
@@ -79,6 +79,13 @@
   border-color: var(--color-accent);
 }
 
+.tower-console__send-error {
+  color: var(--color-status-red);
+  font-weight: bold;
+  font-size: var(--text-sm);
+  cursor: help;
+}
+
 .tower-console__error {
   padding: var(--space-3);
   font-size: var(--text-sm);

--- a/frontend/src/components/tower/TowerConsole.tsx
+++ b/frontend/src/components/tower/TowerConsole.tsx
@@ -39,7 +39,7 @@ export default function TowerConsole() {
     ? `terminal:${towerDetail.current_session_id}`
     : undefined;
 
-  const { attachRef, sendInput } = useTerminal({
+  const { attachRef } = useTerminal({
     channel: terminalChannel,
     enabled: (isRunning || (isClaudeCode && !!terminalChannel)) && !!terminalChannel,
   });
@@ -127,12 +127,22 @@ export default function TowerConsole() {
     }
   }
 
-  function handleSendMessage(e: React.FormEvent) {
+  const [sendError, setSendError] = useState<string | null>(null);
+
+  async function handleSendMessage(e: React.FormEvent) {
     e.preventDefault();
     if (!message.trim()) return;
-    sendInput(message.trim());
+    const text = message.trim();
     setMessage("");
+    setSendError(null);
     messageInputRef.current?.focus();
+    try {
+      await api.post("/tower/message", { message: text });
+    } catch (err) {
+      console.error("Failed to send message to Tower:", err);
+      setSendError("Failed to send message");
+      setMessage(text);
+    }
   }
 
   const statusLabel = brainStatus.status ?? towerDetail.state;
@@ -277,6 +287,11 @@ export default function TowerConsole() {
             >
               Send
             </button>
+            {sendError && (
+              <span className="tower-console__send-error" title={sendError}>
+                !
+              </span>
+            )}
           </form>
         </>
       )}

--- a/frontend/src/components/tower/TowerPanel.css
+++ b/frontend/src/components/tower/TowerPanel.css
@@ -141,6 +141,13 @@
   opacity: 0.6;
 }
 
+.tower-panel__send-error {
+  color: var(--color-status-red);
+  font-weight: bold;
+  font-size: var(--text-sm);
+  cursor: help;
+}
+
 /* Progress indicator in the bar */
 .tower-panel__progress {
   font-size: var(--text-xs);

--- a/frontend/src/components/tower/TowerPanel.tsx
+++ b/frontend/src/components/tower/TowerPanel.tsx
@@ -59,7 +59,7 @@ export default function TowerPanel() {
     ? `terminal:${towerDetail.current_session_id}`
     : undefined;
 
-  const { attachRef, fit, sendInput } = useTerminal({
+  const { attachRef, fit } = useTerminal({
     channel: terminalChannel,
     enabled: (isRunning || (isClaudeCode && !!terminalChannel)) && !!terminalChannel,
   });
@@ -144,15 +144,26 @@ export default function TowerPanel() {
     }
   }, [dispatch]);
 
+  const [sendError, setSendError] = useState<string | null>(null);
+
   const handleSendMessage = useCallback(
-    (e: React.FormEvent) => {
+    async (e: React.FormEvent) => {
       e.preventDefault();
       if (!message.trim()) return;
-      sendInput(message.trim());
+      const text = message.trim();
       setMessage("");
+      setSendError(null);
       messageInputRef.current?.focus();
+      try {
+        await api.post("/tower/message", { message: text });
+      } catch (err) {
+        console.error("Failed to send message to Tower:", err);
+        setSendError("Failed to send message");
+        // Restore message so user can retry
+        setMessage(text);
+      }
     },
-    [message, sendInput],
+    [message],
   );
 
   const tickerText =
@@ -286,6 +297,11 @@ export default function TowerPanel() {
             >
               Send
             </button>
+            {sendError && (
+              <span className="tower-panel__send-error" title={sendError}>
+                !
+              </span>
+            )}
           </form>
         )}
       </div>

--- a/src/atc/api/routers/tower.py
+++ b/src/atc/api/routers/tower.py
@@ -176,6 +176,17 @@ async def send_message(body: MessageRequest, request: Request) -> dict[str, str]
     return {"status": "sent"}
 
 
+@router.post("/complete")
+async def mark_complete(request: Request) -> dict[str, str]:
+    """Mark the current Tower goal as complete."""
+    tower = _get_tower(request)
+    try:
+        await tower.mark_complete()
+    except Exception as exc:
+        raise HTTPException(status_code=409, detail=str(exc)) from exc
+    return {"status": "complete"}
+
+
 @router.get("/progress", response_model=TowerProgressResponse)
 async def get_progress(request: Request) -> TowerProgressResponse:
     """Get the current Leader's task graph progress."""


### PR DESCRIPTION
## Summary
- Tower Send button used sendInput() from the useTerminal hook which sends via WebSocket -- silently failed when WS was not connected or when the backend PTY pool had no reader for the session (no error, no feedback, no visible network request)
- Switch handleSendMessage in both TowerPanel and TowerConsole to use api.post('/tower/message', ...) which goes through the Tower controller proper session lookup and tmux send-keys
- Add error feedback (inline indicator + console.error) so failures are visible to the user
- Add missing POST /tower/complete endpoint that TowerConsole was already calling but did not exist in the router

## Testing Done
- All 175 frontend tests pass (npx vitest run)
- TypeScript compiles cleanly (npx tsc --noEmit)
- All 333 backend tests pass (1 pre-existing failure in test_e2e_wiring unrelated to this change)
- Verified the /tower/message REST endpoint exists and correctly calls tower.send_message() -> send_tower_message() -> _send_keys(pane, message)