### PR TITLE
feat: add project delete and archive functionality

### DIFF
--- a/frontend/src/pages/Dashboard.css
+++ b/frontend/src/pages/Dashboard.css
@@ -111,6 +111,22 @@
   line-height: 1.4;
 }
 
+.dashboard__project-clickable {
+  cursor: pointer;
+}
+
+.dashboard__project-actions {
+  display: flex;
+  gap: var(--space-2);
+  margin-top: var(--space-3);
+  padding-top: var(--space-3);
+  border-top: 1px solid var(--color-border);
+}
+
+.dashboard__project-card--archived {
+  opacity: 0.6;
+}
+
 .dashboard__project-meta {
   display: flex;
   justify-content: space-between;

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -4,6 +4,8 @@ import { useAppContext } from "../context/AppContext";
 import StatusBadge from "../components/common/StatusBadge";
 import TimeAgo from "../components/common/TimeAgo";
 import CreateProjectModal from "../components/common/CreateProjectModal";
+import ConfirmPopover from "../components/common/ConfirmPopover";
+import { api, ApiError } from "../utils/api";
 import "./Dashboard.css";
 
 export default function Dashboard() {
@@ -11,8 +13,32 @@ export default function Dashboard() {
   const { state, fetchAll } = useAppContext();
   const { projects, sessions, usage, notifications } = state;
   const [showCreate, setShowCreate] = useState(false);
+  const [error, setError] = useState<string | null>(null);
 
   const activeProjects = projects.filter((p) => p.status === "active");
+  const archivedProjects = projects.filter((p) => p.status === "archived");
+
+  const handleDelete = async (projectId: string) => {
+    try {
+      setError(null);
+      await api.delete(`/projects/${projectId}`);
+      await fetchAll();
+    } catch (err) {
+      const msg = err instanceof ApiError ? err.message : "Failed to delete project";
+      setError(msg);
+    }
+  };
+
+  const handleArchive = async (projectId: string) => {
+    try {
+      setError(null);
+      await api.patch(`/projects/${projectId}/archive`, {});
+      await fetchAll();
+    } catch (err) {
+      const msg = err instanceof ApiError ? err.message : "Failed to archive project";
+      setError(msg);
+    }
+  };
 
   return (
     <div className="dashboard" data-testid="dashboard-page">
@@ -94,6 +120,12 @@ export default function Dashboard() {
         </div>
       </div>
 
+      {error && (
+        <div className="dashboard__error panel" style={{ color: "var(--color-danger)", marginBottom: "var(--space-4)" }}>
+          {error}
+        </div>
+      )}
+
       {/* Project cards */}
       <section className="dashboard__projects">
         <h2>Projects</h2>
@@ -111,11 +143,60 @@ export default function Dashboard() {
         ) : (
           <div className="dashboard__project-grid">
             {activeProjects.map((project) => (
-              <button
-                key={project.id}
-                className="panel dashboard__project-card"
-                onClick={() => navigate(`/projects/${project.id}`)}
-              >
+              <div key={project.id} className="panel dashboard__project-card">
+                <div
+                  className="dashboard__project-clickable"
+                  onClick={() => navigate(`/projects/${project.id}`)}
+                >
+                  <div className="dashboard__project-header">
+                    <h3>{project.name}</h3>
+                    <StatusBadge status={project.status} size="sm" />
+                  </div>
+                  {project.description && (
+                    <p className="dashboard__project-desc">
+                      {project.description}
+                    </p>
+                  )}
+                  <div className="dashboard__project-meta">
+                    <span>
+                      {
+                        sessions.filter((s) => s.project_id === project.id)
+                          .length
+                      }{" "}
+                      sessions
+                    </span>
+                    <TimeAgo datetime={project.updated_at} />
+                  </div>
+                </div>
+                <div className="dashboard__project-actions">
+                  <button
+                    className="btn btn-sm"
+                    onClick={() => void handleArchive(project.id)}
+                  >
+                    Archive
+                  </button>
+                  <ConfirmPopover
+                    message={`Are you sure you want to delete "${project.name}"? This will remove all tasks and context associated with this project.`}
+                    confirmLabel="Delete"
+                    variant="danger"
+                    onConfirm={() => void handleDelete(project.id)}
+                  >
+                    <button className="btn btn-sm btn-danger">Delete</button>
+                  </ConfirmPopover>
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+      </section>
+
+      {/* Archived projects */}
+      {archivedProjects.length > 0 && (
+        <section className="dashboard__projects">
+          <h2>Archived</h2>
+          <div className="dashboard__project-grid">
+            {archivedProjects.map((project) => (
+              <div key={project.id} className="panel dashboard__project-card dashboard__project-card--archived">
                 <div className="dashboard__project-header">
                   <h3>{project.name}</h3>
                   <StatusBadge status={project.status} size="sm" />
@@ -125,21 +206,21 @@ export default function Dashboard() {
                     {project.description}
                   </p>
                 )}
-                <div className="dashboard__project-meta">
-                  <span>
-                    {
-                      sessions.filter((s) => s.project_id === project.id)
-                        .length
-                    }{" "}
-                    sessions
-                  </span>
-                  <TimeAgo datetime={project.updated_at} />
+                <div className="dashboard__project-actions">
+                  <ConfirmPopover
+                    message={`Permanently delete "${project.name}"? This cannot be undone.`}
+                    confirmLabel="Delete"
+                    variant="danger"
+                    onConfirm={() => void handleDelete(project.id)}
+                  >
+                    <button className="btn btn-sm btn-danger">Delete</button>
+                  </ConfirmPopover>
                 </div>
-              </button>
+              </div>
             ))}
           </div>
-        )}
-      </section>
+        </section>
+      )}
 
       <CreateProjectModal
         open={showCreate}

--- a/src/atc/api/routers/projects.py
+++ b/src/atc/api/routers/projects.py
@@ -106,6 +106,28 @@ async def create_project(body: CreateProjectRequest, request: Request) -> Projec
     return ProjectResponse(**project.__dict__)
 
 
+@router.delete("/{project_id}", status_code=204)
+async def delete_project(project_id: str, request: Request) -> None:
+    """Hard-delete a project and all associated data."""
+    db = await _get_db(request)
+    project = await db_ops.get_project(db, project_id)
+    if project is None:
+        raise HTTPException(status_code=404, detail="Project not found")
+    await db_ops.delete_project(db, project_id)
+
+
+@router.patch("/{project_id}/archive", response_model=ProjectResponse)
+async def archive_project(project_id: str, request: Request) -> ProjectResponse:
+    """Archive a project (hides from dashboard but preserves data)."""
+    db = await _get_db(request)
+    project = await db_ops.get_project(db, project_id)
+    if project is None:
+        raise HTTPException(status_code=404, detail="Project not found")
+    await db_ops.archive_project(db, project_id)
+    project = await db_ops.get_project(db, project_id)
+    return ProjectResponse(**project.__dict__)  # type: ignore[union-attr]
+
+
 @router.get("/{project_id}", response_model=ProjectResponse)
 async def get_project(project_id: str, request: Request) -> ProjectResponse:
     db = await _get_db(request)

--- a/src/atc/state/db.py
+++ b/src/atc/state/db.py
@@ -490,6 +490,53 @@ async def update_project_agent_provider(
     await db.commit()
 
 
+async def archive_project(
+    db: aiosqlite.Connection,
+    project_id: str,
+) -> bool:
+    """Set a project's status to 'archived'. Returns True if updated."""
+    now = _now()
+    cursor = await db.execute(
+        "UPDATE projects SET status = 'archived', updated_at = ? WHERE id = ?",
+        (now, project_id),
+    )
+    await db.commit()
+    return cursor.rowcount > 0
+
+
+async def delete_project(
+    db: aiosqlite.Connection,
+    project_id: str,
+) -> bool:
+    """Hard-delete a project and all dependent rows. Returns True if deleted."""
+    import contextlib
+
+    # Delete in dependency order to avoid FK violations.
+    dependent_tables = [
+        ("task_assignments", "task_graph_id IN (SELECT id FROM task_graphs WHERE project_id = ?)"),
+        ("session_heartbeats", "session_id IN (SELECT id FROM sessions WHERE project_id = ?)"),
+        ("context_entries", "project_id = ?"),
+        ("task_graphs", "project_id = ?"),
+        ("tasks", "project_id = ?"),
+        ("sessions", "project_id = ?"),
+        ("leaders", "project_id = ?"),
+        ("project_budgets", "project_id = ?"),
+        ("usage_events", "project_id = ?"),
+        ("github_prs", "project_id = ?"),
+        ("notifications", "project_id = ?"),
+        ("app_events", "project_id = ?"),
+        ("failure_logs", "project_id = ?"),
+        ("tower_memory", "project_id = ?"),
+    ]
+    for table, where in dependent_tables:
+        with contextlib.suppress(sqlite3.OperationalError):
+            await db.execute(f"DELETE FROM {table} WHERE {where}", (project_id,))  # noqa: S608
+
+    cursor = await db.execute("DELETE FROM projects WHERE id = ?", (project_id,))
+    await db.commit()
+    return cursor.rowcount > 0
+
+
 # ---------------------------------------------------------------------------
 # Leader helpers
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_project_delete.py
+++ b/tests/unit/test_project_delete.py
@@ -1,0 +1,118 @@
+"""Tests for project delete and archive functionality."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from atc.state.db import (
+    _SCHEMA_SQL,
+    archive_project,
+    create_context_entry,
+    create_leader,
+    create_project,
+    create_session,
+    create_task_graph,
+    delete_project,
+    get_connection,
+    get_project,
+    list_projects,
+    run_migrations,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+async def db():
+    """In-memory database with schema applied."""
+    await run_migrations(":memory:")
+    async with get_connection(":memory:") as conn:
+        await conn.executescript(_SCHEMA_SQL)
+        await conn.commit()
+        yield conn
+
+
+@pytest.fixture
+async def project(db):
+    return await create_project(db, "test-project", description="A test project")
+
+
+# ---------------------------------------------------------------------------
+# delete_project tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+class TestDeleteProject:
+    async def test_delete_removes_project(self, db, project) -> None:
+        result = await delete_project(db, project.id)
+        assert result is True
+        assert await get_project(db, project.id) is None
+
+    async def test_delete_nonexistent_returns_false(self, db) -> None:
+        result = await delete_project(db, "nonexistent-id")
+        assert result is False
+
+    async def test_delete_cascades_leader(self, db, project) -> None:
+        await create_leader(db, project.id)
+        result = await delete_project(db, project.id)
+        assert result is True
+        assert await get_project(db, project.id) is None
+
+    async def test_delete_cascades_sessions(self, db, project) -> None:
+        await create_session(db, project.id, "ace", "ace-1")
+        result = await delete_project(db, project.id)
+        assert result is True
+
+    async def test_delete_cascades_context_entries(self, db, project) -> None:
+        await create_context_entry(
+            db,
+            "project",
+            "key1",
+            "text",
+            json.dumps("value"),
+            project_id=project.id,
+        )
+        result = await delete_project(db, project.id)
+        assert result is True
+
+    async def test_delete_cascades_task_graphs(self, db, project) -> None:
+        await create_task_graph(db, project.id, "Test Graph")
+        result = await delete_project(db, project.id)
+        assert result is True
+
+    async def test_delete_removes_from_list(self, db, project) -> None:
+        projects_before = await list_projects(db)
+        assert len(projects_before) == 1
+        await delete_project(db, project.id)
+        projects_after = await list_projects(db)
+        assert len(projects_after) == 0
+
+
+# ---------------------------------------------------------------------------
+# archive_project tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+class TestArchiveProject:
+    async def test_archive_sets_status(self, db, project) -> None:
+        result = await archive_project(db, project.id)
+        assert result is True
+        updated = await get_project(db, project.id)
+        assert updated is not None
+        assert updated.status == "archived"
+
+    async def test_archive_nonexistent_returns_false(self, db) -> None:
+        result = await archive_project(db, "nonexistent-id")
+        assert result is False
+
+    async def test_archived_project_still_in_list(self, db, project) -> None:
+        await archive_project(db, project.id)
+        projects = await list_projects(db)
+        assert len(projects) == 1
+        assert projects[0].status == "archived"


### PR DESCRIPTION
## Summary
- Add `DELETE /api/projects/{id}` endpoint for hard-deleting projects with cascading cleanup of all dependent data (task_assignments, session_heartbeats, context_entries, task_graphs, tasks, sessions, leaders, budgets, usage_events, github_prs, notifications, app_events, failure_logs, tower_memory)
- Add `PATCH /api/projects/{id}/archive` endpoint for soft-archiving projects (sets status to "archived")
- Dashboard project cards now show Archive and Delete action buttons with ConfirmPopover confirmation dialogs
- Archived projects are displayed in a separate "Archived" section on the dashboard with a permanent Delete option
- Includes 10 unit tests covering delete cascading, archive status changes, and edge cases

## Test plan
- [x] Unit tests pass for `delete_project` (cascading, nonexistent, with leaders/sessions/context/task_graphs)
- [x] Unit tests pass for `archive_project` (status update, nonexistent, list visibility)
- [x] TypeScript type-check passes
- [x] Ruff lint passes
- [ ] Manual: create a project, archive it, verify it moves to Archived section
- [ ] Manual: delete a project, verify confirmation dialog and removal from dashboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)