### PR TITLE
fix: make cleardb continues even if git pull fails

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ cleardb: ## Full reset: kill ALL dev processes, nuke venv + DB, rebuild from scr
 	@echo "→ Ensuring git remote uses HTTPS (not SSH)..."
 	@git remote set-url origin https://github.com/wowc8/atc.git
 	@echo "→ Pulling latest code..."
-	@git pull origin main
+	@git pull origin main || echo "⚠ git pull failed (SSH key issue?). Continuing with local code."
 	@if [ -f atc.db ]; then \
 		rm atc.db && echo "✓ atc.db deleted"; \
 	else \


### PR DESCRIPTION
SSH host key warnings were causing git pull to fail with non-zero exit, which stopped make dead after deleting the DB but before rebuilding the venv. Added || echo warning so cleardb always completes.