### PR TITLE
feat: resource-aware dynamic Ace concurrency ceiling

### DIFF
--- a/src/atc/api/routers/leader.py
+++ b/src/atc/api/routers/leader.py
@@ -111,11 +111,22 @@ async def _get_or_create_orchestrator(
             detail=f"No leader found for project {project_id}",
         )
 
+    from atc.tracking.resources import ResourceGovernor
+    settings = getattr(request.app.state, "settings", None)
+    if settings is not None:
+        governor = ResourceGovernor.from_config(settings.resource_monitor)
+        max_aces = settings.resource_monitor.max_concurrent_aces
+    else:
+        governor = ResourceGovernor()
+        max_aces = 3
+
     orch = LeaderOrchestrator(
         project_id=project_id,
         leader_id=leader.id,
         conn=db,
         event_bus=event_bus,
+        _max_concurrent_aces=max_aces,
+        _governor=governor,
     )
 
     # Subscribe to session status changes for Ace monitoring

--- a/src/atc/config.py
+++ b/src/atc/config.py
@@ -29,6 +29,16 @@ class TowerConfig(BaseModel):
 class ResourceMonitorConfig(BaseModel):
     enabled: bool = True
     interval_seconds: int = 5
+    # Maximum concurrent Aces across all projects (absolute ceiling)
+    max_concurrent_aces: int = 3
+    # CPU % threshold above which ace spawning is throttled
+    cpu_throttle_threshold: float = 70.0
+    # RAM % threshold above which ace spawning is throttled
+    ram_throttle_threshold: float = 75.0
+    # CPU % threshold above which no new aces are spawned
+    cpu_pause_threshold: float = 85.0
+    # RAM % threshold above which no new aces are spawned
+    ram_pause_threshold: float = 90.0
 
 
 class GitHubConfig(BaseModel):

--- a/src/atc/leader/orchestrator.py
+++ b/src/atc/leader/orchestrator.py
@@ -25,6 +25,7 @@ from atc.leader.context_package import build_context_package
 from atc.leader.decomposer import get_completion_status, get_ready_tasks
 from atc.session.ace import create_ace, destroy_ace, start_ace
 from atc.state import db as db_ops
+from atc.tracking.resources import ResourceGovernor
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -61,7 +62,8 @@ class LeaderOrchestrator:
     conn: aiosqlite.Connection
     event_bus: EventBus | None = None
     assignments: dict[str, AceAssignment] = field(default_factory=dict)
-    _max_concurrent_aces: int = 5
+    _max_concurrent_aces: int = 3
+    _governor: ResourceGovernor = field(default_factory=ResourceGovernor)
 
     async def spawn_aces_for_ready_tasks(self) -> list[AceAssignment]:
         """Find ready tasks and spawn Ace sessions for them.
@@ -78,17 +80,18 @@ class LeaderOrchestrator:
         if not ready:
             return []
 
-        # Count currently active Aces
+        # Count currently active Aces (across all assignments for this leader)
         active_count = sum(
             1 for a in self.assignments.values() if a.status in ("assigned", "working")
         )
-        available_slots = max(0, self._max_concurrent_aces - active_count)
+        # Use ResourceGovernor for dynamic ceiling based on system load
+        available_slots = self._governor.available_ace_slots(active_count)
 
         if available_slots == 0:
             logger.info(
-                "Leader %s: all %d Ace slots occupied, waiting for completion",
+                "Leader %s: no Ace slots available (active=%d, system load check)",
                 self.leader_id,
-                self._max_concurrent_aces,
+                active_count,
             )
             return []
 

--- a/src/atc/tracking/resources.py
+++ b/src/atc/tracking/resources.py
@@ -188,3 +188,84 @@ class ResourceMonitor:
             await self._ws_hub.broadcast("resources", {"snapshot": snapshot})
 
         logger.debug("ResourceMonitor: sampled %d projects", len(snapshot))
+
+
+# ---------------------------------------------------------------------------
+# Resource Governor — dynamic Ace concurrency ceiling
+# ---------------------------------------------------------------------------
+
+class ResourceGovernor:
+    """Computes the dynamic maximum concurrent Aces based on system resources.
+
+    Reads system-wide CPU and RAM utilisation via psutil and returns a ceiling
+    that protects the developer's machine from becoming unresponsive.
+
+    Thresholds (all configurable via ResourceMonitorConfig):
+      - Below throttle: allow up to max_concurrent_aces
+      - Between throttle and pause: reduce ceiling by half (min 1)
+      - Above pause: ceiling = 0 (no new Aces)
+    """
+
+    def __init__(
+        self,
+        max_concurrent_aces: int = 3,
+        cpu_throttle: float = 70.0,
+        ram_throttle: float = 75.0,
+        cpu_pause: float = 85.0,
+        ram_pause: float = 90.0,
+    ) -> None:
+        self._max = max_concurrent_aces
+        self._cpu_throttle = cpu_throttle
+        self._ram_throttle = ram_throttle
+        self._cpu_pause = cpu_pause
+        self._ram_pause = ram_pause
+
+    def get_system_usage(self) -> tuple[float, float]:
+        """Return (cpu_pct, ram_pct) system-wide."""
+        try:
+            import psutil
+            cpu = psutil.cpu_percent(interval=0.1)
+            ram = psutil.virtual_memory().percent
+            return cpu, ram
+        except Exception:
+            return 0.0, 0.0
+
+    def available_ace_slots(self, currently_active: int) -> int:
+        """Return how many new Aces can be spawned right now.
+
+        Args:
+            currently_active: Number of Aces already running across all projects.
+        """
+        cpu, ram = self.get_system_usage()
+
+        # Hard pause — system is struggling
+        if cpu >= self._cpu_pause or ram >= self._ram_pause:
+            logger.warning(
+                "ResourceGovernor: system overloaded (CPU=%.0f%% RAM=%.0f%%) — "
+                "blocking new Ace spawns",
+                cpu, ram,
+            )
+            return 0
+
+        # Throttle — reduce ceiling by half
+        if cpu >= self._cpu_throttle or ram >= self._ram_throttle:
+            ceiling = max(1, self._max // 2)
+            logger.info(
+                "ResourceGovernor: system under load (CPU=%.0f%% RAM=%.0f%%) — "
+                "throttling to %d concurrent Aces",
+                cpu, ram, ceiling,
+            )
+        else:
+            ceiling = self._max
+
+        return max(0, ceiling - currently_active)
+
+    @classmethod
+    def from_config(cls, cfg: "ResourceMonitorConfig") -> "ResourceGovernor":
+        return cls(
+            max_concurrent_aces=cfg.max_concurrent_aces,
+            cpu_throttle=cfg.cpu_throttle_threshold,
+            ram_throttle=cfg.ram_throttle_threshold,
+            cpu_pause=cfg.cpu_pause_threshold,
+            ram_pause=cfg.ram_pause_threshold,
+        )


### PR DESCRIPTION
Prevents ATC from making a developer's machine unusable by dynamically capping concurrent Aces based on system CPU/RAM.

**How it works:**
- `ResourceGovernor` reads system-wide CPU/RAM via psutil before each spawn batch
- Default ceiling: **3 Aces** (down from 5 — conservative for dev laptops)
- CPU >70% or RAM >75%: throttle to `max(1, ceiling//2)`
- CPU >85% or RAM >90%: block all new spawns until load drops
- Logs warnings when throttling/blocking so it's visible in backend output

**Config** (all tunable in `config.yaml`):
```yaml
resource_monitor:
  max_concurrent_aces: 3
  cpu_throttle_threshold: 70.0
  ram_throttle_threshold: 75.0
  cpu_pause_threshold: 85.0
  ram_pause_threshold: 90.0
```