### PR TITLE
fix: dim box-drawing separator lines in terminal panels

### DIFF
--- a/frontend/src/hooks/useTerminal.ts
+++ b/frontend/src/hooks/useTerminal.ts
@@ -11,6 +11,24 @@ interface UseTerminalOptions {
 }
 
 /**
+ * Transform separator lines (rows of box-drawing ─ characters) into subtle,
+ * dimmed dividers so they don't dominate the terminal UI.
+ *
+ * Claude Code emits ─ (U+2500) repeated across the full terminal width as
+ * section separators.  In xterm.js these render as thick grey bars.  We
+ * wrap them with ANSI dim + dark-grey so they fade into the background.
+ */
+function transformSeparators(data: string): string {
+  // Match runs of 3+ box-drawing horizontal chars (─ ━ ╌ ╍ ┄ ┅ ┈ ┉)
+  // that make up separator lines, possibly surrounded by ANSI escapes.
+  // The regex targets sequences that appear as full-width separator rows.
+  return data.replace(
+    /([─━╌╍┄┅┈┉]{3,})/g,
+    "\x1b[2m\x1b[38;5;238m$1\x1b[0m",
+  );
+}
+
+/**
  * Hook that manages an xterm.js Terminal instance and connects it to the
  * ATC WebSocket for streaming PTY output.
  *
@@ -105,9 +123,9 @@ export function useTerminal({ channel, enabled = true }: UseTerminalOptions) {
         try {
           const msg = JSON.parse(evt.data);
           if (msg.channel === channel && msg.data) {
-            termRef.current?.write(
-              typeof msg.data === "string" ? msg.data : JSON.stringify(msg.data),
-            );
+            const raw =
+              typeof msg.data === "string" ? msg.data : JSON.stringify(msg.data);
+            termRef.current?.write(transformSeparators(raw));
           }
         } catch {
           /* ignore malformed */


### PR DESCRIPTION
## Summary
- Claude Code emits `─` (U+2500) characters across the full terminal width as section separators, which render as thick grey horizontal bars in xterm.js terminal panels
- Added a `transformSeparators()` function in `useTerminal.ts` that intercepts terminal data before writing and wraps runs of box-drawing horizontal characters with ANSI dim + dark-grey escape codes (SGR 2 + 256-color 238)
- Separators now appear as subtle, understated dividers instead of visually dominating bars

## Test plan
- [ ] Open a project with active Leader and Tower terminal sessions
- [ ] Verify separator lines appear dimmed/subtle instead of thick grey bars
- [ ] Confirm normal terminal text and ANSI colors are unaffected
- [ ] Check that box-drawing characters in non-separator contexts (e.g., tables) still render correctly (only runs of 3+ are dimmed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)