### PR TITLE
fix: session lifecycle bugs — hooks, deploy, reconnection

### DIFF
--- a/src/atc/agents/deploy.py
+++ b/src/atc/agents/deploy.py
@@ -73,6 +73,7 @@ class ManagerDeploySpec:
     leader_id: str
     project_name: str
     goal: str
+    session_id: str | None = None  # actual session_id for hooks
     repo_path: str | None = None
     github_repo: str | None = None
     api_base_url: str = "http://127.0.0.1:8420"
@@ -527,9 +528,12 @@ def _ace_hook_scripts(spec: AceDeploySpec) -> list[HookConfig]:
 
 def _manager_hook_scripts(spec: ManagerDeploySpec) -> list[HookConfig]:
     """Build the hook shell scripts for a Manager session."""
+    # Use the actual session_id for hooks (not leader_id) so that
+    # /api/aces/{session_id}/status and /api/heartbeat/{session_id} resolve correctly.
+    hook_session_id = spec.session_id or spec.leader_id
     header = _STATUS_HOOK_TEMPLATE.format(
         api_base_url=spec.api_base_url,
-        session_id=spec.leader_id,
+        session_id=hook_session_id,
     )
     return [
         HookConfig(event="PostToolUse", command=header + _POST_TOOL_USE_BODY),
@@ -546,6 +550,7 @@ def _ace_hooks(spec: AceDeploySpec) -> dict[str, list[dict[str, Any]]]:
 
 def _manager_hooks(spec: ManagerDeploySpec) -> dict[str, list[dict[str, Any]]]:
     """Build the hooks section for .claude/settings.json (Manager)."""
+    # The deploy root uses leader_id as the directory name (see deploy_manager_files)
     hooks_dir = f"/tmp/atc-agents/{spec.leader_id}/.claude/hooks"
     return _hooks_dict(hooks_dir)
 

--- a/src/atc/api/app.py
+++ b/src/atc/api/app.py
@@ -180,6 +180,7 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
 
     # 7. Reconnect sessions that were active at last shutdown
     from atc.session.reconnect import reconnect_all
+    from atc.state import db as db_ops
 
     try:
         results = await reconnect_all(db, event_bus=event_bus)
@@ -188,6 +189,64 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
             logger.info("Reconnected %d/%d sessions on startup", ok, len(results))
     except Exception:
         logger.exception("Session reconnection failed on startup")
+
+    # 7b. Start PTY readers for all reconnected sessions that have live panes
+    # (the event-driven auto-start may have missed sessions that were already idle)
+    try:
+        all_sessions = await db_ops.list_active_sessions(db)
+        for sess in all_sessions:
+            if sess.tmux_pane and pty_pool.get_reader(sess.id) is None:
+                logger.info(
+                    "Starting PTY reader for reconnected session %s (pane %s)",
+                    sess.id,
+                    sess.tmux_pane,
+                )
+                await pty_pool.add_session(sess.id, sess.tmux_pane)
+    except Exception:
+        logger.exception("Failed to start PTY readers for reconnected sessions")
+
+    # 8. Restore TowerController state from DB so existing tower sessions
+    # survive server restarts without the frontend needing to re-create them.
+    from atc.tower.controller import TowerState
+
+    try:
+        projects = await db_ops.list_projects(db)
+        restored = False
+        for proj in projects:
+            if restored:
+                break
+            tower_sessions = await db_ops.list_sessions(
+                db, project_id=proj.id, session_type="tower"
+            )
+            for ts in tower_sessions:
+                if ts.status not in ("error", "disconnected") and ts.tmux_pane:
+                    tower_controller._current_project_id = proj.id
+                    tower_controller._current_session_id = ts.id
+                    tower_controller._state = TowerState.MANAGING
+                    logger.info(
+                        "Restored TowerController state: project=%s session=%s",
+                        proj.id,
+                        ts.id,
+                    )
+                    # Also check for a leader session
+                    leader = await db_ops.get_leader_by_project(db, proj.id)
+                    if leader and leader.session_id:
+                        leader_session = await db_ops.get_session(db, leader.session_id)
+                        if leader_session and leader_session.status not in (
+                            "error",
+                            "disconnected",
+                        ):
+                            tower_controller._leader_session_id = leader.session_id
+                            tower_controller._current_goal = leader.goal
+                            logger.info(
+                                "Restored leader session=%s goal=%s",
+                                leader.session_id,
+                                leader.goal,
+                            )
+                    restored = True
+                    break
+    except Exception:
+        logger.exception("Failed to restore TowerController state from DB")
 
     logger.info("ATC startup complete")
     yield

--- a/src/atc/api/routers/aces.py
+++ b/src/atc/api/routers/aces.py
@@ -18,7 +18,6 @@ from typing import Any
 from fastapi import APIRouter, HTTPException, Request
 from pydantic import BaseModel
 
-from atc.agents.deploy import AceDeploySpec, deploy_ace_files
 from atc.agents.factory import get_launch_command
 from atc.core.errors import CreationFailedError, SessionNotFoundError, SessionStaleError
 from atc.session import ace as ace_ops
@@ -123,21 +122,6 @@ async def create_ace(project_id: str, body: CreateAceRequest, request: Request) 
     if project is None:
         raise HTTPException(status_code=404, detail=f"Project {project_id} not found")
 
-    # Deploy config files so the Ace gets CLAUDE.md + hooks
-    import uuid
-
-    preview_id = str(uuid.uuid4())
-    spec = AceDeploySpec(
-        session_id=preview_id,
-        project_name=project.name,
-        task_title=body.task_title or body.name,
-        task_description=body.task_description,
-        repo_path=project.repo_path,
-        github_repo=project.github_repo,
-    )
-    deployed = deploy_ace_files(spec)
-    working_dir = project.repo_path or str(deployed.root)
-
     launch_cmd = get_launch_command(project.agent_provider)
 
     try:
@@ -148,8 +132,16 @@ async def create_ace(project_id: str, body: CreateAceRequest, request: Request) 
             task_id=body.task_id,
             host=body.host,
             event_bus=event_bus,
-            working_dir=working_dir,
+            working_dir=project.repo_path,
             launch_command=launch_cmd,
+            # Pass deploy info so create_ace can deploy with the real session_id
+            deploy_spec_kwargs={
+                "project_name": project.name,
+                "task_title": body.task_title or body.name,
+                "task_description": body.task_description,
+                "repo_path": project.repo_path,
+                "github_repo": project.github_repo,
+            },
         )
     except RuntimeError as exc:
         raise CreationFailedError(str(exc)) from None

--- a/src/atc/leader/leader.py
+++ b/src/atc/leader/leader.py
@@ -117,15 +117,19 @@ async def start_leader(
             github_repo=ctx.get("github_repo") or (project.github_repo if project else None),
             context_entries=ctx.get("context_entries"),
         )
+        # Pass the real session_id so hooks reference the correct ID
+        spec.session_id = session.id
         deployed = deploy_manager_files(spec)
         logger.info(
-            "Deployed manager config for leader %s → %s",
+            "Deployed manager config for leader %s (session %s) → %s",
             leader.id,
+            session.id,
             deployed.root,
         )
 
-        # Spawn tmux pane in the repo working directory, running claude
-        working_dir = spec.repo_path or str(deployed.root)
+        # Use the staging directory so Claude Code finds the deployed
+        # CLAUDE.md (Leader role/goal) and .claude/settings.json (hooks, model).
+        working_dir = str(deployed.root)
 
         launch_cmd = get_launch_command(
             project.agent_provider if project else "claude_code",

--- a/src/atc/session/ace.py
+++ b/src/atc/session/ace.py
@@ -254,6 +254,7 @@ async def create_ace(
     event_bus: EventBus | None = None,
     working_dir: str | None = None,
     launch_command: str | None = None,
+    deploy_spec_kwargs: dict | None = None,
 ) -> str:
     """Create an ace session (DB-first). Returns the session id.
 
@@ -264,6 +265,8 @@ async def create_ace(
         working_dir: Working directory for the tmux pane (e.g. the repo path).
         launch_command: Shell command to run in the pane (e.g. ``claude``).
             When provided, the pane launches this command instead of a bare shell.
+        deploy_spec_kwargs: If provided, deploy Ace config files (CLAUDE.md,
+            hooks, settings.json) using the real session_id after DB creation.
     """
     # Step 1: DB row first — guarantees the UI always sees every entity
     session = await db_ops.create_session(
@@ -275,6 +278,22 @@ async def create_ace(
         host=host,
         status=SessionStatus.CONNECTING.value,
     )
+
+    # Step 1b: Deploy config files with the real session_id so hooks,
+    # CLAUDE.md, and heartbeat all reference the correct ID.
+    effective_working_dir = working_dir
+    if deploy_spec_kwargs is not None:
+        from atc.agents.deploy import AceDeploySpec, deploy_ace_files
+
+        spec = AceDeploySpec(
+            session_id=session.id,
+            **deploy_spec_kwargs,
+        )
+        deployed = deploy_ace_files(spec)
+        # Use the staging directory as working_dir so Claude Code finds
+        # the deployed CLAUDE.md and .claude/settings.json (hooks, model).
+        # The Ace can still access the repo via the repo_path in CLAUDE.md.
+        effective_working_dir = str(deployed.root)
 
     # Step 2: publish creation event — UI shows it immediately
     if event_bus:
@@ -289,7 +308,7 @@ async def create_ace(
         pane_id = await _spawn_pane(
             ATC_TMUX_SESSION,
             launch_command,
-            working_dir=working_dir,
+            working_dir=effective_working_dir,
         )
         await db_ops.update_session_tmux(conn, session.id, ATC_TMUX_SESSION, pane_id)
 

--- a/tests/unit/test_e2e_wiring.py
+++ b/tests/unit/test_e2e_wiring.py
@@ -165,7 +165,9 @@ class TestTowerToLeaderWiring:
         args, kwargs = mock_spawn.call_args
         assert args[0] == "atc"  # tmux session name
         assert args[1] == get_launch_command("claude_code")
-        assert kwargs.get("working_dir") == "/tmp/repo"
+        # Leader now always uses the deploy staging directory so Claude Code
+        # finds the deployed CLAUDE.md (Leader role/goal instructions).
+        assert kwargs.get("working_dir") == "/tmp/atc-agents/leader-1"
 
     @patch("atc.leader.leader._spawn_pane", new_callable=AsyncMock, return_value="%1")
     @patch("atc.leader.leader._ensure_tmux_session", new_callable=AsyncMock)


### PR DESCRIPTION
## Summary

- **Ace deploy session_id mismatch**: Config files (CLAUDE.md, hooks) were deployed with a random preview_id instead of the real session_id. Hooks called /api/aces/{wrong-id}/status and silently 404d. Fixed by moving deploy into create_ace() after DB row creation.

- **Manager hooks used leader_id**: Hook scripts for Leader sessions referenced leader_id instead of session_id, causing all status/heartbeat API calls to fail silently. Added session_id field to ManagerDeploySpec.

- **TowerController state not restored on startup**: After a server restart, TowerController initialized to IDLE with no session. Browser refresh saw tower as idle and re-created the session. Fixed by scanning DB for existing tower sessions after reconnection.

- **CLAUDE.md not found by sessions**: Ace and Leader sessions started in project.repo_path but CLAUDE.md was deployed to the staging directory. Claude Code could not find role instructions. Fixed by using staging directory as working_dir.

- **PTY reader startup race condition**: Added explicit PTY reader startup for all reconnected sessions on startup, eliminating a race condition.

## Test plan

- [x] All 562 unit tests pass (3 pre-existing failures excluded)
- [ ] Create project, start Tower, start Leader, send message, verify response in terminal
- [ ] Create Ace, verify status transitions (connecting -> idle -> working)
- [ ] Restart server, refresh browser, verify Tower session reconnects
- [ ] Check backend logs for successful hook calls

Generated with Claude Code