### PR TITLE
fix: write trust settings to user-level path to bypass trust dialog

### DIFF
--- a/src/atc/agents/deploy.py
+++ b/src/atc/agents/deploy.py
@@ -126,6 +126,10 @@ def deploy_ace_files(
     # Ensure the staging directory is a git repo so Claude Code finds settings
     _ensure_git_repo(root)
 
+    # Write trust acceptance to the user-level per-project settings so Claude
+    # Code skips the "Do you trust this project?" dialog.
+    _write_user_trust_settings(root)
+
     # CLAUDE.md
     claude_md = _build_ace_claude_md(spec)
     written.append(_write_file(root / "CLAUDE.md", claude_md))
@@ -174,6 +178,10 @@ def deploy_manager_files(
     # Ensure the staging directory is a git repo so Claude Code finds settings
     _ensure_git_repo(root)
 
+    # Write trust acceptance to the user-level per-project settings so Claude
+    # Code skips the "Do you trust this project?" dialog.
+    _write_user_trust_settings(root)
+
     # CLAUDE.md
     claude_md = _build_manager_claude_md(spec)
     written.append(_write_file(root / "CLAUDE.md", claude_md))
@@ -221,6 +229,10 @@ def deploy_tower_files(
 
     # Ensure the staging directory is a git repo so Claude Code finds settings
     _ensure_git_repo(root)
+
+    # Write trust acceptance to the user-level per-project settings so Claude
+    # Code skips the "Do you trust this project?" dialog.
+    _write_user_trust_settings(root)
 
     # CLAUDE.md
     claude_md = _build_tower_claude_md(spec)
@@ -536,6 +548,7 @@ def _build_settings(
     return {
         "model": model,
         "hasTrustDialogAccepted": True,
+        "enableAllProjectMcpServers": True,
         "autoMemoryEnabled": False,
         "spinnerTipsEnabled": False,
         "permissions": {
@@ -739,6 +752,51 @@ def _ensure_git_repo(root: Path) -> None:
             capture_output=True,
         )
         logger.debug("Initialized git repo at %s", root)
+
+
+def _write_user_trust_settings(root: Path) -> None:
+    """Write trust acceptance to the user-level per-project settings.
+
+    Claude Code stores per-project trust decisions at::
+
+        ~/.claude/projects/<encoded-path>/settings.local.json
+
+    where ``<encoded-path>`` is the resolved project path with ``/`` replaced
+    by ``-``.  Writing ``hasTrustDialogAccepted`` at the project level
+    (``.claude/settings.local.json``) is **not** sufficient — Claude Code only
+    reads trust acceptance from the user-level location.
+
+    This function creates the user-level settings file so Claude Code skips
+    the "Do you trust this project?" dialog entirely.
+    """
+    # Resolve symlinks (e.g. /tmp → /private/tmp on macOS) to match
+    # the path Claude Code uses internally.
+    resolved = root.resolve()
+    encoded_path = str(resolved).replace("/", "-")
+
+    claude_home = Path.home() / ".claude"
+    user_project_dir = claude_home / "projects" / encoded_path
+    user_settings_path = user_project_dir / "settings.local.json"
+
+    trust_settings = {
+        "hasTrustDialogAccepted": True,
+        "enableAllProjectMcpServers": True,
+    }
+
+    # Merge with existing settings if the file already exists
+    if user_settings_path.exists():
+        try:
+            existing = json.loads(user_settings_path.read_text())
+            existing.update(trust_settings)
+            trust_settings = existing
+        except (json.JSONDecodeError, OSError):
+            pass  # overwrite if corrupt
+
+    user_project_dir.mkdir(parents=True, exist_ok=True)
+    user_settings_path.write_text(json.dumps(trust_settings, indent=2))
+    logger.debug(
+        "Wrote user-level trust settings for %s → %s", resolved, user_settings_path
+    )
 
 
 def _write_file(path: Path, content: str) -> str:

--- a/tests/unit/test_deploy.py
+++ b/tests/unit/test_deploy.py
@@ -215,6 +215,31 @@ class TestDeployAceFiles:
         settings = json.loads(local_path.read_text())
         assert settings["hasTrustDialogAccepted"] is True
 
+    def test_settings_has_enable_all_project_mcp_servers(
+        self, ace_spec: AceDeploySpec, staging_root: Path
+    ) -> None:
+        result = deploy_ace_files(ace_spec, staging_root=staging_root)
+        settings = json.loads(result.settings_path.read_text())
+        assert settings["enableAllProjectMcpServers"] is True
+
+    def test_writes_user_level_trust_settings(
+        self, ace_spec: AceDeploySpec, staging_root: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Deploy should write trust settings to ~/.claude/projects/<encoded>/settings.local.json."""
+        fake_home = tmp_path / "fakehome"
+        fake_home.mkdir()
+        monkeypatch.setenv("HOME", str(fake_home))
+
+        result = deploy_ace_files(ace_spec, staging_root=staging_root)
+
+        # Find the user-level project settings
+        encoded_path = str(result.root.resolve()).replace("/", "-")
+        user_settings = fake_home / ".claude" / "projects" / encoded_path / "settings.local.json"
+        assert user_settings.exists(), f"Expected {user_settings} to exist"
+        settings = json.loads(user_settings.read_text())
+        assert settings["hasTrustDialogAccepted"] is True
+        assert settings["enableAllProjectMcpServers"] is True
+
     def test_initializes_git_repo(self, ace_spec: AceDeploySpec, staging_root: Path) -> None:
         result = deploy_ace_files(ace_spec, staging_root=staging_root)
         assert (result.root / ".git").exists()
@@ -348,6 +373,23 @@ class TestDeployManagerFiles:
         settings = json.loads(local_path.read_text())
         assert settings["hasTrustDialogAccepted"] is True
 
+    def test_writes_user_level_trust_settings(
+        self, manager_spec: ManagerDeploySpec, staging_root: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Deploy should write trust settings to ~/.claude/projects/<encoded>/settings.local.json."""
+        fake_home = tmp_path / "fakehome"
+        fake_home.mkdir()
+        monkeypatch.setenv("HOME", str(fake_home))
+
+        result = deploy_manager_files(manager_spec, staging_root=staging_root)
+
+        encoded_path = str(result.root.resolve()).replace("/", "-")
+        user_settings = fake_home / ".claude" / "projects" / encoded_path / "settings.local.json"
+        assert user_settings.exists()
+        settings = json.loads(user_settings.read_text())
+        assert settings["hasTrustDialogAccepted"] is True
+        assert settings["enableAllProjectMcpServers"] is True
+
     def test_initializes_git_repo(
         self, manager_spec: ManagerDeploySpec, staging_root: Path
     ) -> None:
@@ -461,6 +503,23 @@ class TestDeployTowerFiles:
         assert local_path.exists()
         settings = json.loads(local_path.read_text())
         assert settings["hasTrustDialogAccepted"] is True
+
+    def test_writes_user_level_trust_settings(
+        self, tower_spec: TowerDeploySpec, staging_root: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Deploy should write trust settings to ~/.claude/projects/<encoded>/settings.local.json."""
+        fake_home = tmp_path / "fakehome"
+        fake_home.mkdir()
+        monkeypatch.setenv("HOME", str(fake_home))
+
+        result = deploy_tower_files(tower_spec, staging_root=staging_root)
+
+        encoded_path = str(result.root.resolve()).replace("/", "-")
+        user_settings = fake_home / ".claude" / "projects" / encoded_path / "settings.local.json"
+        assert user_settings.exists()
+        settings = json.loads(user_settings.read_text())
+        assert settings["hasTrustDialogAccepted"] is True
+        assert settings["enableAllProjectMcpServers"] is True
 
     def test_initializes_git_repo(
         self, tower_spec: TowerDeploySpec, staging_root: Path


### PR DESCRIPTION
## Summary
- Claude Code reads trust acceptance from `~/.claude/projects/<encoded-path>/settings.local.json` (user-level), **not** from the project's `.claude/settings.local.json`. PR #65 wrote `hasTrustDialogAccepted` to the project-level file, which Claude Code ignores for trust decisions — so the dialog kept appearing.
- Deploy functions now write `hasTrustDialogAccepted: true` and `enableAllProjectMcpServers: true` to the correct user-level per-project settings path (`~/.claude/projects/-private-tmp-atc-agents-<session-id>/settings.local.json`).
- Also adds `enableAllProjectMcpServers: true` to project-level `settings.json` to prevent MCP server consent dialogs.

## Root Cause

Investigated `~/.claude/projects/` on the host and found per-project directories named by path encoding (e.g. `-private-tmp-atc-agents-<session-id>`), but **none** had a `settings.local.json` file. This confirmed Claude Code never received trust acceptance at the user level, which is the only location it checks.

## Test plan
- [x] All 56 deploy unit tests pass (3 new tests for user-level trust settings)
- [x] Verified path encoding matches Claude Code convention (`/` → `-`, symlinks resolved)
- [ ] Manual: start a Tower/Leader session and verify no trust dialog appears

Generated with [Claude Code](https://claude.com/claude-code)