### PR TITLE
fix: kill stale Tower panes on reconnect to ensure fresh identity

### DIFF
--- a/src/atc/session/ace.py
+++ b/src/atc/session/ace.py
@@ -96,6 +96,12 @@ async def _spawn_pane(
         args.extend(["-c", working_dir])
     if command:
         args.extend([command])
+    logger.warning(
+        "=== SPAWN_PANE DEBUG ===\n  tmux args: %s\n  working_dir: %s\n  command: %s",
+        args,
+        working_dir,
+        command,
+    )
     pane_id = await _tmux_run(*args)
     return pane_id
 

--- a/src/atc/session/reconnect.py
+++ b/src/atc/session/reconnect.py
@@ -8,6 +8,7 @@ the TUI is ready (alternate_on == False).
 from __future__ import annotations
 
 import logging
+import os
 from typing import TYPE_CHECKING
 
 from atc.agents.deploy import TowerDeploySpec, deploy_tower_files
@@ -15,6 +16,7 @@ from atc.agents.factory import get_launch_command
 from atc.session.ace import (
     ATC_TMUX_SESSION,
     _ensure_tmux_session,
+    _kill_pane,
     _pane_is_alive,
     _spawn_pane,
 )
@@ -58,23 +60,39 @@ async def reconnect_session(
 
     # Check if pane is still alive
     if session.tmux_pane and await _pane_is_alive(session.tmux_pane):
-        logger.info("Session %s: tmux pane %s still alive", session_id, session.tmux_pane)
-        # Transition back to idle if it was working/waiting/disconnected
-        if current in (
-            SessionStatus.WORKING,
-            SessionStatus.WAITING,
-            SessionStatus.DISCONNECTED,
-            SessionStatus.CONNECTING,
-        ):
-            target = SessionStatus.IDLE
-            # disconnected → idle not directly valid; go through connecting
-            if current == SessionStatus.DISCONNECTED:
-                await transition(session_id, current, SessionStatus.CONNECTING, event_bus)
-                await db_ops.update_session_status(conn, session_id, SessionStatus.CONNECTING.value)
-                current = SessionStatus.CONNECTING
-            await transition(session_id, current, target, event_bus)
-            await db_ops.update_session_status(conn, session_id, target.value)
-        return True
+        # Tower sessions must always be respawned with fresh config so Claude
+        # Code picks up the latest CLAUDE.md identity and settings.  A stale
+        # pane from a prior app run may have been launched with outdated (or
+        # missing) Tower identity files, causing "no specific ATC role".
+        session_type = getattr(session, "session_type", None)
+        if session_type == "tower":
+            logger.info(
+                "Session %s: tower pane %s alive but killing to respawn with fresh config",
+                session_id,
+                session.tmux_pane,
+            )
+            await _kill_pane(session.tmux_pane)
+            # Fall through to the respawn logic below
+        else:
+            logger.info("Session %s: tmux pane %s still alive", session_id, session.tmux_pane)
+            # Transition back to idle if it was working/waiting/disconnected
+            if current in (
+                SessionStatus.WORKING,
+                SessionStatus.WAITING,
+                SessionStatus.DISCONNECTED,
+                SessionStatus.CONNECTING,
+            ):
+                target = SessionStatus.IDLE
+                # disconnected → idle not directly valid; go through connecting
+                if current == SessionStatus.DISCONNECTED:
+                    await transition(session_id, current, SessionStatus.CONNECTING, event_bus)
+                    await db_ops.update_session_status(
+                        conn, session_id, SessionStatus.CONNECTING.value
+                    )
+                    current = SessionStatus.CONNECTING
+                await transition(session_id, current, target, event_bus)
+                await db_ops.update_session_status(conn, session_id, target.value)
+            return True
 
     # Pane is dead — try to respawn
     logger.info("Session %s: pane dead, attempting respawn", session_id)
@@ -127,6 +145,10 @@ async def reconnect_session(
             working_dir = str(deployed.root)
             logger.info("Re-deployed tower config for %s → %s", session_id, deployed.root)
 
+        # --- Runtime debug: verify working_dir contents before spawn ---
+        if working_dir:
+            _log_reconnect_working_dir(working_dir, session_id)
+
         await _ensure_tmux_session(ATC_TMUX_SESSION)
         pane_id = await _spawn_pane(
             ATC_TMUX_SESSION,
@@ -174,3 +196,29 @@ async def reconnect_all(
     succeeded = sum(1 for v in results.values() if v)
     logger.info("Reconnected %d/%d sessions", succeeded, len(results))
     return results
+
+
+def _log_reconnect_working_dir(working_dir: str, session_id: str) -> None:
+    """Log working_dir contents during reconnection for runtime debugging."""
+    logger.warning(
+        "=== RECONNECT DEBUG session=%s ===\n"
+        "  working_dir: %s\n"
+        "  exists: %s",
+        session_id,
+        working_dir,
+        os.path.isdir(working_dir),
+    )
+    if os.path.isdir(working_dir):
+        try:
+            entries = os.listdir(working_dir)
+            logger.warning("  Files at working_dir root: %s", entries)
+        except OSError as exc:
+            logger.warning("  Failed to list working_dir: %s", exc)
+
+        claude_md = os.path.join(working_dir, "CLAUDE.md")
+        if os.path.isfile(claude_md):
+            logger.warning("  CLAUDE.md FOUND (%d bytes)", os.path.getsize(claude_md))
+        else:
+            logger.warning("  CLAUDE.md NOT FOUND at %s", claude_md)
+    else:
+        logger.warning("  working_dir DOES NOT EXIST")

--- a/src/atc/tower/session.py
+++ b/src/atc/tower/session.py
@@ -10,9 +10,11 @@ Uses the same tmux infrastructure as aces and leaders.
 from __future__ import annotations
 
 import logging
+import os
+from pathlib import Path
 from typing import TYPE_CHECKING
 
-from atc.agents.deploy import TowerDeploySpec, deploy_tower_files
+from atc.agents.deploy import _DEFAULT_STAGING_ROOT, TowerDeploySpec, deploy_tower_files
 from atc.agents.factory import get_launch_command
 from atc.session.ace import (
     ATC_TMUX_SESSION,
@@ -49,6 +51,7 @@ async def start_tower_session(
     name = f"tower-{project.name}" if project else f"tower-{project_id[:8]}"
 
     # Check for existing tower session — validate tmux pane is actually alive
+    # AND that the Tower identity files are deployed at the working directory.
     existing = await db_ops.list_sessions(conn, project_id=project_id, session_type="tower")
     for sess in existing:
         if sess.status in (SessionStatus.ERROR.value, SessionStatus.DISCONNECTED.value):
@@ -56,7 +59,23 @@ async def start_tower_session(
         # Verify the tmux pane is still alive; stale sessions from a previous
         # app run may have a non-terminal DB status but a dead pane.
         if sess.tmux_pane and await _pane_is_alive(sess.tmux_pane):
-            return sess.id
+            # Verify CLAUDE.md is deployed — a stale pane from a prior app run
+            # may have been launched without Tower identity files.
+            staging_dir = Path(_DEFAULT_STAGING_ROOT) / sess.id
+            if (staging_dir / "CLAUDE.md").is_file():
+                logger.info(
+                    "Reusing existing tower session %s (CLAUDE.md present at %s)",
+                    sess.id,
+                    staging_dir,
+                )
+                return sess.id
+            # CLAUDE.md missing — kill stale pane and create fresh session
+            logger.warning(
+                "Tower session %s has live pane but CLAUDE.md missing at %s — killing stale pane",
+                sess.id,
+                staging_dir,
+            )
+            await _kill_pane(sess.tmux_pane)
         # Pane is dead or missing — mark session as disconnected so we create fresh
         logger.warning(
             "Tower session %s has dead/missing tmux pane %s — discarding",
@@ -109,6 +128,9 @@ async def start_tower_session(
         # Tower never writes code directly — it delegates through Leaders —
         # so it doesn't need to start in the repo directory.
         working_dir = str(deployed.root)
+
+        # --- Runtime debug: verify CLAUDE.md is present at working_dir ---
+        _log_working_dir_contents(working_dir, session.id, "start_tower_session")
 
         await _ensure_tmux_session(ATC_TMUX_SESSION)
         pane_id = await _spawn_pane(
@@ -182,3 +204,55 @@ async def send_tower_message(
         await db_ops.update_session_status(conn, session.id, SessionStatus.WORKING.value)
 
     await _send_keys(session.tmux_pane, message)
+
+
+def _log_working_dir_contents(working_dir: str, session_id: str, caller: str) -> None:
+    """Log the contents of the working directory for runtime debugging.
+
+    Verifies that CLAUDE.md and .claude/settings.json are present at the
+    path that will be passed as -c to tmux (i.e. where Claude Code starts).
+    """
+    logger.warning(
+        "=== TOWER DEBUG [%s] session=%s ===\n"
+        "  working_dir: %s\n"
+        "  working_dir exists: %s",
+        caller,
+        session_id,
+        working_dir,
+        os.path.isdir(working_dir),
+    )
+
+    if not os.path.isdir(working_dir):
+        logger.warning("  working_dir DOES NOT EXIST — Claude Code will NOT find CLAUDE.md")
+        return
+
+    # List all files at the root of working_dir
+    try:
+        entries = os.listdir(working_dir)
+        logger.warning("  Files at working_dir root: %s", entries)
+    except OSError as exc:
+        logger.warning("  Failed to list working_dir: %s", exc)
+        return
+
+    # Check CLAUDE.md specifically
+    claude_md_path = os.path.join(working_dir, "CLAUDE.md")
+    if os.path.isfile(claude_md_path):
+        try:
+            with open(claude_md_path) as f:
+                first_lines = "".join(f.readlines()[:5])
+            logger.warning(
+                "  CLAUDE.md FOUND (%d bytes), first lines:\n%s",
+                os.path.getsize(claude_md_path),
+                first_lines,
+            )
+        except OSError as exc:
+            logger.warning("  CLAUDE.md exists but could not read: %s", exc)
+    else:
+        logger.warning("  CLAUDE.md NOT FOUND at %s", claude_md_path)
+
+    # Check .claude/settings.json
+    settings_path = os.path.join(working_dir, ".claude", "settings.json")
+    if os.path.isfile(settings_path):
+        logger.warning("  .claude/settings.json FOUND (%d bytes)", os.path.getsize(settings_path))
+    else:
+        logger.warning("  .claude/settings.json NOT FOUND at %s", settings_path)


### PR DESCRIPTION
## Summary

- **Root cause found**: When the app restarts (`make dev`), tmux panes survive. Both `reconnect_session()` and `start_tower_session()` treated alive panes as reusable without verifying Tower identity files were deployed. A stale pane from before PRs #55/#56 would keep running without CLAUDE.md, causing "no specific ATC role".

- **Fix in `reconnect_session()`**: Tower sessions always kill alive panes and respawn with freshly deployed CLAUDE.md + settings.json. Non-tower sessions keep the existing behavior (reuse alive panes).

- **Fix in `start_tower_session()`**: Before reusing an existing session, verify CLAUDE.md exists at the staging directory. If missing, kill the stale pane and create a fresh session.

- **Runtime debug logging**: Added `TOWER DEBUG` / `SPAWN_PANE DEBUG` / `RECONNECT DEBUG` log lines (at WARNING level) that print working_dir contents and tmux args at launch time for future debugging.

## Testing Done

**Runtime verification** (not just static analysis):

1. Started backend with `uvicorn` on port 8421 with debug logging
2. Created a test project and started a Tower session via `POST /api/tower/start`
3. Confirmed debug logs show:
   - `working_dir: /tmp/atc-agents/<session-id>` exists
   - `CLAUDE.md FOUND (951 bytes)` at working_dir root
   - `.claude/settings.json FOUND` at working_dir root
   - tmux args include correct `-c <working_dir>` and `claude --dangerously-skip-permissions`
4. Captured tmux pane output — Claude Code correctly identifies as: **"I'm Tower, the top-level orchestrator in the ATC agent hierarchy"**
5. All 118 tower/reconnect/session tests pass
6. Pre-existing test failures (task_graph status transitions) are unrelated

## Files Changed

- `src/atc/tower/session.py` — CLAUDE.md presence check before reusing sessions + debug logging
- `src/atc/session/reconnect.py` — Kill+respawn tower panes on reconnect + debug logging
- `src/atc/session/ace.py` — Debug logging in `_spawn_pane()`
