### PR TITLE
fix: Ace list mosaic grid layout

### DIFF
--- a/frontend/src/components/ace/AceList.css
+++ b/frontend/src/components/ace/AceList.css
@@ -92,10 +92,10 @@
   opacity: 0.4;
 }
 
-/* ── Compact cards grid ─────────────────────────────────── */
+/* ── Compact cards mosaic grid ──────────────────────────── */
 .ace-list__cards {
-  display: flex;
-  flex-direction: column;
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
   gap: var(--space-2);
 }
 
@@ -107,6 +107,7 @@
   flex-direction: column;
   background: var(--color-bg-surface);
   transition: border-color 0.15s, box-shadow 0.15s;
+  min-width: 0;
 }
 
 .ace-list__card:hover {


### PR DESCRIPTION
Ace cards were stacking full-width in a column. Changed to auto-fill grid (min 180px per card) so they tile as mosaic blocks.