### PR TITLE
feat: dashboard views — Grid/Row/Board toggle with drag-to-reorder

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,6 +8,9 @@
       "name": "atc-frontend",
       "version": "0.1.0",
       "dependencies": {
+        "@dnd-kit/core": "^6.3.1",
+        "@dnd-kit/sortable": "^10.0.0",
+        "@dnd-kit/utilities": "^3.2.2",
         "@sentry/react": "^9.0.0",
         "@tanstack/react-query": "^5.62.0",
         "@tauri-apps/api": "^2.0.0",
@@ -550,6 +553,59 @@
       "license": "MIT",
       "engines": {
         "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@dnd-kit/accessibility": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/accessibility/-/accessibility-3.1.1.tgz",
+      "integrity": "sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/core": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz",
+      "integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/accessibility": "^3.1.1",
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/sortable": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/sortable/-/sortable-10.0.0.tgz",
+      "integrity": "sha512-+xqhmIIzvAYMGfBYYnbKuNicfSsk4RksY2XdmJhT+HAC01nix6fHCztU68jooFiMUB01Ky3F0FyOvhG/BZrWkg==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "@dnd-kit/core": "^6.3.0",
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/utilities": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/utilities/-/utilities-3.2.2.tgz",
+      "integrity": "sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -4640,6 +4696,12 @@
       "peerDependencies": {
         "typescript": ">=4.8.4"
       }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
     },
     "node_modules/type-check": {
       "version": "0.4.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -13,6 +13,9 @@
     "test:watch": "vitest"
   },
   "dependencies": {
+    "@dnd-kit/core": "^6.3.1",
+    "@dnd-kit/sortable": "^10.0.0",
+    "@dnd-kit/utilities": "^3.2.2",
     "@sentry/react": "^9.0.0",
     "@tanstack/react-query": "^5.62.0",
     "@tauri-apps/api": "^2.0.0",

--- a/frontend/src/components/common/AceStatusSummary.tsx
+++ b/frontend/src/components/common/AceStatusSummary.tsx
@@ -1,0 +1,64 @@
+import type { Session } from "../../types";
+
+interface Props {
+  sessions: Session[];
+  projectId: string;
+}
+
+export default function AceStatusSummary({ sessions, projectId }: Props) {
+  const aces = sessions.filter(
+    (s) => s.project_id === projectId && s.session_type === "ace",
+  );
+
+  if (aces.length === 0) {
+    return <span className="ace-status ace-status--none">0 active</span>;
+  }
+
+  const working = aces.filter((s) => s.status === "working").length;
+  const waiting = aces.filter((s) => s.status === "waiting").length;
+  const idle = aces.filter(
+    (s) => s.status === "idle" || s.status === "paused" || s.status === "disconnected",
+  ).length;
+
+  if (working === 0 && waiting === 0) {
+    return <span className="ace-status ace-status--none">0 active</span>;
+  }
+
+  const parts: React.ReactNode[] = [];
+
+  if (working > 0) {
+    parts.push(
+      <span key="working" className="ace-status__item">
+        <span className="ace-status__dot ace-status__dot--working" />
+        {working} working
+      </span>,
+    );
+  }
+  if (waiting > 0) {
+    parts.push(
+      <span key="waiting" className="ace-status__item">
+        <span className="ace-status__dot ace-status__dot--waiting" />
+        {waiting} waiting
+      </span>,
+    );
+  }
+  if (idle > 0) {
+    parts.push(
+      <span key="idle" className="ace-status__item">
+        <span className="ace-status__dot ace-status__dot--idle" />
+        {idle} idle
+      </span>,
+    );
+  }
+
+  return (
+    <span className="ace-status">
+      {parts.map((part, i) => (
+        <span key={i}>
+          {i > 0 && <span className="ace-status__sep"> · </span>}
+          {part}
+        </span>
+      ))}
+    </span>
+  );
+}

--- a/frontend/src/components/common/KanbanBar.tsx
+++ b/frontend/src/components/common/KanbanBar.tsx
@@ -1,0 +1,52 @@
+interface Props {
+  done: number;
+  inProgress: number;
+  todo: number;
+  width?: number;
+}
+
+export default function KanbanBar({ done, inProgress, todo, width }: Props) {
+  const total = done + inProgress + todo;
+  if (total === 0) {
+    return (
+      <div
+        className="kanban-bar kanban-bar--empty"
+        style={width !== undefined ? { width } : undefined}
+        title="No tasks"
+      />
+    );
+  }
+
+  const donePct = (done / total) * 100;
+  const inProgressPct = (inProgress / total) * 100;
+  const todoPct = (todo / total) * 100;
+  const tooltipText = `${done} done / ${inProgress} in progress / ${todo} todo`;
+
+  return (
+    <div
+      className="kanban-bar"
+      style={width !== undefined ? { width } : undefined}
+      title={tooltipText}
+      aria-label={tooltipText}
+    >
+      {done > 0 && (
+        <div
+          className="kanban-bar__segment kanban-bar__segment--done"
+          style={{ width: `${donePct}%` }}
+        />
+      )}
+      {inProgress > 0 && (
+        <div
+          className="kanban-bar__segment kanban-bar__segment--in-progress"
+          style={{ width: `${inProgressPct}%` }}
+        />
+      )}
+      {todo > 0 && (
+        <div
+          className="kanban-bar__segment kanban-bar__segment--todo"
+          style={{ width: `${todoPct}%` }}
+        />
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/dashboard/ProjectBoardView.tsx
+++ b/frontend/src/components/dashboard/ProjectBoardView.tsx
@@ -1,0 +1,236 @@
+import { useState } from "react";
+import { useNavigate } from "react-router-dom";
+import {
+  DndContext,
+  closestCenter,
+  PointerSensor,
+  useSensor,
+  useSensors,
+  type DragEndEvent,
+  useDroppable,
+} from "@dnd-kit/core";
+import {
+  SortableContext,
+  useSortable,
+  verticalListSortingStrategy,
+  arrayMove,
+} from "@dnd-kit/sortable";
+import { CSS } from "@dnd-kit/utilities";
+import type { Project, Session, Task, Leader, GitHubSummary } from "../../types";
+import { getProjectMilestoneStatus } from "../../utils/milestones";
+import AceStatusSummary from "../common/AceStatusSummary";
+import { api, ApiError } from "../../utils/api";
+
+type ColumnStatus = "active" | "paused" | "archived";
+
+interface Props {
+  projects: Project[];
+  sessions: Session[];
+  tasks: Record<string, Task[]>;
+  leaders: Record<string, Leader>;
+  github: Record<string, GitHubSummary>;
+  onProjectsChange: (projects: Project[]) => void;
+}
+
+interface CardProps {
+  project: Project;
+  sessions: Session[];
+  tasks: Task[];
+  leader: Leader | undefined;
+}
+
+function SortableCard({ project, sessions, tasks, leader }: CardProps) {
+  const navigate = useNavigate();
+  const { attributes, listeners, setNodeRef, transform, transition, isDragging } =
+    useSortable({ id: project.id });
+
+  const style: React.CSSProperties = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+    opacity: isDragging ? 0.4 : 1,
+  };
+
+  const ms = getProjectMilestoneStatus(tasks);
+  return (
+    <div
+      ref={setNodeRef}
+      style={style}
+      className="board-card"
+      {...attributes}
+      {...listeners}
+    >
+      <div className="board-card__header">
+        <span className="board-card__name" onClick={() => navigate(`/projects/${project.id}`)}>
+          {project.name}
+        </span>
+      </div>
+
+      {leader && (
+        <div className={`board-card__leader leader-status--${leader.status}`}>
+          {leader.status}
+        </div>
+      )}
+
+      <div className="board-card__milestone">{ms.label}</div>
+
+      <div className="board-card__ace-row">
+        <AceStatusSummary sessions={sessions} projectId={project.id} />
+      </div>
+    </div>
+  );
+}
+
+interface ColumnProps {
+  status: ColumnStatus;
+  label: string;
+  projects: Project[];
+  sessions: Session[];
+  tasks: Record<string, Task[]>;
+  leaders: Record<string, Leader>;
+}
+
+function BoardColumn({ status, label, projects, sessions, tasks, leaders }: ColumnProps) {
+  const { setNodeRef, isOver } = useDroppable({ id: status });
+
+  return (
+    <div
+      ref={setNodeRef}
+      className={`board-column${isOver ? " board-column--over" : ""}`}
+    >
+      <div className="board-column__header">
+        <span className="board-column__label">{label}</span>
+        <span className="board-column__count">{projects.length}</span>
+      </div>
+
+      <SortableContext
+        items={projects.map((p) => p.id)}
+        strategy={verticalListSortingStrategy}
+      >
+        <div className="board-column__cards">
+          {projects.length === 0 ? (
+            <div className="board-column__empty">
+              No {label.toLowerCase()} projects
+            </div>
+          ) : (
+            projects.map((project) => (
+              <SortableCard
+                key={project.id}
+                project={project}
+                sessions={sessions}
+                tasks={tasks[project.id] ?? []}
+                leader={leaders[project.id]}
+              />
+            ))
+          )}
+        </div>
+      </SortableContext>
+    </div>
+  );
+}
+
+const COLUMNS: { status: ColumnStatus; label: string }[] = [
+  { status: "active", label: "Active" },
+  { status: "paused", label: "Paused" },
+  { status: "archived", label: "Archived" },
+];
+
+export default function ProjectBoardView({
+  projects,
+  sessions,
+  tasks,
+  leaders,
+  onProjectsChange,
+}: Props) {
+  const [error, setError] = useState<string | null>(null);
+
+  const sensors = useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 5 } }),
+  );
+
+  const byStatus = (status: ColumnStatus) =>
+    projects.filter((p) => p.status === status);
+
+  const handleDragEnd = async (event: DragEndEvent) => {
+    const { active, over } = event;
+    if (!over) return;
+
+    const draggedProject = projects.find((p) => p.id === active.id);
+    if (!draggedProject) return;
+
+    // Determine target column: over.id is either a project id or a column status
+    let targetStatus: ColumnStatus | null = null;
+    const overProject = projects.find((p) => p.id === over.id);
+    if (overProject) {
+      targetStatus = overProject.status as ColumnStatus;
+    } else if (["active", "paused", "archived"].includes(over.id as string)) {
+      targetStatus = over.id as ColumnStatus;
+    }
+
+    if (!targetStatus) return;
+
+    const prevProjects = [...projects];
+
+    if (draggedProject.status !== targetStatus) {
+      // Cross-column drag: update status
+      const updated = projects.map((p) =>
+        p.id === draggedProject.id ? { ...p, status: targetStatus! } : p,
+      );
+      onProjectsChange(updated);
+
+      try {
+        setError(null);
+        await api.put(`/projects/${draggedProject.id}`, { status: targetStatus });
+      } catch (err) {
+        const msg = err instanceof ApiError ? err.message : "Status update failed";
+        setError(msg);
+        onProjectsChange(prevProjects);
+      }
+    } else if (overProject && draggedProject.id !== overProject.id) {
+      // Same-column reorder
+      const colProjects = byStatus(targetStatus);
+      const oldIdx = colProjects.findIndex((p) => p.id === draggedProject.id);
+      const newIdx = colProjects.findIndex((p) => p.id === overProject.id);
+      const reorderedCol = arrayMove(colProjects, oldIdx, newIdx);
+
+      // Merge reordered column back into full list
+      const otherProjects = projects.filter((p) => p.status !== targetStatus);
+      const merged = [...otherProjects, ...reorderedCol];
+      onProjectsChange(merged);
+
+      const positions = merged.map((p, i) => ({ id: p.id, position: i }));
+      try {
+        setError(null);
+        await api.patch("/projects/reorder", { positions });
+      } catch (err) {
+        const msg = err instanceof ApiError ? err.message : "Reorder failed";
+        setError(msg);
+        onProjectsChange(prevProjects);
+      }
+    }
+  };
+
+  return (
+    <div className="project-board-view">
+      {error && <div className="view-error">{error}</div>}
+      <DndContext
+        sensors={sensors}
+        collisionDetection={closestCenter}
+        onDragEnd={(e) => void handleDragEnd(e)}
+      >
+        <div className="board-columns">
+          {COLUMNS.map(({ status, label }) => (
+            <BoardColumn
+              key={status}
+              status={status}
+              label={label}
+              projects={byStatus(status)}
+              sessions={sessions}
+              tasks={tasks}
+              leaders={leaders}
+            />
+          ))}
+        </div>
+      </DndContext>
+    </div>
+  );
+}

--- a/frontend/src/components/dashboard/ProjectGridView.tsx
+++ b/frontend/src/components/dashboard/ProjectGridView.tsx
@@ -1,0 +1,219 @@
+import { useState } from "react";
+import { useNavigate } from "react-router-dom";
+import {
+  DndContext,
+  closestCenter,
+  PointerSensor,
+  useSensor,
+  useSensors,
+  type DragEndEvent,
+} from "@dnd-kit/core";
+import {
+  SortableContext,
+  useSortable,
+  rectSortingStrategy,
+  arrayMove,
+} from "@dnd-kit/sortable";
+import { CSS } from "@dnd-kit/utilities";
+import type { Project, Session, Task, Leader, GitHubSummary } from "../../types";
+import { getProjectMilestoneStatus } from "../../utils/milestones";
+import KanbanBar from "../common/KanbanBar";
+import AceStatusSummary from "../common/AceStatusSummary";
+import ConfirmPopover from "../common/ConfirmPopover";
+import { api, ApiError } from "../../utils/api";
+
+interface Props {
+  projects: Project[];
+  sessions: Session[];
+  tasks: Record<string, Task[]>;
+  leaders: Record<string, Leader>;
+  github: Record<string, GitHubSummary>;
+  onReorder: (projects: Project[]) => void;
+  onArchive: (id: string) => Promise<void>;
+  onDelete: (id: string) => Promise<void>;
+}
+
+interface CardProps {
+  project: Project;
+  sessions: Session[];
+  tasks: Task[];
+  leader: Leader | undefined;
+  github: GitHubSummary | undefined;
+  onArchive: (id: string) => Promise<void>;
+  onDelete: (id: string) => Promise<void>;
+}
+
+function CIBadge({ summary }: { summary: GitHubSummary | undefined }) {
+  if (!summary) return <span className="ci-badge ci-badge--none">—</span>;
+  const rate = summary.ci_pass_rate;
+  if (rate >= 1) return <span className="ci-badge ci-badge--pass">✓</span>;
+  if (rate <= 0) return <span className="ci-badge ci-badge--fail">✗</span>;
+  return <span className="ci-badge ci-badge--partial">⟳</span>;
+}
+
+function StatusDot({ status }: { status: Project["status"] }) {
+  return <span className={`status-dot status-dot--${status}`} />;
+}
+
+function SortableProjectCard({
+  project,
+  sessions,
+  tasks,
+  leader,
+  github,
+  onArchive,
+  onDelete,
+}: CardProps) {
+  const navigate = useNavigate();
+  const { attributes, listeners, setNodeRef, transform, transition, isDragging } =
+    useSortable({ id: project.id });
+
+  const style: React.CSSProperties = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+    opacity: isDragging ? 0.5 : 1,
+    zIndex: isDragging ? 1 : undefined,
+  };
+
+  const ms = getProjectMilestoneStatus(tasks);
+  const done = tasks.filter((t) => t.status === "done").length;
+  const inProgress = tasks.filter((t) => t.status === "in_progress" || t.status === "assigned").length;
+  const todo = tasks.filter((t) => t.status === "pending" || t.status === "blocked").length;
+
+  return (
+    <div
+      ref={setNodeRef}
+      style={style}
+      className="panel project-card project-card--grid"
+    >
+      {/* drag handle */}
+      <div
+        className="project-card__drag-handle"
+        {...attributes}
+        {...listeners}
+        aria-label="Drag to reorder"
+      >
+        ⠿
+      </div>
+
+      <div
+        className="project-card__body"
+        onClick={() => navigate(`/projects/${project.id}`)}
+      >
+        <div className="project-card__header">
+          <StatusDot status={project.status} />
+          <h3 className="project-card__name">{project.name}</h3>
+          <CIBadge summary={github} />
+        </div>
+
+        {leader && (
+          <div className="project-card__leader">
+            Leader: <span className={`leader-status leader-status--${leader.status}`}>{leader.status}</span>
+          </div>
+        )}
+
+        <div className="project-card__milestone">{ms.label}</div>
+
+        <KanbanBar done={done} inProgress={inProgress} todo={todo} />
+
+        <div className="project-card__ace-row">
+          <AceStatusSummary sessions={sessions} projectId={project.id} />
+        </div>
+      </div>
+
+      <div className="project-card__actions">
+        <button className="btn btn-sm" onClick={() => void onArchive(project.id)}>
+          Archive
+        </button>
+        <ConfirmPopover
+          message={`Delete "${project.name}"? This removes all tasks and context.`}
+          confirmLabel="Delete"
+          variant="danger"
+          onConfirm={() => void onDelete(project.id)}
+        >
+          <button className="btn btn-sm btn-danger">Delete</button>
+        </ConfirmPopover>
+      </div>
+    </div>
+  );
+}
+
+export default function ProjectGridView({
+  projects,
+  sessions,
+  tasks,
+  leaders,
+  github,
+  onReorder,
+  onArchive,
+  onDelete,
+}: Props) {
+  const [reorderError, setReorderError] = useState<string | null>(null);
+
+  const sensors = useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 5 } }),
+  );
+
+  const handleDragEnd = async (event: DragEndEvent) => {
+    const { active, over } = event;
+    if (!over || active.id === over.id) return;
+
+    const oldIndex = projects.findIndex((p) => p.id === active.id);
+    const newIndex = projects.findIndex((p) => p.id === over.id);
+    const reordered = arrayMove(projects, oldIndex, newIndex);
+    onReorder(reordered);
+
+    const positions = reordered.map((p, i) => ({ id: p.id, position: i }));
+    try {
+      setReorderError(null);
+      await api.patch("/projects/reorder", { positions });
+    } catch (err) {
+      const msg = err instanceof ApiError ? err.message : "Reorder failed";
+      setReorderError(msg);
+      onReorder(projects); // revert
+    }
+  };
+
+  const activeProjects = projects.filter((p) => p.status !== "archived");
+
+  if (activeProjects.length === 0) {
+    return (
+      <div className="dashboard__empty">
+        <p>No active projects.</p>
+      </div>
+    );
+  }
+
+  return (
+    <>
+      {reorderError && (
+        <div className="view-error">{reorderError}</div>
+      )}
+      <DndContext
+        sensors={sensors}
+        collisionDetection={closestCenter}
+        onDragEnd={(e) => void handleDragEnd(e)}
+      >
+        <SortableContext
+          items={activeProjects.map((p) => p.id)}
+          strategy={rectSortingStrategy}
+        >
+          <div className="project-grid-view">
+            {activeProjects.map((project) => (
+              <SortableProjectCard
+                key={project.id}
+                project={project}
+                sessions={sessions}
+                tasks={tasks[project.id] ?? []}
+                leader={leaders[project.id]}
+                github={github[project.id]}
+                onArchive={onArchive}
+                onDelete={onDelete}
+              />
+            ))}
+          </div>
+        </SortableContext>
+      </DndContext>
+    </>
+  );
+}

--- a/frontend/src/components/dashboard/ProjectRowView.tsx
+++ b/frontend/src/components/dashboard/ProjectRowView.tsx
@@ -1,0 +1,201 @@
+import { useState } from "react";
+import { useNavigate } from "react-router-dom";
+import {
+  DndContext,
+  closestCenter,
+  PointerSensor,
+  useSensor,
+  useSensors,
+  type DragEndEvent,
+} from "@dnd-kit/core";
+import {
+  SortableContext,
+  useSortable,
+  verticalListSortingStrategy,
+  arrayMove,
+} from "@dnd-kit/sortable";
+import { CSS } from "@dnd-kit/utilities";
+import type { Project, Session, Task, Leader, GitHubSummary } from "../../types";
+import { getProjectMilestoneStatus } from "../../utils/milestones";
+import KanbanBar from "../common/KanbanBar";
+import AceStatusSummary from "../common/AceStatusSummary";
+import { api, ApiError } from "../../utils/api";
+
+interface Props {
+  projects: Project[];
+  sessions: Session[];
+  tasks: Record<string, Task[]>;
+  leaders: Record<string, Leader>;
+  github: Record<string, GitHubSummary>;
+  onReorder: (projects: Project[]) => void;
+}
+
+interface RowProps {
+  project: Project;
+  sessions: Session[];
+  tasks: Task[];
+  leader: Leader | undefined;
+  github: GitHubSummary | undefined;
+}
+
+function CIBadgeCompact({ summary }: { summary: GitHubSummary | undefined }) {
+  if (!summary) return <span className="ci-badge ci-badge--none">—</span>;
+  const rate = summary.ci_pass_rate;
+  if (rate >= 1) return <span className="ci-badge ci-badge--pass">✓</span>;
+  if (rate <= 0) return <span className="ci-badge ci-badge--fail">✗</span>;
+  return <span className="ci-badge ci-badge--partial">⟳</span>;
+}
+
+function StatusDot({ status }: { status: Project["status"] }) {
+  return <span className={`status-dot status-dot--${status}`} />;
+}
+
+function SortableProjectRow({ project, sessions, tasks, github }: RowProps) {
+  const navigate = useNavigate();
+  const { attributes, listeners, setNodeRef, transform, transition, isDragging } =
+    useSortable({ id: project.id });
+
+  const style: React.CSSProperties = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+    opacity: isDragging ? 0.5 : 1,
+  };
+
+  const ms = getProjectMilestoneStatus(tasks);
+  const done = tasks.filter((t) => t.status === "done").length;
+  const inProgress = tasks.filter((t) => t.status === "in_progress" || t.status === "assigned").length;
+  const todo = tasks.filter((t) => t.status === "pending" || t.status === "blocked").length;
+
+  return (
+    <div
+      ref={setNodeRef}
+      style={style}
+      className={`project-row${isDragging ? " project-row--dragging" : ""}`}
+    >
+      {/* drag handle */}
+      <span
+        className="project-row__handle"
+        {...attributes}
+        {...listeners}
+        aria-label="Drag to reorder"
+      >
+        ⋮⋮
+      </span>
+
+      <StatusDot status={project.status} />
+
+      <span
+        className="project-row__name"
+        onClick={() => navigate(`/projects/${project.id}`)}
+        role="link"
+        tabIndex={0}
+        onKeyDown={(e) => e.key === "Enter" && navigate(`/projects/${project.id}`)}
+      >
+        {project.name}
+      </span>
+
+      <span className="project-row__milestone">{ms.label}</span>
+
+      <KanbanBar done={done} inProgress={inProgress} todo={todo} />
+
+      <span className="project-row__ace">
+        <AceStatusSummary sessions={sessions} projectId={project.id} />
+      </span>
+
+      <CIBadgeCompact summary={github} />
+
+      <button
+        className="btn btn-sm project-row__open"
+        onClick={() => navigate(`/projects/${project.id}`)}
+        aria-label={`Open ${project.name}`}
+      >
+        →
+      </button>
+    </div>
+  );
+}
+
+export default function ProjectRowView({
+  projects,
+  sessions,
+  tasks,
+  leaders,
+  github,
+  onReorder,
+}: Props) {
+  const [reorderError, setReorderError] = useState<string | null>(null);
+
+  const sensors = useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 5 } }),
+  );
+
+  const handleDragEnd = async (event: DragEndEvent) => {
+    const { active, over } = event;
+    if (!over || active.id === over.id) return;
+
+    const oldIndex = projects.findIndex((p) => p.id === active.id);
+    const newIndex = projects.findIndex((p) => p.id === over.id);
+    const reordered = arrayMove(projects, oldIndex, newIndex);
+    onReorder(reordered);
+
+    const positions = reordered.map((p, i) => ({ id: p.id, position: i }));
+    try {
+      setReorderError(null);
+      await api.patch("/projects/reorder", { positions });
+    } catch (err) {
+      const msg = err instanceof ApiError ? err.message : "Reorder failed";
+      setReorderError(msg);
+      onReorder(projects); // revert
+    }
+  };
+
+  const activeProjects = projects.filter((p) => p.status !== "archived");
+
+  if (activeProjects.length === 0) {
+    return (
+      <div className="dashboard__empty">
+        <p>No active projects.</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="project-row-view">
+      {reorderError && <div className="view-error">{reorderError}</div>}
+
+      {/* Column headers */}
+      <div className="project-row project-row--header">
+        <span className="project-row__handle" />
+        <span />
+        <span className="project-row__name">Project</span>
+        <span className="project-row__milestone">Milestone</span>
+        <span>Progress</span>
+        <span className="project-row__ace">Aces</span>
+        <span>CI</span>
+        <span />
+      </div>
+
+      <DndContext
+        sensors={sensors}
+        collisionDetection={closestCenter}
+        onDragEnd={(e) => void handleDragEnd(e)}
+      >
+        <SortableContext
+          items={activeProjects.map((p) => p.id)}
+          strategy={verticalListSortingStrategy}
+        >
+          {activeProjects.map((project) => (
+            <SortableProjectRow
+              key={project.id}
+              project={project}
+              sessions={sessions}
+              tasks={tasks[project.id] ?? []}
+              leader={leaders[project.id]}
+              github={github[project.id]}
+            />
+          ))}
+        </SortableContext>
+      </DndContext>
+    </div>
+  );
+}

--- a/frontend/src/pages/Dashboard.css
+++ b/frontend/src/pages/Dashboard.css
@@ -133,3 +133,466 @@
   font-size: var(--text-xs);
   color: var(--color-text-muted);
 }
+
+/* ─── Projects section header with view toggle ─────────────────────────────── */
+
+.dashboard__projects-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: var(--space-4);
+}
+
+.dashboard__projects-header h2 {
+  font-size: var(--text-lg);
+  font-weight: 600;
+  margin-bottom: 0;
+}
+
+/* ─── View toggle ───────────────────────────────────────────────────────────── */
+
+.view-toggle {
+  display: flex;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  overflow: hidden;
+}
+
+.view-toggle__btn {
+  padding: var(--space-1) var(--space-3);
+  font-size: var(--text-sm);
+  background: transparent;
+  border: none;
+  border-left: 1px solid var(--color-border);
+  color: var(--color-text-secondary);
+  cursor: pointer;
+  transition: background var(--transition-fast), color var(--transition-fast);
+}
+
+.view-toggle__btn:first-child {
+  border-left: none;
+}
+
+.view-toggle__btn:hover {
+  background: var(--color-bg-hover);
+  color: var(--color-text);
+}
+
+.view-toggle__btn--active {
+  background: var(--color-accent-muted);
+  color: var(--color-accent);
+  font-weight: 500;
+}
+
+/* ─── Shared project card parts ─────────────────────────────────────────────── */
+
+.status-dot {
+  display: inline-block;
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
+.status-dot--active   { background: var(--color-success); }
+.status-dot--paused   { background: var(--color-warning); }
+.status-dot--archived { background: var(--color-text-muted); }
+
+.ci-badge {
+  font-size: var(--text-xs);
+  font-weight: 600;
+  padding: 1px 4px;
+  border-radius: var(--radius-sm);
+}
+
+.ci-badge--pass    { color: var(--color-success); }
+.ci-badge--fail    { color: var(--color-danger); }
+.ci-badge--partial { color: var(--color-warning); }
+.ci-badge--none    { color: var(--color-text-muted); }
+
+.leader-status {
+  font-size: var(--text-xs);
+  color: var(--color-text-muted);
+}
+
+.leader-status--managing { color: var(--color-success); }
+.leader-status--planning { color: var(--color-warning); }
+.leader-status--error    { color: var(--color-danger); }
+
+/* ─── KanbanBar ─────────────────────────────────────────────────────────────── */
+
+.kanban-bar {
+  display: flex;
+  height: 6px;
+  border-radius: 3px;
+  overflow: hidden;
+  background: var(--color-border);
+  width: 100%;
+}
+
+.kanban-bar--empty {
+  background: var(--color-border);
+}
+
+.kanban-bar__segment {
+  height: 100%;
+  transition: width 0.3s ease;
+}
+
+.kanban-bar__segment--done        { background: var(--color-success); }
+.kanban-bar__segment--in-progress { background: var(--color-accent); }
+.kanban-bar__segment--todo        { background: var(--color-border); }
+
+/* ─── AceStatusSummary ──────────────────────────────────────────────────────── */
+
+.ace-status {
+  font-size: var(--text-xs);
+  color: var(--color-text-secondary);
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-1);
+  flex-wrap: wrap;
+}
+
+.ace-status--none {
+  color: var(--color-text-muted);
+}
+
+.ace-status__item {
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
+}
+
+.ace-status__dot {
+  display: inline-block;
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+}
+
+.ace-status__dot--working { background: var(--color-success); }
+.ace-status__dot--waiting { background: var(--color-warning); }
+.ace-status__dot--idle    { background: var(--color-text-muted); }
+
+.ace-status__sep {
+  color: var(--color-text-muted);
+}
+
+/* ─── Grid view ─────────────────────────────────────────────────────────────── */
+
+.project-grid-view {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+  gap: var(--space-4);
+}
+
+.project-card--grid {
+  display: flex;
+  flex-direction: column;
+  padding: var(--space-4);
+  position: relative;
+  transition: border-color var(--transition-fast), box-shadow var(--transition-fast);
+  cursor: default;
+}
+
+.project-card--grid:hover {
+  border-color: var(--color-accent);
+  box-shadow: 0 0 0 1px var(--color-accent-muted);
+}
+
+.project-card__drag-handle {
+  position: absolute;
+  top: var(--space-2);
+  right: var(--space-2);
+  cursor: grab;
+  color: var(--color-text-muted);
+  font-size: var(--text-sm);
+  line-height: 1;
+  padding: var(--space-1);
+  border-radius: var(--radius-sm);
+  touch-action: none;
+  user-select: none;
+}
+
+.project-card__drag-handle:hover {
+  background: var(--color-bg-hover);
+  color: var(--color-text);
+}
+
+.project-card__body {
+  flex: 1;
+  cursor: pointer;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+
+.project-card__header {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  margin-bottom: var(--space-1);
+}
+
+.project-card__name {
+  font-size: var(--text-base);
+  font-weight: 600;
+  flex: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.project-card__leader {
+  font-size: var(--text-xs);
+  color: var(--color-text-secondary);
+}
+
+.project-card__milestone {
+  font-size: var(--text-xs);
+  color: var(--color-text-secondary);
+}
+
+.project-card__ace-row {
+  margin-top: var(--space-1);
+}
+
+.project-card__actions {
+  display: flex;
+  gap: var(--space-2);
+  margin-top: var(--space-3);
+  padding-top: var(--space-3);
+  border-top: 1px solid var(--color-border);
+}
+
+/* ─── Row view ──────────────────────────────────────────────────────────────── */
+
+.project-row-view {
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  overflow: hidden;
+}
+
+.project-row {
+  display: grid;
+  grid-template-columns: 24px 12px 1fr 180px 120px 160px 28px 40px;
+  align-items: center;
+  gap: var(--space-3);
+  padding: var(--space-3) var(--space-4);
+  border-bottom: 1px solid var(--color-border);
+  background: var(--color-bg-surface);
+  transition: background var(--transition-fast);
+}
+
+.project-row:last-child {
+  border-bottom: none;
+}
+
+.project-row:hover:not(.project-row--header) {
+  background: var(--color-bg-hover);
+}
+
+.project-row--header {
+  background: var(--color-bg);
+  font-size: var(--text-xs);
+  font-weight: 500;
+  color: var(--color-text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  padding: var(--space-2) var(--space-4);
+}
+
+.project-row--dragging {
+  background: var(--color-bg-hover);
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
+}
+
+.project-row__handle {
+  cursor: grab;
+  color: var(--color-text-muted);
+  font-size: var(--text-sm);
+  text-align: center;
+  touch-action: none;
+  user-select: none;
+}
+
+.project-row__handle:hover {
+  color: var(--color-text);
+}
+
+.project-row__name {
+  font-weight: 600;
+  font-size: var(--text-sm);
+  cursor: pointer;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.project-row__name:hover {
+  color: var(--color-accent);
+  text-decoration: underline;
+}
+
+.project-row__milestone {
+  font-size: var(--text-xs);
+  color: var(--color-text-secondary);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.project-row__ace {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.project-row__open {
+  padding: var(--space-1) var(--space-2);
+  font-size: var(--text-sm);
+}
+
+/* ─── Board view ────────────────────────────────────────────────────────────── */
+
+.project-board-view {
+  width: 100%;
+}
+
+.board-columns {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: var(--space-4);
+}
+
+@media (max-width: 768px) {
+  .board-columns {
+    grid-template-columns: 1fr;
+  }
+}
+
+.board-column {
+  display: flex;
+  flex-direction: column;
+  background: var(--color-bg-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  min-height: 200px;
+  transition: border-color var(--transition-fast);
+}
+
+.board-column--over {
+  border-color: var(--color-accent);
+  background: var(--color-accent-muted);
+}
+
+.board-column__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: var(--space-3) var(--space-4);
+  border-bottom: 1px solid var(--color-border);
+}
+
+.board-column__label {
+  font-size: var(--text-sm);
+  font-weight: 600;
+  color: var(--color-text-secondary);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.board-column__count {
+  font-size: var(--text-xs);
+  background: var(--color-bg);
+  border: 1px solid var(--color-border);
+  border-radius: 9999px;
+  padding: 0 var(--space-2);
+  color: var(--color-text-muted);
+}
+
+.board-column__cards {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  padding: var(--space-3);
+}
+
+.board-column__empty {
+  padding: var(--space-4);
+  text-align: center;
+  color: var(--color-text-muted);
+  font-size: var(--text-sm);
+  border: 1px dashed var(--color-border);
+  border-radius: var(--radius-md);
+}
+
+.board-card {
+  background: var(--color-bg);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  padding: var(--space-3);
+  cursor: grab;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+  transition: border-color var(--transition-fast), box-shadow var(--transition-fast);
+  touch-action: none;
+  user-select: none;
+}
+
+.board-card:hover {
+  border-color: var(--color-accent);
+  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.1);
+}
+
+.board-card__header {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+}
+
+.board-card__name {
+  font-size: var(--text-sm);
+  font-weight: 600;
+  flex: 1;
+  cursor: pointer;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.board-card__name:hover {
+  color: var(--color-accent);
+  text-decoration: underline;
+}
+
+.board-card__leader {
+  font-size: var(--text-xs);
+}
+
+.board-card__milestone {
+  font-size: var(--text-xs);
+  color: var(--color-text-secondary);
+}
+
+.board-card__ace-row {
+  margin-top: 2px;
+}
+
+/* ─── View-level error ──────────────────────────────────────────────────────── */
+
+.view-error {
+  color: var(--color-danger);
+  font-size: var(--text-sm);
+  margin-bottom: var(--space-3);
+  padding: var(--space-2) var(--space-3);
+  background: var(--color-bg-surface);
+  border: 1px solid var(--color-danger);
+  border-radius: var(--radius-md);
+}

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -1,22 +1,43 @@
 import { useState } from "react";
-import { useNavigate } from "react-router-dom";
 import { useAppContext } from "../context/AppContext";
-import StatusBadge from "../components/common/StatusBadge";
-import TimeAgo from "../components/common/TimeAgo";
 import CreateProjectModal from "../components/common/CreateProjectModal";
 import ConfirmPopover from "../components/common/ConfirmPopover";
+import ProjectGridView from "../components/dashboard/ProjectGridView";
+import ProjectRowView from "../components/dashboard/ProjectRowView";
+import ProjectBoardView from "../components/dashboard/ProjectBoardView";
 import { api, ApiError } from "../utils/api";
+import type { Project } from "../types";
 import "./Dashboard.css";
 
+type ViewMode = "grid" | "row" | "board";
+
+const VIEW_PREF_KEY = "atc_dashboard_view";
+
+function loadViewPref(): ViewMode {
+  const stored = localStorage.getItem(VIEW_PREF_KEY);
+  if (stored === "grid" || stored === "row" || stored === "board") return stored;
+  return "grid";
+}
+
 export default function Dashboard() {
-  const navigate = useNavigate();
   const { state, fetchAll } = useAppContext();
-  const { projects, sessions, usage, notifications } = state;
+  const { projects, sessions, tasks, leaders, github, usage, notifications } = state;
+
   const [showCreate, setShowCreate] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [view, setView] = useState<ViewMode>(loadViewPref);
+  // Local order state for optimistic drag-to-reorder
+  const [orderedProjects, setOrderedProjects] = useState<Project[]>(projects);
 
-  const activeProjects = projects.filter((p) => p.status === "active");
-  const archivedProjects = projects.filter((p) => p.status === "archived");
+  // Sync orderedProjects when global state changes (new project created, etc.)
+  const latestIds = projects.map((p) => p.id).join(",");
+  const orderedIds = orderedProjects.map((p) => p.id).join(",");
+  const displayProjects = latestIds === orderedIds ? orderedProjects : projects;
+
+  const handleViewChange = (v: ViewMode) => {
+    setView(v);
+    localStorage.setItem(VIEW_PREF_KEY, v);
+  };
 
   const handleDelete = async (projectId: string) => {
     try {
@@ -40,14 +61,21 @@ export default function Dashboard() {
     }
   };
 
+  const handleReorder = (reordered: Project[]) => {
+    setOrderedProjects(reordered);
+  };
+
+  const handleProjectsChange = (updated: Project[]) => {
+    setOrderedProjects(updated);
+  };
+
+  const archivedProjects = displayProjects.filter((p) => p.status === "archived");
+
   return (
     <div className="dashboard" data-testid="dashboard-page">
       <div className="dashboard__header">
         <h1>Dashboard</h1>
-        <button
-          className="btn btn-primary"
-          onClick={() => setShowCreate(true)}
-        >
+        <button className="btn btn-primary" onClick={() => setShowCreate(true)}>
           + New Project
         </button>
       </div>
@@ -112,24 +140,55 @@ export default function Dashboard() {
             <span className="dashboard__stat-label">unread</span>
           </div>
           <div className="dashboard__stat">
-            <span className="dashboard__stat-value">
-              {notifications.length}
-            </span>
+            <span className="dashboard__stat-value">{notifications.length}</span>
             <span className="dashboard__stat-label">total</span>
           </div>
         </div>
       </div>
 
       {error && (
-        <div className="dashboard__error panel" style={{ color: "var(--color-danger)", marginBottom: "var(--space-4)" }}>
+        <div
+          className="dashboard__error panel"
+          style={{ color: "var(--color-danger)", marginBottom: "var(--space-4)" }}
+        >
           {error}
         </div>
       )}
 
-      {/* Project cards */}
+      {/* Projects section with view toggle */}
       <section className="dashboard__projects">
-        <h2>Projects</h2>
-        {activeProjects.length === 0 ? (
+        <div className="dashboard__projects-header">
+          <h2>Projects</h2>
+          <div className="view-toggle" role="group" aria-label="View mode">
+            <button
+              className={`view-toggle__btn${view === "grid" ? " view-toggle__btn--active" : ""}`}
+              onClick={() => handleViewChange("grid")}
+              title="Grid view"
+              aria-pressed={view === "grid"}
+            >
+              ⊞ Grid
+            </button>
+            <button
+              className={`view-toggle__btn${view === "row" ? " view-toggle__btn--active" : ""}`}
+              onClick={() => handleViewChange("row")}
+              title="Row view"
+              aria-pressed={view === "row"}
+            >
+              ☰ Row
+            </button>
+            <button
+              className={`view-toggle__btn${view === "board" ? " view-toggle__btn--active" : ""}`}
+              onClick={() => handleViewChange("board")}
+              title="Board view"
+              aria-pressed={view === "board"}
+            >
+              ▦ Board
+            </button>
+          </div>
+        </div>
+
+        {displayProjects.filter((p) => p.status !== "archived").length === 0 &&
+        view !== "board" ? (
           <div className="dashboard__empty">
             <p>No active projects.</p>
             <button
@@ -140,71 +199,53 @@ export default function Dashboard() {
               Create your first project
             </button>
           </div>
+        ) : view === "grid" ? (
+          <ProjectGridView
+            projects={displayProjects}
+            sessions={sessions}
+            tasks={tasks}
+            leaders={leaders}
+            github={github}
+            onReorder={handleReorder}
+            onArchive={handleArchive}
+            onDelete={handleDelete}
+          />
+        ) : view === "row" ? (
+          <ProjectRowView
+            projects={displayProjects}
+            sessions={sessions}
+            tasks={tasks}
+            leaders={leaders}
+            github={github}
+            onReorder={handleReorder}
+          />
         ) : (
-          <div className="dashboard__project-grid">
-            {activeProjects.map((project) => (
-              <div key={project.id} className="panel dashboard__project-card">
-                <div
-                  className="dashboard__project-clickable"
-                  onClick={() => navigate(`/projects/${project.id}`)}
-                >
-                  <div className="dashboard__project-header">
-                    <h3>{project.name}</h3>
-                    <StatusBadge status={project.status} size="sm" />
-                  </div>
-                  {project.description && (
-                    <p className="dashboard__project-desc">
-                      {project.description}
-                    </p>
-                  )}
-                  <div className="dashboard__project-meta">
-                    <span>
-                      {
-                        sessions.filter((s) => s.project_id === project.id)
-                          .length
-                      }{" "}
-                      sessions
-                    </span>
-                    <TimeAgo datetime={project.updated_at} />
-                  </div>
-                </div>
-                <div className="dashboard__project-actions">
-                  <button
-                    className="btn btn-sm"
-                    onClick={() => void handleArchive(project.id)}
-                  >
-                    Archive
-                  </button>
-                  <ConfirmPopover
-                    message={`Are you sure you want to delete "${project.name}"? This will remove all tasks and context associated with this project.`}
-                    confirmLabel="Delete"
-                    variant="danger"
-                    onConfirm={() => void handleDelete(project.id)}
-                  >
-                    <button className="btn btn-sm btn-danger">Delete</button>
-                  </ConfirmPopover>
-                </div>
-              </div>
-            ))}
-          </div>
+          <ProjectBoardView
+            projects={displayProjects}
+            sessions={sessions}
+            tasks={tasks}
+            leaders={leaders}
+            github={github}
+            onProjectsChange={handleProjectsChange}
+          />
         )}
       </section>
 
-      {/* Archived projects */}
-      {archivedProjects.length > 0 && (
-        <section className="dashboard__projects">
+      {/* Archived projects — only shown outside board view (board has its own column) */}
+      {view !== "board" && archivedProjects.length > 0 && (
+        <section className="dashboard__projects" style={{ marginTop: "var(--space-8)" }}>
           <h2>Archived</h2>
           <div className="dashboard__project-grid">
             {archivedProjects.map((project) => (
-              <div key={project.id} className="panel dashboard__project-card dashboard__project-card--archived">
+              <div
+                key={project.id}
+                className="panel dashboard__project-card dashboard__project-card--archived"
+              >
                 <div className="dashboard__project-header">
                   <h3>{project.name}</h3>
-                  <StatusBadge status={project.status} size="sm" />
                 </div>
                 {project.description && (
-                  <p className="dashboard__project-desc">
-                    {project.description}
-                  </p>
+                  <p className="dashboard__project-desc">{project.description}</p>
                 )}
                 <div className="dashboard__project-actions">
                   <ConfirmPopover

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -8,6 +8,7 @@ export interface Project {
   github_repo: string | null;
   agent_provider: "claude_code" | "opencode";
   status: "active" | "paused" | "archived";
+  position: number;
   created_at: string;
   updated_at: string;
 }

--- a/frontend/src/utils/milestones.ts
+++ b/frontend/src/utils/milestones.ts
@@ -1,0 +1,66 @@
+import type { Task } from "../types";
+
+export interface MilestoneStatus {
+  completed: number;
+  current: number;
+  label: string;
+}
+
+/** Extract milestone number from a task title prefix like "M1:", "M2 -", "[M3]", etc. */
+function parseMilestone(title: string): number | null {
+  const match = title.match(/^\[?[Mm](\d+)[^\d]?/);
+  return match && match[1] ? parseInt(match[1], 10) : null;
+}
+
+/**
+ * Derive milestone status from a project's task list.
+ * Groups tasks by milestone number, finds the highest fully-done milestone,
+ * and returns a human-readable label.
+ */
+export function getProjectMilestoneStatus(tasks: Task[]): MilestoneStatus {
+  // Group tasks by milestone number
+  const byMilestone = new Map<number, Task[]>();
+
+  for (const task of tasks) {
+    const m = parseMilestone(task.title);
+    if (m !== null) {
+      const group = byMilestone.get(m) ?? [];
+      group.push(task);
+      byMilestone.set(m, group);
+    }
+  }
+
+  if (byMilestone.size === 0) {
+    return { completed: 0, current: 0, label: "planning" };
+  }
+
+  const milestones = [...byMilestone.keys()].sort((a, b) => a - b);
+
+  // Highest milestone where every task is done
+  let completed = 0;
+  for (const m of milestones) {
+    const taskList = byMilestone.get(m)!;
+    if (taskList.every((t) => t.status === "done" || t.status === "cancelled")) {
+      completed = m;
+    } else {
+      break;
+    }
+  }
+
+  // Current milestone = next after completed, or first if none done
+  const firstIncomplete = milestones.find((m) => m > completed);
+  const current = firstIncomplete ?? milestones[milestones.length - 1] ?? 0;
+
+  let label: string;
+  if (completed === 0 && current === 0) {
+    label = "planning";
+  } else if (completed === current) {
+    label = `M${completed} done`;
+  } else if (completed > 0) {
+    label = `M${completed} done · working M${current}`;
+  } else {
+    label = `M${current} · in progress`;
+  }
+
+  return { completed, current, label };
+}

--- a/src/atc/api/routers/projects.py
+++ b/src/atc/api/routers/projects.py
@@ -42,6 +42,7 @@ class ProjectResponse(BaseModel):
     repo_path: str | None = None
     github_repo: str | None = None
     agent_provider: str = "claude_code"
+    position: int = 0
     created_at: str
     updated_at: str
 
@@ -156,6 +157,64 @@ async def archive_project(project_id: str, request: Request) -> ProjectResponse:
     resp = ProjectResponse(**project.__dict__)  # type: ignore[union-attr]
 
     # Broadcast project update to all connected WebSocket clients
+    ws_hub = await _get_ws_hub(request)
+    if ws_hub is not None:
+        try:
+            await ws_hub.broadcast("state", {
+                "project_updated": True,
+                "project": resp.model_dump(),
+            })
+        except Exception:
+            logger.debug("Failed to broadcast project_updated via WebSocket")
+
+    return resp
+
+
+class ReorderPositionItem(BaseModel):
+    id: str
+    position: int
+
+
+class ReorderProjectsRequest(BaseModel):
+    positions: list[ReorderPositionItem]
+
+
+@router.patch("/reorder", response_model=list[ProjectResponse])
+async def reorder_projects(body: ReorderProjectsRequest, request: Request) -> list[ProjectResponse]:
+    """Bulk-update project positions for drag-to-reorder."""
+    db = await _get_db(request)
+    pairs: list[tuple[str, int]] = [(item.id, item.position) for item in body.positions]
+    await db_ops.update_project_positions(db, pairs)
+    projects = await db_ops.list_projects(db)
+    return [ProjectResponse(**p.__dict__) for p in projects]
+
+
+class UpdateProjectStatusRequest(BaseModel):
+    status: str
+
+
+@router.put("/{project_id}", response_model=ProjectResponse)
+async def update_project_status(
+    project_id: str,
+    body: UpdateProjectStatusRequest,
+    request: Request,
+) -> ProjectResponse:
+    """Update a project's status (e.g. active|paused|archived via board drag)."""
+    valid_statuses = {"active", "paused", "archived"}
+    if body.status not in valid_statuses:
+        allowed = ", ".join(sorted(valid_statuses))
+        raise HTTPException(
+            status_code=422,
+            detail=f"Invalid status {body.status!r}. Must be one of: {allowed}",
+        )
+    db = await _get_db(request)
+    project = await db_ops.get_project(db, project_id)
+    if project is None:
+        raise HTTPException(status_code=404, detail="Project not found")
+    await db_ops.update_project_status(db, project_id, body.status)
+    project = await db_ops.get_project(db, project_id)
+    resp = ProjectResponse(**project.__dict__)  # type: ignore[union-attr]
+
     ws_hub = await _get_ws_hub(request)
     if ws_hub is not None:
         try:

--- a/src/atc/state/db.py
+++ b/src/atc/state/db.py
@@ -503,6 +503,10 @@ async def create_project(
 ) -> Project:
     """Insert a new project row and return the dataclass."""
     now = _now()
+    # Assign position after the last existing project.
+    cursor = await db.execute("SELECT COALESCE(MAX(position), -1) + 1 FROM projects")
+    row = await cursor.fetchone()
+    next_position: int = row[0] if row else 0
     project = Project(
         id=_uuid(),
         name=name,
@@ -511,14 +515,15 @@ async def create_project(
         repo_path=repo_path,
         github_repo=github_repo,
         agent_provider=agent_provider,
+        position=next_position,
         created_at=now,
         updated_at=now,
     )
     await db.execute(
         """INSERT INTO projects
            (id, name, description, repo_path, github_repo, agent_provider,
-            status, created_at, updated_at)
-           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+            status, position, created_at, updated_at)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
         (
             project.id,
             project.name,
@@ -527,6 +532,7 @@ async def create_project(
             project.github_repo,
             project.agent_provider,
             project.status,
+            project.position,
             project.created_at,
             project.updated_at,
         ),
@@ -545,10 +551,39 @@ async def get_project(db: aiosqlite.Connection, project_id: str) -> Project | No
 
 
 async def list_projects(db: aiosqlite.Connection) -> list[Project]:
-    """Return all projects."""
-    cursor = await db.execute("SELECT * FROM projects ORDER BY created_at DESC")
+    """Return all projects ordered by position, then created_at."""
+    cursor = await db.execute(
+        "SELECT * FROM projects ORDER BY position ASC, created_at ASC"
+    )
     rows = await cursor.fetchall()
     return [Project(**dict(r)) for r in rows]
+
+
+async def update_project_positions(
+    db: aiosqlite.Connection,
+    positions: list[tuple[str, int]],
+) -> None:
+    """Bulk-update positions for a list of (project_id, position) pairs."""
+    now = _now()
+    await db.executemany(
+        "UPDATE projects SET position = ?, updated_at = ? WHERE id = ?",
+        [(pos, now, pid) for pid, pos in positions],
+    )
+    await db.commit()
+
+
+async def update_project_status(
+    db: aiosqlite.Connection,
+    project_id: str,
+    status: str,
+) -> None:
+    """Update the status of a project (active|paused|archived)."""
+    now = _now()
+    await db.execute(
+        "UPDATE projects SET status = ?, updated_at = ? WHERE id = ?",
+        (status, now, project_id),
+    )
+    await db.commit()
 
 
 async def update_project_agent_provider(

--- a/src/atc/state/migrations/versions/013_project_position.sql
+++ b/src/atc/state/migrations/versions/013_project_position.sql
@@ -1,0 +1,11 @@
+-- Add position column to projects table for drag-to-reorder support.
+ALTER TABLE projects ADD COLUMN position INTEGER DEFAULT 0;
+
+-- Assign sequential positions based on created_at order (oldest = 0).
+UPDATE projects
+SET position = (
+    SELECT COUNT(*)
+    FROM projects p2
+    WHERE p2.created_at < projects.created_at
+      OR (p2.created_at = projects.created_at AND p2.id < projects.id)
+);

--- a/src/atc/state/models.py
+++ b/src/atc/state/models.py
@@ -16,6 +16,7 @@ class Project:
     repo_path: str | None = None
     github_repo: str | None = None
     agent_provider: str = "claude_code"
+    position: int = 0
     created_at: str = ""
     updated_at: str = ""
 


### PR DESCRIPTION
Three project views for the dashboard with a toggle and persistent preferences.

## Views

### Grid (⊞)
Cards with drag-to-reorder. Each card: name, status dot, leader status, KanbanBar, milestone label, ace count, CI badge.

### Row (☰)
Compact rows with drag handle on left. Columns: drag handle · status dot · name · milestone summary · KanbanBar · ace status dots · CI badge · Open →

### Board (▦)
3-column kanban: Active | Paused | Archived. Drag cards between columns to update project status. Drag within column to reorder.

## New shared components
- `KanbanBar`: proportional colored bar (green=done, blue=in_progress, gray=todo) with hover tooltip
- `AceStatusSummary`: colored dots for working/waiting/idle counts per project
- `milestones.ts`: detects milestone status from task title prefixes (M1, M2, etc.)

## Persistence
- View preference: localStorage (`atc_dashboard_view`)
- Project order: DB `position` column, `PATCH /api/projects/reorder`
- Board drag (status change): `PUT /api/projects/{id}`

## Backend
- Migration 013: `position INTEGER DEFAULT 0` on projects
- `list_projects()` orders by position ASC, created_at ASC
- `update_project_positions()` bulk update
- `PATCH /api/projects/reorder` endpoint