### PR TITLE
fix: aggressive process kill in make cleardb; hide Tower Workspace from UI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,9 +33,13 @@ clean: ## Remove build artifacts and venv
 	rm -rf $(VENV) frontend/node_modules dist/ build/ *.egg-info
 	find . -type d -name __pycache__ -exec rm -rf {} + 2>/dev/null || true
 
-cleardb: ## Full reset: kill backend, delete DB, reinstall package, restart dev servers
-	@echo "→ Stopping any running backend..."
-	@pkill -f "uvicorn atc" 2>/dev/null || true
+cleardb: ## Full reset: kill ALL dev processes, delete DB, reinstall package, restart dev servers
+	@echo "→ Killing all ATC dev processes (uvicorn, vite, node)..."
+	@pkill -f "uvicorn" 2>/dev/null || true
+	@pkill -f "vite" 2>/dev/null || true
+	@pkill -f "atc.api.app" 2>/dev/null || true
+	@lsof -ti:8420 | xargs kill -9 2>/dev/null || true
+	@lsof -ti:5173,5174,5175,5176,5177 | xargs kill -9 2>/dev/null || true
 	@sleep 1
 	@if [ -f atc.db ]; then \
 		rm atc.db && echo "✓ atc.db deleted"; \

--- a/src/atc/state/db.py
+++ b/src/atc/state/db.py
@@ -591,11 +591,23 @@ async def get_project(db: aiosqlite.Connection, project_id: str) -> Project | No
     return Project(**dict(row))
 
 
-async def list_projects(db: aiosqlite.Connection) -> list[Project]:
-    """Return all projects ordered by position, then created_at."""
-    cursor = await db.execute(
-        "SELECT * FROM projects ORDER BY position ASC, created_at ASC"
-    )
+async def list_projects(
+    db: aiosqlite.Connection,
+    *,
+    include_system: bool = False,
+) -> list[Project]:
+    """Return all projects ordered by position, then created_at.
+
+    System projects (e.g. the auto-created 'Tower Workspace' sentinel) are
+    excluded by default.  Pass include_system=True to include them.
+    """
+    if include_system:
+        sql = "SELECT * FROM projects ORDER BY position ASC, created_at ASC"
+        params: tuple[()] = ()
+    else:
+        sql = "SELECT * FROM projects WHERE name != ? ORDER BY position ASC, created_at ASC"
+        params = ("Tower Workspace",)
+    cursor = await db.execute(sql, params)
     rows = await cursor.fetchall()
     return [Project(**dict(r)) for r in rows]
 


### PR DESCRIPTION
Two fixes:

**1. make cleardb kills everything:**
- pkill on uvicorn, vite, atc.api.app
- lsof + kill -9 on ports 8420 and 5173-5177
- Ensures no stale process survives and causes 'position column missing' errors on fresh DB

**2. Tower Workspace sentinel hidden from dashboard:**
- `list_projects()` now filters out 'Tower Workspace' by default
- Pass `include_system=True` to include it (used by Tower internals)
- Long-term fix is a proper `is_system` column migration (separate ticket)