### PR TITLE
fix: auto-accept trust dialog for all deployed sessions

### DIFF
--- a/src/atc/agents/deploy.py
+++ b/src/atc/agents/deploy.py
@@ -504,6 +504,7 @@ def _build_settings(
     """Build the .claude/settings.json content."""
     return {
         "model": model,
+        "hasTrustDialogAccepted": True,
         "autoMemoryEnabled": False,
         "spinnerTipsEnabled": False,
         "permissions": {

--- a/tests/unit/test_deploy.py
+++ b/tests/unit/test_deploy.py
@@ -133,6 +133,7 @@ class TestDeployAceFiles:
         settings = json.loads(result.settings_path.read_text())
         assert settings["model"] == "opus"
         assert settings["autoMemoryEnabled"] is False
+        assert settings["hasTrustDialogAccepted"] is True
 
     def test_settings_has_permissions(self, ace_spec: AceDeploySpec, staging_root: Path) -> None:
         result = deploy_ace_files(ace_spec, staging_root=staging_root)


### PR DESCRIPTION
## Summary
- Adds `hasTrustDialogAccepted: true` to the `.claude/settings.json` generated by `deploy.py` for all session types (Tower, Leader, Ace)
- This prevents Claude Code from showing the "Is this a project you created or one you trust?" prompt that blocks fresh sessions
- Bypass permissions (`--dangerously-skip-permissions`) was already configured in all launch paths via `factory.py`

## Changes
- `src/atc/agents/deploy.py`: Added `hasTrustDialogAccepted: True` to `_build_settings()` output
- `tests/unit/test_deploy.py`: Added assertion for the new setting

## Test plan
- [x] All 45 deploy unit tests pass
- [x] 285/286 unit tests pass (1 pre-existing failure unrelated to this change)
- [ ] Manual: Create a new project via UI, verify Tower starts without trust prompt
- [ ] Manual: Navigate to project, verify Leader starts without trust prompt
- [ ] Manual: Create an ace, verify it starts without trust prompt

🤖 Generated with [Claude Code](https://claude.com/claude-code)