### PR TITLE
feat: real-time dashboard project list via WebSocket

### DIFF
--- a/frontend/src/context/AppContext.tsx
+++ b/frontend/src/context/AppContext.tsx
@@ -89,7 +89,10 @@ type Action =
   | { type: "SET_TOWER_PROGRESS"; payload: TowerProgress }
   | { type: "SET_HEARTBEATS"; payload: Record<string, SessionHeartbeat> }
   | { type: "UPDATE_HEARTBEAT"; payload: SessionHeartbeat }
-  | { type: "UPDATE_SESSION_STATUS"; payload: { session_id: string; status: string } };
+  | { type: "UPDATE_SESSION_STATUS"; payload: { session_id: string; status: string } }
+  | { type: "ADD_PROJECT"; payload: Project }
+  | { type: "UPDATE_PROJECT"; payload: Project }
+  | { type: "REMOVE_PROJECT"; payload: string };
 
 function reducer(state: AppState, action: Action): AppState {
   switch (action.type) {
@@ -170,6 +173,29 @@ function reducer(state: AppState, action: Action): AppState {
             ? { ...s, status: action.payload.status as Session["status"] }
             : s,
         ),
+      };
+    case "ADD_PROJECT":
+      // Avoid duplicates — if project already exists, update it instead
+      if (state.projects.some((p) => p.id === action.payload.id)) {
+        return {
+          ...state,
+          projects: state.projects.map((p) =>
+            p.id === action.payload.id ? action.payload : p,
+          ),
+        };
+      }
+      return { ...state, projects: [...state.projects, action.payload] };
+    case "UPDATE_PROJECT":
+      return {
+        ...state,
+        projects: state.projects.map((p) =>
+          p.id === action.payload.id ? action.payload : p,
+        ),
+      };
+    case "REMOVE_PROJECT":
+      return {
+        ...state,
+        projects: state.projects.filter((p) => p.id !== action.payload),
       };
   }
 }
@@ -283,6 +309,12 @@ export function AppProvider({ children }: AppProviderProps) {
           type: "UPDATE_SESSION_STATUS",
           payload: { session_id: data.session_id, status: data.new_status },
         });
+      } else if (data.project_created && data.project) {
+        dispatch({ type: "ADD_PROJECT", payload: data.project as Project });
+      } else if (data.project_updated && data.project) {
+        dispatch({ type: "UPDATE_PROJECT", payload: data.project as Project });
+      } else if (data.project_deleted && typeof data.project_id === "string") {
+        dispatch({ type: "REMOVE_PROJECT", payload: data.project_id });
       } else {
         dispatch({ type: "SET_STATE", payload: data as Partial<AppState> });
       }

--- a/src/atc/api/routers/projects.py
+++ b/src/atc/api/routers/projects.py
@@ -72,6 +72,10 @@ async def _get_event_bus(request: Request):  # noqa: ANN202
     return getattr(request.app.state, "event_bus", None)
 
 
+async def _get_ws_hub(request: Request):  # noqa: ANN202
+    return getattr(request.app.state, "ws_hub", None)
+
+
 @router.get("", response_model=list[ProjectResponse])
 async def list_projects(request: Request) -> list[ProjectResponse]:
     db = await _get_db(request)
@@ -103,7 +107,20 @@ async def create_project(body: CreateProjectRequest, request: Request) -> Projec
         # Project was created but leader failed — don't leave the user hanging
         # Return the project anyway; leader can be created later.
 
-    return ProjectResponse(**project.__dict__)
+    resp = ProjectResponse(**project.__dict__)
+
+    # Broadcast project creation to all connected WebSocket clients
+    ws_hub = await _get_ws_hub(request)
+    if ws_hub is not None:
+        try:
+            await ws_hub.broadcast("state", {
+                "project_created": True,
+                "project": resp.model_dump(),
+            })
+        except Exception:
+            logger.debug("Failed to broadcast project_created via WebSocket")
+
+    return resp
 
 
 @router.delete("/{project_id}", status_code=204)
@@ -115,6 +132,17 @@ async def delete_project(project_id: str, request: Request) -> None:
         raise HTTPException(status_code=404, detail="Project not found")
     await db_ops.delete_project(db, project_id)
 
+    # Broadcast project deletion to all connected WebSocket clients
+    ws_hub = await _get_ws_hub(request)
+    if ws_hub is not None:
+        try:
+            await ws_hub.broadcast("state", {
+                "project_deleted": True,
+                "project_id": project_id,
+            })
+        except Exception:
+            logger.debug("Failed to broadcast project_deleted via WebSocket")
+
 
 @router.patch("/{project_id}/archive", response_model=ProjectResponse)
 async def archive_project(project_id: str, request: Request) -> ProjectResponse:
@@ -125,7 +153,20 @@ async def archive_project(project_id: str, request: Request) -> ProjectResponse:
         raise HTTPException(status_code=404, detail="Project not found")
     await db_ops.archive_project(db, project_id)
     project = await db_ops.get_project(db, project_id)
-    return ProjectResponse(**project.__dict__)  # type: ignore[union-attr]
+    resp = ProjectResponse(**project.__dict__)  # type: ignore[union-attr]
+
+    # Broadcast project update to all connected WebSocket clients
+    ws_hub = await _get_ws_hub(request)
+    if ws_hub is not None:
+        try:
+            await ws_hub.broadcast("state", {
+                "project_updated": True,
+                "project": resp.model_dump(),
+            })
+        except Exception:
+            logger.debug("Failed to broadcast project_updated via WebSocket")
+
+    return resp
 
 
 @router.get("/{project_id}", response_model=ProjectResponse)
@@ -164,7 +205,20 @@ async def update_project_provider(
 
     await db_ops.update_project_agent_provider(db, project_id, body.agent_provider)
     project = await db_ops.get_project(db, project_id)
-    return ProjectResponse(**project.__dict__)  # type: ignore[union-attr]
+    resp = ProjectResponse(**project.__dict__)  # type: ignore[union-attr]
+
+    # Broadcast project update to all connected WebSocket clients
+    ws_hub = await _get_ws_hub(request)
+    if ws_hub is not None:
+        try:
+            await ws_hub.broadcast("state", {
+                "project_updated": True,
+                "project": resp.model_dump(),
+            })
+        except Exception:
+            logger.debug("Failed to broadcast project_updated via WebSocket")
+
+    return resp
 
 
 @router.get("/{project_id}/manager", response_model=LeaderResponse)


### PR DESCRIPTION
## Summary
- Backend broadcasts `project_created`, `project_updated`, and `project_deleted` events on the `state` WebSocket channel when projects are created, archived, provider-changed, or deleted
- Frontend AppContext handles these events with `ADD_PROJECT`, `UPDATE_PROJECT`, and `REMOVE_PROJECT` reducer actions for reactive UI updates
- Dashboard no longer shows stale "No active projects" after Tower creates a project — updates appear without page refresh

## Testing Done
- Python syntax check passes
- TypeScript type check passes (`tsc --noEmit`)
- Frontend build succeeds (`vite build`)
- Verified `ADD_PROJECT` reducer deduplicates (handles race between WS event and `fetchAll` callback)

🤖 Generated with [Claude Code](https://claude.com/claude-code)