### PR TITLE
feat: define identity roles for Tower, Leader, and Ace

### DIFF
--- a/src/atc/agents/deploy.py
+++ b/src/atc/agents/deploy.py
@@ -84,6 +84,20 @@ class ManagerDeploySpec:
     budget_ceiling_usd: float | None = None
 
 
+@dataclass
+class TowerDeploySpec:
+    """Everything needed to deploy a Tower session's config files."""
+
+    session_id: str
+    project_name: str
+    project_id: str
+    repo_path: str | None = None
+    github_repo: str | None = None
+    api_base_url: str = "http://127.0.0.1:8420"
+    model: str = "opus"
+    allowed_commands: list[str] = field(default_factory=list)
+
+
 # ---------------------------------------------------------------------------
 # Public API
 # ---------------------------------------------------------------------------
@@ -173,6 +187,48 @@ def deploy_manager_files(
     return DeployedFiles(root=root, files=written)
 
 
+def deploy_tower_files(
+    spec: TowerDeploySpec,
+    *,
+    staging_root: Path | None = None,
+) -> DeployedFiles:
+    """Write CLAUDE.md, .claude/settings.json, and hooks for a Tower session.
+
+    Args:
+        spec: Deployment specification for the Tower.
+        staging_root: Override the staging root directory (default: /tmp/atc-agents).
+
+    Returns:
+        DeployedFiles with the root directory and list of all written file paths.
+    """
+    root = (staging_root or _DEFAULT_STAGING_ROOT) / spec.session_id
+    written: list[str] = []
+
+    # CLAUDE.md
+    claude_md = _build_tower_claude_md(spec)
+    written.append(_write_file(root / "CLAUDE.md", claude_md))
+
+    # .claude/settings.json
+    settings = _build_settings(
+        model=spec.model,
+        allowed_commands=_tower_allowed_commands(spec),
+        hooks=_tower_hooks(spec),
+    )
+    written.append(_write_file(root / ".claude" / "settings.json", json.dumps(settings, indent=2)))
+
+    # Hook scripts
+    for hook in _tower_hook_scripts(spec):
+        path = root / ".claude" / "hooks" / f"{hook.event}.sh"
+        written.append(_write_executable(path, hook.command))
+
+    # Manifest
+    manifest = {"session_id": spec.session_id, "session_type": "tower", "files": written}
+    written.append(_write_file(root / ".manifest.json", json.dumps(manifest, indent=2)))
+
+    logger.info("Deployed tower files for %s → %s (%d files)", spec.session_id, root, len(written))
+    return DeployedFiles(root=root, files=written)
+
+
 def cleanup_deployed_files(root: Path) -> None:
     """Remove all files listed in a deployment manifest, then the directory tree.
 
@@ -207,6 +263,23 @@ def _build_ace_claude_md(spec: AceDeploySpec) -> str:
         f"# {spec.project_name} — Ace Session",
         "",
         f"Session ID: `{spec.session_id}`",
+        "",
+        "## Role",
+        "",
+        "You are an **Ace** — an expert developer in the ATC agent hierarchy.",
+        "You receive a single task from your Leader and own it end-to-end:",
+        "",
+        "- **Design** the solution before writing code.",
+        "- **Implement** clean, production-quality code that follows project conventions.",
+        "- **Write tests** that cover the critical paths and edge cases.",
+        "- **Run tests** and fix failures — do not move on until all tests pass.",
+        "- **Self-review** your diff for bugs, security issues, and style.",
+        "- **Iterate** until the code is solid and CI-ready.",
+        "- **Create a PR** with a clear description: what, why, how tested.",
+        "",
+        "Never move on to the next step until the current one is done right.",
+        "Never ask the Leader for help you can figure out yourself.",
+        "When blocked on something outside your control, report it immediately.",
         "",
         "## Task",
         "",
@@ -262,6 +335,22 @@ def _build_manager_claude_md(spec: ManagerDeploySpec) -> str:
         "",
         f"Leader ID: `{spec.leader_id}`",
         "",
+        "## Role",
+        "",
+        "You are a **Leader** — a project manager in the ATC agent hierarchy.",
+        "You receive a goal from Tower and are responsible for delivering it:",
+        "",
+        "- **Plan** — decompose the goal into well-scoped tasks with acceptance criteria.",
+        "- **Create Aces** — spin up Ace sessions and assign one task each.",
+        "- **Monitor** — track Ace progress, unblock them, reassign if needed.",
+        "- **Review** — inspect Ace output to ensure quality before marking done.",
+        "- **Coordinate** — manage dependencies between tasks so Aces don't conflict.",
+        "- **Report** — keep Tower informed of milestone progress and blockers.",
+        "",
+        "You never write code directly — always delegate implementation to Aces.",
+        "You own the task graph: create it, maintain it, and drive it to completion.",
+        "When all tasks are done and verified, report completion to Tower.",
+        "",
         "## Goal",
         "",
         spec.goal,
@@ -312,6 +401,44 @@ def _build_manager_claude_md(spec: ManagerDeploySpec) -> str:
             "",
         ]
     )
+
+    if spec.github_repo:
+        lines.extend(
+            [
+                "## Repository",
+                "",
+                f"GitHub: `{spec.github_repo}`",
+                "",
+            ]
+        )
+
+    return "\n".join(lines)
+
+
+def _build_tower_claude_md(spec: TowerDeploySpec) -> str:
+    """Build the CLAUDE.md content for a Tower session."""
+    lines = [
+        f"# {spec.project_name} — Tower Session",
+        "",
+        f"Session ID: `{spec.session_id}`",
+        f"Project ID: `{spec.project_id}`",
+        "",
+        "## Role",
+        "",
+        "You are **Tower** — the top-level orchestrator in the ATC agent hierarchy.",
+        "You talk directly to the user, understand their vision, and turn it into action:",
+        "",
+        "- **Listen** — understand the user's goal and ask clarifying questions when needed.",
+        "- **Plan** — break the goal into projects and high-level milestones.",
+        "- **Delegate** — spin up Leaders and provide them with goals and context.",
+        "- **Monitor** — track Leader progress and intervene when off track.",
+        "- **Communicate** — keep the user informed and ask for decisions.",
+        "",
+        "You never write code directly — always delegate through Leaders.",
+        "You never manage individual tasks — that is the Leader's job.",
+        "You are the single point of contact between the user and the agent hierarchy.",
+        "",
+    ]
 
     if spec.github_repo:
         lines.extend(
@@ -424,6 +551,25 @@ def _manager_hooks(spec: ManagerDeploySpec) -> dict[str, list[dict[str, Any]]]:
     return _hooks_dict(hooks_dir)
 
 
+def _tower_hook_scripts(spec: TowerDeploySpec) -> list[HookConfig]:
+    """Build the hook shell scripts for a Tower session."""
+    header = _STATUS_HOOK_TEMPLATE.format(
+        api_base_url=spec.api_base_url,
+        session_id=spec.session_id,
+    )
+    return [
+        HookConfig(event="PostToolUse", command=header + _POST_TOOL_USE_BODY),
+        HookConfig(event="Stop", command=header + _STOP_HOOK_BODY),
+        HookConfig(event="Notification", command=header + _NOTIFICATION_HOOK_BODY),
+    ]
+
+
+def _tower_hooks(spec: TowerDeploySpec) -> dict[str, list[dict[str, Any]]]:
+    """Build the hooks section for .claude/settings.json (Tower)."""
+    hooks_dir = f"/tmp/atc-agents/{spec.session_id}/.claude/hooks"
+    return _hooks_dict(hooks_dir)
+
+
 def _hooks_dict(hooks_dir: str) -> dict[str, list[dict[str, Any]]]:
     """Build a hooks dict pointing to shell scripts in the given directory.
 
@@ -484,6 +630,14 @@ def _ace_allowed_commands(spec: AceDeploySpec) -> list[str]:
 
 def _manager_allowed_commands(spec: ManagerDeploySpec) -> list[str]:
     """Build the allowed commands list for a Manager."""
+    commands = list(_BASE_ALLOWED_COMMANDS)
+    commands.append("Bash(atc tower *)")
+    commands.extend(spec.allowed_commands)
+    return commands
+
+
+def _tower_allowed_commands(spec: TowerDeploySpec) -> list[str]:
+    """Build the allowed commands list for a Tower."""
     commands = list(_BASE_ALLOWED_COMMANDS)
     commands.append("Bash(atc tower *)")
     commands.extend(spec.allowed_commands)

--- a/src/atc/tower/session.py
+++ b/src/atc/tower/session.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING
 
+from atc.agents.deploy import TowerDeploySpec, deploy_tower_files
 from atc.agents.factory import get_launch_command
 from atc.session.ace import (
     ATC_TMUX_SESSION,
@@ -91,6 +92,21 @@ async def start_tower_session(
         provider = project.agent_provider if project else "claude_code"
         launch_cmd = get_launch_command(provider)
         working_dir = project.repo_path if project and project.repo_path else None
+
+        # Deploy config files (CLAUDE.md, hooks, settings.json) before launch
+        spec = TowerDeploySpec(
+            session_id=session.id,
+            project_name=project.name if project else "",
+            project_id=project_id,
+            repo_path=working_dir,
+            github_repo=project.github_repo if project else None,
+        )
+        deployed = deploy_tower_files(spec)
+        logger.info("Deployed tower config for %s → %s", session.id, deployed.root)
+
+        # Use repo path if available, otherwise the deployed config directory
+        if not working_dir:
+            working_dir = str(deployed.root)
 
         await _ensure_tmux_session(ATC_TMUX_SESSION)
         pane_id = await _spawn_pane(

--- a/tests/unit/test_deploy.py
+++ b/tests/unit/test_deploy.py
@@ -15,9 +15,11 @@ from atc.agents.deploy import (
     AceDeploySpec,
     DeployedFiles,
     ManagerDeploySpec,
+    TowerDeploySpec,
     cleanup_deployed_files,
     deploy_ace_files,
     deploy_manager_files,
+    deploy_tower_files,
 )
 
 
@@ -82,6 +84,17 @@ class TestDeployAceFiles:
         assert "ace-001" in content
         assert "Implement login page" in content
         assert "OAuth login" in content
+
+    def test_claude_md_includes_role_identity(
+        self, ace_spec: AceDeploySpec, staging_root: Path
+    ) -> None:
+        result = deploy_ace_files(ace_spec, staging_root=staging_root)
+        content = result.claude_md_path.read_text()
+        assert "## Role" in content
+        assert "Ace" in content
+        assert "expert developer" in content
+        assert "Create a PR" in content
+        assert "Run tests" in content
 
     def test_claude_md_includes_constraints(
         self, ace_spec: AceDeploySpec, staging_root: Path
@@ -246,6 +259,17 @@ class TestDeployManagerFiles:
         assert "leader-bravo" in content
         assert "Ship the MVP" in content
 
+    def test_claude_md_includes_role_identity(
+        self, manager_spec: ManagerDeploySpec, staging_root: Path
+    ) -> None:
+        result = deploy_manager_files(manager_spec, staging_root=staging_root)
+        content = result.claude_md_path.read_text()
+        assert "## Role" in content
+        assert "Leader" in content
+        assert "project manager" in content
+        assert "never write code directly" in content
+        assert "Create Aces" in content
+
     def test_claude_md_includes_budget(
         self, manager_spec: ManagerDeploySpec, staging_root: Path
     ) -> None:
@@ -312,6 +336,88 @@ class TestDeployManagerFiles:
         result = deploy_manager_files(spec, staging_root=staging_root)
         content = result.claude_md_path.read_text()
         assert "Budget" not in content
+
+
+# ---------------------------------------------------------------------------
+# Tower deployment
+# ---------------------------------------------------------------------------
+
+
+class TestDeployTowerFiles:
+    @pytest.fixture
+    def tower_spec(self) -> TowerDeploySpec:
+        return TowerDeploySpec(
+            session_id="tower-001",
+            project_name="Phoenix",
+            project_id="proj-abc",
+            repo_path="/home/user/phoenix",
+            github_repo="acme/phoenix",
+        )
+
+    def test_returns_deployed_files(self, tower_spec: TowerDeploySpec, staging_root: Path) -> None:
+        result = deploy_tower_files(tower_spec, staging_root=staging_root)
+        assert isinstance(result, DeployedFiles)
+        assert result.root == staging_root / "tower-001"
+
+    def test_creates_claude_md(self, tower_spec: TowerDeploySpec, staging_root: Path) -> None:
+        result = deploy_tower_files(tower_spec, staging_root=staging_root)
+        assert result.claude_md_path.exists()
+        content = result.claude_md_path.read_text()
+        assert "Phoenix — Tower Session" in content
+        assert "tower-001" in content
+
+    def test_claude_md_includes_role_identity(
+        self, tower_spec: TowerDeploySpec, staging_root: Path
+    ) -> None:
+        result = deploy_tower_files(tower_spec, staging_root=staging_root)
+        content = result.claude_md_path.read_text()
+        assert "## Role" in content
+        assert "Tower" in content
+        assert "top-level orchestrator" in content
+        assert "never write code directly" in content
+        assert "Delegate" in content
+
+    def test_claude_md_includes_github_repo(
+        self, tower_spec: TowerDeploySpec, staging_root: Path
+    ) -> None:
+        result = deploy_tower_files(tower_spec, staging_root=staging_root)
+        content = result.claude_md_path.read_text()
+        assert "acme/phoenix" in content
+
+    def test_no_github_repo_omits_section(self, staging_root: Path) -> None:
+        spec = TowerDeploySpec(
+            session_id="tower-002",
+            project_name="Test",
+            project_id="proj-x",
+        )
+        result = deploy_tower_files(spec, staging_root=staging_root)
+        content = result.claude_md_path.read_text()
+        assert "Repository" not in content
+
+    def test_creates_settings_json(
+        self, tower_spec: TowerDeploySpec, staging_root: Path
+    ) -> None:
+        result = deploy_tower_files(tower_spec, staging_root=staging_root)
+        assert result.settings_path.exists()
+        settings = json.loads(result.settings_path.read_text())
+        assert settings["model"] == "opus"
+        assert "Bash(atc tower *)" in settings["permissions"]["allow"]
+
+    def test_creates_hook_scripts(
+        self, tower_spec: TowerDeploySpec, staging_root: Path
+    ) -> None:
+        result = deploy_tower_files(tower_spec, staging_root=staging_root)
+        hooks_dir = result.root / ".claude" / "hooks"
+        assert (hooks_dir / "PostToolUse.sh").exists()
+        assert (hooks_dir / "Stop.sh").exists()
+        assert (hooks_dir / "Notification.sh").exists()
+
+    def test_manifest_session_type_is_tower(
+        self, tower_spec: TowerDeploySpec, staging_root: Path
+    ) -> None:
+        result = deploy_tower_files(tower_spec, staging_root=staging_root)
+        manifest = json.loads(result.manifest_path.read_text())
+        assert manifest["session_type"] == "tower"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Add role identity sections to Ace and Leader CLAUDE.md templates, defining each agent's responsibilities and behavioral expectations
- Create new `TowerDeploySpec` and `deploy_tower_files()` so Tower sessions get CLAUDE.md, settings.json, and hooks — matching the pattern already used by Leader and Ace
- Update `start_tower_session()` to deploy config files before launching the tmux pane

## Role Definitions
- **Ace**: Expert developer — designs, implements, writes tests, self-reviews, iterates, creates PRs
- **Leader**: Project manager — plans tasks, creates Aces, monitors progress, reviews output, coordinates dependencies
- **Tower**: Top-level orchestrator — listens to user, delegates to Leaders, monitors milestones, communicates status

## Test plan
- [x] All 44 deploy unit tests pass (including 11 new tests for role identity + Tower deployment)
- [x] Full test suite: 632 passed, 3 pre-existing failures (unrelated task graph transition issues)
- [x] Ruff linting clean on all changed files
