### PR TITLE
feat: auto-start Tower on app startup

### DIFF
--- a/src/atc/api/app.py
+++ b/src/atc/api/app.py
@@ -303,6 +303,16 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
     except Exception:
         logger.exception("Failed to restore TowerController state from DB")
 
+    # 8b. Auto-start Tower if it's still idle after restore attempt.
+    # Tower should always be running when the app starts — no manual click required.
+    try:
+        if tower_controller._state == TowerState.IDLE:
+            logger.info("Tower is idle after startup — auto-starting session")
+            await tower_controller.start_session()
+            logger.info("Tower auto-started: session=%s", tower_controller._current_session_id)
+    except Exception:
+        logger.exception("Tower auto-start failed — Tower will start in idle state")
+
     # 9. Start resource monitor
     from atc.tracking.resources import ResourceMonitor
 


### PR DESCRIPTION
Tower should be running and ready when the app loads — no manual Start click needed.

After the existing session restore step (step 8), if Tower is still idle, `start_session()` is called automatically. Errors are non-fatal so the app still boots if Tower fails to start for any reason.