### PR TITLE
feat: add project/leader/ace CLI commands for Tower

### DIFF
--- a/src/atc/agents/deploy.py
+++ b/src/atc/agents/deploy.py
@@ -441,6 +441,43 @@ def _build_tower_claude_md(spec: TowerDeploySpec) -> str:
         "",
     ]
 
+    # CLI commands documentation
+    lines.extend([
+        "## ATC CLI Commands",
+        "",
+        "Use these commands to manage projects, leaders, and aces.",
+        "",
+        "### Project Management",
+        "```bash",
+        "atc projects list                                    # List all projects",
+        "atc projects create --name 'Name' --description '...' # Create a new project",
+        "atc projects show <project-id>                       # Show project details",
+        "```",
+        "",
+        "### Leader Lifecycle",
+        "```bash",
+        "atc leader start --project-id <id>                   # Start leader for a project",
+        "atc leader start --project-id <id> --goal '...'      # Start leader with a goal",
+        "atc leader stop --project-id <id>                    # Stop leader for a project",
+        "```",
+        "",
+        "### Ace Management",
+        "```bash",
+        "atc ace create --project-id <id> --name 'ace-name'   # Create an ace session",
+        "atc ace list --project-id <id>                       # List aces for a project",
+        "```",
+        "",
+        "### Workflow",
+        "",
+        "When the user asks to create a project:",
+        "1. `atc projects create --name '...' --description '...'` — note the project ID from the response",
+        "2. `atc leader start --project-id <id>` — start the leader for the project",
+        "3. `atc ace create --project-id <id> --name '...'` — add aces as needed",
+        "",
+        "All commands output JSON. Parse the `id` field from create responses to use in subsequent commands.",
+        "",
+    ])
+
     if spec.repo_path or spec.github_repo:
         lines.append("## Repository")
         lines.append("")
@@ -644,6 +681,8 @@ def _tower_allowed_commands(spec: TowerDeploySpec) -> list[str]:
     """Build the allowed commands list for a Tower."""
     commands = list(_BASE_ALLOWED_COMMANDS)
     commands.append("Bash(atc tower *)")
+    commands.append("Bash(atc projects *)")
+    commands.append("Bash(atc leader *)")
     commands.extend(spec.allowed_commands)
     return commands
 

--- a/src/atc/cli/ace.py
+++ b/src/atc/cli/ace.py
@@ -67,6 +67,24 @@ def register(subparsers: argparse._SubParsersAction) -> None:  # type: ignore[ty
     )
     notify_parser.set_defaults(handler=_handle_notify)
 
+    # atc ace create --project-id <id> --name '...'
+    create_parser = ace_sub.add_parser("create", help="Create a new ace session")
+    create_parser.add_argument("--project-id", required=True, help="Project UUID")
+    create_parser.add_argument("--name", required=True, help="Ace session name")
+    create_parser.add_argument("--task-id", default=None, help="Task ID to assign")
+    create_parser.add_argument(
+        "--api", default=_DEFAULT_API, help="ATC API base URL",
+    )
+    create_parser.set_defaults(handler=_handle_create)
+
+    # atc ace list --project-id <id>
+    list_parser = ace_sub.add_parser("list", help="List ace sessions for a project")
+    list_parser.add_argument("--project-id", required=True, help="Project UUID")
+    list_parser.add_argument(
+        "--api", default=_DEFAULT_API, help="ATC API base URL",
+    )
+    list_parser.set_defaults(handler=_handle_list)
+
     ace_parser.set_defaults(handler=lambda _: ace_parser.print_help() or 1)
 
 
@@ -135,3 +153,46 @@ def _handle_blocked(args: argparse.Namespace) -> int:
 
 def _handle_notify(args: argparse.Namespace) -> int:
     return _api_post_notify(args.api, args.session_id, args.message)
+
+
+def _handle_create(args: argparse.Namespace) -> int:
+    """POST /api/projects/{project_id}/aces to create a new ace session."""
+    url = f"{args.api}/api/projects/{args.project_id}/aces"
+    payload: dict = {"name": args.name}
+    if args.task_id:
+        payload["task_id"] = args.task_id
+    data = json.dumps(payload).encode()
+    req = urllib.request.Request(
+        url, data=data, method="POST",
+        headers={"Content-Type": "application/json"},
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=30) as resp:
+            body = json.loads(resp.read().decode())
+            print(json.dumps(body, indent=2))
+            return 0
+    except urllib.error.HTTPError as exc:
+        detail = exc.read().decode() if exc.fp else str(exc)
+        print(f"Error: {exc.code} — {detail}", file=sys.stderr)
+        return 1
+    except urllib.error.URLError as exc:
+        print(f"Error: cannot reach ATC API at {args.api} — {exc.reason}", file=sys.stderr)
+        return 1
+
+
+def _handle_list(args: argparse.Namespace) -> int:
+    """GET /api/projects/{project_id}/aces to list ace sessions."""
+    url = f"{args.api}/api/projects/{args.project_id}/aces"
+    req = urllib.request.Request(url, method="GET")
+    try:
+        with urllib.request.urlopen(req, timeout=10) as resp:
+            body = json.loads(resp.read().decode())
+            print(json.dumps(body, indent=2))
+            return 0
+    except urllib.error.HTTPError as exc:
+        detail = exc.read().decode() if exc.fp else str(exc)
+        print(f"Error: {exc.code} — {detail}", file=sys.stderr)
+        return 1
+    except urllib.error.URLError as exc:
+        print(f"Error: cannot reach ATC API at {args.api} — {exc.reason}", file=sys.stderr)
+        return 1

--- a/src/atc/cli/leader.py
+++ b/src/atc/cli/leader.py
@@ -1,0 +1,70 @@
+"""``atc leader`` subcommands — Leader lifecycle management from Tower sessions.
+
+Tower uses these commands to start and stop Leaders via the ATC REST API.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+import urllib.error
+import urllib.request
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import argparse
+
+_DEFAULT_API = "http://127.0.0.1:8420"
+
+
+def register(subparsers: argparse._SubParsersAction) -> None:  # type: ignore[type-arg]
+    """Register the ``leader`` command group."""
+    leader_parser = subparsers.add_parser("leader", help="Leader lifecycle commands")
+    leader_sub = leader_parser.add_subparsers(dest="leader_command")
+
+    # atc leader start --project-id <id>
+    start_parser = leader_sub.add_parser("start", help="Start leader for a project")
+    start_parser.add_argument("--project-id", required=True, help="Project UUID")
+    start_parser.add_argument("--goal", default=None, help="Goal for the leader")
+    start_parser.add_argument("--api", default=_DEFAULT_API, help="ATC API base URL")
+    start_parser.set_defaults(handler=_handle_start)
+
+    # atc leader stop --project-id <id>
+    stop_parser = leader_sub.add_parser("stop", help="Stop leader for a project")
+    stop_parser.add_argument("--project-id", required=True, help="Project UUID")
+    stop_parser.add_argument("--api", default=_DEFAULT_API, help="ATC API base URL")
+    stop_parser.set_defaults(handler=_handle_stop)
+
+    leader_parser.set_defaults(handler=lambda _: leader_parser.print_help() or 1)
+
+
+def _post_json(url: str, payload: dict) -> int:
+    """POST JSON to a URL and print the response."""
+    data = json.dumps(payload).encode()
+    req = urllib.request.Request(
+        url, data=data, method="POST",
+        headers={"Content-Type": "application/json"},
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=30) as resp:
+            body = json.loads(resp.read().decode())
+            print(json.dumps(body, indent=2))
+            return 0
+    except urllib.error.HTTPError as exc:
+        detail = exc.read().decode() if exc.fp else str(exc)
+        print(f"Error: {exc.code} — {detail}", file=sys.stderr)
+        return 1
+    except urllib.error.URLError as exc:
+        print(f"Error: cannot reach ATC API — {exc.reason}", file=sys.stderr)
+        return 1
+
+
+def _handle_start(args: argparse.Namespace) -> int:
+    payload: dict = {}
+    if args.goal:
+        payload["goal"] = args.goal
+    return _post_json(f"{args.api}/api/projects/{args.project_id}/leader/start", payload)
+
+
+def _handle_stop(args: argparse.Namespace) -> int:
+    return _post_json(f"{args.api}/api/projects/{args.project_id}/leader/stop", {})

--- a/src/atc/cli/main.py
+++ b/src/atc/cli/main.py
@@ -1,9 +1,16 @@
-"""ATC CLI entry point — dispatches to ``ace`` and ``tower`` subcommands.
+"""ATC CLI entry point — dispatches to ``ace``, ``leader``, ``projects``, and ``tower`` subcommands.
 
 Usage::
 
     atc ace status <session_id> working
     atc ace done <session_id>
+    atc ace create --project-id <id> --name '...'
+    atc ace list --project-id <id>
+    atc leader start --project-id <id>
+    atc leader stop --project-id <id>
+    atc projects list
+    atc projects create --name '...' --description '...'
+    atc projects show <id>
     atc tower status
 """
 
@@ -12,7 +19,7 @@ from __future__ import annotations
 import argparse
 import sys
 
-from atc.cli import ace, tower
+from atc.cli import ace, leader, projects, tower
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -24,6 +31,8 @@ def build_parser() -> argparse.ArgumentParser:
     subparsers = parser.add_subparsers(dest="command")
 
     ace.register(subparsers)
+    leader.register(subparsers)
+    projects.register(subparsers)
     tower.register(subparsers)
 
     return parser

--- a/src/atc/cli/projects.py
+++ b/src/atc/cli/projects.py
@@ -1,0 +1,102 @@
+"""``atc projects`` subcommands — project management from Tower sessions.
+
+Tower uses these commands to create and inspect projects via the ATC REST API.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+import urllib.error
+import urllib.request
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import argparse
+
+_DEFAULT_API = "http://127.0.0.1:8420"
+
+
+def register(subparsers: argparse._SubParsersAction) -> None:  # type: ignore[type-arg]
+    """Register the ``projects`` command group."""
+    proj_parser = subparsers.add_parser("projects", help="Project management commands")
+    proj_sub = proj_parser.add_subparsers(dest="projects_command")
+
+    # atc projects list
+    list_parser = proj_sub.add_parser("list", help="List all projects")
+    list_parser.add_argument("--api", default=_DEFAULT_API, help="ATC API base URL")
+    list_parser.set_defaults(handler=_handle_list)
+
+    # atc projects create --name '...' --description '...'
+    create_parser = proj_sub.add_parser("create", help="Create a new project")
+    create_parser.add_argument("--name", required=True, help="Project name")
+    create_parser.add_argument("--description", default=None, help="Project description")
+    create_parser.add_argument("--repo-path", default=None, help="Local repository path")
+    create_parser.add_argument("--github-repo", default=None, help="GitHub repo (owner/repo)")
+    create_parser.add_argument("--api", default=_DEFAULT_API, help="ATC API base URL")
+    create_parser.set_defaults(handler=_handle_create)
+
+    # atc projects show <id>
+    show_parser = proj_sub.add_parser("show", help="Show project details")
+    show_parser.add_argument("project_id", help="Project UUID")
+    show_parser.add_argument("--api", default=_DEFAULT_API, help="ATC API base URL")
+    show_parser.set_defaults(handler=_handle_show)
+
+    proj_parser.set_defaults(handler=lambda _: proj_parser.print_help() or 1)
+
+
+def _get_json(url: str) -> int:
+    """GET a URL and print the JSON response."""
+    req = urllib.request.Request(url, method="GET")
+    try:
+        with urllib.request.urlopen(req, timeout=10) as resp:
+            body = json.loads(resp.read().decode())
+            print(json.dumps(body, indent=2))
+            return 0
+    except urllib.error.HTTPError as exc:
+        detail = exc.read().decode() if exc.fp else str(exc)
+        print(f"Error: {exc.code} — {detail}", file=sys.stderr)
+        return 1
+    except urllib.error.URLError as exc:
+        print(f"Error: cannot reach ATC API — {exc.reason}", file=sys.stderr)
+        return 1
+
+
+def _post_json(url: str, payload: dict) -> int:
+    """POST JSON to a URL and print the response."""
+    data = json.dumps(payload).encode()
+    req = urllib.request.Request(
+        url, data=data, method="POST",
+        headers={"Content-Type": "application/json"},
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=10) as resp:
+            body = json.loads(resp.read().decode())
+            print(json.dumps(body, indent=2))
+            return 0
+    except urllib.error.HTTPError as exc:
+        detail = exc.read().decode() if exc.fp else str(exc)
+        print(f"Error: {exc.code} — {detail}", file=sys.stderr)
+        return 1
+    except urllib.error.URLError as exc:
+        print(f"Error: cannot reach ATC API — {exc.reason}", file=sys.stderr)
+        return 1
+
+
+def _handle_list(args: argparse.Namespace) -> int:
+    return _get_json(f"{args.api}/api/projects")
+
+
+def _handle_create(args: argparse.Namespace) -> int:
+    payload: dict = {"name": args.name}
+    if args.description:
+        payload["description"] = args.description
+    if args.repo_path:
+        payload["repo_path"] = args.repo_path
+    if args.github_repo:
+        payload["github_repo"] = args.github_repo
+    return _post_json(f"{args.api}/api/projects", payload)
+
+
+def _handle_show(args: argparse.Namespace) -> int:
+    return _get_json(f"{args.api}/api/projects/{args.project_id}")

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -225,3 +225,152 @@ class TestTowerMemory:
         req = _StubHandler.requests[0]
         assert req["method"] == "GET"
         assert req["path"] == "/api/tower/memory"
+
+
+# ---------------------------------------------------------------------------
+# atc projects list
+# ---------------------------------------------------------------------------
+
+
+class TestProjectsList:
+    def test_lists_projects(self, api_stub: str) -> None:
+        _StubHandler.response_body = []  # type: ignore[assignment]
+        rc = cli(["projects", "list", "--api", api_stub])
+        assert rc == 0
+        req = _StubHandler.requests[0]
+        assert req["method"] == "GET"
+        assert req["path"] == "/api/projects"
+
+
+# ---------------------------------------------------------------------------
+# atc projects create
+# ---------------------------------------------------------------------------
+
+
+class TestProjectsCreate:
+    def test_creates_project(self, api_stub: str) -> None:
+        _StubHandler.response_body = {"id": "proj-1", "name": "Test", "status": "active"}
+        rc = cli([
+            "projects", "create",
+            "--name", "Test Project",
+            "--description", "A test project",
+            "--api", api_stub,
+        ])
+        assert rc == 0
+        req = _StubHandler.requests[0]
+        assert req["method"] == "POST"
+        assert req["path"] == "/api/projects"
+        assert req["body"]["name"] == "Test Project"
+        assert req["body"]["description"] == "A test project"
+
+    def test_creates_project_name_only(self, api_stub: str) -> None:
+        _StubHandler.response_body = {"id": "proj-2", "name": "Minimal", "status": "active"}
+        rc = cli(["projects", "create", "--name", "Minimal", "--api", api_stub])
+        assert rc == 0
+        req = _StubHandler.requests[0]
+        assert req["body"]["name"] == "Minimal"
+        assert "description" not in req["body"]
+
+    def test_name_required(self) -> None:
+        with pytest.raises(SystemExit):
+            cli(["projects", "create"])
+
+
+# ---------------------------------------------------------------------------
+# atc projects show
+# ---------------------------------------------------------------------------
+
+
+class TestProjectsShow:
+    def test_shows_project(self, api_stub: str) -> None:
+        _StubHandler.response_body = {"id": "proj-1", "name": "Test", "status": "active"}
+        rc = cli(["projects", "show", "proj-1", "--api", api_stub])
+        assert rc == 0
+        req = _StubHandler.requests[0]
+        assert req["method"] == "GET"
+        assert req["path"] == "/api/projects/proj-1"
+
+
+# ---------------------------------------------------------------------------
+# atc leader start
+# ---------------------------------------------------------------------------
+
+
+class TestLeaderStart:
+    def test_starts_leader(self, api_stub: str) -> None:
+        _StubHandler.response_body = {"status": "started", "session_id": "sess-1"}
+        rc = cli(["leader", "start", "--project-id", "proj-1", "--api", api_stub])
+        assert rc == 0
+        req = _StubHandler.requests[0]
+        assert req["method"] == "POST"
+        assert req["path"] == "/api/projects/proj-1/leader/start"
+
+    def test_starts_leader_with_goal(self, api_stub: str) -> None:
+        _StubHandler.response_body = {"status": "started", "session_id": "sess-2"}
+        rc = cli([
+            "leader", "start",
+            "--project-id", "proj-1",
+            "--goal", "Build a calculator",
+            "--api", api_stub,
+        ])
+        assert rc == 0
+        req = _StubHandler.requests[0]
+        assert req["body"]["goal"] == "Build a calculator"
+
+    def test_project_id_required(self) -> None:
+        with pytest.raises(SystemExit):
+            cli(["leader", "start"])
+
+
+# ---------------------------------------------------------------------------
+# atc leader stop
+# ---------------------------------------------------------------------------
+
+
+class TestLeaderStop:
+    def test_stops_leader(self, api_stub: str) -> None:
+        rc = cli(["leader", "stop", "--project-id", "proj-1", "--api", api_stub])
+        assert rc == 0
+        req = _StubHandler.requests[0]
+        assert req["method"] == "POST"
+        assert req["path"] == "/api/projects/proj-1/leader/stop"
+
+
+# ---------------------------------------------------------------------------
+# atc ace create
+# ---------------------------------------------------------------------------
+
+
+class TestAceCreate:
+    def test_creates_ace(self, api_stub: str) -> None:
+        _StubHandler.response_body = {"id": "sess-1", "name": "frontend-ace", "status": "idle"}
+        rc = cli([
+            "ace", "create",
+            "--project-id", "proj-1",
+            "--name", "frontend-ace",
+            "--api", api_stub,
+        ])
+        assert rc == 0
+        req = _StubHandler.requests[0]
+        assert req["method"] == "POST"
+        assert req["path"] == "/api/projects/proj-1/aces"
+        assert req["body"]["name"] == "frontend-ace"
+
+    def test_project_id_and_name_required(self) -> None:
+        with pytest.raises(SystemExit):
+            cli(["ace", "create"])
+
+
+# ---------------------------------------------------------------------------
+# atc ace list
+# ---------------------------------------------------------------------------
+
+
+class TestAceList:
+    def test_lists_aces(self, api_stub: str) -> None:
+        _StubHandler.response_body = []  # type: ignore[assignment]
+        rc = cli(["ace", "list", "--project-id", "proj-1", "--api", api_stub])
+        assert rc == 0
+        req = _StubHandler.requests[0]
+        assert req["method"] == "GET"
+        assert req["path"] == "/api/projects/proj-1/aces"


### PR DESCRIPTION
## Summary
- Adds `atc projects list|create|show` CLI commands for project management
- Adds `atc leader start|stop` CLI commands for leader lifecycle control
- Adds `atc ace create|list` CLI commands for ace session management
- Updates Tower's CLAUDE.md with CLI command documentation and workflow instructions
- Adds `Bash(atc projects *)` and `Bash(atc leader *)` to Tower's allowed commands
- All new commands call existing REST API endpoints (no backend changes needed)
- 12 new tests added, all 28 CLI tests pass

## Test plan
- [x] All 28 unit tests pass (`pytest tests/unit/test_cli.py`)
- [x] CLI parsers verified for all new subcommands
- [ ] Playwright verification: send Tower "Create a new project" and verify it uses CLI commands

🤖 Generated with [Claude Code](https://claude.com/claude-code)