### PR TITLE
feat: agent runtime context read/write via hooks

### DIFF
--- a/src/atc/agents/deploy.py
+++ b/src/atc/agents/deploy.py
@@ -59,12 +59,14 @@ class AceDeploySpec:
     project_name: str
     task_title: str
     task_description: str | None = None
+    project_id: str | None = None
     repo_path: str | None = None
     github_repo: str | None = None
     api_base_url: str = "http://127.0.0.1:8420"
     model: str = "opus"
     allowed_commands: list[str] = field(default_factory=list)
     constraints: list[str] = field(default_factory=list)
+    context_entries: list[dict[str, Any]] = field(default_factory=list)
     extra_context: str = ""
 
 
@@ -358,8 +360,21 @@ def _build_ace_claude_md(spec: AceDeploySpec) -> str:
             lines.append(f"- {c}")
         lines.append("")
 
+    if spec.context_entries:
+        lines.extend(["## Project Context", ""])
+        for entry in spec.context_entries:
+            key = entry.get("key", "")
+            value = entry.get("value", "")
+            if isinstance(value, dict):
+                value = json.dumps(value, indent=2)
+            lines.extend([f"### {key}", "", str(value), ""])
+
     if spec.extra_context:
         lines.extend(["## Context", "", spec.extra_context, ""])
+
+    # Context read/write CLI instructions
+    hooks_dir = f"/tmp/atc-agents/{spec.session_id}/.claude/hooks"
+    lines.extend(_context_cli_instructions(hooks_dir))
 
     if spec.github_repo:
         lines.extend(
@@ -448,6 +463,10 @@ def _build_manager_claude_md(spec: ManagerDeploySpec) -> str:
             if isinstance(value, dict):
                 value = json.dumps(value, indent=2)
             lines.extend([f"### {key}", "", str(value), ""])
+
+    # Context read/write CLI instructions
+    hooks_dir = f"/tmp/atc-agents/{spec.leader_id}/.claude/hooks"
+    lines.extend(_context_cli_instructions(hooks_dir))
 
     lines.extend(
         [
@@ -544,6 +563,10 @@ def _build_tower_claude_md(spec: TowerDeploySpec) -> str:
         "",
     ])
 
+    # Context read/write CLI instructions
+    hooks_dir = f"/tmp/atc-agents/{spec.session_id}/.claude/hooks"
+    lines.extend(_context_cli_instructions(hooks_dir))
+
     if spec.repo_path or spec.github_repo:
         lines.append("## Repository")
         lines.append("")
@@ -587,6 +610,36 @@ def _build_settings(
 # Hook configuration
 # ---------------------------------------------------------------------------
 
+def _context_cli_instructions(hooks_dir: str) -> list[str]:
+    """Return CLAUDE.md lines explaining the context read/write scripts."""
+    return [
+        "## Context Read/Write",
+        "",
+        "You can read and write context entries that persist across sessions.",
+        "Use the deployed helper scripts:",
+        "",
+        "```bash",
+        "# List all context entries visible to you",
+        f"bash {hooks_dir}/context_read.sh",
+        "",
+        "# Read a specific entry by key",
+        f'bash {hooks_dir}/context_read.sh --key "my-key"',
+        "",
+        "# Write a context entry (creates or updates by key)",
+        f'bash {hooks_dir}/context_write.sh --key "my-key" --value "my value"',
+        "",
+        "# Write with explicit type (text, json, list, status, link)",
+        f'bash {hooks_dir}/context_write.sh --key "config"'
+        ' --value \'{"a":1}\' --type json',
+        "```",
+        "",
+        "Context entries are scoped to your session and visible to your scope's",
+        "inheritance rules. Use them to record findings, decisions, and notes",
+        "that should persist beyond the current conversation.",
+        "",
+    ]
+
+
 _STATUS_HOOK_TEMPLATE = """#!/usr/bin/env bash
 set -euo pipefail
 ATC_API="{api_base_url}"
@@ -619,6 +672,91 @@ curl -sf -X POST "$ATC_API/api/aces/$SESSION_ID/notify" \
 """
 
 
+_CONTEXT_READ_TEMPLATE = r"""#!/usr/bin/env bash
+set -euo pipefail
+ATC_API="{api_base_url}"
+SESSION_ID="{session_id}"
+
+# Usage: context_read.sh [--key KEY]
+# Lists context entries visible to this session, or fetches a specific entry by key.
+
+KEY=""
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --key) KEY="$2"; shift 2 ;;
+    *) echo "Unknown option: $1" >&2; exit 1 ;;
+  esac
+done
+
+if [[ -n "$KEY" ]]; then
+  curl -sf "$ATC_API/api/sessions/$SESSION_ID/context?key=$KEY" \
+    -H "Accept: application/json" 2>/dev/null
+else
+  curl -sf "$ATC_API/api/sessions/$SESSION_ID/context" \
+    -H "Accept: application/json" 2>/dev/null
+fi
+"""
+
+_CONTEXT_WRITE_TEMPLATE = r"""#!/usr/bin/env bash
+set -euo pipefail
+ATC_API="{api_base_url}"
+SESSION_ID="{session_id}"
+SCOPE="{scope}"
+
+# Usage: context_write.sh --key KEY --value VALUE [--type TYPE]
+# Creates or updates a context entry for this session.
+# TYPE defaults to "text". Valid types: text, json, list, status, link.
+
+KEY=""
+VALUE=""
+ENTRY_TYPE="text"
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --key) KEY="$2"; shift 2 ;;
+    --value) VALUE="$2"; shift 2 ;;
+    --type) ENTRY_TYPE="$2"; shift 2 ;;
+    *) echo "Unknown option: $1" >&2; exit 1 ;;
+  esac
+done
+
+if [[ -z "$KEY" || -z "$VALUE" ]]; then
+  echo "Usage: context_write.sh --key KEY --value VALUE [--type TYPE]" >&2
+  exit 1
+fi
+
+# Check if entry with this key already exists
+EXISTING=$(curl -sf "$ATC_API/api/sessions/$SESSION_ID/context?key=$KEY" \
+  -H "Accept: application/json" 2>/dev/null || echo "[]")
+
+ENTRY_ID=$(echo "$EXISTING" | python3 -c "
+import sys, json
+entries = json.load(sys.stdin)
+if entries:
+    print(entries[0]['id'])
+" 2>/dev/null || true)
+
+if [[ -n "$ENTRY_ID" ]]; then
+  # Update existing entry
+  curl -sf -X PUT "$ATC_API/api/context/$ENTRY_ID" \
+    -H "Content-Type: application/json" \
+    -d "$(python3 -c "
+import json, sys
+print(json.dumps({{'value': sys.argv[1], 'entry_type': sys.argv[2], 'updated_by': '$SCOPE'}}))
+" "$VALUE" "$ENTRY_TYPE")" 2>/dev/null
+else
+  # Create new entry
+  curl -sf -X POST "$ATC_API/api/sessions/$SESSION_ID/context" \
+    -H "Content-Type: application/json" \
+    -d "$(python3 -c "
+import json, sys
+d = {{'scope': '$SCOPE', 'key': sys.argv[1], 'value': sys.argv[2]}}
+d.update({{'entry_type': sys.argv[3], 'updated_by': '$SCOPE'}})
+print(json.dumps(d))
+" "$KEY" "$VALUE" "$ENTRY_TYPE")" 2>/dev/null
+fi
+"""
+
+
 def _ace_hook_scripts(spec: AceDeploySpec) -> list[HookConfig]:
     """Build the hook shell scripts for an Ace session."""
     header = _STATUS_HOOK_TEMPLATE.format(
@@ -629,6 +767,18 @@ def _ace_hook_scripts(spec: AceDeploySpec) -> list[HookConfig]:
         HookConfig(event="PostToolUse", command=header + _POST_TOOL_USE_BODY),
         HookConfig(event="Stop", command=header + _STOP_HOOK_BODY),
         HookConfig(event="Notification", command=header + _NOTIFICATION_HOOK_BODY),
+        HookConfig(
+            event="context_read",
+            command=_CONTEXT_READ_TEMPLATE.format(
+                api_base_url=spec.api_base_url, session_id=spec.session_id,
+            ),
+        ),
+        HookConfig(
+            event="context_write",
+            command=_CONTEXT_WRITE_TEMPLATE.format(
+                api_base_url=spec.api_base_url, session_id=spec.session_id, scope="ace",
+            ),
+        ),
     ]
 
 
@@ -645,6 +795,18 @@ def _manager_hook_scripts(spec: ManagerDeploySpec) -> list[HookConfig]:
         HookConfig(event="PostToolUse", command=header + _POST_TOOL_USE_BODY),
         HookConfig(event="Stop", command=header + _STOP_HOOK_BODY),
         HookConfig(event="Notification", command=header + _NOTIFICATION_HOOK_BODY),
+        HookConfig(
+            event="context_read",
+            command=_CONTEXT_READ_TEMPLATE.format(
+                api_base_url=spec.api_base_url, session_id=hook_session_id,
+            ),
+        ),
+        HookConfig(
+            event="context_write",
+            command=_CONTEXT_WRITE_TEMPLATE.format(
+                api_base_url=spec.api_base_url, session_id=hook_session_id, scope="leader",
+            ),
+        ),
     ]
 
 
@@ -671,6 +833,18 @@ def _tower_hook_scripts(spec: TowerDeploySpec) -> list[HookConfig]:
         HookConfig(event="PostToolUse", command=header + _POST_TOOL_USE_BODY),
         HookConfig(event="Stop", command=header + _STOP_HOOK_BODY),
         HookConfig(event="Notification", command=header + _NOTIFICATION_HOOK_BODY),
+        HookConfig(
+            event="context_read",
+            command=_CONTEXT_READ_TEMPLATE.format(
+                api_base_url=spec.api_base_url, session_id=spec.session_id,
+            ),
+        ),
+        HookConfig(
+            event="context_write",
+            command=_CONTEXT_WRITE_TEMPLATE.format(
+                api_base_url=spec.api_base_url, session_id=spec.session_id, scope="tower",
+            ),
+        ),
     ]
 
 

--- a/src/atc/leader/orchestrator.py
+++ b/src/atc/leader/orchestrator.py
@@ -21,6 +21,7 @@ from typing import TYPE_CHECKING, Any
 
 from atc.agents.deploy import AceDeploySpec, cleanup_deployed_files, deploy_ace_files
 from atc.agents.factory import get_launch_command
+from atc.leader.context_package import build_context_package
 from atc.leader.decomposer import get_completion_status, get_ready_tasks
 from atc.session.ace import create_ace, destroy_ace, start_ace
 from atc.state import db as db_ops
@@ -136,14 +137,29 @@ class LeaderOrchestrator:
             # Generate a stable session id up-front so deploy can use it
             session_id_preview = str(uuid.uuid4())
 
+            # Fetch inherited context entries for the Ace
+            context_entries: list[dict[str, Any]] = []
+            with contextlib.suppress(Exception):
+                ctx = await build_context_package(
+                    self.conn,
+                    self.project_id,
+                    title,
+                    session_id=session_id_preview,
+                    parent_session_id=self.leader_id,
+                    scope="ace",
+                )
+                context_entries = ctx.get("context_entries", [])
+
             # Deploy config files before launching the session
             spec = AceDeploySpec(
                 session_id=session_id_preview,
                 project_name=project_name,
                 task_title=title,
                 task_description=description,
+                project_id=self.project_id,
                 repo_path=repo_path,
                 github_repo=github_repo,
+                context_entries=context_entries,
             )
             deployed = deploy_ace_files(spec)
             logger.info("Deployed ace config for task '%s' → %s", title, deployed.root)

--- a/tests/unit/test_deploy.py
+++ b/tests/unit/test_deploy.py
@@ -586,3 +586,203 @@ class TestDeployedFiles:
         df = DeployedFiles(root=tmp_path, files=["a.txt"])
         with pytest.raises(AttributeError):
             df.root = tmp_path / "other"  # type: ignore[misc]
+
+
+# ---------------------------------------------------------------------------
+# Context read/write hook scripts
+# ---------------------------------------------------------------------------
+
+
+class TestContextHookScripts:
+    """Test that context_read.sh and context_write.sh are deployed for all agent types."""
+
+    def test_ace_deploys_context_read_script(
+        self, ace_spec: AceDeploySpec, staging_root: Path
+    ) -> None:
+        result = deploy_ace_files(ace_spec, staging_root=staging_root)
+        script = result.root / ".claude" / "hooks" / "context_read.sh"
+        assert script.exists()
+        content = script.read_text()
+        assert "#!/usr/bin/env bash" in content
+        assert "127.0.0.1:8420" in content
+        assert "ace-001" in content
+        assert "/api/sessions/" in content
+        assert "--key" in content
+
+    def test_ace_deploys_context_write_script(
+        self, ace_spec: AceDeploySpec, staging_root: Path
+    ) -> None:
+        result = deploy_ace_files(ace_spec, staging_root=staging_root)
+        script = result.root / ".claude" / "hooks" / "context_write.sh"
+        assert script.exists()
+        content = script.read_text()
+        assert "#!/usr/bin/env bash" in content
+        assert "ace-001" in content
+        assert 'SCOPE="ace"' in content
+        assert "--key" in content
+        assert "--value" in content
+
+    def test_ace_context_scripts_are_executable(
+        self, ace_spec: AceDeploySpec, staging_root: Path
+    ) -> None:
+        result = deploy_ace_files(ace_spec, staging_root=staging_root)
+        for name in ("context_read.sh", "context_write.sh"):
+            script = result.root / ".claude" / "hooks" / name
+            assert script.stat().st_mode & stat.S_IEXEC, f"{name} should be executable"
+
+    def test_manager_deploys_context_scripts(
+        self, manager_spec: ManagerDeploySpec, staging_root: Path
+    ) -> None:
+        result = deploy_manager_files(manager_spec, staging_root=staging_root)
+        hooks_dir = result.root / ".claude" / "hooks"
+        assert (hooks_dir / "context_read.sh").exists()
+        assert (hooks_dir / "context_write.sh").exists()
+        write_content = (hooks_dir / "context_write.sh").read_text()
+        assert 'SCOPE="leader"' in write_content
+
+    def test_manager_context_scripts_use_session_id(self, staging_root: Path) -> None:
+        """Manager context scripts should use session_id (not leader_id) when available."""
+        spec = ManagerDeploySpec(
+            leader_id="leader-x",
+            project_name="Test",
+            goal="Do something",
+            session_id="session-real-123",
+        )
+        result = deploy_manager_files(spec, staging_root=staging_root)
+        read_content = (result.root / ".claude" / "hooks" / "context_read.sh").read_text()
+        assert "session-real-123" in read_content
+
+    def test_tower_deploys_context_scripts(self, staging_root: Path) -> None:
+        spec = TowerDeploySpec(
+            session_id="tower-ctx-001",
+            project_name="Test",
+            project_id="proj-x",
+        )
+        result = deploy_tower_files(spec, staging_root=staging_root)
+        hooks_dir = result.root / ".claude" / "hooks"
+        assert (hooks_dir / "context_read.sh").exists()
+        assert (hooks_dir / "context_write.sh").exists()
+        write_content = (hooks_dir / "context_write.sh").read_text()
+        assert 'SCOPE="tower"' in write_content
+        assert "tower-ctx-001" in write_content
+
+    def test_context_scripts_in_manifest(
+        self, ace_spec: AceDeploySpec, staging_root: Path
+    ) -> None:
+        result = deploy_ace_files(ace_spec, staging_root=staging_root)
+        manifest = json.loads(result.manifest_path.read_text())
+        paths = manifest["files"]
+        assert any("context_read.sh" in p for p in paths)
+        assert any("context_write.sh" in p for p in paths)
+
+    def test_context_read_script_supports_key_filter(
+        self, ace_spec: AceDeploySpec, staging_root: Path
+    ) -> None:
+        """context_read.sh should accept --key parameter for filtering."""
+        result = deploy_ace_files(ace_spec, staging_root=staging_root)
+        content = (result.root / ".claude" / "hooks" / "context_read.sh").read_text()
+        assert "key=$KEY" in content
+
+    def test_context_write_script_supports_upsert(
+        self, ace_spec: AceDeploySpec, staging_root: Path
+    ) -> None:
+        """context_write.sh should check for existing entry and update or create."""
+        result = deploy_ace_files(ace_spec, staging_root=staging_root)
+        content = (result.root / ".claude" / "hooks" / "context_write.sh").read_text()
+        # Should have both PUT (update) and POST (create) logic
+        assert "PUT" in content
+        assert "POST" in content
+
+
+# ---------------------------------------------------------------------------
+# Context entries in Ace CLAUDE.md
+# ---------------------------------------------------------------------------
+
+
+class TestAceContextEntries:
+    """Test that context entries are rendered in Ace CLAUDE.md."""
+
+    def test_ace_claude_md_includes_context_entries(self, staging_root: Path) -> None:
+        spec = AceDeploySpec(
+            session_id="ace-ctx-001",
+            project_name="Phoenix",
+            task_title="Build feature",
+            context_entries=[
+                {"key": "tech-stack", "value": "Python + FastAPI"},
+                {"key": "conventions", "value": {"linter": "ruff", "formatter": "black"}},
+            ],
+        )
+        result = deploy_ace_files(spec, staging_root=staging_root)
+        content = result.claude_md_path.read_text()
+        assert "## Project Context" in content
+        assert "### tech-stack" in content
+        assert "Python + FastAPI" in content
+        assert "### conventions" in content
+        assert "ruff" in content
+
+    def test_ace_claude_md_omits_empty_context_entries(self, staging_root: Path) -> None:
+        spec = AceDeploySpec(
+            session_id="ace-ctx-002",
+            project_name="Phoenix",
+            task_title="Build feature",
+        )
+        result = deploy_ace_files(spec, staging_root=staging_root)
+        content = result.claude_md_path.read_text()
+        assert "## Project Context" not in content
+
+    def test_ace_spec_accepts_project_id(self, staging_root: Path) -> None:
+        spec = AceDeploySpec(
+            session_id="ace-ctx-003",
+            project_name="Phoenix",
+            task_title="Build feature",
+            project_id="proj-abc",
+        )
+        result = deploy_ace_files(spec, staging_root=staging_root)
+        assert result.claude_md_path.exists()
+
+
+# ---------------------------------------------------------------------------
+# Context CLI instructions in CLAUDE.md
+# ---------------------------------------------------------------------------
+
+
+class TestContextCLIInstructions:
+    """Test that context read/write CLI instructions appear in CLAUDE.md for all agents."""
+
+    def test_ace_claude_md_has_context_instructions(
+        self, ace_spec: AceDeploySpec, staging_root: Path
+    ) -> None:
+        result = deploy_ace_files(ace_spec, staging_root=staging_root)
+        content = result.claude_md_path.read_text()
+        assert "## Context Read/Write" in content
+        assert "context_read.sh" in content
+        assert "context_write.sh" in content
+
+    def test_manager_claude_md_has_context_instructions(
+        self, manager_spec: ManagerDeploySpec, staging_root: Path
+    ) -> None:
+        result = deploy_manager_files(manager_spec, staging_root=staging_root)
+        content = result.claude_md_path.read_text()
+        assert "## Context Read/Write" in content
+        assert "context_read.sh" in content
+        assert "context_write.sh" in content
+
+    def test_tower_claude_md_has_context_instructions(self, staging_root: Path) -> None:
+        spec = TowerDeploySpec(
+            session_id="tower-ctx-002",
+            project_name="Test",
+            project_id="proj-x",
+        )
+        result = deploy_tower_files(spec, staging_root=staging_root)
+        content = result.claude_md_path.read_text()
+        assert "## Context Read/Write" in content
+        assert "context_read.sh" in content
+        assert "context_write.sh" in content
+
+    def test_context_instructions_reference_correct_hooks_dir(
+        self, ace_spec: AceDeploySpec, staging_root: Path
+    ) -> None:
+        result = deploy_ace_files(ace_spec, staging_root=staging_root)
+        content = result.claude_md_path.read_text()
+        expected_dir = f"/tmp/atc-agents/{ace_spec.session_id}/.claude/hooks"
+        assert expected_dir in content


### PR DESCRIPTION
## Summary
- Deploy `context_read.sh` and `context_write.sh` scripts to each agent's `.claude/hooks/` directory, enabling Tower, Leader, and Ace agents to read/write context entries at runtime via the CRUD API (from PR #72)
- Add `context_entries` and `project_id` fields to `AceDeploySpec`, rendering inherited context entries in Ace CLAUDE.md at spawn time (matching the existing Manager behavior)
- Wire context entry fetching into the Leader orchestrator's Ace spawn flow using `build_context_package()` with scope inheritance
- Add "Context Read/Write" instructions section to all agent CLAUDE.md files (Tower, Leader, Ace)

## Changes
- **`src/atc/agents/deploy.py`** — New `_CONTEXT_READ_TEMPLATE` and `_CONTEXT_WRITE_TEMPLATE` bash scripts; `_context_cli_instructions()` helper; extended `AceDeploySpec` with `context_entries` and `project_id`; context entries rendering in Ace CLAUDE.md; context scripts added to all hook script builders
- **`src/atc/leader/orchestrator.py`** — Fetch inherited context via `build_context_package()` when spawning Aces; pass `context_entries` and `project_id` to `AceDeploySpec`
- **`tests/unit/test_deploy.py`** — 16 new tests covering context script deployment, executability, scope correctness, manifest inclusion, Ace context entry rendering, and CLI instructions for all agent types (98% coverage)

## Test plan
- [x] All 73 deploy tests pass (57 existing + 16 new)
- [x] Full test suite: 762 passed (2 pre-existing failures unrelated to this PR)
- [x] Ruff clean (no new lint issues)
- [x] 98% code coverage on `atc.agents.deploy`

🤖 Generated with [Claude Code](https://claude.com/claude-code)