### PR TITLE
feat: ContextHub component with CRUD and scope tabs

### DIFF
--- a/frontend/src/components/context/ContextHub.css
+++ b/frontend/src/components/context/ContextHub.css
@@ -1,0 +1,322 @@
+/* ContextHub — CRUD context entries with scope tabs */
+
+.context-hub {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+}
+
+.context-hub__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.context-hub__header h3 {
+  font-size: var(--text-sm);
+  color: var(--color-text-secondary);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+/* Scope tabs */
+.context-hub__tabs {
+  display: flex;
+  gap: var(--space-1);
+  border-bottom: 1px solid var(--color-border-subtle);
+  padding-bottom: var(--space-1);
+}
+
+.context-hub__tab {
+  padding: var(--space-1) var(--space-3);
+  font-size: var(--text-xs);
+  font-family: var(--font-sans);
+  font-weight: 500;
+  color: var(--color-text-muted);
+  background: none;
+  border: none;
+  border-bottom: 2px solid transparent;
+  cursor: pointer;
+  transition: color var(--transition-fast), border-color var(--transition-fast);
+}
+
+.context-hub__tab:hover {
+  color: var(--color-text-secondary);
+}
+
+.context-hub__tab--active {
+  color: var(--color-accent);
+  border-bottom-color: var(--color-accent);
+}
+
+/* Status messages */
+.context-hub__loading,
+.context-hub__empty {
+  font-size: var(--text-sm);
+  color: var(--color-text-muted);
+}
+
+.context-hub__error {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-2);
+  padding: var(--space-2) var(--space-3);
+  font-size: var(--text-sm);
+  color: var(--color-status-red);
+  background: rgba(248, 81, 73, 0.1);
+  border: 1px solid rgba(248, 81, 73, 0.3);
+  border-radius: var(--radius-md);
+}
+
+.context-hub__error-dismiss {
+  background: none;
+  border: none;
+  font-size: var(--text-xs);
+  color: var(--color-text-muted);
+  cursor: pointer;
+  text-decoration: underline;
+}
+
+/* Entry list */
+.context-hub__entries {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+
+/* Entry card */
+.context-hub__entry {
+  background: var(--color-bg);
+  border: 1px solid var(--color-border-subtle);
+  border-radius: var(--radius-md);
+  transition: border-color var(--transition-fast);
+}
+
+.context-hub__entry:hover {
+  border-color: var(--color-border);
+}
+
+.context-hub__entry--expanded {
+  border-color: var(--color-accent);
+}
+
+.context-hub__entry--restricted {
+  opacity: 0.7;
+}
+
+/* Entry header — clickable row */
+.context-hub__entry-header {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+  width: 100%;
+  padding: var(--space-2) var(--space-3);
+  background: none;
+  border: none;
+  cursor: pointer;
+  text-align: left;
+  color: var(--color-text);
+  font-family: var(--font-sans);
+}
+
+.context-hub__entry-meta {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  flex-wrap: wrap;
+}
+
+.context-hub__entry-key {
+  font-size: var(--text-xs);
+  font-family: var(--font-mono);
+  color: var(--color-accent);
+  font-weight: 500;
+}
+
+.context-hub__entry-type-badge {
+  font-size: 0.625rem;
+  padding: 1px 6px;
+  background: var(--color-bg-elevated);
+  border: 1px solid var(--color-border-subtle);
+  border-radius: var(--radius-sm);
+  color: var(--color-text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.context-hub__entry-restricted-badge {
+  font-size: 0.625rem;
+  padding: 1px 6px;
+  background: rgba(210, 153, 34, 0.15);
+  border: 1px solid rgba(210, 153, 34, 0.3);
+  border-radius: var(--radius-sm);
+  color: var(--color-status-amber);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.context-hub__entry-preview {
+  font-size: var(--text-sm);
+  color: var(--color-text-secondary);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+/* Entry body — expanded edit area */
+.context-hub__entry-body {
+  padding: 0 var(--space-3) var(--space-3);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+}
+
+.context-hub__entry-fields {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+
+.context-hub__entry-value-input {
+  width: 100%;
+  padding: var(--space-2) var(--space-3);
+  font-size: var(--text-sm);
+  font-family: var(--font-mono);
+  color: var(--color-text);
+  background: var(--color-bg-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  outline: none;
+  resize: vertical;
+  transition: border-color var(--transition-fast);
+  line-height: 1.5;
+}
+
+.context-hub__entry-value-input:focus {
+  border-color: var(--color-accent);
+}
+
+.context-hub__entry-row {
+  display: flex;
+  align-items: center;
+  gap: var(--space-4);
+}
+
+.context-hub__entry-field {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  font-size: var(--text-xs);
+  color: var(--color-text-secondary);
+}
+
+.context-hub__entry-field select {
+  padding: var(--space-1) var(--space-2);
+  font-size: var(--text-xs);
+  font-family: var(--font-sans);
+  color: var(--color-text);
+  background: var(--color-bg-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  outline: none;
+}
+
+.context-hub__entry-toggle {
+  display: flex;
+  align-items: center;
+  gap: var(--space-1);
+  font-size: var(--text-xs);
+  color: var(--color-text-secondary);
+  cursor: pointer;
+}
+
+.context-hub__entry-toggle input[type="checkbox"] {
+  accent-color: var(--color-accent);
+}
+
+.context-hub__entry-actions {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+}
+
+.context-hub__entry-footer {
+  font-size: var(--text-xs);
+  color: var(--color-text-muted);
+}
+
+.context-hub__entry-updated-by {
+  font-style: italic;
+}
+
+/* Create form */
+.context-hub__create-form {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  padding: var(--space-3);
+  background: var(--color-bg);
+  border: 1px solid var(--color-accent);
+  border-radius: var(--radius-md);
+}
+
+.context-hub__create-row {
+  display: flex;
+  gap: var(--space-2);
+}
+
+.context-hub__create-key {
+  flex: 1;
+  padding: var(--space-2) var(--space-3);
+  font-size: var(--text-sm);
+  font-family: var(--font-mono);
+  color: var(--color-text);
+  background: var(--color-bg-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  outline: none;
+}
+
+.context-hub__create-key:focus {
+  border-color: var(--color-accent);
+}
+
+.context-hub__create-type {
+  padding: var(--space-2) var(--space-3);
+  font-size: var(--text-sm);
+  font-family: var(--font-sans);
+  color: var(--color-text);
+  background: var(--color-bg-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  outline: none;
+}
+
+.context-hub__create-value {
+  padding: var(--space-2) var(--space-3);
+  font-size: var(--text-sm);
+  font-family: var(--font-mono);
+  color: var(--color-text);
+  background: var(--color-bg-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  outline: none;
+  resize: vertical;
+  line-height: 1.5;
+}
+
+.context-hub__create-value:focus {
+  border-color: var(--color-accent);
+}
+
+.context-hub__create-actions {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.context-hub__create-buttons {
+  display: flex;
+  gap: var(--space-2);
+}

--- a/frontend/src/components/context/ContextHub.tsx
+++ b/frontend/src/components/context/ContextHub.tsx
@@ -1,0 +1,471 @@
+import { useState, useEffect, useCallback, useRef } from "react";
+import type { ContextEntry, ContextScope } from "../../types";
+import { api, ApiError } from "../../utils/api";
+import ConfirmPopover from "../common/ConfirmPopover";
+import "./ContextHub.css";
+
+/** Props for the ContextHub component. */
+interface ContextHubProps {
+  /** Which scope tab to show initially. */
+  scope: ContextScope;
+  /** Project ID — required for project-scoped entries. */
+  projectId?: string;
+  /** Session ID — required for tower/leader/ace scoped entries. */
+  sessionId?: string;
+  /** Whether to show scope tabs or lock to a single scope. */
+  showScopeTabs?: boolean;
+  /** Which scopes to show in the tab bar (defaults to all). */
+  availableScopes?: ContextScope[];
+}
+
+const SCOPE_LABELS: Record<ContextScope, string> = {
+  global: "Global",
+  project: "Project",
+  tower: "Tower",
+  leader: "Leader",
+  ace: "Ace",
+};
+
+const ENTRY_TYPES = ["text", "status", "list", "link", "json"] as const;
+
+export default function ContextHub({
+  scope: initialScope,
+  projectId,
+  sessionId,
+  showScopeTabs = false,
+  availableScopes = ["global", "project", "tower", "leader", "ace"],
+}: ContextHubProps) {
+  const [activeScope, setActiveScope] = useState<ContextScope>(initialScope);
+  const [entries, setEntries] = useState<ContextEntry[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [expandedId, setExpandedId] = useState<string | null>(null);
+  const [showCreateForm, setShowCreateForm] = useState(false);
+
+  // Fetch entries for the active scope
+  const fetchEntries = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      let path: string;
+      if (activeScope === "global") {
+        path = "/context";
+      } else if (activeScope === "project" && projectId) {
+        path = `/projects/${projectId}/context`;
+      } else if (sessionId) {
+        path = `/sessions/${sessionId}/context?scope=${activeScope}`;
+      } else {
+        setEntries([]);
+        setLoading(false);
+        return;
+      }
+      const data = await api.get<ContextEntry[]>(path);
+      setEntries(data);
+    } catch (err) {
+      const msg = err instanceof ApiError ? err.message : "Failed to load context entries";
+      setError(msg);
+    } finally {
+      setLoading(false);
+    }
+  }, [activeScope, projectId, sessionId]);
+
+  useEffect(() => {
+    void fetchEntries();
+  }, [fetchEntries]);
+
+  // Update scope when initialScope prop changes
+  useEffect(() => {
+    setActiveScope(initialScope);
+  }, [initialScope]);
+
+  const handleCreate = async (data: {
+    key: string;
+    value: string;
+    entry_type: string;
+    restricted: boolean;
+  }) => {
+    try {
+      let path: string;
+      let body: Record<string, unknown> = { ...data };
+      if (activeScope === "global") {
+        path = "/context";
+      } else if (activeScope === "project" && projectId) {
+        path = `/projects/${projectId}/context`;
+      } else if (sessionId) {
+        path = `/sessions/${sessionId}/context`;
+        body = { ...data, scope: activeScope };
+      } else {
+        return;
+      }
+      await api.post(path, body);
+      setShowCreateForm(false);
+      await fetchEntries();
+    } catch (err) {
+      const msg = err instanceof ApiError ? err.message : "Failed to create entry";
+      setError(msg);
+    }
+  };
+
+  const handleUpdate = async (
+    entryId: string,
+    updates: { value?: string; entry_type?: string; restricted?: boolean },
+  ) => {
+    try {
+      await api.put(`/context/${entryId}`, updates);
+      await fetchEntries();
+    } catch (err) {
+      const msg = err instanceof ApiError ? err.message : "Failed to update entry";
+      setError(msg);
+    }
+  };
+
+  const handleDelete = async (entryId: string) => {
+    try {
+      await api.delete(`/context/${entryId}`);
+      setExpandedId(null);
+      await fetchEntries();
+    } catch (err) {
+      const msg = err instanceof ApiError ? err.message : "Failed to delete entry";
+      setError(msg);
+    }
+  };
+
+  return (
+    <div className="context-hub" data-testid="context-hub">
+      <div className="context-hub__header">
+        <h3>Context</h3>
+        <button
+          className="btn btn-sm btn-primary"
+          onClick={() => setShowCreateForm((v) => !v)}
+          data-testid="context-hub-create-btn"
+        >
+          {showCreateForm ? "Cancel" : "+ New"}
+        </button>
+      </div>
+
+      {showScopeTabs && (
+        <div className="context-hub__tabs" data-testid="context-hub-tabs">
+          {availableScopes.map((s) => (
+            <button
+              key={s}
+              className={`context-hub__tab ${s === activeScope ? "context-hub__tab--active" : ""}`}
+              onClick={() => {
+                setActiveScope(s);
+                setExpandedId(null);
+                setShowCreateForm(false);
+              }}
+            >
+              {SCOPE_LABELS[s]}
+            </button>
+          ))}
+        </div>
+      )}
+
+      {error && (
+        <div className="context-hub__error" data-testid="context-hub-error">
+          {error}
+          <button className="context-hub__error-dismiss" onClick={() => setError(null)}>
+            Dismiss
+          </button>
+        </div>
+      )}
+
+      {showCreateForm && (
+        <CreateEntryForm
+          onSubmit={handleCreate}
+          onCancel={() => setShowCreateForm(false)}
+        />
+      )}
+
+      {loading ? (
+        <p className="context-hub__loading">Loading...</p>
+      ) : entries.length === 0 ? (
+        <p className="context-hub__empty">No context entries yet.</p>
+      ) : (
+        <div className="context-hub__entries" data-testid="context-hub-entries">
+          {entries.map((entry) => (
+            <EntryCard
+              key={entry.id}
+              entry={entry}
+              expanded={expandedId === entry.id}
+              onToggle={() =>
+                setExpandedId(expandedId === entry.id ? null : entry.id)
+              }
+              onUpdate={handleUpdate}
+              onDelete={handleDelete}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Entry Card — click to expand/edit inline
+// ---------------------------------------------------------------------------
+
+interface EntryCardProps {
+  entry: ContextEntry;
+  expanded: boolean;
+  onToggle: () => void;
+  onUpdate: (
+    id: string,
+    updates: { value?: string; entry_type?: string; restricted?: boolean },
+  ) => Promise<void>;
+  onDelete: (id: string) => Promise<void>;
+}
+
+function EntryCard({ entry, expanded, onToggle, onUpdate, onDelete }: EntryCardProps) {
+  const [editValue, setEditValue] = useState(entry.value);
+  const [editType, setEditType] = useState(entry.entry_type);
+  const [editRestricted, setEditRestricted] = useState(entry.restricted);
+  const [saving, setSaving] = useState(false);
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+
+  // Sync local state when entry changes
+  useEffect(() => {
+    setEditValue(entry.value);
+    setEditType(entry.entry_type);
+    setEditRestricted(entry.restricted);
+  }, [entry.value, entry.entry_type, entry.restricted]);
+
+  // Auto-focus textarea when expanded
+  useEffect(() => {
+    if (expanded && textareaRef.current) {
+      textareaRef.current.focus();
+    }
+  }, [expanded]);
+
+  const hasChanges =
+    editValue !== entry.value ||
+    editType !== entry.entry_type ||
+    editRestricted !== entry.restricted;
+
+  const handleSave = async () => {
+    if (!hasChanges) return;
+    setSaving(true);
+    const updates: Record<string, unknown> = {};
+    if (editValue !== entry.value) updates.value = editValue;
+    if (editType !== entry.entry_type) updates.entry_type = editType;
+    if (editRestricted !== entry.restricted) updates.restricted = editRestricted;
+    await onUpdate(entry.id, updates);
+    setSaving(false);
+  };
+
+  const handleBlur = () => {
+    if (hasChanges) {
+      void handleSave();
+    }
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === "Enter" && (e.metaKey || e.ctrlKey)) {
+      e.preventDefault();
+      void handleSave();
+    }
+  };
+
+  // Value preview — first line, truncated
+  const preview =
+    entry.value.length > 120
+      ? entry.value.slice(0, 120) + "..."
+      : entry.value.split("\n")[0];
+
+  return (
+    <div
+      className={`context-hub__entry ${expanded ? "context-hub__entry--expanded" : ""} ${entry.restricted ? "context-hub__entry--restricted" : ""}`}
+      data-testid="context-hub-entry"
+    >
+      <button
+        className="context-hub__entry-header"
+        onClick={onToggle}
+        type="button"
+      >
+        <div className="context-hub__entry-meta">
+          <span className="context-hub__entry-key">{entry.key}</span>
+          <span className="context-hub__entry-type-badge">{entry.entry_type}</span>
+          {entry.restricted && (
+            <span className="context-hub__entry-restricted-badge">restricted</span>
+          )}
+        </div>
+        {!expanded && (
+          <span className="context-hub__entry-preview">{preview}</span>
+        )}
+      </button>
+
+      {expanded && (
+        <div className="context-hub__entry-body">
+          <div className="context-hub__entry-fields">
+            <textarea
+              ref={textareaRef}
+              className="context-hub__entry-value-input"
+              value={editValue}
+              onChange={(e) => setEditValue(e.target.value)}
+              onBlur={handleBlur}
+              onKeyDown={handleKeyDown}
+              rows={Math.min(Math.max(editValue.split("\n").length, 3), 16)}
+              data-testid="context-hub-entry-value"
+            />
+            <div className="context-hub__entry-row">
+              <label className="context-hub__entry-field">
+                <span>Type</span>
+                <select
+                  value={editType}
+                  onChange={(e) => {
+                    setEditType(e.target.value);
+                  }}
+                  onBlur={handleBlur}
+                >
+                  {ENTRY_TYPES.map((t) => (
+                    <option key={t} value={t}>
+                      {t}
+                    </option>
+                  ))}
+                </select>
+              </label>
+              <label className="context-hub__entry-field context-hub__entry-toggle">
+                <input
+                  type="checkbox"
+                  checked={editRestricted}
+                  onChange={(e) => {
+                    setEditRestricted(e.target.checked);
+                    // Auto-save toggle immediately
+                    void onUpdate(entry.id, { restricted: e.target.checked });
+                  }}
+                />
+                <span>Restricted</span>
+              </label>
+            </div>
+          </div>
+
+          <div className="context-hub__entry-actions">
+            {hasChanges && (
+              <button
+                className="btn btn-sm btn-primary"
+                onClick={() => void handleSave()}
+                disabled={saving}
+              >
+                {saving ? "Saving..." : "Save"}
+              </button>
+            )}
+            <ConfirmPopover
+              message={`Delete "${entry.key}"?`}
+              confirmLabel="Delete"
+              variant="danger"
+              onConfirm={() => void onDelete(entry.id)}
+            >
+              <button className="btn btn-sm btn-danger">Delete</button>
+            </ConfirmPopover>
+          </div>
+
+          <div className="context-hub__entry-footer">
+            {entry.updated_by && (
+              <span className="context-hub__entry-updated-by">
+                by {entry.updated_by}
+              </span>
+            )}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Create Entry Form
+// ---------------------------------------------------------------------------
+
+interface CreateEntryFormProps {
+  onSubmit: (data: {
+    key: string;
+    value: string;
+    entry_type: string;
+    restricted: boolean;
+  }) => Promise<void>;
+  onCancel: () => void;
+}
+
+function CreateEntryForm({ onSubmit, onCancel }: CreateEntryFormProps) {
+  const [key, setKey] = useState("");
+  const [value, setValue] = useState("");
+  const [entryType, setEntryType] = useState("text");
+  const [restricted, setRestricted] = useState(false);
+  const [submitting, setSubmitting] = useState(false);
+  const keyRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    keyRef.current?.focus();
+  }, []);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!key.trim() || !value.trim()) return;
+    setSubmitting(true);
+    await onSubmit({ key: key.trim(), value, entry_type: entryType, restricted });
+    setSubmitting(false);
+  };
+
+  return (
+    <form
+      className="context-hub__create-form"
+      onSubmit={(e) => void handleSubmit(e)}
+      data-testid="context-hub-create-form"
+    >
+      <div className="context-hub__create-row">
+        <input
+          ref={keyRef}
+          className="context-hub__create-key"
+          type="text"
+          placeholder="Key"
+          value={key}
+          onChange={(e) => setKey(e.target.value)}
+          required
+          data-testid="context-hub-create-key"
+        />
+        <select
+          className="context-hub__create-type"
+          value={entryType}
+          onChange={(e) => setEntryType(e.target.value)}
+        >
+          {ENTRY_TYPES.map((t) => (
+            <option key={t} value={t}>
+              {t}
+            </option>
+          ))}
+        </select>
+      </div>
+      <textarea
+        className="context-hub__create-value"
+        placeholder="Value"
+        value={value}
+        onChange={(e) => setValue(e.target.value)}
+        rows={3}
+        required
+        data-testid="context-hub-create-value"
+      />
+      <div className="context-hub__create-actions">
+        <label className="context-hub__entry-toggle">
+          <input
+            type="checkbox"
+            checked={restricted}
+            onChange={(e) => setRestricted(e.target.checked)}
+          />
+          <span>Restricted</span>
+        </label>
+        <div className="context-hub__create-buttons">
+          <button type="button" className="btn btn-sm" onClick={onCancel}>
+            Cancel
+          </button>
+          <button
+            type="submit"
+            className="btn btn-sm btn-primary"
+            disabled={submitting || !key.trim() || !value.trim()}
+          >
+            {submitting ? "Creating..." : "Create"}
+          </button>
+        </div>
+      </div>
+    </form>
+  );
+}

--- a/frontend/src/components/context/__tests__/ContextHub.test.tsx
+++ b/frontend/src/components/context/__tests__/ContextHub.test.tsx
@@ -1,0 +1,143 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import ContextHub from "../ContextHub";
+import { renderWithProviders } from "../../../test/helpers";
+import type { ContextEntry } from "../../../types";
+
+const MOCK_ENTRIES: ContextEntry[] = [
+  {
+    id: "e1",
+    scope: "global",
+    project_id: null,
+    session_id: null,
+    key: "coding-standards",
+    entry_type: "text",
+    value: "Follow TypeScript strict mode",
+    restricted: false,
+    position: 0,
+    updated_by: "admin",
+    created_at: "2026-01-01T00:00:00Z",
+    updated_at: "2026-01-01T00:00:00Z",
+  },
+  {
+    id: "e2",
+    scope: "global",
+    project_id: null,
+    session_id: null,
+    key: "internal-hooks",
+    entry_type: "json",
+    value: '{"pre_deploy": "lint"}',
+    restricted: true,
+    position: 1,
+    updated_by: "system",
+    created_at: "2026-01-01T00:00:00Z",
+    updated_at: "2026-01-01T00:00:00Z",
+  },
+];
+
+function mockFetch(data: unknown = MOCK_ENTRIES, status = 200) {
+  return vi.spyOn(globalThis, "fetch").mockResolvedValue(
+    new Response(JSON.stringify(data), { status }),
+  );
+}
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("ContextHub", () => {
+  it("renders the component", async () => {
+    mockFetch();
+    renderWithProviders(<ContextHub scope="global" />);
+    expect(screen.getByTestId("context-hub")).toBeInTheDocument();
+  });
+
+  it("shows loading then entries", async () => {
+    mockFetch();
+    renderWithProviders(<ContextHub scope="global" />);
+    expect(screen.getByText("Loading...")).toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.getByText("coding-standards")).toBeInTheDocument();
+    });
+  });
+
+  it("shows entries with type badges", async () => {
+    mockFetch();
+    renderWithProviders(<ContextHub scope="global" />);
+    await waitFor(() => {
+      expect(screen.getByText("coding-standards")).toBeInTheDocument();
+    });
+    expect(screen.getByText("text")).toBeInTheDocument();
+    expect(screen.getByText("json")).toBeInTheDocument();
+  });
+
+  it("shows restricted badge for restricted entries", async () => {
+    mockFetch();
+    renderWithProviders(<ContextHub scope="global" />);
+    await waitFor(() => {
+      expect(screen.getByText("restricted")).toBeInTheDocument();
+    });
+  });
+
+  it("shows empty state when no entries", async () => {
+    mockFetch([]);
+    renderWithProviders(<ContextHub scope="global" />);
+    await waitFor(() => {
+      expect(screen.getByText("No context entries yet.")).toBeInTheDocument();
+    });
+  });
+
+  it("expands entry on click to show edit form", async () => {
+    mockFetch();
+    const user = userEvent.setup();
+    renderWithProviders(<ContextHub scope="global" />);
+    await waitFor(() => {
+      expect(screen.getByText("coding-standards")).toBeInTheDocument();
+    });
+    await user.click(screen.getByText("coding-standards"));
+    expect(screen.getByTestId("context-hub-entry-value")).toBeInTheDocument();
+  });
+
+  it("shows scope tabs when showScopeTabs is true", async () => {
+    mockFetch();
+    renderWithProviders(
+      <ContextHub scope="global" showScopeTabs availableScopes={["global", "project"]} />,
+    );
+    expect(screen.getByTestId("context-hub-tabs")).toBeInTheDocument();
+    expect(screen.getByText("Global")).toBeInTheDocument();
+    expect(screen.getByText("Project")).toBeInTheDocument();
+  });
+
+  it("toggles create form", async () => {
+    mockFetch();
+    const user = userEvent.setup();
+    renderWithProviders(<ContextHub scope="global" />);
+    await waitFor(() => {
+      expect(screen.getByTestId("context-hub-create-btn")).toBeInTheDocument();
+    });
+    await user.click(screen.getByTestId("context-hub-create-btn"));
+    expect(screen.getByTestId("context-hub-create-form")).toBeInTheDocument();
+  });
+
+  it("shows error on fetch failure", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response("Server error", { status: 500 }),
+    );
+    renderWithProviders(<ContextHub scope="global" />);
+    await waitFor(() => {
+      expect(screen.getByTestId("context-hub-error")).toBeInTheDocument();
+    });
+  });
+
+  it("calls correct API path for project scope", async () => {
+    const fetchSpy = mockFetch();
+    renderWithProviders(<ContextHub scope="project" projectId="proj-1" />);
+    await waitFor(() => {
+      expect(fetchSpy).toHaveBeenCalledWith(
+        expect.stringContaining("/projects/proj-1/context"),
+        expect.anything(),
+      );
+    });
+  });
+});

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -4,6 +4,7 @@ import { useAppContext } from "../context/AppContext";
 import StatusBadge from "../components/common/StatusBadge";
 import TimeAgo from "../components/common/TimeAgo";
 import CreateProjectModal from "../components/common/CreateProjectModal";
+import ContextHub from "../components/context/ContextHub";
 import "./Dashboard.css";
 
 export default function Dashboard() {
@@ -139,6 +140,13 @@ export default function Dashboard() {
             ))}
           </div>
         )}
+      </section>
+
+      {/* Global context section */}
+      <section className="dashboard__context">
+        <div className="panel">
+          <ContextHub scope="global" />
+        </div>
       </section>
 
       <CreateProjectModal

--- a/frontend/src/pages/ProjectView.tsx
+++ b/frontend/src/pages/ProjectView.tsx
@@ -4,6 +4,7 @@ import StatusBadge from "../components/common/StatusBadge";
 import LeaderConsole from "../components/leader/LeaderConsole";
 import TaskBoard from "../components/leader/TaskBoard";
 import AceList from "../components/ace/AceList";
+import ContextHub from "../components/context/ContextHub";
 import "./ProjectView.css";
 
 export default function ProjectView() {
@@ -57,6 +58,15 @@ export default function ProjectView() {
               sessions={projectSessions}
               onRefresh={fetchAll}
               compact
+            />
+          </div>
+
+          <div className="panel project-view__context">
+            <ContextHub
+              scope="project"
+              projectId={project.id}
+              showScopeTabs
+              availableScopes={["project", "global"]}
             />
           </div>
         </aside>

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -185,6 +185,23 @@ export interface AppEvent {
   created_at: string;
 }
 
+export type ContextScope = "global" | "project" | "tower" | "leader" | "ace";
+
+export interface ContextEntry {
+  id: string;
+  scope: ContextScope;
+  project_id: string | null;
+  session_id: string | null;
+  key: string;
+  entry_type: string;
+  value: string;
+  restricted: boolean;
+  position: number;
+  updated_by: string;
+  created_at: string;
+  updated_at: string;
+}
+
 export interface FeatureFlag {
   id: string;
   key: string;


### PR DESCRIPTION
## Summary
- **New `ContextHub` component** (`frontend/src/components/context/ContextHub.tsx`) — full CRUD UI for context entries with scope tabs (Global/Project/Tower/Leader/Ace), inline Notion-style editing, auto-save on blur, entry_type badges, restricted entry indicators, and delete with confirmation
- **`ContextEntry` TypeScript type** added to `frontend/src/types/index.ts` matching the backend schema (id, scope, project_id, session_id, key, entry_type, value, restricted, position, updated_by, timestamps)
- **Dashboard integration** — Global context section added below the projects list
- **ProjectView integration** — ContextHub panel added to the left sidebar with Project/Global scope tabs, replacing the unused ContextViewer
- **10 unit tests** covering rendering, entry display, scope tabs, create form toggle, expand/edit, error handling, and API path routing

## API Endpoints Used
- `GET /api/context` — list global entries
- `POST /api/context` — create global entry
- `GET /api/projects/{id}/context` — list project entries
- `POST /api/projects/{id}/context` — create project entry
- `GET /api/sessions/{id}/context` — list session entries
- `POST /api/sessions/{id}/context` — create session entry
- `PUT /api/context/{id}` — update entry
- `DELETE /api/context/{id}` — delete entry

## Test plan
- [x] TypeScript compiles with no errors
- [x] Vite build succeeds
- [x] All 178 tests pass (168 existing + 10 new)
- [ ] Manual: Dashboard shows Global context section with CRUD
- [ ] Manual: ProjectView shows context panel with Project/Global tabs
- [ ] Manual: Create, edit, and delete entries work end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)