### PR TITLE
feat: polished Ace panel, expandable Ace tabs, resource limits in Settings

### DIFF
--- a/frontend/src/components/ace/AceConsole.css
+++ b/frontend/src/components/ace/AceConsole.css
@@ -1,0 +1,150 @@
+.ace-console {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  min-height: 0;
+  gap: 0;
+}
+
+/* Tab bar */
+.ace-console__tabs {
+  display: flex;
+  align-items: center;
+  gap: 0;
+  border-bottom: 1px solid var(--color-border);
+  flex-shrink: 0;
+  overflow-x: auto;
+}
+
+.ace-console__tabs::-webkit-scrollbar {
+  display: none;
+}
+
+.ace-console__tab {
+  background: none;
+  border: none;
+  border-bottom: 2px solid transparent;
+  color: var(--color-text-muted);
+  cursor: pointer;
+  font-size: var(--text-sm);
+  font-family: var(--font-sans);
+  padding: var(--space-2) var(--space-3);
+  white-space: nowrap;
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  transition: color 0.15s, border-color 0.15s;
+  flex-shrink: 0;
+}
+
+.ace-console__tab:hover {
+  color: var(--color-text);
+}
+
+.ace-console__tab--active {
+  color: var(--color-text);
+  border-bottom-color: var(--color-accent);
+}
+
+.ace-console__tab--leader {
+  color: var(--color-text-secondary);
+  font-size: var(--text-xs);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  padding-right: var(--space-2);
+}
+
+.ace-console__tab--leader:hover {
+  color: var(--color-accent);
+}
+
+.ace-console__tab-divider {
+  width: 1px;
+  height: 16px;
+  background: var(--color-border);
+  flex-shrink: 0;
+  margin: 0 var(--space-1);
+}
+
+.ace-console__tab-name {
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+}
+
+/* Body */
+.ace-console__body {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  min-height: 0;
+  gap: var(--space-3);
+  padding-top: var(--space-3);
+}
+
+/* Header row */
+.ace-console__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  flex-shrink: 0;
+}
+
+.ace-console__identity {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  min-width: 0;
+}
+
+.ace-console__name {
+  font-size: var(--text-base);
+  font-weight: 600;
+  font-family: var(--font-mono);
+  color: var(--color-text);
+  white-space: nowrap;
+}
+
+.ace-console__task-label {
+  font-size: var(--text-xs);
+  color: var(--color-text-muted);
+  background: var(--color-bg-active);
+  border-radius: var(--radius-sm);
+  padding: 1px 6px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  max-width: 200px;
+}
+
+.ace-console__controls {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  flex-shrink: 0;
+}
+
+/* Terminal fills remaining space */
+.ace-console__terminal {
+  flex: 1;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+}
+
+.ace-console__terminal .ace-terminal {
+  flex: 1;
+  min-height: 0;
+}
+
+.ace-console__terminal .ace-terminal__view {
+  flex: 1;
+  min-height: 0;
+  height: 100%;
+}
+
+.ace-console__not-found {
+  padding: var(--space-8);
+  text-align: center;
+  color: var(--color-text-muted);
+  font-size: var(--text-sm);
+}

--- a/frontend/src/components/ace/AceConsole.tsx
+++ b/frontend/src/components/ace/AceConsole.tsx
@@ -1,0 +1,175 @@
+import { useState } from "react";
+import { api } from "../../utils/api";
+import { useAppContext } from "../../context/AppContext";
+import AceTerminal from "./AceTerminal";
+import StatusBadge from "../common/StatusBadge";
+import HealthIndicator from "../common/HealthIndicator";
+import ConfirmPopover from "../common/ConfirmPopover";
+import type { Session } from "../../types";
+import "./AceConsole.css";
+
+interface AceConsoleProps {
+  projectId: string;
+  sessions: Session[];
+  activeAceId: string;
+  onRefresh: () => void;
+  onSelectAce: (id: string | null) => void;
+}
+
+export default function AceConsole({
+  projectId,
+  sessions,
+  activeAceId,
+  onRefresh,
+  onSelectAce,
+}: AceConsoleProps) {
+  const { state } = useAppContext();
+  const [loadingId, setLoadingId] = useState<string | null>(null);
+
+  const activeSession = sessions.find((s) => s.id === activeAceId);
+  const taskGraphs = state.taskGraphs[projectId] ?? [];
+
+  function getTaskTitle(session: Session): string | null {
+    const tg = taskGraphs.find((t) => t.assigned_ace_id === session.id);
+    return tg ? tg.title : null;
+  }
+
+  function isRunning(s: Session) {
+    return (
+      s.status === "working" ||
+      s.status === "waiting" ||
+      s.status === "connecting"
+    );
+  }
+
+  async function handleStart(sessionId: string) {
+    setLoadingId(sessionId);
+    try {
+      await api.post(`/aces/${sessionId}/start`, {});
+      onRefresh();
+    } catch (err) {
+      console.error("Failed to start ace:", err);
+    } finally {
+      setLoadingId(null);
+    }
+  }
+
+  async function handleStop(sessionId: string) {
+    setLoadingId(sessionId);
+    try {
+      await api.post(`/aces/${sessionId}/stop`);
+      onRefresh();
+    } catch (err) {
+      console.error("Failed to stop ace:", err);
+    } finally {
+      setLoadingId(null);
+    }
+  }
+
+  async function handleDelete(sessionId: string) {
+    setLoadingId(sessionId);
+    try {
+      await api.delete(`/aces/${sessionId}`);
+      // Go to leader view after deleting the active ace
+      onSelectAce(null);
+      onRefresh();
+    } catch (err) {
+      console.error("Failed to delete ace:", err);
+    } finally {
+      setLoadingId(null);
+    }
+  }
+
+  return (
+    <div className="ace-console" data-testid="ace-console">
+      {/* Tab bar: Leader + one tab per ace */}
+      <div className="ace-console__tabs">
+        <button
+          className="ace-console__tab ace-console__tab--leader"
+          onClick={() => onSelectAce(null)}
+          title="Return to Leader"
+        >
+          ← Leader
+        </button>
+        <div className="ace-console__tab-divider" />
+        {sessions.map((s) => (
+          <button
+            key={s.id}
+            className={`ace-console__tab${activeAceId === s.id ? " ace-console__tab--active" : ""}`}
+            onClick={() => onSelectAce(s.id)}
+            title={s.name}
+          >
+            <span className="ace-console__tab-name">{s.name}</span>
+            <StatusBadge status={s.status} size="sm" />
+          </button>
+        ))}
+      </div>
+
+      {/* Ace content */}
+      {activeSession ? (
+        <div className="ace-console__body">
+          <div className="ace-console__header">
+            <div className="ace-console__identity">
+              <span className="ace-console__name">{activeSession.name}</span>
+              <StatusBadge status={activeSession.status} />
+              <HealthIndicator
+                health={state.heartbeats[activeSession.id]?.health}
+              />
+              {getTaskTitle(activeSession) && (
+                <span className="ace-console__task-label">
+                  {getTaskTitle(activeSession)}
+                </span>
+              )}
+            </div>
+            <div className="ace-console__controls">
+              {!isRunning(activeSession) ? (
+                <button
+                  className="btn btn-sm btn-primary"
+                  onClick={() => handleStart(activeSession.id)}
+                  disabled={loadingId === activeSession.id}
+                >
+                  {loadingId === activeSession.id ? "Starting…" : "Start"}
+                </button>
+              ) : (
+                <ConfirmPopover
+                  message={`Stop ${activeSession.name}?`}
+                  confirmLabel="Stop"
+                  onConfirm={() => handleStop(activeSession.id)}
+                  variant="danger"
+                >
+                  <button
+                    className="btn btn-sm btn-danger"
+                    disabled={loadingId === activeSession.id}
+                  >
+                    Stop
+                  </button>
+                </ConfirmPopover>
+              )}
+              <ConfirmPopover
+                message={`Delete ${activeSession.name}? This cannot be undone.`}
+                confirmLabel="Delete"
+                onConfirm={() => handleDelete(activeSession.id)}
+                variant="danger"
+              >
+                <button
+                  className="btn btn-sm btn-danger"
+                  disabled={
+                    loadingId === activeSession.id || isRunning(activeSession)
+                  }
+                >
+                  Delete
+                </button>
+              </ConfirmPopover>
+            </div>
+          </div>
+
+          <div className="ace-console__terminal">
+            <AceTerminal key={activeSession.id} session={activeSession} />
+          </div>
+        </div>
+      ) : (
+        <div className="ace-console__not-found">Ace not found.</div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/ace/AceList.css
+++ b/frontend/src/components/ace/AceList.css
@@ -4,6 +4,7 @@
   gap: var(--space-3);
 }
 
+/* ── Header ────────────────────────────────────────────── */
 .ace-list__header {
   display: flex;
   align-items: center;
@@ -15,6 +16,7 @@
   color: var(--color-text-secondary);
   text-transform: uppercase;
   letter-spacing: 0.05em;
+  flex: 1;
 }
 
 .ace-list__count {
@@ -25,6 +27,25 @@
   border-radius: var(--radius-sm);
 }
 
+/* Small "+" toggle button, right-aligned in the header */
+.ace-list__add-btn {
+  background: none;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  color: var(--color-text-muted);
+  cursor: pointer;
+  font-size: var(--text-xs);
+  line-height: 1;
+  padding: 2px 6px;
+  transition: color 0.15s, border-color 0.15s;
+}
+
+.ace-list__add-btn:hover {
+  color: var(--color-accent);
+  border-color: var(--color-accent);
+}
+
+/* ── Error banner ──────────────────────────────────────── */
 .ace-list__error {
   font-size: var(--text-sm);
   color: var(--color-danger, #f85149);
@@ -34,6 +55,7 @@
   padding: var(--space-2) var(--space-3);
 }
 
+/* ── Create form (inline, subtle) ──────────────────────── */
 .ace-list__create {
   display: flex;
   gap: var(--space-2);
@@ -55,6 +77,129 @@
   border-color: var(--color-accent);
 }
 
+/* ── Empty state ───────────────────────────────────────── */
+.ace-list__empty {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  padding: var(--space-3) var(--space-1);
+  font-size: var(--text-sm);
+  color: var(--color-text-muted);
+}
+
+.ace-list__empty-icon {
+  font-size: var(--text-base);
+  opacity: 0.4;
+}
+
+/* ── Compact cards grid ─────────────────────────────────── */
+.ace-list__cards {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+
+.ace-list__card {
+  border: 1px solid var(--color-border-subtle);
+  border-radius: var(--radius-md);
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+  background: var(--color-bg-surface);
+  transition: border-color 0.15s, box-shadow 0.15s;
+}
+
+.ace-list__card:hover {
+  border-color: var(--color-border);
+  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.12);
+}
+
+.ace-list__card--running {
+  border-color: var(--color-accent-muted, rgba(88, 166, 255, 0.3));
+}
+
+.ace-list__card--running:hover {
+  border-color: var(--color-accent);
+}
+
+/* Card header row */
+.ace-list__card-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: var(--space-2) var(--space-2) var(--space-1);
+  background: var(--color-bg-surface);
+}
+
+.ace-list__card-identity {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  min-width: 0;
+}
+
+.ace-list__card-name {
+  font-size: var(--text-xs);
+  font-weight: 600;
+  color: var(--color-text);
+  font-family: var(--font-mono);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+/* Expand button */
+.ace-list__expand-btn {
+  background: none;
+  border: none;
+  color: var(--color-text-muted);
+  cursor: pointer;
+  font-size: 13px;
+  line-height: 1;
+  padding: 2px 4px;
+  border-radius: var(--radius-sm);
+  flex-shrink: 0;
+  transition: color 0.15s, background 0.15s;
+}
+
+.ace-list__expand-btn:hover {
+  color: var(--color-accent);
+  background: var(--color-accent-muted, rgba(88, 166, 255, 0.1));
+}
+
+/* Task assignment label */
+.ace-list__card-task {
+  font-size: 10px;
+  color: var(--color-text-muted);
+  padding: 0 var(--space-2) var(--space-1);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  font-style: italic;
+}
+
+/* Terminal preview */
+.ace-list__card-terminal {
+  height: 120px;
+  overflow: hidden;
+  border-top: 1px solid var(--color-border-subtle);
+  display: flex;
+  flex-direction: column;
+}
+
+.ace-list__card-terminal .ace-terminal {
+  flex: 1;
+  min-height: 0;
+}
+
+.ace-list__card-terminal .ace-terminal__view {
+  min-height: 100px;
+  border: none;
+  border-radius: 0;
+  flex: 1;
+}
+
+/* ── Full (non-compact) list styles ────────────────────── */
 .ace-list__tabs {
   display: flex;
   flex-direction: column;
@@ -105,64 +250,7 @@
   min-height: 250px;
 }
 
-.ace-list__empty {
-  font-size: var(--text-sm);
-  color: var(--color-text-muted);
-  padding: var(--space-4) 0;
-}
-
-/* Compact / mini grid layout */
+/* Compact empty override (kept for legacy use) */
 .ace-list--compact .ace-list__empty {
-  padding: var(--space-2) 0;
-}
-
-.ace-list__mini-grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
-  gap: var(--space-3);
-}
-
-.ace-list__mini-card {
-  border: 1px solid var(--color-border-subtle);
-  border-radius: var(--radius-md);
-  overflow: hidden;
-  display: flex;
-  flex-direction: column;
-}
-
-.ace-list__mini-header {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  padding: var(--space-1) var(--space-2);
-  background: var(--color-bg-surface);
-  border-bottom: 1px solid var(--color-border-subtle);
-}
-
-.ace-list__mini-name {
-  font-size: var(--text-xs);
-  font-weight: 500;
-  color: var(--color-text);
-  font-family: var(--font-mono);
-}
-
-.ace-list__mini-terminal {
-  height: 150px;
-  display: flex;
-  flex-direction: column;
-}
-
-.ace-list__mini-terminal .ace-terminal__view {
-  min-height: 100px;
-  border: none;
-  border-radius: 0;
-}
-
-.ace-list__mini-terminal .ace-terminal__input {
-  padding: var(--space-1) var(--space-2);
-}
-
-.ace-list__mini-terminal .ace-terminal__input input {
-  padding: var(--space-1) var(--space-2);
-  font-size: var(--text-xs);
+  padding: var(--space-2) var(--space-1);
 }

--- a/frontend/src/components/ace/AceList.tsx
+++ b/frontend/src/components/ace/AceList.tsx
@@ -12,6 +12,7 @@ interface AceListProps {
   projectId: string;
   sessions: Session[];
   onRefresh: () => void;
+  onExpand?: (sessionId: string) => void;
   compact?: boolean;
 }
 
@@ -19,6 +20,7 @@ export default function AceList({
   projectId,
   sessions,
   onRefresh,
+  onExpand,
   compact = false,
 }: AceListProps) {
   const { state } = useAppContext();
@@ -27,8 +29,15 @@ export default function AceList({
   const [selectedId, setSelectedId] = useState<string | null>(null);
   const [loadingId, setLoadingId] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const [showCreate, setShowCreate] = useState(false);
 
   const selectedSession = sessions.find((s) => s.id === selectedId);
+  const taskGraphs = state.taskGraphs[projectId] ?? [];
+
+  function getTaskTitle(session: Session): string | null {
+    const tg = taskGraphs.find((t) => t.assigned_ace_id === session.id);
+    return tg ? tg.title : null;
+  }
 
   async function handleCreate(e: React.FormEvent) {
     e.preventDefault();
@@ -40,6 +49,7 @@ export default function AceList({
         name: newName.trim(),
       });
       setNewName("");
+      setShowCreate(false);
       setSelectedId(created.id);
       onRefresh();
     } catch (err) {
@@ -89,7 +99,11 @@ export default function AceList({
   }
 
   function isRunning(s: Session) {
-    return s.status === "working" || s.status === "waiting" || s.status === "connecting";
+    return (
+      s.status === "working" ||
+      s.status === "waiting" ||
+      s.status === "connecting"
+    );
   }
 
   if (compact) {
@@ -97,7 +111,16 @@ export default function AceList({
       <div className="ace-list ace-list--compact" data-testid="ace-list">
         <div className="ace-list__header">
           <h3>Aces</h3>
-          <span className="ace-list__count">{sessions.length}</span>
+          {sessions.length > 0 && (
+            <span className="ace-list__count">{sessions.length}</span>
+          )}
+          <button
+            className="ace-list__add-btn"
+            onClick={() => setShowCreate((v) => !v)}
+            title="Add ace"
+          >
+            {showCreate ? "✕" : "+"}
+          </button>
         </div>
 
         {error && (
@@ -106,41 +129,73 @@ export default function AceList({
           </div>
         )}
 
-        {sessions.length === 0 ? (
-          <p className="ace-list__empty">No aces yet.</p>
-        ) : (
-          <div className="ace-list__mini-grid">
-            {sessions.map((session) => (
-              <div key={session.id} className="ace-list__mini-card">
-                <div className="ace-list__mini-header">
-                  <span className="ace-list__mini-name">{session.name}</span>
-                  <StatusBadge status={session.status} size="sm" />
-                  <HealthIndicator health={state.heartbeats[session.id]?.health} />
-                </div>
-                <div className="ace-list__mini-terminal">
-                  <AceTerminal key={session.id} session={session} />
-                </div>
-              </div>
-            ))}
-          </div>
+        {showCreate && (
+          <form className="ace-list__create" onSubmit={handleCreate}>
+            <input
+              type="text"
+              value={newName}
+              onChange={(e) => setNewName(e.target.value)}
+              placeholder="Ace name…"
+              disabled={creating}
+              autoFocus
+            />
+            <button
+              type="submit"
+              className="btn btn-sm btn-primary"
+              disabled={creating || !newName.trim()}
+            >
+              {creating ? "…" : "Add"}
+            </button>
+          </form>
         )}
 
-        <form className="ace-list__create" onSubmit={handleCreate}>
-          <input
-            type="text"
-            value={newName}
-            onChange={(e) => setNewName(e.target.value)}
-            placeholder="New ace name..."
-            disabled={creating}
-          />
-          <button
-            type="submit"
-            className="btn btn-sm btn-primary"
-            disabled={creating || !newName.trim()}
-          >
-            {creating ? "..." : "+ Add"}
-          </button>
-        </form>
+        {sessions.length === 0 ? (
+          <div className="ace-list__empty">
+            <span className="ace-list__empty-icon">⬡</span>
+            <span>No aces yet</span>
+          </div>
+        ) : (
+          <div className="ace-list__cards">
+            {sessions.map((session) => {
+              const taskTitle = getTaskTitle(session);
+              return (
+                <div
+                  key={session.id}
+                  className={`ace-list__card${isRunning(session) ? " ace-list__card--running" : ""}`}
+                >
+                  <div className="ace-list__card-header">
+                    <div className="ace-list__card-identity">
+                      <span className="ace-list__card-name">{session.name}</span>
+                      <StatusBadge status={session.status} size="sm" />
+                      <HealthIndicator
+                        health={state.heartbeats[session.id]?.health}
+                      />
+                    </div>
+                    {onExpand && (
+                      <button
+                        className="ace-list__expand-btn"
+                        onClick={() => onExpand(session.id)}
+                        title={`Expand ${session.name}`}
+                      >
+                        ⤢
+                      </button>
+                    )}
+                  </div>
+
+                  {taskTitle && (
+                    <div className="ace-list__card-task" title={taskTitle}>
+                      {taskTitle}
+                    </div>
+                  )}
+
+                  <div className="ace-list__card-terminal">
+                    <AceTerminal key={session.id} session={session} />
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        )}
       </div>
     );
   }

--- a/frontend/src/components/settings/ResourceLimitsPanel.tsx
+++ b/frontend/src/components/settings/ResourceLimitsPanel.tsx
@@ -1,0 +1,148 @@
+import { useState, useEffect } from "react";
+import { api, ApiError } from "../../utils/api";
+
+interface ResourceLimits {
+  max_concurrent_aces: number;
+  cpu_throttle_threshold: number;
+  ram_throttle_threshold: number;
+  cpu_pause_threshold: number;
+  ram_pause_threshold: number;
+}
+
+export function ResourceLimitsPanel() {
+  const [limits, setLimits] = useState<ResourceLimits | null>(null);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [saved, setSaved] = useState(false);
+
+  useEffect(() => {
+    api.get<ResourceLimits>("/settings/resource-limits")
+      .then(setLimits)
+      .catch(() => setError("Failed to load resource limits"));
+  }, []);
+
+  const handleSave = async () => {
+    if (!limits) return;
+    setSaving(true);
+    setError(null);
+    try {
+      const updated = await api.put<ResourceLimits>("/settings/resource-limits", limits);
+      setLimits(updated);
+      setSaved(true);
+      setTimeout(() => setSaved(false), 2000);
+    } catch (err) {
+      setError(err instanceof ApiError ? err.message : "Failed to save");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  if (!limits) return <p className="settings-pane__description">Loading...</p>;
+
+  return (
+    <section className="panel settings-pane__section">
+      <h3>Resource Limits</h3>
+      <p className="settings-pane__description">
+        Control how many Ace workers ATC can run simultaneously and when to
+        throttle based on CPU / RAM pressure.
+      </p>
+
+      {error && <p className="settings-pane__error">{error}</p>}
+
+      <div className="form-group">
+        <label htmlFor="max-aces">Max concurrent Aces</label>
+        <input
+          id="max-aces"
+          type="number"
+          min={1}
+          max={20}
+          value={limits.max_concurrent_aces}
+          onChange={(e) =>
+            setLimits({ ...limits, max_concurrent_aces: parseInt(e.target.value) || 1 })
+          }
+        />
+        <span className="form-hint">
+          Hard cap across all projects. Recommended: 2–4 on a dev laptop.
+        </span>
+      </div>
+
+      <div className="form-group">
+        <label htmlFor="cpu-throttle">CPU throttle threshold (%)</label>
+        <input
+          id="cpu-throttle"
+          type="number"
+          min={10}
+          max={100}
+          value={limits.cpu_throttle_threshold}
+          onChange={(e) =>
+            setLimits({ ...limits, cpu_throttle_threshold: parseFloat(e.target.value) || 70 })
+          }
+        />
+        <span className="form-hint">
+          Above this CPU %, halve the Ace limit. Default: 70%.
+        </span>
+      </div>
+
+      <div className="form-group">
+        <label htmlFor="ram-throttle">RAM throttle threshold (%)</label>
+        <input
+          id="ram-throttle"
+          type="number"
+          min={10}
+          max={100}
+          value={limits.ram_throttle_threshold}
+          onChange={(e) =>
+            setLimits({ ...limits, ram_throttle_threshold: parseFloat(e.target.value) || 75 })
+          }
+        />
+        <span className="form-hint">
+          Above this RAM %, halve the Ace limit. Default: 75%.
+        </span>
+      </div>
+
+      <div className="form-group">
+        <label htmlFor="cpu-pause">CPU pause threshold (%)</label>
+        <input
+          id="cpu-pause"
+          type="number"
+          min={10}
+          max={100}
+          value={limits.cpu_pause_threshold}
+          onChange={(e) =>
+            setLimits({ ...limits, cpu_pause_threshold: parseFloat(e.target.value) || 85 })
+          }
+        />
+        <span className="form-hint">
+          Above this CPU %, stop spawning Aces entirely. Default: 85%.
+        </span>
+      </div>
+
+      <div className="form-group">
+        <label htmlFor="ram-pause">RAM pause threshold (%)</label>
+        <input
+          id="ram-pause"
+          type="number"
+          min={10}
+          max={100}
+          value={limits.ram_pause_threshold}
+          onChange={(e) =>
+            setLimits({ ...limits, ram_pause_threshold: parseFloat(e.target.value) || 90 })
+          }
+        />
+        <span className="form-hint">
+          Above this RAM %, stop spawning Aces entirely. Default: 90%.
+        </span>
+      </div>
+
+      <div className="settings-pane__actions">
+        <button
+          className="btn btn-primary"
+          onClick={() => void handleSave()}
+          disabled={saving}
+        >
+          {saving ? "Saving..." : saved ? "Saved ✓" : "Save"}
+        </button>
+      </div>
+    </section>
+  );
+}

--- a/frontend/src/components/tower/SettingsPane.tsx
+++ b/frontend/src/components/tower/SettingsPane.tsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import { useAppContext } from "../../context/AppContext";
 import { BackupPanel } from "../settings/BackupPanel";
+import { ResourceLimitsPanel } from "../settings/ResourceLimitsPanel";
 import "./SettingsPane.css";
 
 interface Props {
@@ -73,6 +74,8 @@ export default function SettingsPane({ onClose }: Props) {
         </section>
 
         <BackupPanel />
+
+        <ResourceLimitsPanel />
 
         <section className="panel settings-pane__section">
           <h3>Tower Status</h3>

--- a/frontend/src/pages/ProjectView.css
+++ b/frontend/src/pages/ProjectView.css
@@ -63,14 +63,14 @@
   flex-shrink: 0;
 }
 
-/* Right column: leader full height */
+/* Right column: leader or ace console, full height */
 .project-view__right {
   display: flex;
   flex-direction: column;
   min-height: 0;
 }
 
-.project-view__leader {
+.project-view__console {
   flex: 1;
   display: flex;
   flex-direction: column;

--- a/frontend/src/pages/ProjectView.tsx
+++ b/frontend/src/pages/ProjectView.tsx
@@ -1,7 +1,9 @@
+import { useState } from "react";
 import { useParams } from "react-router-dom";
 import { useAppContext } from "../context/AppContext";
 import StatusBadge from "../components/common/StatusBadge";
 import LeaderConsole from "../components/leader/LeaderConsole";
+import AceConsole from "../components/ace/AceConsole";
 import TaskBoard from "../components/leader/TaskBoard";
 import AceList from "../components/ace/AceList";
 import ContextHub from "../components/context/ContextHub";
@@ -17,12 +19,19 @@ export default function ProjectView() {
   const leader = id ? leaders[id] : undefined;
   const projectTaskGraphs = id ? (taskGraphs[id] ?? []) : [];
 
+  // null = show Leader, string = show that Ace full-screen
+  const [expandedAceId, setExpandedAceId] = useState<string | null>(null);
+
+  // If the expanded ace was removed, fall back to leader view
+  const expandedAceExists =
+    expandedAceId !== null &&
+    projectSessions.some((s) => s.id === expandedAceId);
+  const activeAceId = expandedAceExists ? expandedAceId : null;
+
   if (!project) {
     return (
       <div className="project-view" data-testid="project-view">
-        <div className="project-view__empty">
-          Project not found.
-        </div>
+        <div className="project-view__empty">Project not found.</div>
       </div>
     );
   }
@@ -42,7 +51,7 @@ export default function ProjectView() {
 
       {/* Main 60/40 layout */}
       <div className="project-view__layout">
-        {/* Left column — Tasks + Aces */}
+        {/* Left column — Tasks + Aces + Context */}
         <aside className="project-view__left">
           <div className="panel project-view__tasks">
             <TaskBoard
@@ -57,6 +66,7 @@ export default function ProjectView() {
               projectId={project.id}
               sessions={projectSessions}
               onRefresh={fetchAll}
+              onExpand={(sessionId) => setExpandedAceId(sessionId)}
               compact
             />
           </div>
@@ -70,15 +80,25 @@ export default function ProjectView() {
           </div>
         </aside>
 
-        {/* Right column — Leader terminal full height */}
+        {/* Right column — Leader or expanded Ace */}
         <main className="project-view__right">
-          <div className="panel project-view__leader">
-            <LeaderConsole
-              projectId={project.id}
-              leader={leader}
-              project={project}
-              onRefresh={fetchAll}
-            />
+          <div className="panel project-view__console">
+            {activeAceId !== null ? (
+              <AceConsole
+                projectId={project.id}
+                sessions={projectSessions}
+                activeAceId={activeAceId}
+                onRefresh={fetchAll}
+                onSelectAce={(id) => setExpandedAceId(id)}
+              />
+            ) : (
+              <LeaderConsole
+                projectId={project.id}
+                leader={leader}
+                project={project}
+                onRefresh={fetchAll}
+              />
+            )}
           </div>
         </main>
       </div>

--- a/src/atc/api/routers/settings.py
+++ b/src/atc/api/routers/settings.py
@@ -303,3 +303,64 @@ async def send_sentry_report(
 
     event_id = capture_message(body.message, level="error", **extra)
     return SendReportResponse(sent=event_id is not None, event_id=event_id)
+
+
+# ---------------------------------------------------------------------------
+# Resource limits settings
+# ---------------------------------------------------------------------------
+
+class ResourceLimitsResponse(BaseModel):
+    max_concurrent_aces: int
+    cpu_throttle_threshold: float
+    ram_throttle_threshold: float
+    cpu_pause_threshold: float
+    ram_pause_threshold: float
+
+
+class ResourceLimitsUpdate(BaseModel):
+    max_concurrent_aces: int | None = None
+    cpu_throttle_threshold: float | None = None
+    ram_throttle_threshold: float | None = None
+    cpu_pause_threshold: float | None = None
+    ram_pause_threshold: float | None = None
+
+
+@router.get("/resource-limits", response_model=ResourceLimitsResponse)
+async def get_resource_limits(request: Request) -> ResourceLimitsResponse:
+    """Get current resource limit settings."""
+    settings = request.app.state.settings
+    cfg = settings.resource_monitor
+    return ResourceLimitsResponse(
+        max_concurrent_aces=cfg.max_concurrent_aces,
+        cpu_throttle_threshold=cfg.cpu_throttle_threshold,
+        ram_throttle_threshold=cfg.ram_throttle_threshold,
+        cpu_pause_threshold=cfg.cpu_pause_threshold,
+        ram_pause_threshold=cfg.ram_pause_threshold,
+    )
+
+
+@router.put("/resource-limits", response_model=ResourceLimitsResponse)
+async def update_resource_limits(
+    body: ResourceLimitsUpdate,
+    request: Request,
+) -> ResourceLimitsResponse:
+    """Update resource limit settings (persisted in memory until restart)."""
+    settings = request.app.state.settings
+    cfg = settings.resource_monitor
+    if body.max_concurrent_aces is not None:
+        cfg.max_concurrent_aces = max(1, min(body.max_concurrent_aces, 20))
+    if body.cpu_throttle_threshold is not None:
+        cfg.cpu_throttle_threshold = body.cpu_throttle_threshold
+    if body.ram_throttle_threshold is not None:
+        cfg.ram_throttle_threshold = body.ram_throttle_threshold
+    if body.cpu_pause_threshold is not None:
+        cfg.cpu_pause_threshold = body.cpu_pause_threshold
+    if body.ram_pause_threshold is not None:
+        cfg.ram_pause_threshold = body.ram_pause_threshold
+    return ResourceLimitsResponse(
+        max_concurrent_aces=cfg.max_concurrent_aces,
+        cpu_throttle_threshold=cfg.cpu_throttle_threshold,
+        ram_throttle_threshold=cfg.ram_throttle_threshold,
+        cpu_pause_threshold=cfg.cpu_pause_threshold,
+        ram_pause_threshold=cfg.ram_pause_threshold,
+    )


### PR DESCRIPTION
Three things in one:

**Ace panel polish:**
- Cards: name + status badge + health indicator + task assignment label
- Running Aces get accent-colored border tint
- Compact create form (toggle with +/✕), clean empty state
- `⤢` expand button switches right column to that Ace's full terminal

**Expandable Ace tab view (ProjectView):**
- `expandedAceId` state: null = Leader, string = Ace console
- New `AceConsole` component: tab bar (← Leader + per-Ace tabs) + full AceTerminal
- Tabs styled to match TowerBar nav; auto-falls back if Ace is deleted

**Resource limits in Settings UI:**
- `GET/PUT /api/settings/resource-limits` endpoints
- `ResourceLimitsPanel` in Settings pane: max concurrent Aces, CPU/RAM throttle + pause thresholds
- No yaml editing — all configurable in the app UI
- Changes apply immediately to active ResourceGovernor