### PR TITLE
fix: Tower identity not applied — use staging dir as working_dir

### DIFF
--- a/src/atc/agents/deploy.py
+++ b/src/atc/agents/deploy.py
@@ -440,15 +440,14 @@ def _build_tower_claude_md(spec: TowerDeploySpec) -> str:
         "",
     ]
 
-    if spec.github_repo:
-        lines.extend(
-            [
-                "## Repository",
-                "",
-                f"GitHub: `{spec.github_repo}`",
-                "",
-            ]
-        )
+    if spec.repo_path or spec.github_repo:
+        lines.append("## Repository")
+        lines.append("")
+        if spec.repo_path:
+            lines.append(f"Local path: `{spec.repo_path}`")
+        if spec.github_repo:
+            lines.append(f"GitHub: `{spec.github_repo}`")
+        lines.append("")
 
     return "\n".join(lines)
 

--- a/src/atc/cli/tower.py
+++ b/src/atc/cli/tower.py
@@ -30,15 +30,6 @@ def register(subparsers: argparse._SubParsersAction) -> None:  # type: ignore[ty
     )
     status_parser.set_defaults(handler=_handle_status)
 
-    # atc tower goal <project_id> <goal>
-    goal_parser = tower_sub.add_parser("goal", help="Submit a goal to the Tower")
-    goal_parser.add_argument("project_id", help="Project UUID")
-    goal_parser.add_argument("goal", help="Goal description")
-    goal_parser.add_argument(
-        "--api", default=_DEFAULT_API, help="ATC API base URL",
-    )
-    goal_parser.set_defaults(handler=_handle_goal)
-
     # atc tower cancel
     cancel_parser = tower_sub.add_parser("cancel", help="Cancel the current goal")
     cancel_parser.add_argument(
@@ -97,12 +88,6 @@ def _post_json(url: str, payload: dict) -> int:
 def _handle_status(args: argparse.Namespace) -> int:
     return _get_json(f"{args.api}/api/tower/status")
 
-
-def _handle_goal(args: argparse.Namespace) -> int:
-    return _post_json(
-        f"{args.api}/api/tower/goal",
-        {"project_id": args.project_id, "goal": args.goal},
-    )
 
 
 def _handle_cancel(args: argparse.Namespace) -> int:

--- a/src/atc/tower/session.py
+++ b/src/atc/tower/session.py
@@ -104,9 +104,11 @@ async def start_tower_session(
         deployed = deploy_tower_files(spec)
         logger.info("Deployed tower config for %s → %s", session.id, deployed.root)
 
-        # Use repo path if available, otherwise the deployed config directory
-        if not working_dir:
-            working_dir = str(deployed.root)
+        # Always use the staging directory so Claude Code finds the deployed
+        # CLAUDE.md (Tower identity) and .claude/settings.json (hooks, model).
+        # Tower never writes code directly — it delegates through Leaders —
+        # so it doesn't need to start in the repo directory.
+        working_dir = str(deployed.root)
 
         await _ensure_tmux_session(ATC_TMUX_SESSION)
         pane_id = await _spawn_pane(

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -199,21 +199,6 @@ class TestTowerStatus:
 
 
 # ---------------------------------------------------------------------------
-# atc tower goal
-# ---------------------------------------------------------------------------
-
-
-class TestTowerGoal:
-    def test_submits_goal(self, api_stub: str) -> None:
-        rc = cli(["tower", "goal", "proj-1", "Build the MVP", "--api", api_stub])
-        assert rc == 0
-        req = _StubHandler.requests[0]
-        assert req["method"] == "POST"
-        assert req["path"] == "/api/tower/goal"
-        assert req["body"] == {"project_id": "proj-1", "goal": "Build the MVP"}
-
-
-# ---------------------------------------------------------------------------
 # atc tower cancel
 # ---------------------------------------------------------------------------
 

--- a/tests/unit/test_deploy.py
+++ b/tests/unit/test_deploy.py
@@ -384,7 +384,14 @@ class TestDeployTowerFiles:
         content = result.claude_md_path.read_text()
         assert "acme/phoenix" in content
 
-    def test_no_github_repo_omits_section(self, staging_root: Path) -> None:
+    def test_claude_md_includes_repo_path(
+        self, tower_spec: TowerDeploySpec, staging_root: Path
+    ) -> None:
+        result = deploy_tower_files(tower_spec, staging_root=staging_root)
+        content = result.claude_md_path.read_text()
+        assert "/home/user/phoenix" in content
+
+    def test_no_repo_info_omits_section(self, staging_root: Path) -> None:
         spec = TowerDeploySpec(
             session_id="tower-002",
             project_name="Test",


### PR DESCRIPTION
## Summary

- **Tower identity fix**: Tower's CLAUDE.md and `.claude/settings.json` were deployed to `/tmp/atc-agents/{session_id}/` but the tmux pane launched in `repo_path`, so Claude Code never found the deployed Tower identity, hooks, or settings. Tower would read the repo's generic CLAUDE.md and respond as a generic agent instead of as Tower.
  - Fix: Always use the staging directory as the working dir for Tower sessions. Tower never writes code — it delegates through Leaders — so it doesn't need to start in the repo. The repo path is now included in the CLAUDE.md so Tower knows where the code lives.
- **Remove `atc tower goal` CLI subcommand**: Leaders seeing this command in their allowed commands would try to set goals instead of focusing on task decomposition and ace management.
- **New test**: Verifies `repo_path` is included in the Tower's deployed CLAUDE.md.

## Root cause

In `session.py`, the Tower session preferred `repo_path` over `deployed.root` as the working directory:
```python
# Before (broken)
if not working_dir:
    working_dir = str(deployed.root)

# After (fixed)
working_dir = str(deployed.root)
```

## Test plan

- [x] All 45 deploy tests pass (including new `test_claude_md_includes_repo_path`)
- [x] All 33 tower controller tests pass
- [x] All 16 CLI tests pass (goal test removed)
- [x] Linting (`ruff check`) passes
- [x] Pre-existing mypy/e2e failures confirmed unrelated

## Note: Leader duplicate lines

Exhaustive static analysis of the Leader terminal output pipeline (PTY reader → event bus → WsHub → WebSocket → xterm.js) did not reveal a definitive root cause. All paths appear correct: single PTY reader, single WebSocket subscription, cancelled guards intact. Needs runtime debugging with logging to identify where duplication occurs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)