### PR TITLE
fix: guard WebSocket callbacks against StrictMode double-mount

### DIFF
--- a/frontend/src/hooks/useTerminal.ts
+++ b/frontend/src/hooks/useTerminal.ts
@@ -77,11 +77,10 @@ export function useTerminal({ channel, enabled = true }: UseTerminalOptions) {
   }, [enabled]);
 
   // WebSocket connection for terminal channel.
-  // Uses a local `cancelled` variable (captured in the closure) instead of a
-  // shared ref so that React StrictMode double-mount cannot cause a stale
-  // onclose handler to schedule a spurious reconnect after the new effect has
-  // already started.  This prevents the duplicate-lines bug where two
-  // WebSocket connections subscribe to the same channel simultaneously.
+  // The `cancelled` flag gates every callback so that React StrictMode
+  // double-mount cannot cause two live subscriptions.  Without these guards
+  // the first WebSocket's `onopen` can fire (and subscribe) before the
+  // cleanup's `ws.close()` takes effect, leading to duplicate lines.
   useEffect(() => {
     if (!enabled || !channel) return;
 
@@ -94,10 +93,15 @@ export function useTerminal({ channel, enabled = true }: UseTerminalOptions) {
       wsRef.current = ws;
 
       ws.onopen = () => {
+        if (cancelled) {
+          ws.close();
+          return;
+        }
         ws.send(JSON.stringify({ channel: "subscribe", data: [channel] }));
       };
 
       ws.onmessage = (evt) => {
+        if (cancelled) return;
         try {
           const msg = JSON.parse(evt.data);
           if (msg.channel === channel && msg.data) {


### PR DESCRIPTION
## Summary
- Adds `cancelled` flag checks to `onopen` and `onmessage` WebSocket callbacks in `useTerminal` hook
- Previously only `connect()` and `onclose` checked the flag, allowing a race where the first WebSocket could subscribe and write output before cleanup's `close()` took effect
- Fixes duplicate terminal lines in Leader console, Tower panel, and Ace terminals

## Root cause
React 18 StrictMode double-mounts effects in dev. The cleanup sets `cancelled=true` and calls `ws.close()`, but WebSocket close is async. The first connection's `onopen` fires before close completes, subscribes to the channel, and both connections write identical PTY output to the terminal.

## Test plan
- [x] All 175 frontend tests pass
- [x] TypeScript compiles cleanly
- [ ] Manual: verify Leader/Tower terminals show each line once (not duplicated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)