### PR TITLE
fix: end-to-end terminal resize for proper text wrapping

### DIFF
--- a/frontend/src/hooks/useTerminal.ts
+++ b/frontend/src/hooks/useTerminal.ts
@@ -49,11 +49,15 @@ export function useTerminal({ channel, enabled = true }: UseTerminalOptions) {
   const containerRef = useRef<HTMLDivElement | null>(null);
   const wsRef = useRef<WebSocket | null>(null);
   const reconnectRef = useRef<ReturnType<typeof setTimeout>>(undefined);
+  const channelRef = useRef<string | undefined>(channel);
   // Buffer for data received before the terminal is opened (attached to DOM).
   // xterm.js throws "Cannot read properties of undefined (reading 'dimensions')"
   // when write() is called on a terminal that hasn't been opened yet.
   const pendingWritesRef = useRef<string[]>([]);
   const termOpenRef = useRef(false);
+
+  // Keep channel ref in sync for use in non-reactive callbacks
+  channelRef.current = channel;
 
   // Create terminal once
   useEffect(() => {
@@ -144,6 +148,17 @@ export function useTerminal({ channel, enabled = true }: UseTerminalOptions) {
           return;
         }
         ws.send(JSON.stringify({ channel: "subscribe", data: [channel] }));
+        // Send initial terminal dimensions so tmux pane matches display
+        const term = termRef.current;
+        if (term && term.cols > 0 && term.rows > 0) {
+          ws.send(
+            JSON.stringify({
+              channel,
+              type: "resize",
+              data: { cols: term.cols, rows: term.rows },
+            }),
+          );
+        }
       };
 
       ws.onmessage = (evt) => {
@@ -194,14 +209,31 @@ export function useTerminal({ channel, enabled = true }: UseTerminalOptions) {
     const term = termRef.current;
     if (!term) return;
 
-    const disposable = term.onData((data) => {
+    const dataDisposable = term.onData((data) => {
       const ws = wsRef.current;
       if (ws?.readyState === WebSocket.OPEN) {
         ws.send(JSON.stringify({ channel, data }));
       }
     });
 
-    return () => disposable.dispose();
+    // Send terminal dimensions to backend so tmux pane matches xterm.js size
+    const resizeDisposable = term.onResize((evt) => {
+      const ws = wsRef.current;
+      if (ws?.readyState === WebSocket.OPEN) {
+        ws.send(
+          JSON.stringify({
+            channel,
+            type: "resize",
+            data: { cols: evt.cols, rows: evt.rows },
+          }),
+        );
+      }
+    });
+
+    return () => {
+      dataDisposable.dispose();
+      resizeDisposable.dispose();
+    };
   }, [channel, enabled]);
 
   // Ref callback for container div — handles initial open and re-attach
@@ -226,6 +258,18 @@ export function useTerminal({ channel, enabled = true }: UseTerminalOptions) {
             fitRef.current?.fit();
           } catch {
             // Terminal may not be fully initialized yet — safe to ignore
+          }
+          // Send initial dimensions to backend so tmux pane matches
+          const t = termRef.current;
+          const ws = wsRef.current;
+          if (t && ws?.readyState === WebSocket.OPEN && channelRef.current) {
+            ws.send(
+              JSON.stringify({
+                channel: channelRef.current,
+                type: "resize",
+                data: { cols: t.cols, rows: t.rows },
+              }),
+            );
           }
           // Flush any data that arrived before the terminal was opened
           const pending = pendingWritesRef.current;

--- a/src/atc/api/app.py
+++ b/src/atc/api/app.py
@@ -94,6 +94,16 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
 
     ws_hub.on_input(_on_ws_input)
 
+    # Forward terminal resize events from WebSocket clients to PTY
+    async def _on_ws_resize(channel: str, cols: int, rows: int) -> None:
+        session_id = channel.removeprefix("terminal:")
+        try:
+            await pty_pool.resize_pane(session_id, cols, rows)
+        except (ValueError, RuntimeError):
+            logger.debug("Resize failed for session %s (cols=%d, rows=%d)", session_id, cols, rows)
+
+    ws_hub.on_resize(_on_ws_resize)
+
     # Send initial terminal content when a client subscribes to a terminal channel.
     # This captures the current tmux pane content so the terminal isn't blank on load.
     async def _on_terminal_subscribe(ws: Any, channel: str) -> None:

--- a/src/atc/api/ws/hub.py
+++ b/src/atc/api/ws/hub.py
@@ -35,6 +35,7 @@ class WsHub:
         self._input_callback: Any | None = None
         self._heartbeat_callback: Any | None = None
         self._subscribe_callback: Any | None = None
+        self._resize_callback: Any | None = None
 
     @property
     def client_count(self) -> int:
@@ -53,6 +54,13 @@ class WsHub:
         Callback signature: ``async def cb(session_id: str) -> None``
         """
         self._heartbeat_callback = callback
+
+    def on_resize(self, callback: Any) -> None:
+        """Register a callback for terminal resize events from clients.
+
+        Callback signature: ``async def cb(channel: str, cols: int, rows: int) -> None``
+        """
+        self._resize_callback = callback
 
     def on_subscribe(self, callback: Any) -> None:
         """Register a callback invoked when a client subscribes to a channel.
@@ -138,6 +146,20 @@ class WsHub:
                             await self._heartbeat_callback(session_id)
                         except Exception:
                             logger.exception("Heartbeat callback error for %s", session_id)
+                elif (
+                    channel
+                    and channel.startswith("terminal:")
+                    and msg.get("type") == "resize"
+                    and isinstance(data, dict)
+                    and self._resize_callback
+                ):
+                    cols = data.get("cols", 0)
+                    rows = data.get("rows", 0)
+                    if cols > 0 and rows > 0:
+                        try:
+                            await self._resize_callback(channel, cols, rows)
+                        except Exception:
+                            logger.debug("Resize callback error for %s", channel)
                 elif (
                     channel
                     and channel.startswith("terminal:")

--- a/src/atc/session/ace.py
+++ b/src/atc/session/ace.py
@@ -69,14 +69,15 @@ async def _tmux_run(*args: str) -> str:
 async def _ensure_tmux_session(session_name: str) -> None:
     """Create the tmux session if it doesn't already exist.
 
-    Uses explicit dimensions (-x 200 -y 50) so panes work correctly even
-    when no real terminal is attached (e.g. PTY output streams to xterm.js
-    in the frontend).
+    Uses explicit dimensions so panes work correctly even when no real
+    terminal is attached (PTY output streams to xterm.js in the frontend).
+    The frontend sends a resize event once xterm.js measures its actual
+    column width, so the initial size here is a reasonable default.
     """
     try:
         await _tmux_run("has-session", "-t", session_name)
     except RuntimeError:
-        await _tmux_run("new-session", "-d", "-s", session_name, "-x", "200", "-y", "50")
+        await _tmux_run("new-session", "-d", "-s", session_name, "-x", "120", "-y", "40")
 
 
 async def _spawn_pane(

--- a/src/atc/terminal/pty_stream.py
+++ b/src/atc/terminal/pty_stream.py
@@ -256,6 +256,19 @@ class PtyStreamPool:
         if reader:
             await reader.stop()
 
+    async def resize_pane(self, session_id: str, cols: int, rows: int) -> None:
+        """Resize a session's tmux pane to the given dimensions.
+
+        Called when the frontend xterm.js terminal is resized so the PTY
+        output matches the actual display width.
+        """
+        reader = self._readers.get(session_id)
+        if reader is None:
+            raise ValueError(f"No active reader for session {session_id}")
+        await PtyStreamReader._run_tmux(
+            "resize-window", "-t", reader._tmux_pane, "-x", str(cols), "-y", str(rows),
+        )
+
     async def send_keys(self, session_id: str, keys: str) -> None:
         """Send keystrokes to a session's tmux pane via tmux send-keys.
 
@@ -299,11 +312,16 @@ class PtyStreamPool:
             return False
 
     async def capture_pane(self, session_id: str) -> str:
-        """Capture the current visible content of a session's tmux pane."""
+        """Capture the current visible content of a session's tmux pane.
+
+        Uses ``-e`` to preserve ANSI escape sequences (colors) and ``-J``
+        to join wrapped lines so xterm.js can re-wrap them at its actual
+        display width instead of inheriting the tmux pane width.
+        """
         reader = self._readers.get(session_id)
         if reader is None:
             raise ValueError(f"No active reader for session {session_id}")
 
         return await PtyStreamReader._run_tmux(
-            "capture-pane", "-t", reader._tmux_pane, "-p"
+            "capture-pane", "-t", reader._tmux_pane, "-p", "-e", "-J"
         )


### PR DESCRIPTION
## Summary
- Adds end-to-end terminal resize signaling: frontend xterm.js sends resize events via WebSocket to backend, which resizes tmux panes to match the actual display width
- Fixes text wrapping mid-word in Tower, Leader, and Ace terminal panels (tmux was at 200 cols, xterm.js panels were ~80-120 cols)
- Improves `capture-pane` with `-e` (preserve ANSI colors) and `-J` (join wrapped lines) flags so initial terminal content renders correctly
- Reduces default tmux session size from 200x50 to 120x40 as a better baseline before resize events propagate

## Test plan
- [x] Frontend TypeScript compiles cleanly (`npx tsc -b --noEmit`)
- [x] All 168 frontend tests pass (`npx vitest run`)
- [x] All 32 relevant backend tests pass (`pytest tests/unit/test_pty_stream.py tests/integration/test_websocket_hub.py`)
- [x] Visual verification with Playwright: Tower, Leader, and Ace terminals all show proper word wrapping
- [ ] Manual test: resize browser window and verify terminal text reflows correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)