### PR TITLE
feat: context panel as full-width bottom bar with resize

### DIFF
--- a/frontend/src/pages/ProjectView.css
+++ b/frontend/src/pages/ProjectView.css
@@ -35,15 +35,23 @@
   color: var(--color-text-secondary);
 }
 
-/* Main layout: flex row, resize handle replaces the gap */
+/* Outer layout: column — top row stacked above full-width context */
 .project-view__layout {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  min-height: 0;
+}
+
+/* Top row: left + right columns side by side */
+.project-view__top {
   display: flex;
   flex-direction: row;
   flex: 1;
   min-height: 0;
 }
 
-/* Left column: stacked panels separated by row resize handles */
+/* Left column: stacked panels separated by row resize handle */
 .project-view__left {
   display: flex;
   flex-direction: column;
@@ -57,14 +65,15 @@
   overflow-y: auto;
 }
 
+/* Aces fills remaining left-column space after tasks */
 .project-view__aces {
-  flex-shrink: 0;
+  flex: 1;
+  min-height: 120px;
   overflow: hidden;
 }
 
 /* When an Ace is expanded, the panel grows to fill available space */
 .project-view__aces--expanded {
-  flex: 1;
   display: flex;
   flex-direction: column;
   min-height: 0;
@@ -77,14 +86,7 @@
   min-height: 0;
 }
 
-/* Context hub fills the remaining left-column space */
-.project-view__context {
-  flex: 1;
-  min-height: 0;
-  overflow-y: auto;
-}
-
-/* Right column: leader always full height */
+/* Right column: leader always full height of top row */
 .project-view__right {
   flex: 1;
   display: flex;
@@ -98,4 +100,10 @@
   display: flex;
   flex-direction: column;
   min-height: 0;
+}
+
+/* Context panel: full width, fixed height controlled by JS state */
+.project-view__context {
+  flex-shrink: 0;
+  overflow-y: auto;
 }

--- a/frontend/src/pages/ProjectView.tsx
+++ b/frontend/src/pages/ProjectView.tsx
@@ -13,7 +13,8 @@ import "./ProjectView.css";
 const MIN_LEFT = 280;
 const MIN_RIGHT = 400;
 const MIN_TASKS = 120;
-const MIN_ACES = 80;
+const MIN_CTX = 80;
+const MAX_CTX = 400;
 
 function readStorage(key: string, fallback: number): number {
   const v = localStorage.getItem(key);
@@ -46,8 +47,8 @@ export default function ProjectView() {
   const [tasksHeight, setTasksHeight] = useState(() =>
     readStorage("atc:pv:tasks-h", 240)
   );
-  const [acesHeight, setAcesHeight] = useState(() =>
-    readStorage("atc:pv:aces-h", 200)
+  const [ctxHeight, setCtxHeight] = useState(() =>
+    readStorage("atc:pv:ctx-h", 180)
   );
 
   const layoutRef = useRef<HTMLDivElement>(null);
@@ -59,8 +60,8 @@ export default function ProjectView() {
     localStorage.setItem("atc:pv:tasks-h", String(tasksHeight));
   }, [tasksHeight]);
   useEffect(() => {
-    localStorage.setItem("atc:pv:aces-h", String(acesHeight));
-  }, [acesHeight]);
+    localStorage.setItem("atc:pv:ctx-h", String(ctxHeight));
+  }, [ctxHeight]);
 
   const handleSplitDrag = useCallback(
     (e: React.MouseEvent) => {
@@ -114,15 +115,19 @@ export default function ProjectView() {
     [tasksHeight]
   );
 
-  const handleAcesDrag = useCallback(
+  const handleCtxDrag = useCallback(
     (e: React.MouseEvent) => {
       e.preventDefault();
       const startY = e.clientY;
-      const startHeight = acesHeight;
+      const startHeight = ctxHeight;
 
       const onMove = (ev: MouseEvent) => {
-        const next = Math.max(MIN_ACES, startHeight + ev.clientY - startY);
-        setAcesHeight(next);
+        // Drag up (negative delta) → context grows; drag down → context shrinks
+        const next = Math.max(
+          MIN_CTX,
+          Math.min(MAX_CTX, startHeight - (ev.clientY - startY))
+        );
+        setCtxHeight(next);
       };
 
       const onUp = () => {
@@ -133,7 +138,7 @@ export default function ProjectView() {
       document.addEventListener("mousemove", onMove);
       document.addEventListener("mouseup", onUp);
     },
-    [acesHeight]
+    [ctxHeight]
   );
 
   if (!project) {
@@ -157,73 +162,79 @@ export default function ProjectView() {
         )}
       </div>
 
-      {/* Main layout: left col always shows tasks+aces+context, right always shows leader */}
+      {/* Main layout: top row (left+right) stacked above full-width context */}
       <div className="project-view__layout" ref={layoutRef}>
-        {/* Left column */}
-        <aside className="project-view__left" style={{ width: leftWidth }}>
-          <div
-            className="panel project-view__tasks"
-            style={{ height: tasksHeight }}
-          >
-            <TaskBoard
-              projectId={project.id}
-              taskGraphs={projectTaskGraphs}
-              onRefresh={fetchAll}
-            />
-          </div>
-
-          <ResizeHandle direction="row" onMouseDown={handleTasksDrag} />
-
-          {/* Aces panel: collapses to list or expands to tabbed console IN-PLACE */}
-          <div
-            className={`panel project-view__aces${activeAceId ? " project-view__aces--expanded" : ""}`}
-            style={activeAceId ? undefined : { height: acesHeight }}
-          >
-            {activeAceId ? (
-              <AceConsole
+        {/* Top row: left column + vertical handle + right column */}
+        <div className="project-view__top">
+          {/* Left column: tasks + aces */}
+          <aside className="project-view__left" style={{ width: leftWidth }}>
+            <div
+              className="panel project-view__tasks"
+              style={{ height: tasksHeight }}
+            >
+              <TaskBoard
                 projectId={project.id}
-                sessions={projectSessions}
-                activeAceId={activeAceId}
+                taskGraphs={projectTaskGraphs}
                 onRefresh={fetchAll}
-                onSelectAce={(sid) => setExpandedAceId(sid)}
-                onCollapse={() => setExpandedAceId(null)}
               />
-            ) : (
-              <AceList
+            </div>
+
+            <ResizeHandle direction="row" onMouseDown={handleTasksDrag} />
+
+            {/* Aces panel: collapses to list or expands to tabbed console IN-PLACE */}
+            <div
+              className={`panel project-view__aces${activeAceId ? " project-view__aces--expanded" : ""}`}
+            >
+              {activeAceId ? (
+                <AceConsole
+                  projectId={project.id}
+                  sessions={projectSessions}
+                  activeAceId={activeAceId}
+                  onRefresh={fetchAll}
+                  onSelectAce={(sid) => setExpandedAceId(sid)}
+                  onCollapse={() => setExpandedAceId(null)}
+                />
+              ) : (
+                <AceList
+                  projectId={project.id}
+                  sessions={projectSessions}
+                  onRefresh={fetchAll}
+                  onExpand={(sid) => setExpandedAceId(sid)}
+                  compact
+                />
+              )}
+            </div>
+          </aside>
+
+          <ResizeHandle direction="col" onMouseDown={handleSplitDrag} />
+
+          {/* Right column — Leader always here, fills full height of top row */}
+          <main className="project-view__right">
+            <div className="panel project-view__leader">
+              <LeaderConsole
                 projectId={project.id}
-                sessions={projectSessions}
+                leader={leader}
+                project={project}
                 onRefresh={fetchAll}
-                onExpand={(sid) => setExpandedAceId(sid)}
-                compact
               />
-            )}
-          </div>
+            </div>
+          </main>
+        </div>
 
-          <ResizeHandle direction="row" onMouseDown={handleAcesDrag} />
+        {/* Context resize handle — sits at top edge of context panel */}
+        <ResizeHandle direction="row" onMouseDown={handleCtxDrag} />
 
-          {/* Context hub — always visible, fills remaining space */}
-          <div className="panel project-view__context">
-            <ContextHub
-              scope="project"
-              projectId={project.id}
-              showScopeTabs={false}
-            />
-          </div>
-        </aside>
-
-        <ResizeHandle direction="col" onMouseDown={handleSplitDrag} />
-
-        {/* Right column — Leader always here */}
-        <main className="project-view__right">
-          <div className="panel project-view__leader">
-            <LeaderConsole
-              projectId={project.id}
-              leader={leader}
-              project={project}
-              onRefresh={fetchAll}
-            />
-          </div>
-        </main>
+        {/* Context panel — full width, resizable height */}
+        <div
+          className="panel project-view__context"
+          style={{ height: ctxHeight }}
+        >
+          <ContextHub
+            scope="project"
+            projectId={project.id}
+            showScopeTabs={false}
+          />
+        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
Restructures ProjectView layout:

- Context panel moved to full-width strip at the bottom spanning both columns
- Drag handle on the top edge of context to resize height (default 180px, min 80px, max 400px)
- Top row holds left/right column split, fills all remaining space above context
- Aces panel now fills remaining left column height (flex: 1)
- All sizes persist in localStorage