### PR TITLE
fix: remove 'Send message to Tower' input from TowerPanel

### DIFF
--- a/frontend/src/components/tower/TowerPanel.css
+++ b/frontend/src/components/tower/TowerPanel.css
@@ -104,50 +104,6 @@
 }
 
 /* Unified input bar at bottom -- terminal-style */
-.tower-panel__input-bar {
-  display: flex;
-  align-items: center;
-  gap: var(--space-2);
-  padding: var(--space-2) var(--space-3);
-  border-top: 1px solid var(--color-border-subtle);
-  flex-shrink: 0;
-  background: var(--color-bg);
-}
-
-.tower-panel__prompt {
-  font-family: var(--font-mono);
-  font-size: var(--text-sm);
-  color: var(--color-accent);
-  flex-shrink: 0;
-  user-select: none;
-}
-
-.tower-panel__input {
-  flex: 1;
-  padding: var(--space-1) var(--space-2);
-  font-size: var(--text-sm);
-  font-family: var(--font-mono);
-  color: var(--color-text);
-  background: transparent;
-  border: none;
-  outline: none;
-}
-
-.tower-panel__input::placeholder {
-  color: var(--color-text-muted);
-}
-
-.tower-panel__input:disabled {
-  opacity: 0.6;
-}
-
-.tower-panel__send-error {
-  color: var(--color-status-red);
-  font-weight: bold;
-  font-size: var(--text-sm);
-  cursor: help;
-}
-
 /* Progress indicator in the bar */
 .tower-panel__progress {
   font-size: var(--text-xs);

--- a/frontend/src/components/tower/TowerPanel.tsx
+++ b/frontend/src/components/tower/TowerPanel.tsx
@@ -25,9 +25,7 @@ export default function TowerPanel() {
   const routeProjectId = useRouteProjectId();
 
   const [expanded, setExpanded] = useState(false);
-  const [message, setMessage] = useState("");
   const [starting, setStarting] = useState(false);
-  const messageInputRef = useRef<HTMLInputElement>(null);
   const autoStarted = useRef(false);
   const userStopped = useRef(false);
 
@@ -151,27 +149,6 @@ export default function TowerPanel() {
     }
   }, [dispatch]);
 
-  const [sendError, setSendError] = useState<string | null>(null);
-
-  const handleSendMessage = useCallback(
-    async (e: React.FormEvent) => {
-      e.preventDefault();
-      if (!message.trim()) return;
-      const text = message.trim();
-      setMessage("");
-      setSendError(null);
-      messageInputRef.current?.focus();
-      try {
-        await api.post("/tower/message", { message: text });
-      } catch (err) {
-        console.error("Failed to send message to Tower:", err);
-        setSendError("Failed to send message");
-        // Restore message so user can retry
-        setMessage(text);
-      }
-    },
-    [message],
-  );
 
   const tickerText =
     brainStatus.message ||
@@ -279,38 +256,6 @@ export default function TowerPanel() {
           </div>
         )}
 
-        {/* Message input bar — always at the bottom when terminal is showing */}
-        {showTerminal && (
-          <form
-            className="tower-panel__input-bar"
-            onSubmit={handleSendMessage}
-            data-testid="tower-panel-message-form"
-          >
-            <span className="tower-panel__prompt">&gt;</span>
-            <input
-              ref={messageInputRef}
-              type="text"
-              className="tower-panel__input"
-              value={message}
-              onChange={(e) => setMessage(e.target.value)}
-              placeholder="Send message to Tower..."
-              data-testid="tower-panel-message"
-            />
-            <button
-              type="submit"
-              className="btn btn-primary btn-sm"
-              disabled={!message.trim()}
-              data-testid="tower-panel-send"
-            >
-              Send
-            </button>
-            {sendError && (
-              <span className="tower-panel__send-error" title={sendError}>
-                !
-              </span>
-            )}
-          </form>
-        )}
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- Removes the `Send message to Tower...` text input and Send button from the bottom of `TowerPanel`
- Cleans up related React state (`message`, `sendError`, `messageInputRef`) and `handleSendMessage` callback
- Removes associated CSS styles (`.tower-panel__input-bar`, `.tower-panel__prompt`, `.tower-panel__input`, `.tower-panel__send-error`)

PR #66 removed input boxes from TowerConsole, LeaderConsole, and AceTerminal, but missed this separate input bar in the TowerPanel wrapper component.

## Test plan
- [ ] Verify Tower panel no longer shows text input or Send button at the bottom
- [ ] Verify Tower terminal still renders and functions correctly
- [ ] TypeScript compiles cleanly (`npx tsc --noEmit` passes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)