### PR TITLE
fix: leader spawn reliability

### DIFF
--- a/src/atc/leader/leader.py
+++ b/src/atc/leader/leader.py
@@ -22,8 +22,8 @@ from atc.session.ace import (
     _accept_trust_dialog,
     _ensure_tmux_session,
     _kill_pane,
-    _send_keys,
     _spawn_pane,
+    send_instruction,
 )
 from atc.session.state_machine import SessionStatus, transition
 from atc.state import db as db_ops
@@ -130,9 +130,9 @@ async def start_leader(
             deployed.root,
         )
 
-        # Use the staging directory so Claude Code finds the deployed
-        # CLAUDE.md (Leader role/goal) and .claude/settings.json (hooks, model).
-        working_dir = str(deployed.root)
+        # Use repo_path if available so Claude Code starts in the actual repo;
+        # fall back to staging dir so it finds the deployed CLAUDE.md and hooks.
+        working_dir = spec.repo_path or str(deployed.root)
 
         launch_cmd = get_launch_command(
             project.agent_provider if project else "claude_code",
@@ -247,4 +247,4 @@ async def send_leader_message(
     if not await _pane_is_alive(session.tmux_pane):
         raise ValueError("Leader tmux pane is dead — stop and restart the leader")
 
-    await _send_keys(session.tmux_pane, message)
+    await send_instruction(session.tmux_pane, message)

--- a/src/atc/leader/orchestrator.py
+++ b/src/atc/leader/orchestrator.py
@@ -111,7 +111,7 @@ class LeaderOrchestrator:
             _GLOBAL_ACTIVE_ACES += slots_to_use
 
         new_assignments: list[AceAssignment] = []
-        for tg in ready[:available_slots]:
+        for tg in ready[:slots_to_use]:
             # Skip if already assigned
             if tg.id in self.assignments:
                 continue
@@ -119,6 +119,9 @@ class LeaderOrchestrator:
             assignment = await self._spawn_ace_for_task(tg.id, tg.title, tg.description)
             if assignment is not None:
                 new_assignments.append(assignment)
+            else:
+                # Spawn failed — return the reserved slot to the global counter
+                _GLOBAL_ACTIVE_ACES = max(0, _GLOBAL_ACTIVE_ACES - 1)
 
         return new_assignments
 

--- a/src/atc/tower/controller.py
+++ b/src/atc/tower/controller.py
@@ -602,12 +602,22 @@ class TowerController:
                 return
 
             logger.warning(
-                "Leader session %s has no output yet (attempt %d/%d) — resending kickoff",
+                "Leader session %s has no output yet (attempt %d/%d) — sending nudge",
                 session_id,
                 attempt + 1,
                 max_retries,
             )
-            await self._send_leader_kickoff(session_id, goal)
+            try:
+                await send_leader_message(
+                    self._db,
+                    project_id,
+                    "Please continue with your goal.",
+                    event_bus=self._event_bus,
+                )
+            except Exception:
+                logger.exception(
+                    "Failed to send nudge to leader session %s", session_id
+                )
             await asyncio.sleep(retry_wait)
 
         # Final check after last retry

--- a/tests/e2e/test_smoke.py
+++ b/tests/e2e/test_smoke.py
@@ -119,7 +119,7 @@ class TestProjectCRUD:
 @patch("atc.session.ace._tmux_run", new_callable=AsyncMock)
 @patch("atc.leader.leader._ensure_tmux_session", new_callable=AsyncMock)
 @patch("atc.leader.leader._spawn_pane", new_callable=AsyncMock, return_value="%1")
-@patch("atc.leader.leader._send_keys", new_callable=AsyncMock)
+@patch("atc.leader.leader.send_instruction", new_callable=AsyncMock)
 class TestLeaderLifecycle:
     def test_start_leader(
         self,
@@ -267,7 +267,7 @@ class TestTowerStatus:
         # At least 1 session (the ace; leader session is only created on start)
         assert data["total_sessions"] >= 1
 
-    @patch("atc.leader.leader._send_keys", new_callable=AsyncMock)
+    @patch("atc.leader.leader.send_instruction", new_callable=AsyncMock)
     @patch("atc.leader.leader._spawn_pane", new_callable=AsyncMock, return_value="%1")
     @patch("atc.leader.leader._ensure_tmux_session", new_callable=AsyncMock)
     def test_submit_goal(
@@ -299,7 +299,7 @@ class TestTowerStatus:
         )
         assert resp.status_code == 404
 
-    @patch("atc.leader.leader._send_keys", new_callable=AsyncMock)
+    @patch("atc.leader.leader.send_instruction", new_callable=AsyncMock)
     @patch("atc.leader.leader._spawn_pane", new_callable=AsyncMock, return_value="%1")
     @patch("atc.leader.leader._ensure_tmux_session", new_callable=AsyncMock)
     def test_submit_goal_twice_while_managing_succeeds(
@@ -327,7 +327,7 @@ class TestTowerStatus:
 
     @patch("atc.tower.session.stop_tower_session", new_callable=AsyncMock)
     @patch("atc.leader.leader._kill_pane", new_callable=AsyncMock)
-    @patch("atc.leader.leader._send_keys", new_callable=AsyncMock)
+    @patch("atc.leader.leader.send_instruction", new_callable=AsyncMock)
     @patch("atc.leader.leader._spawn_pane", new_callable=AsyncMock, return_value="%1")
     @patch("atc.leader.leader._ensure_tmux_session", new_callable=AsyncMock)
     def test_stop_tower(


### PR DESCRIPTION
Fixes four reliability issues in the Leader spawn path:

- **send_instruction guard**: `send_leader_message` now uses `send_instruction` (with TUI-ready check) instead of raw `_send_keys`
- **counter decrement**: global running counter is decremented inside the spawn loop on failure, using `slots_to_use` consistently as the slice bound
- **retry nudge**: Tower kickoff retry sends short nudge ("Please continue with your goal.") instead of full mission brief
- **repo_path workdir**: Leader working dir uses `repo_path` if available, falls back to staging dir

Tests updated to patch `send_instruction` instead of `_send_keys` in all affected test classes.