### PR TITLE
fix: broadcast session_created to frontend so Aces panel updates in real-time

### DIFF
--- a/frontend/src/context/AppContext.tsx
+++ b/frontend/src/context/AppContext.tsx
@@ -92,7 +92,9 @@ type Action =
   | { type: "UPDATE_SESSION_STATUS"; payload: { session_id: string; status: string } }
   | { type: "ADD_PROJECT"; payload: Project }
   | { type: "UPDATE_PROJECT"; payload: Project }
-  | { type: "REMOVE_PROJECT"; payload: string };
+  | { type: "REMOVE_PROJECT"; payload: string }
+  | { type: "ADD_SESSION"; payload: Session }
+  | { type: "REMOVE_SESSION"; payload: string };
 
 function reducer(state: AppState, action: Action): AppState {
   switch (action.type) {
@@ -196,6 +198,22 @@ function reducer(state: AppState, action: Action): AppState {
       return {
         ...state,
         projects: state.projects.filter((p) => p.id !== action.payload),
+      };
+    case "ADD_SESSION":
+      // Avoid duplicates
+      if (state.sessions.some((s) => s.id === action.payload.id)) {
+        return {
+          ...state,
+          sessions: state.sessions.map((s) =>
+            s.id === action.payload.id ? action.payload : s,
+          ),
+        };
+      }
+      return { ...state, sessions: [...state.sessions, action.payload] };
+    case "REMOVE_SESSION":
+      return {
+        ...state,
+        sessions: state.sessions.filter((s) => s.id !== action.payload),
       };
   }
 }
@@ -315,6 +333,8 @@ export function AppProvider({ children }: AppProviderProps) {
         dispatch({ type: "UPDATE_PROJECT", payload: data.project as Project });
       } else if (data.project_deleted && typeof data.project_id === "string") {
         dispatch({ type: "REMOVE_PROJECT", payload: data.project_id });
+      } else if (data.session_created && data.session) {
+        dispatch({ type: "ADD_SESSION", payload: data.session as Session });
       } else {
         dispatch({ type: "SET_STATE", payload: data as Partial<AppState> });
       }

--- a/src/atc/api/app.py
+++ b/src/atc/api/app.py
@@ -125,10 +125,30 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
         session_id = data.get("session_id", "")
         if not session_id:
             return
-        # Look up the session to get its tmux_pane (it may not be set yet at
-        # creation time; the pane is spawned right after the event).  We
-        # subscribe to status changes instead to catch the pane_id.
-        pass
+        # Broadcast new session to the frontend so the Aces panel updates
+        # immediately without waiting for the next fetchAll poll.
+        from atc.state import db as db_ops
+
+        session = await db_ops.get_session(db, session_id)
+        if session:
+            await ws_hub.broadcast(
+                "state",
+                {
+                    "session_created": True,
+                    "session": {
+                        "id": session.id,
+                        "project_id": session.project_id,
+                        "session_type": session.session_type,
+                        "name": session.name,
+                        "status": session.status,
+                        "task_id": session.task_id,
+                        "tmux_session": session.tmux_session,
+                        "tmux_pane": session.tmux_pane,
+                        "created_at": session.created_at,
+                        "updated_at": session.updated_at,
+                    },
+                },
+            )
 
     async def _on_session_status_changed(data: dict[str, Any]) -> None:
         session_id = data.get("session_id", "")


### PR DESCRIPTION
The Aces panel was showing 'No aces yet' even when Leader had spawned 3 Aces.

**Root cause:** `_on_session_created` in `app.py` was a no-op (`pass`). When Leader spawned Aces via orchestrator, the `session_created` event fired but nothing broadcast it to the frontend. The Aces panel only populated on the next `fetchAll` poll (page reload/re-navigate).

**Fix:**
- Backend: `_on_session_created` now looks up the session and broadcasts it on the `state` channel
- Frontend: Added `ADD_SESSION` / `REMOVE_SESSION` reducer cases and a `session_created` WS handler in AppContext

Aces now appear in the panel immediately as Leader spawns them.