### PR TITLE
fix: allow Tower to start without a project_id

### DIFF
--- a/frontend/src/components/tower/TowerPanel.tsx
+++ b/frontend/src/components/tower/TowerPanel.tsx
@@ -103,13 +103,12 @@ export default function TowerPanel() {
   const contextLabel = deriveContextLabel(location.pathname, contextProject?.name);
 
   const handleStart = useCallback(async () => {
-    if (!resolvedProjectId) return;
     userStopped.current = false;
     setStarting(true);
     try {
       const res = await api.post<{ session_id?: string }>(
         "/tower/start",
-        { project_id: resolvedProjectId },
+        resolvedProjectId ? { project_id: resolvedProjectId } : {},
       );
       if (res.session_id) {
         dispatch({
@@ -204,7 +203,7 @@ export default function TowerPanel() {
             <button
               className="btn btn-primary btn-sm"
               onClick={handleStart}
-              disabled={starting || !resolvedProjectId}
+              disabled={starting}
               data-testid="tower-panel-start"
             >
               {starting ? "Starting..." : "Start"}

--- a/src/atc/api/routers/tower.py
+++ b/src/atc/api/routers/tower.py
@@ -22,7 +22,7 @@ router = APIRouter()
 
 
 class StartRequest(BaseModel):
-    project_id: str
+    project_id: str | None = None
 
 
 class GoalRequest(BaseModel):
@@ -122,11 +122,12 @@ async def start_tower(body: StartRequest, request: Request) -> dict:
     db = await _get_db(request)
     tower = _get_tower(request)
 
-    # Verify project exists
-    cursor = await db.execute("SELECT id FROM projects WHERE id = ?", (body.project_id,))
-    row = await cursor.fetchone()
-    if row is None:
-        raise HTTPException(status_code=404, detail=f"Project {body.project_id} not found")
+    # Verify project exists only when a project_id is provided
+    if body.project_id is not None:
+        cursor = await db.execute("SELECT id FROM projects WHERE id = ?", (body.project_id,))
+        row = await cursor.fetchone()
+        if row is None:
+            raise HTTPException(status_code=404, detail=f"Project {body.project_id} not found")
 
     try:
         session_id = await tower.start_session(body.project_id)

--- a/src/atc/tower/controller.py
+++ b/src/atc/tower/controller.py
@@ -143,7 +143,7 @@ class TowerController:
                 },
             )
 
-    async def start_session(self, project_id: str) -> str:
+    async def start_session(self, project_id: str | None = None) -> str:
         """Start Tower's own Claude Code session (independent from Leader).
 
         Returns the tower session id.  If a session already exists, returns


### PR DESCRIPTION
Tower Start was broken when no projects exist (e.g. after `make cleardb`). The frontend required a resolved project ID and the backend validated it against the DB — so starting Tower from a clean slate always 404'd.

**Root cause (per Matthew's correct observation):** Tower's job is to *create* projects, so requiring one to start is backwards.

**Changes:**
- `POST /api/tower/start`: `project_id` is now optional; DB lookup is skipped when omitted
- `TowerController.start_session()`: accepts `project_id: str | None = None`
- `TowerPanel`: removes the `!resolvedProjectId` guard on both `handleStart` and the Start button's `disabled` prop; sends `{}` body when no project is in context