### PR TITLE
fix: remove goal text from LeaderConsole header

### DIFF
--- a/frontend/src/components/leader/LeaderConsole.tsx
+++ b/frontend/src/components/leader/LeaderConsole.tsx
@@ -193,10 +193,6 @@ export default function LeaderConsole({
         <div className="leader-console__loading">Starting terminal...</div>
       )}
 
-      {leader?.goal && (
-        <p className="leader-console__goal">{leader.goal}</p>
-      )}
-
       {/* Terminal — always keep alive when running */}
       {(isRunning || (isClaudeCode && !!terminalChannel)) && (
         <div className="leader-console__terminal" ref={attachRef} />


### PR DESCRIPTION
Goal text was being rendered as a paragraph above the terminal in the Leader panel. It belongs in the Context hub, not the terminal header.