### PR TITLE
feat: Context as top-level nav tab, project-only context on project page

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -7,6 +7,7 @@ import { useUpdater } from "./hooks/useUpdater";
 import Dashboard from "./pages/Dashboard";
 import ProjectView from "./pages/ProjectView";
 import UsagePage from "./pages/UsagePage";
+import ContextPage from "./pages/ContextPage";
 
 function Layout() {
   const updater = useUpdater();
@@ -42,6 +43,7 @@ export default function App() {
             <Route path="/dashboard" element={<Dashboard />} />
             <Route path="/projects/:id" element={<ProjectView />} />
             <Route path="/usage" element={<UsagePage />} />
+            <Route path="/context" element={<ContextPage />} />
           </Route>
         </Routes>
       </BrowserRouter>

--- a/frontend/src/components/tower/TowerBar.tsx
+++ b/frontend/src/components/tower/TowerBar.tsx
@@ -65,6 +65,12 @@ export default function TowerBar() {
             Dashboard
           </button>
           <button
+            className={`tower-bar__nav-item ${isActive("/context") ? "active" : ""}`}
+            onClick={() => navigate("/context")}
+          >
+            Context
+          </button>
+          <button
             className={`tower-bar__nav-item ${isActive("/usage") ? "active" : ""}`}
             onClick={() => navigate("/usage")}
           >

--- a/frontend/src/pages/ContextPage.css
+++ b/frontend/src/pages/ContextPage.css
@@ -1,0 +1,9 @@
+.context-page {
+  padding: var(--space-4);
+  max-width: 960px;
+  margin: 0 auto;
+}
+
+.context-page h1 {
+  margin-bottom: var(--space-4);
+}

--- a/frontend/src/pages/ContextPage.tsx
+++ b/frontend/src/pages/ContextPage.tsx
@@ -1,0 +1,17 @@
+import ContextHub from "../components/context/ContextHub";
+import "./ContextPage.css";
+
+export default function ContextPage() {
+  return (
+    <div className="context-page" data-testid="context-page">
+      <h1>Context</h1>
+      <div className="panel">
+        <ContextHub
+          scope="global"
+          showScopeTabs
+          availableScopes={["global", "project", "tower", "leader", "ace"]}
+        />
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -4,7 +4,6 @@ import { useAppContext } from "../context/AppContext";
 import StatusBadge from "../components/common/StatusBadge";
 import TimeAgo from "../components/common/TimeAgo";
 import CreateProjectModal from "../components/common/CreateProjectModal";
-import ContextHub from "../components/context/ContextHub";
 import "./Dashboard.css";
 
 export default function Dashboard() {
@@ -140,13 +139,6 @@ export default function Dashboard() {
             ))}
           </div>
         )}
-      </section>
-
-      {/* Global context section */}
-      <section className="dashboard__context">
-        <div className="panel">
-          <ContextHub scope="global" />
-        </div>
       </section>
 
       <CreateProjectModal

--- a/frontend/src/pages/ProjectView.tsx
+++ b/frontend/src/pages/ProjectView.tsx
@@ -65,8 +65,7 @@ export default function ProjectView() {
             <ContextHub
               scope="project"
               projectId={project.id}
-              showScopeTabs
-              availableScopes={["project", "global"]}
+              showScopeTabs={false}
             />
           </div>
         </aside>


### PR DESCRIPTION
## Summary
- Add `/context` route with a new `ContextPage` showing the full ContextHub with all scope tabs (global, project, tower, leader, ace)
- Add "Context" tab to TowerBar navigation (between Dashboard and Usage)
- Remove ContextHub embed from the Dashboard page
- Lock ProjectView context panel to project scope only — `showScopeTabs={false}` with `scope="project"`

## Files Changed
- `frontend/src/pages/ContextPage.tsx` — New page component
- `frontend/src/pages/ContextPage.css` — Styles for the context page
- `frontend/src/App.tsx` — Add `/context` route
- `frontend/src/components/tower/TowerBar.tsx` — Add Context nav tab
- `frontend/src/pages/Dashboard.tsx` — Remove ContextHub section
- `frontend/src/pages/ProjectView.tsx` — Lock to project scope, hide scope tabs

## Testing Done
- TypeScript compilation passes with zero errors (`npx tsc -b --noEmit`)
- Verified ContextHub component already supports `showScopeTabs` and `availableScopes` props