### PR TITLE
fix: task graph WS sync and invalid transition errors

### DIFF
--- a/frontend/src/context/AppContext.tsx
+++ b/frontend/src/context/AppContext.tsx
@@ -94,7 +94,8 @@ type Action =
   | { type: "UPDATE_PROJECT"; payload: Project }
   | { type: "REMOVE_PROJECT"; payload: string }
   | { type: "ADD_SESSION"; payload: Session }
-  | { type: "REMOVE_SESSION"; payload: string };
+  | { type: "REMOVE_SESSION"; payload: string }
+  | { type: "SET_PROJECT_TASK_GRAPHS"; payload: { projectId: string; taskGraphs: TaskGraph[] } };
 
 function reducer(state: AppState, action: Action): AppState {
   switch (action.type) {
@@ -214,6 +215,14 @@ function reducer(state: AppState, action: Action): AppState {
       return {
         ...state,
         sessions: state.sessions.filter((s) => s.id !== action.payload),
+      };
+    case "SET_PROJECT_TASK_GRAPHS":
+      return {
+        ...state,
+        taskGraphs: {
+          ...state.taskGraphs,
+          [action.payload.projectId]: action.payload.taskGraphs,
+        },
       };
   }
 }
@@ -335,6 +344,11 @@ export function AppProvider({ children }: AppProviderProps) {
         dispatch({ type: "REMOVE_PROJECT", payload: data.project_id });
       } else if (data.session_created && data.session) {
         dispatch({ type: "ADD_SESSION", payload: data.session as Session });
+      } else if (data.task_graphs_updated && data.project_id && Array.isArray(data.task_graphs)) {
+        dispatch({
+          type: "SET_PROJECT_TASK_GRAPHS",
+          payload: { projectId: data.project_id as string, taskGraphs: data.task_graphs as TaskGraph[] },
+        });
       } else {
         dispatch({ type: "SET_STATE", payload: data as Partial<AppState> });
       }

--- a/src/atc/api/routers/leader.py
+++ b/src/atc/api/routers/leader.py
@@ -179,6 +179,28 @@ async def decompose(
     if result.error:
         raise HTTPException(status_code=422, detail=result.error)
 
+    # Broadcast task graphs to frontend so TaskBoard updates immediately
+    ws_hub = getattr(request.app.state, "ws_hub", None)
+    if ws_hub is not None:
+        tg_data = [
+            {
+                "id": tg.id,
+                "title": tg.title,
+                "description": tg.description,
+                "status": tg.status,
+                "dependencies": tg.dependencies,
+                "project_id": project_id,
+                "assigned_ace_id": tg.assigned_ace_id,
+                "created_at": tg.created_at,
+                "updated_at": tg.updated_at,
+            }
+            for tg in result.task_graphs
+        ]
+        await ws_hub.broadcast(
+            "state",
+            {"task_graphs_updated": True, "project_id": project_id, "task_graphs": tg_data},
+        )
+
     return DecomposeResponse(
         project_id=result.project_id,
         goal=result.goal,

--- a/src/atc/state/db.py
+++ b/src/atc/state/db.py
@@ -905,10 +905,10 @@ _VALID_TASK_GRAPH_STATUSES = {"todo", "assigned", "in_progress", "review", "done
 
 _TASK_GRAPH_TRANSITIONS: dict[str, set[str]] = {
     "todo": {"assigned"},
-    "assigned": {"in_progress", "todo", "error"},
-    "in_progress": {"review", "done", "error"},
+    "assigned": {"in_progress", "todo", "error", "assigned"},  # assigned→assigned is a no-op re-assign
+    "in_progress": {"review", "done", "error", "assigned"},    # allow re-assignment from in_progress
     "review": {"done", "in_progress", "error"},
-    "done": {"todo"},  # re-open for retry
+    "done": {"todo"},   # re-open for retry
     "error": {"todo"},  # retry from scratch
 }
 


### PR DESCRIPTION
Three fixes:

1. **Transition rules** (`db.py`): allow `in_progress→assigned` and `assigned→assigned` so Leader can re-assign tasks without crashing with `ValueError: Cannot transition from 'in_progress' to 'assigned'`

2. **WS broadcast** (`leader.py`): after `/leader/decompose`, broadcast `task_graphs_updated` on the `state` channel so TaskBoard populates immediately without a page reload

3. **AppContext** (`frontend`): add `SET_PROJECT_TASK_GRAPHS` reducer and wire `task_graphs_updated` WS handler