### PR TITLE
fix: kickoff message includes the actual goal text

### DIFF
--- a/src/atc/tower/controller.py
+++ b/src/atc/tower/controller.py
@@ -512,10 +512,14 @@ class TowerController:
         if not self._current_project_id:
             return
         try:
+            kickoff_msg = (
+                f"Your goal is: {goal}\n\n"
+                "Begin immediately: decompose this goal into tasks, spawn Aces, and drive to completion."
+            )
             await send_leader_message(
                 self._db,
                 self._current_project_id,
-                "Start working on your goal now.",
+                kickoff_msg,
                 event_bus=self._event_bus,
             )
             logger.info(


### PR DESCRIPTION
Leader's CLAUDE.md was showing '(No specific goal set)' when Tower called `atc leader start` without `--goal`. The kickoff now explicitly states the goal so Leader always knows what to work on regardless of how it was started.