### PR TITLE
fix: Ace expand stays in left panel, Leader always stays right

### DIFF
--- a/frontend/src/components/ace/AceConsole.tsx
+++ b/frontend/src/components/ace/AceConsole.tsx
@@ -13,7 +13,9 @@ interface AceConsoleProps {
   sessions: Session[];
   activeAceId: string;
   onRefresh: () => void;
-  onSelectAce: (id: string | null) => void;
+  onSelectAce: (id: string) => void;
+  /** Collapse back to the Ace list view */
+  onCollapse: () => void;
 }
 
 export default function AceConsole({
@@ -22,6 +24,7 @@ export default function AceConsole({
   activeAceId,
   onRefresh,
   onSelectAce,
+  onCollapse,
 }: AceConsoleProps) {
   const { state } = useAppContext();
   const [loadingId, setLoadingId] = useState<string | null>(null);
@@ -35,61 +38,43 @@ export default function AceConsole({
   }
 
   function isRunning(s: Session) {
-    return (
-      s.status === "working" ||
-      s.status === "waiting" ||
-      s.status === "connecting"
-    );
+    return s.status === "working" || s.status === "waiting" || s.status === "connecting";
   }
 
   async function handleStart(sessionId: string) {
     setLoadingId(sessionId);
-    try {
-      await api.post(`/aces/${sessionId}/start`, {});
-      onRefresh();
-    } catch (err) {
-      console.error("Failed to start ace:", err);
-    } finally {
-      setLoadingId(null);
-    }
+    try { await api.post(`/aces/${sessionId}/start`, {}); onRefresh(); }
+    catch (err) { console.error("Failed to start ace:", err); }
+    finally { setLoadingId(null); }
   }
 
   async function handleStop(sessionId: string) {
     setLoadingId(sessionId);
-    try {
-      await api.post(`/aces/${sessionId}/stop`);
-      onRefresh();
-    } catch (err) {
-      console.error("Failed to stop ace:", err);
-    } finally {
-      setLoadingId(null);
-    }
+    try { await api.post(`/aces/${sessionId}/stop`); onRefresh(); }
+    catch (err) { console.error("Failed to stop ace:", err); }
+    finally { setLoadingId(null); }
   }
 
   async function handleDelete(sessionId: string) {
     setLoadingId(sessionId);
     try {
       await api.delete(`/aces/${sessionId}`);
-      // Go to leader view after deleting the active ace
-      onSelectAce(null);
+      onCollapse();
       onRefresh();
-    } catch (err) {
-      console.error("Failed to delete ace:", err);
-    } finally {
-      setLoadingId(null);
-    }
+    } catch (err) { console.error("Failed to delete ace:", err); }
+    finally { setLoadingId(null); }
   }
 
   return (
     <div className="ace-console" data-testid="ace-console">
-      {/* Tab bar: Leader + one tab per ace */}
+      {/* Tab bar: collapse button + one tab per Ace */}
       <div className="ace-console__tabs">
         <button
-          className="ace-console__tab ace-console__tab--leader"
-          onClick={() => onSelectAce(null)}
-          title="Return to Leader"
+          className="ace-console__collapse-btn"
+          onClick={onCollapse}
+          title="Collapse to Ace list"
         >
-          ← Leader
+          ↙ Collapse
         </button>
         <div className="ace-console__tab-divider" />
         {sessions.map((s) => (
@@ -112,9 +97,7 @@ export default function AceConsole({
             <div className="ace-console__identity">
               <span className="ace-console__name">{activeSession.name}</span>
               <StatusBadge status={activeSession.status} />
-              <HealthIndicator
-                health={state.heartbeats[activeSession.id]?.health}
-              />
+              <HealthIndicator health={state.heartbeats[activeSession.id]?.health} />
               {getTaskTitle(activeSession) && (
                 <span className="ace-console__task-label">
                   {getTaskTitle(activeSession)}
@@ -137,10 +120,7 @@ export default function AceConsole({
                   onConfirm={() => handleStop(activeSession.id)}
                   variant="danger"
                 >
-                  <button
-                    className="btn btn-sm btn-danger"
-                    disabled={loadingId === activeSession.id}
-                  >
+                  <button className="btn btn-sm btn-danger" disabled={loadingId === activeSession.id}>
                     Stop
                   </button>
                 </ConfirmPopover>
@@ -153,9 +133,7 @@ export default function AceConsole({
               >
                 <button
                   className="btn btn-sm btn-danger"
-                  disabled={
-                    loadingId === activeSession.id || isRunning(activeSession)
-                  }
+                  disabled={loadingId === activeSession.id || isRunning(activeSession)}
                 >
                   Delete
                 </button>

--- a/frontend/src/pages/ProjectView.css
+++ b/frontend/src/pages/ProjectView.css
@@ -63,14 +63,29 @@
   flex-shrink: 0;
 }
 
-/* Right column: leader or ace console, full height */
+/* When an Ace is expanded, the panel grows to fill available space */
+.project-view__aces--expanded {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+}
+
+.project-view__aces--expanded .ace-console {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+}
+
+/* Right column: leader always full height */
 .project-view__right {
   display: flex;
   flex-direction: column;
   min-height: 0;
 }
 
-.project-view__console {
+.project-view__leader {
   flex: 1;
   display: flex;
   flex-direction: column;

--- a/frontend/src/pages/ProjectView.tsx
+++ b/frontend/src/pages/ProjectView.tsx
@@ -3,9 +3,9 @@ import { useParams } from "react-router-dom";
 import { useAppContext } from "../context/AppContext";
 import StatusBadge from "../components/common/StatusBadge";
 import LeaderConsole from "../components/leader/LeaderConsole";
-import AceConsole from "../components/ace/AceConsole";
 import TaskBoard from "../components/leader/TaskBoard";
 import AceList from "../components/ace/AceList";
+import AceConsole from "../components/ace/AceConsole";
 import ContextHub from "../components/context/ContextHub";
 import "./ProjectView.css";
 
@@ -19,10 +19,10 @@ export default function ProjectView() {
   const leader = id ? leaders[id] : undefined;
   const projectTaskGraphs = id ? (taskGraphs[id] ?? []) : [];
 
-  // null = show Leader, string = show that Ace full-screen
+  // null = collapsed Ace list, string = expanded Ace panel with tabs
   const [expandedAceId, setExpandedAceId] = useState<string | null>(null);
 
-  // If the expanded ace was removed, fall back to leader view
+  // If the expanded Ace was removed, collapse back to list
   const expandedAceExists =
     expandedAceId !== null &&
     projectSessions.some((s) => s.id === expandedAceId);
@@ -49,9 +49,9 @@ export default function ProjectView() {
         )}
       </div>
 
-      {/* Main 60/40 layout */}
+      {/* Main layout: left col always shows tasks+aces+context, right always shows leader */}
       <div className="project-view__layout">
-        {/* Left column — Tasks + Aces + Context */}
+        {/* Left column */}
         <aside className="project-view__left">
           <div className="panel project-view__tasks">
             <TaskBoard
@@ -61,16 +61,29 @@ export default function ProjectView() {
             />
           </div>
 
-          <div className="panel project-view__aces">
-            <AceList
-              projectId={project.id}
-              sessions={projectSessions}
-              onRefresh={fetchAll}
-              onExpand={(sessionId) => setExpandedAceId(sessionId)}
-              compact
-            />
+          {/* Aces panel: collapses to list or expands to tabbed console IN-PLACE */}
+          <div className={`panel project-view__aces${activeAceId ? " project-view__aces--expanded" : ""}`}>
+            {activeAceId ? (
+              <AceConsole
+                projectId={project.id}
+                sessions={projectSessions}
+                activeAceId={activeAceId}
+                onRefresh={fetchAll}
+                onSelectAce={(sid) => setExpandedAceId(sid)}
+                onCollapse={() => setExpandedAceId(null)}
+              />
+            ) : (
+              <AceList
+                projectId={project.id}
+                sessions={projectSessions}
+                onRefresh={fetchAll}
+                onExpand={(sid) => setExpandedAceId(sid)}
+                compact
+              />
+            )}
           </div>
 
+          {/* Context hub — always visible */}
           <div className="panel project-view__context">
             <ContextHub
               scope="project"
@@ -80,25 +93,15 @@ export default function ProjectView() {
           </div>
         </aside>
 
-        {/* Right column — Leader or expanded Ace */}
+        {/* Right column — Leader always here */}
         <main className="project-view__right">
-          <div className="panel project-view__console">
-            {activeAceId !== null ? (
-              <AceConsole
-                projectId={project.id}
-                sessions={projectSessions}
-                activeAceId={activeAceId}
-                onRefresh={fetchAll}
-                onSelectAce={(id) => setExpandedAceId(id)}
-              />
-            ) : (
-              <LeaderConsole
-                projectId={project.id}
-                leader={leader}
-                project={project}
-                onRefresh={fetchAll}
-              />
-            )}
+          <div className="panel project-view__leader">
+            <LeaderConsole
+              projectId={project.id}
+              leader={leader}
+              project={project}
+              onRefresh={fetchAll}
+            />
           </div>
         </main>
       </div>


### PR DESCRIPTION
Corrected the expand layout — was replacing the right column (Leader) which was wrong.\n\n**Correct behaviour:**\n- Leader terminal always in the right column\n- Clicking ⤢ on an Ace expands the Aces panel in-place (left column) with tabs\n- '↙ Collapse' collapses back to the list\n- Context hub stays below the Aces panel