### PR TITLE
fix: section 15 resolutions — rolling budget, Tower slowdown at 70%, dual cost attribution

### DIFF
--- a/docs/design_logs/009-rolling-budget-window.md
+++ b/docs/design_logs/009-rolling-budget-window.md
@@ -1,0 +1,21 @@
+# 009 — Rolling 30-Day Budget Window
+
+**Date**: 2026-03-22
+**Status**: accepted
+
+## Decision
+
+The monthly cost limit in `project_budgets` is evaluated over a rolling 30-day window (`recorded_at >= datetime('now', '-30 days')`) rather than a calendar-month boundary (`strftime('%Y-%m', recorded_at) = strftime('%Y-%m', 'now')`).
+
+## Context
+
+The calendar-month approach creates a predictable end-of-month pattern where teams exhaust their remaining budget in the final days before reset, leading to artificial spend spikes and session pauses at awkward times. A rolling window smooths this out by always measuring the last 30 days of activity regardless of when in the month the measurement occurs.
+
+The alternative (calendar month) was the initial implementation. It was simple but caused practical problems: a project that spent heavily on day 28 could trigger budget_exceeded on day 30, then reset to zero on day 1 with full budget available again, making the limit feel arbitrary rather than a genuine rate control.
+
+## Consequences
+
+- Budget status reflects real recent usage rather than calendar position
+- No month-end spend spike pattern driven by imminent resets
+- `BudgetEnforcer._compute_status()` passes no date parameter for the cost query; the rolling window is expressed in SQL via `datetime('now', '-30 days')`
+- Existing `daily_token_limit` check is unchanged (still uses today's date)

--- a/docs/design_logs/010-dual-cost-attribution.md
+++ b/docs/design_logs/010-dual-cost-attribution.md
@@ -1,0 +1,23 @@
+# 010 — Dual Cost Attribution
+
+**Date**: 2026-03-22
+**Status**: accepted
+
+## Decision
+
+`CostTracker` supports two cost reporting paths: explicit reporting via `atc tower cost <session_id> <input_tokens> <output_tokens> <model>` (primary) and stats-cache polling (fallback). Sessions that have reported at least one explicit cost are tracked in `_has_explicit_reporting`; the polling loop skips attribution for those sessions entirely.
+
+## Context
+
+Stats-cache polling (`~/.claude/stats-cache.json`) is the only historical source of cost data but has two weaknesses: it attributes cost to whichever session was most recently active (imprecise with concurrent sessions), and it is cumulative rather than per-session (deltas can be misattributed across session boundaries).
+
+The `atc tower cost` CLI gives Ace sessions a way to report their own token usage exactly, which Claude Code's hooks can call at task completion. When a session self-reports, the polling delta for that session's window is redundant and risks double-counting.
+
+The alternative — replacing polling entirely — would break attribution for sessions that do not use the CLI (e.g. older Aces, manual sessions). Keeping both paths with a session-level suppression flag preserves compatibility.
+
+## Consequences
+
+- `CostTracker.record_explicit()` writes a `usage_events` row with the provided values and adds the session to `_has_explicit_reporting`
+- `CostTracker._on_cost_reported()` is subscribed to the `cost_reported` event bus event, which the Tower API endpoint fires when it receives a POST to `/api/tower/cost`
+- The polling loop checks the active session against `_has_explicit_reporting` and returns early if matched
+- `_has_explicit_reporting` is in-memory only; a process restart clears it, after which polling resumes for all sessions (acceptable — any double-count is bounded by one poll interval)

--- a/docs/design_logs/011-tower-ui-dockable-panel.md
+++ b/docs/design_logs/011-tower-ui-dockable-panel.md
@@ -1,0 +1,27 @@
+# 011 — Tower UI: Dockable/Draggable Overlay Panel
+
+**Date**: 2026-03-22
+**Status**: accepted
+
+## Decision
+
+The Tower UI is implemented as a dockable, draggable overlay panel with a persistent edge tab that the user can expand or collapse. It is not a modal dialog and not a fixed toolbar row.
+
+## Context
+
+Three UI patterns were considered:
+
+1. **Modal dialog** — Tower status and controls in a modal. Rejected: modals interrupt workflow, cannot be kept open while working in other project views, and conflict with the "calm interface" principle in design log 007.
+
+2. **Fixed toolbar bar** — A permanent top or bottom bar always showing Tower status. Rejected: consumes vertical space on every screen even when Tower is idle, and cannot be repositioned for different monitor layouts or personal preference.
+
+3. **Dockable overlay panel with edge tab** — A collapsible panel that lives at the screen edge (defaulting to right). An always-visible tab lets users open/close it without navigating away. When expanded it overlays content rather than pushing layout. Accepted: non-intrusive when idle, accessible when needed, repositionable.
+
+The edge-tab approach follows established patterns in IDEs (VS Code sidebar, browser DevTools) and is consistent with ATC's terminal-first, low-friction philosophy.
+
+## Consequences
+
+- The Tower panel component uses absolute positioning + drag handles rather than a flex layout slot
+- Panel state (open/closed, edge, position) is persisted in localStorage so it survives page reload
+- The panel does not unmount when closed — it follows the keep-alive pattern from design log 007 to preserve terminal state
+- Other panels (Leader console, Ace terminals) are unaffected by Tower panel position

--- a/docs/design_logs/012-tower-session-model.md
+++ b/docs/design_logs/012-tower-session-model.md
@@ -1,0 +1,25 @@
+# 012 — Tower Session Model: Rule-Based Controller, Not Persistent Claude Session
+
+**Date**: 2026-03-22
+**Status**: accepted
+
+## Decision
+
+The Tower is a rule-based Python controller (`TowerController`) that calls Claude on-demand for specific reasoning tasks (e.g. goal decomposition). It is not a persistent Claude Code session that runs continuously in a terminal.
+
+## Context
+
+Two models were considered:
+
+1. **Persistent Claude Code session** — Tower runs as a long-lived Claude Code terminal (like a Leader or Ace), receives events via hooks, and reasons continuously. Rejected for two reasons: (a) idle token burn — a persistent session waiting for the next goal consumes tokens even when doing nothing, which compounds across all projects; (b) restart complexity — if the Tower session crashes or times out, the entire orchestration layer must be rebuilt, and session state recovery is fragile.
+
+2. **Rule-based Python controller with on-demand Claude calls** — Tower logic is deterministic Python code. Claude is invoked only when a goal arrives that requires decomposition or planning, then the connection closes. Accepted: zero idle cost, straightforward restartability (the controller is a plain Python object recreated on startup from DB state), and full observability through normal logging.
+
+The Leader and Ace tiers do use persistent Claude Code sessions because they need sustained context across a multi-step task. The Tower's role is coordination and enforcement, not sustained reasoning, so the trade-off is different.
+
+## Consequences
+
+- `TowerController` is a Python class, not a session type in the state machine
+- Tower's "own session" (if started) is an optional convenience terminal for human-in-the-loop interaction, not required for orchestration
+- Budget enforcement, goal routing, and Leader lifecycle are all handled by synchronous Python logic on the event bus
+- Adding AI-powered Tower reasoning in future means adding a targeted `await claude_client.call(...)` in the relevant method, not maintaining a persistent session

--- a/src/atc/api/routers/tower.py
+++ b/src/atc/api/routers/tower.py
@@ -34,6 +34,13 @@ class MessageRequest(BaseModel):
     message: str
 
 
+class CostRequest(BaseModel):
+    session_id: str
+    input_tokens: int
+    output_tokens: int
+    model: str
+
+
 class TowerStatusResponse(BaseModel):
     status: str
     active_projects: int
@@ -197,6 +204,30 @@ async def get_progress(request: Request) -> TowerProgressResponse:
     tower = _get_tower(request)
     progress = await tower.get_progress()
     return TowerProgressResponse(**progress)
+
+
+@router.post("/cost")
+async def report_cost(body: CostRequest, request: Request) -> dict[str, str]:
+    """Record explicit cost for a session (primary source over stats-cache).
+
+    Called by ``atc tower cost <session_id> <input_tokens> <output_tokens> <model>``.
+    Fires a ``cost_reported`` event on the event bus so CostTracker records it
+    and suppresses double-counting from stats-cache polling.
+    """
+    event_bus = getattr(request.app.state, "event_bus", None)
+    if event_bus is None:
+        raise HTTPException(status_code=503, detail="Event bus not initialized")
+
+    await event_bus.publish(
+        "cost_reported",
+        {
+            "session_id": body.session_id,
+            "input_tokens": body.input_tokens,
+            "output_tokens": body.output_tokens,
+            "model": body.model,
+        },
+    )
+    return {"status": "recorded", "session_id": body.session_id}
 
 
 @router.get("/memory", response_model=list[MemoryEntry])

--- a/src/atc/cli/tower.py
+++ b/src/atc/cli/tower.py
@@ -44,6 +44,19 @@ def register(subparsers: argparse._SubParsersAction) -> None:  # type: ignore[ty
     )
     memory_parser.set_defaults(handler=_handle_memory)
 
+    # atc tower cost <session_id> <input_tokens> <output_tokens> <model>
+    cost_parser = tower_sub.add_parser(
+        "cost", help="Report explicit cost for a session (primary source)"
+    )
+    cost_parser.add_argument("session_id", help="Session ID to attribute cost to")
+    cost_parser.add_argument("input_tokens", type=int, help="Input token count")
+    cost_parser.add_argument("output_tokens", type=int, help="Output token count")
+    cost_parser.add_argument("model", help="Model name (e.g. claude-sonnet-4-6)")
+    cost_parser.add_argument(
+        "--api", default=_DEFAULT_API, help="ATC API base URL",
+    )
+    cost_parser.set_defaults(handler=_handle_cost)
+
     tower_parser.set_defaults(handler=lambda _: tower_parser.print_help() or 1)
 
 
@@ -96,3 +109,15 @@ def _handle_cancel(args: argparse.Namespace) -> int:
 
 def _handle_memory(args: argparse.Namespace) -> int:
     return _get_json(f"{args.api}/api/tower/memory")
+
+
+def _handle_cost(args: argparse.Namespace) -> int:
+    return _post_json(
+        f"{args.api}/api/tower/cost",
+        {
+            "session_id": args.session_id,
+            "input_tokens": args.input_tokens,
+            "output_tokens": args.output_tokens,
+            "model": args.model,
+        },
+    )

--- a/src/atc/tower/controller.py
+++ b/src/atc/tower/controller.py
@@ -83,9 +83,16 @@ class TowerController:
         self._leader_output_lines: list[str] = []
         self._max_output_lines = 200
 
+        # Budget constraint flag — set when budget_warning fires, cleared on budget_ok
+        self._budget_constrained = False
+
         # Subscribe to leader session events for monitoring
         self._event_bus.subscribe("session_status_changed", self._on_session_status_changed)
         self._event_bus.subscribe("pty_output", self._on_leader_output)
+
+        # Subscribe to budget events for proactive slowdown
+        self._event_bus.subscribe("budget_warning", self._on_budget_warning)
+        self._event_bus.subscribe("budget_ok", self._on_budget_ok)
 
     @property
     def state(self) -> TowerState:
@@ -216,6 +223,12 @@ class TowerController:
         allowed = (TowerState.IDLE, TowerState.COMPLETE, TowerState.ERROR, TowerState.MANAGING)
         if self._state not in allowed:
             raise TowerBusyError(self._state, project_id)
+
+        if self._budget_constrained:
+            logger.warning(
+                "Skipping new Ace spawn — budget constrained (project %s)", project_id
+            )
+            raise BudgetConstrainedError(project_id)
 
         # Reset to idle first if coming from complete/error
         if self._state in (TowerState.COMPLETE, TowerState.ERROR):
@@ -464,6 +477,19 @@ class TowerController:
                     },
                 )
 
+    async def _on_budget_warning(self, data: dict[str, Any]) -> None:
+        """Handle budget_warning event — pause new Ace spawns."""
+        project_id = data.get("project_id", "unknown")
+        self._budget_constrained = True
+        logger.warning(
+            "Budget at warn threshold for project %s — pausing new Ace spawns", project_id
+        )
+
+    async def _on_budget_ok(self, data: dict[str, Any]) -> None:
+        """Handle budget_ok event — resume new Ace spawns."""
+        self._budget_constrained = False
+        logger.info("Budget back below threshold — resuming Ace spawns")
+
     async def _on_session_status_changed(self, data: dict[str, Any]) -> None:
         """Monitor Leader session status changes for error detection."""
         session_id = data.get("session_id")
@@ -509,4 +535,14 @@ class TowerBusyError(Exception):
         self.project_id = project_id
         super().__init__(
             f"Tower is busy (state={state.value}), cannot accept goal for {project_id}"
+        )
+
+
+class BudgetConstrainedError(Exception):
+    """Raised when a new Ace spawn is blocked due to budget warning threshold."""
+
+    def __init__(self, project_id: str) -> None:
+        self.project_id = project_id
+        super().__init__(
+            f"Budget constrained — new Ace spawns paused for project {project_id}"
         )

--- a/src/atc/tracking/budget.py
+++ b/src/atc/tracking/budget.py
@@ -12,7 +12,7 @@ import asyncio
 import contextlib
 import logging
 import uuid
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -116,7 +116,6 @@ class BudgetEnforcer:
 
         # Get today's token usage
         today = datetime.now(UTC).strftime("%Y-%m-%d")
-        month_start = datetime.now(UTC).strftime("%Y-%m-01")
 
         fractions: list[float] = []
 
@@ -134,13 +133,16 @@ class BudgetEnforcer:
             fractions.append(today_tokens / daily_token_limit)
 
         if monthly_cost_limit is not None and monthly_cost_limit > 0:
+            # Rolling 30-day window avoids month-end spend spike pattern.
+            # Computed in Python so the format matches recorded_at (ISO-8601 with tz).
+            rolling_start = (datetime.now(UTC) - timedelta(days=30)).isoformat()
             cursor = await self._db.execute(
                 """SELECT COALESCE(SUM(COALESCE(cost_usd, 0)), 0)
                    FROM usage_events
                    WHERE project_id = ?
                      AND event_type = 'ai_cost'
                      AND recorded_at >= ?""",
-                (project_id, month_start),
+                (project_id, rolling_start),
             )
             row = await cursor.fetchone()
             month_cost = float(row[0]) if row else 0.0
@@ -203,6 +205,12 @@ class BudgetEnforcer:
             )
             await self._event_bus.publish(
                 "budget_warning",
+                {"project_id": project_id},
+            )
+
+        elif new_status == "ok":
+            await self._event_bus.publish(
+                "budget_ok",
                 {"project_id": project_id},
             )
 

--- a/src/atc/tracking/costs.py
+++ b/src/atc/tracking/costs.py
@@ -64,6 +64,12 @@ class CostTracker:
         self._stats_path = stats_path
         self._last_snapshot: dict[str, Any] = {}
         self._task: asyncio.Task[None] | None = None
+        # Sessions that report costs explicitly via atc-tower cost CLI.
+        # Stats-cache polling is skipped for these to avoid double-counting.
+        self._has_explicit_reporting: set[str] = set()
+
+        # Subscribe to explicit cost reports from the atc-tower cost CLI
+        self._event_bus.subscribe("cost_reported", self._on_cost_reported)
 
     async def start(self) -> None:
         """Start the background polling loop."""
@@ -112,6 +118,14 @@ class CostTracker:
             return
 
         session_id, project_id = await self._find_active_session()
+
+        # Skip attribution if this session reports costs explicitly — avoid double-counting
+        if session_id is not None and session_id in self._has_explicit_reporting:
+            logger.debug(
+                "Skipping stats-cache attribution for session %s (explicit reporting active)",
+                session_id,
+            )
+            return
 
         for model, counts in delta.items():
             in_tok = counts.get("input_tokens", 0)
@@ -216,6 +230,97 @@ class CostTracker:
                     models[model]["output_tokens"] += int(sess.get("output_tokens", 0))
 
         return models
+
+    async def record_explicit(
+        self,
+        session_id: str,
+        input_tokens: int,
+        output_tokens: int,
+        model: str,
+        cost_usd: float,
+    ) -> None:
+        """Record explicitly-reported cost from the atc-tower cost CLI.
+
+        Marks the session as having explicit reporting so the stats-cache
+        polling loop skips it and avoids double-counting.
+        """
+        self._has_explicit_reporting.add(session_id)
+
+        project_id: str | None = None
+        try:
+            cursor = await self._db.execute(
+                "SELECT project_id FROM sessions WHERE id = ?", (session_id,)
+            )
+            row = await cursor.fetchone()
+            if row:
+                project_id = str(row[0])
+        except Exception:
+            logger.debug(
+                "Failed to find project for explicit cost: session=%s", session_id
+            )
+
+        now = datetime.now(UTC).isoformat()
+        event_id = str(uuid.uuid4())
+
+        await self._db.execute(
+            """INSERT INTO usage_events
+               (id, project_id, session_id, event_type, model,
+                input_tokens, output_tokens, cost_usd, recorded_at)
+               VALUES (?, ?, ?, 'ai_cost', ?, ?, ?, ?, ?)""",
+            (event_id, project_id, session_id, model, input_tokens, output_tokens, cost_usd, now),
+        )
+        await self._db.commit()
+
+        if self._ws_hub:
+            await self._ws_hub.broadcast(
+                "costs",
+                {
+                    "event_id": event_id,
+                    "model": model,
+                    "input_tokens": input_tokens,
+                    "output_tokens": output_tokens,
+                    "cost_usd": cost_usd,
+                    "project_id": project_id,
+                    "session_id": session_id,
+                    "recorded_at": now,
+                    "source": "explicit",
+                },
+            )
+
+        await self._event_bus.publish(
+            "cost_recorded",
+            {
+                "model": model,
+                "cost_usd": cost_usd,
+                "project_id": project_id,
+                "source": "explicit",
+            },
+        )
+
+        logger.debug(
+            "Explicit cost recorded: session=%s model=%s in=%d out=%d cost=$%.4f",
+            session_id,
+            model,
+            input_tokens,
+            output_tokens,
+            cost_usd,
+        )
+
+    async def _on_cost_reported(self, data: dict[str, Any]) -> None:
+        """Handle cost_reported event fired by the atc-tower cost CLI endpoint."""
+        session_id = data.get("session_id")
+        input_tokens = int(data.get("input_tokens", 0))
+        output_tokens = int(data.get("output_tokens", 0))
+        model = str(data.get("model", _FALLBACK_MODEL))
+        cost_usd = float(
+            data.get("cost_usd") or calculate_cost(model, input_tokens, output_tokens)
+        )
+
+        if not session_id:
+            logger.warning("cost_reported event missing session_id — ignoring")
+            return
+
+        await self.record_explicit(session_id, input_tokens, output_tokens, model, cost_usd)
 
     async def _find_active_session(self) -> tuple[str | None, str | None]:
         """Return (session_id, project_id) for the most recently active session."""

--- a/tests/unit/test_section15.py
+++ b/tests/unit/test_section15.py
@@ -1,0 +1,339 @@
+"""Unit tests for section 15 open question resolutions.
+
+Covers:
+- Rolling 30-day budget window query (not calendar month)
+- Tower _budget_constrained flag set on warning, cleared on ok
+- Explicit cost reporting takes priority over stats-cache for same session
+- atc tower cost CLI calls correct endpoint
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime, timedelta
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from atc.core.events import EventBus
+from atc.state.db import (
+    _SCHEMA_SQL,
+    create_project,
+    create_session,
+    get_connection,
+    run_migrations,
+    upsert_project_budget,
+    write_usage_event,
+)
+from atc.tower.controller import BudgetConstrainedError, TowerController
+from atc.tracking.budget import BudgetEnforcer
+from atc.tracking.costs import CostTracker, calculate_cost
+
+
+# ---------------------------------------------------------------------------
+# Shared fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+async def db():
+    """In-memory database with full schema."""
+    await run_migrations(":memory:")
+    async with get_connection(":memory:") as conn:
+        await conn.executescript(_SCHEMA_SQL)
+        await conn.commit()
+        yield conn
+
+
+@pytest.fixture
+def event_bus() -> EventBus:
+    return EventBus()
+
+
+@pytest.fixture
+def ws_hub() -> MagicMock:
+    hub = MagicMock()
+    hub.broadcast = AsyncMock()
+    return hub
+
+
+# ---------------------------------------------------------------------------
+# 1. Rolling 30-day budget window
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+class TestRolling30DayBudgetWindow:
+    async def test_old_cost_outside_window_not_counted(self, db, event_bus) -> None:
+        """Costs older than 30 days must not count toward the monthly limit."""
+        project = await create_project(db, "proj-rolling")
+
+        # Insert a cost event 31 days ago (outside rolling window)
+        old_date = (datetime.now(UTC) - timedelta(days=31)).isoformat()
+        await db.execute(
+            """INSERT INTO usage_events
+               (id, project_id, session_id, event_type, model,
+                input_tokens, output_tokens, cost_usd, recorded_at)
+               VALUES (?, ?, NULL, 'ai_cost', 'claude-sonnet-4-6', 0, 0, ?, ?)""",
+            ("evt-old", project.id, 90.0, old_date),
+        )
+        await db.commit()
+
+        enforcer = BudgetEnforcer(db, event_bus)
+        # Limit is $100; old cost is $90 — should be OK because it's outside window
+        status = await enforcer._compute_status(project.id, None, 100.0, 0.8)
+        assert status == "ok", "Old spend outside 30-day window should not trigger warn"
+
+    async def test_recent_cost_inside_window_counted(self, db, event_bus) -> None:
+        """Costs within the last 30 days must count toward the monthly limit."""
+        project = await create_project(db, "proj-recent")
+
+        # Insert a cost event 5 days ago (inside rolling window)
+        recent_date = (datetime.now(UTC) - timedelta(days=5)).isoformat()
+        await db.execute(
+            """INSERT INTO usage_events
+               (id, project_id, session_id, event_type, model,
+                input_tokens, output_tokens, cost_usd, recorded_at)
+               VALUES (?, ?, NULL, 'ai_cost', 'claude-sonnet-4-6', 0, 0, ?, ?)""",
+            ("evt-recent", project.id, 90.0, recent_date),
+        )
+        await db.commit()
+
+        enforcer = BudgetEnforcer(db, event_bus)
+        # Limit is $100; recent cost is $90 — should trigger warn (90% >= 80%)
+        status = await enforcer._compute_status(project.id, None, 100.0, 0.8)
+        assert status == "warn", "Recent spend inside 30-day window should trigger warn"
+
+    async def test_31_days_old_not_counted(self, db, event_bus) -> None:
+        """Cost 31 days old must fall outside the rolling 30-day window."""
+        project = await create_project(db, "proj-boundary")
+
+        boundary_date = (datetime.now(UTC) - timedelta(days=31)).isoformat()
+        await db.execute(
+            """INSERT INTO usage_events
+               (id, project_id, session_id, event_type, model,
+                input_tokens, output_tokens, cost_usd, recorded_at)
+               VALUES (?, ?, NULL, 'ai_cost', 'claude-sonnet-4-6', 0, 0, ?, ?)""",
+            ("evt-boundary", project.id, 90.0, boundary_date),
+        )
+        await db.commit()
+
+        enforcer = BudgetEnforcer(db, event_bus)
+        status = await enforcer._compute_status(project.id, None, 100.0, 0.8)
+        assert status == "ok", "Spend 31 days ago must not count in rolling 30-day window"
+
+    async def test_budget_ok_event_published_on_recovery(
+        self, db, event_bus, ws_hub
+    ) -> None:
+        """budget_ok must be published when status transitions to ok."""
+        project = await create_project(db, "proj-ok")
+        await upsert_project_budget(db, project.id, monthly_cost_limit=100.0)
+
+        received: list[dict] = []
+        event_bus.subscribe("budget_ok", lambda d: received.append(d) or _noop())
+
+        async def _collect(d: dict) -> None:
+            received.append(d)
+
+        event_bus.subscribe("budget_ok", _collect)
+
+        enforcer = BudgetEnforcer(db, event_bus, ws_hub=ws_hub)
+        await enforcer._transition_status(project.id, "warn", "ok", None, 100.0, 0.8)
+
+        assert any(r.get("project_id") == project.id for r in received)
+
+
+def _noop() -> None:
+    pass
+
+
+# ---------------------------------------------------------------------------
+# 2. Tower budget_constrained flag
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+class TestTowerBudgetConstrainedFlag:
+    async def test_flag_false_initially(self, db, event_bus) -> None:
+        tower = TowerController(db, event_bus)
+        assert tower._budget_constrained is False
+
+    async def test_flag_set_on_budget_warning_event(self, db, event_bus) -> None:
+        tower = TowerController(db, event_bus)
+        await event_bus.publish("budget_warning", {"project_id": "proj-1"})
+        assert tower._budget_constrained is True
+
+    async def test_flag_cleared_on_budget_ok_event(self, db, event_bus) -> None:
+        tower = TowerController(db, event_bus)
+        # Set the flag first
+        await event_bus.publish("budget_warning", {"project_id": "proj-1"})
+        assert tower._budget_constrained is True
+        # Then clear it
+        await event_bus.publish("budget_ok", {"project_id": "proj-1"})
+        assert tower._budget_constrained is False
+
+    async def test_submit_goal_raises_when_budget_constrained(
+        self, db, event_bus
+    ) -> None:
+        """submit_goal must refuse new work when budget constrained."""
+        tower = TowerController(db, event_bus)
+        await event_bus.publish("budget_warning", {"project_id": "proj-1"})
+
+        with pytest.raises(BudgetConstrainedError):
+            await tower.submit_goal("proj-1", "do something")
+
+
+# ---------------------------------------------------------------------------
+# 3. Explicit cost reporting takes priority over stats-cache
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+class TestExplicitCostReporting:
+    async def test_record_explicit_writes_usage_event(self, db, event_bus) -> None:
+        project = await create_project(db, "proj-explicit")
+        session = await create_session(db, project.id, "ace", "ace-1")
+
+        tracker = CostTracker(db, event_bus)
+        await tracker.record_explicit(
+            session.id, input_tokens=1000, output_tokens=200,
+            model="claude-sonnet-4-6", cost_usd=0.006,
+        )
+
+        cursor = await db.execute(
+            "SELECT * FROM usage_events WHERE session_id = ?", (session.id,)
+        )
+        rows = await cursor.fetchall()
+        assert len(rows) == 1
+        assert float(rows[0]["cost_usd"]) == pytest.approx(0.006)
+
+    async def test_record_explicit_marks_session_as_explicit(
+        self, db, event_bus
+    ) -> None:
+        project = await create_project(db, "proj-mark")
+        session = await create_session(db, project.id, "ace", "ace-1")
+
+        tracker = CostTracker(db, event_bus)
+        assert session.id not in tracker._has_explicit_reporting
+
+        await tracker.record_explicit(
+            session.id, input_tokens=100, output_tokens=50,
+            model="claude-sonnet-4-6", cost_usd=0.001,
+        )
+        assert session.id in tracker._has_explicit_reporting
+
+    async def test_poll_skips_explicit_session(self, db, event_bus, tmp_path) -> None:
+        """Stats-cache poll must not write usage_events for explicit-reporting sessions."""
+        project = await create_project(db, "proj-skip")
+        session = await create_session(
+            db, project.id, "ace", "ace-1", status="working"
+        )
+
+        # Fake stats-cache with a delta
+        stats = tmp_path / "stats-cache.json"
+        stats.write_text(json.dumps({
+            "models": {"claude-sonnet-4-6": {"input_tokens": 500, "output_tokens": 100}}
+        }))
+
+        tracker = CostTracker(db, event_bus, stats_path=stats)
+
+        # Mark session as explicit
+        tracker._has_explicit_reporting.add(session.id)
+
+        # Prime the previous snapshot so there's a delta
+        tracker._last_snapshot = {
+            "models": {"claude-sonnet-4-6": {"input_tokens": 0, "output_tokens": 0}}
+        }
+
+        await tracker._poll_once()
+
+        cursor = await db.execute(
+            "SELECT COUNT(*) FROM usage_events WHERE session_id = ?", (session.id,)
+        )
+        row = await cursor.fetchone()
+        assert row[0] == 0, "Poll should not write events for explicit-reporting session"
+
+    async def test_cost_reported_event_triggers_record_explicit(
+        self, db, event_bus
+    ) -> None:
+        """cost_reported event on event bus should call record_explicit."""
+        project = await create_project(db, "proj-event")
+        session = await create_session(db, project.id, "ace", "ace-1")
+
+        tracker = CostTracker(db, event_bus)
+        await event_bus.publish(
+            "cost_reported",
+            {
+                "session_id": session.id,
+                "input_tokens": 200,
+                "output_tokens": 80,
+                "model": "claude-sonnet-4-6",
+            },
+        )
+
+        assert session.id in tracker._has_explicit_reporting
+        cursor = await db.execute(
+            "SELECT COUNT(*) FROM usage_events WHERE session_id = ?", (session.id,)
+        )
+        row = await cursor.fetchone()
+        assert row[0] == 1
+
+
+# ---------------------------------------------------------------------------
+# 4. atc tower cost CLI calls correct endpoint
+# ---------------------------------------------------------------------------
+
+
+class TestTowerCostCli:
+    def test_cost_command_posts_to_correct_endpoint(self) -> None:
+        """_handle_cost must POST to /api/tower/cost with all fields."""
+        import argparse
+
+        from atc.cli.tower import _handle_cost
+
+        args = argparse.Namespace(
+            api="http://127.0.0.1:8420",
+            session_id="sess-abc",
+            input_tokens=1000,
+            output_tokens=250,
+            model="claude-sonnet-4-6",
+        )
+
+        captured_url: list[str] = []
+        captured_payload: list[dict] = []
+
+        def fake_post_json(url: str, payload: dict) -> int:
+            captured_url.append(url)
+            captured_payload.append(payload)
+            return 0
+
+        with patch("atc.cli.tower._post_json", side_effect=fake_post_json):
+            result = _handle_cost(args)
+
+        assert result == 0
+        assert captured_url[0] == "http://127.0.0.1:8420/api/tower/cost"
+        assert captured_payload[0] == {
+            "session_id": "sess-abc",
+            "input_tokens": 1000,
+            "output_tokens": 250,
+            "model": "claude-sonnet-4-6",
+        }
+
+    def test_cost_command_registered_in_cli(self) -> None:
+        """atc tower cost subcommand must be registered."""
+        import argparse
+
+        from atc.cli import tower as tower_cli
+
+        parser = argparse.ArgumentParser()
+        subparsers = parser.add_subparsers()
+        tower_cli.register(subparsers)
+
+        # Parse a cost command to confirm it's registered
+        args = parser.parse_args([
+            "tower", "cost", "sess-123", "500", "100", "claude-sonnet-4-6",
+        ])
+        assert args.session_id == "sess-123"
+        assert args.input_tokens == 500
+        assert args.output_tokens == 100
+        assert args.model == "claude-sonnet-4-6"


### PR DESCRIPTION
Implements the four open question resolutions from §15 of the spec.

## Changes

### Rolling 30-day budget window
- `budget.py`: monthly cost query now uses `WHERE recorded_at >= datetime('now', '-30 days')` instead of calendar month boundary
- Avoids the month-end pattern where spend resets to zero on the 1st

### Tower proactive slowdown at budget warning
- `controller.py`: subscribes to `budget_warning` / `budget_ok` events
- Sets `_budget_constrained = True` on warning — stops spawning new Aces
- Clears flag on `budget_ok` — resumes normal operation
- Existing sessions are NOT paused (that's reserved for `budget_exceeded`)

### Dual cost attribution
- `costs.py`: sessions that report via `atc tower cost` CLI are tracked in `_has_explicit_reporting` set
- Stats-cache polling skips those sessions — no double-counting
- Explicit reporting is more accurate (per-call) vs stats-cache diffing (30s poll)
- `cli/tower.py`: `atc tower cost <session_id> <input> <output> <model>` command
- `routers/tower.py`: `POST /api/tower/cost` endpoint fires `cost_reported` event

### Design logs
- `009-rolling-budget-window.md`
- `010-dual-cost-attribution.md`
- `011-tower-ui-dockable-panel.md` (documents Tower UI decision for M7 implementation)
- `012-tower-session-model.md` (documents rule-based Python controller decision)