### PR TITLE
fix: configure hatchling editable install to use src/ directory

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,9 @@ atc = "atc.cli.main:main"
 [tool.hatch.build.targets.wheel]
 packages = ["src/atc"]
 
+[tool.hatch.build.targets.editable]
+path = "src"
+
 [tool.ruff]
 target-version = "py312"
 line-length = 100


### PR DESCRIPTION
Without `[tool.hatch.build.targets.editable]`, `pip install -e .` with hatchling copies package files to `.venv/lib/pythonX.Y/site-packages/` instead of symlinking to `src/`. This means `git pull` changes don't take effect until you re-run `pip install -e`.

Adding `path = 'src'` makes the editable install a true live symlink — source edits and pulls are picked up immediately by uvicorn's reloader.

After merging, one-time re-install required:
```bash
pip install -e '.[dev]'
```