### PR TITLE
fix: prevent _GLOBAL_ACTIVE_ACES counter inflation on Ace spawn chaos

### DIFF
--- a/src/atc/leader/orchestrator.py
+++ b/src/atc/leader/orchestrator.py
@@ -111,11 +111,8 @@ class LeaderOrchestrator:
             _GLOBAL_ACTIVE_ACES += slots_to_use
 
         new_assignments: list[AceAssignment] = []
-        for tg in ready[:slots_to_use]:
-            # Skip if already assigned
-            if tg.id in self.assignments:
-                continue
-
+        unassigned_ready = [tg for tg in ready if tg.id not in self.assignments]
+        for tg in unassigned_ready[:slots_to_use]:
             assignment = await self._spawn_ace_for_task(tg.id, tg.title, tg.description)
             if assignment is not None:
                 new_assignments.append(assignment)

--- a/tests/unit/test_leader_orchestrator.py
+++ b/tests/unit/test_leader_orchestrator.py
@@ -34,6 +34,18 @@ def event_bus() -> EventBus:
     return EventBus()
 
 
+@pytest.fixture(autouse=True)
+def reset_global_ace_counter():
+    """Reset the global Ace counter and lock before each test for isolation."""
+    import atc.leader.orchestrator as orch_mod
+
+    orch_mod._GLOBAL_ACTIVE_ACES = 0
+    orch_mod._GLOBAL_LOCK = None
+    yield
+    orch_mod._GLOBAL_ACTIVE_ACES = 0
+    orch_mod._GLOBAL_LOCK = None
+
+
 @pytest.fixture
 async def project_with_leader(db):
     """Create a project and leader, return (project, leader)."""
@@ -141,7 +153,7 @@ class TestSpawnAces:
         db,
         orchestrator: LeaderOrchestrator,
     ) -> None:
-        orchestrator._max_concurrent_aces = 2
+        orchestrator._governor._max = 2
 
         for i in range(5):
             await create_task_graph(db, orchestrator.project_id, f"Task {i}")
@@ -253,6 +265,48 @@ class TestSpawnAces:
         # Second call -- task is already in self.assignments, so skipped
         assignments2 = await orchestrator.spawn_aces_for_ready_tasks()
         assert len(assignments2) == 0
+
+    async def test_counter_not_inflated_for_already_assigned(
+        self,
+        mock_create: AsyncMock,
+        db,
+        orchestrator: LeaderOrchestrator,
+    ) -> None:
+        """Pre-reserved slots must not be counted for already-assigned tasks."""
+        import atc.leader.orchestrator as orch_mod
+
+        tg1 = await create_task_graph(db, orchestrator.project_id, "Task A")
+        await create_task_graph(db, orchestrator.project_id, "Task B")
+
+        # Pre-assign the first task
+        orchestrator.assignments[tg1.id] = AceAssignment(
+            ace_session_id="existing-ace",
+            task_graph_id=tg1.id,
+            task_title="Task A",
+        )
+
+        assignments = await orchestrator.spawn_aces_for_ready_tasks()
+
+        assert len(assignments) == 1
+        assert assignments[0].task_title == "Task B"
+        # Counter should reflect exactly 1 active Ace, not 2
+        assert orch_mod._GLOBAL_ACTIVE_ACES == 1
+
+    async def test_counter_decremented_on_spawn_failure(
+        self,
+        mock_create: AsyncMock,
+        db,
+        orchestrator: LeaderOrchestrator,
+    ) -> None:
+        """Counter must return to zero after a failed spawn."""
+        import atc.leader.orchestrator as orch_mod
+
+        mock_create.side_effect = RuntimeError("tmux exploded")
+        await create_task_graph(db, orchestrator.project_id, "Task A")
+
+        assignments = await orchestrator.spawn_aces_for_ready_tasks()
+        assert len(assignments) == 0
+        assert orch_mod._GLOBAL_ACTIVE_ACES == 0
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- **Counter inflation bug**: `spawn_aces_for_ready_tasks` pre-filtered `slots_to_use` to exclude already-assigned tasks, but then looped over `ready[:slots_to_use]` (unfiltered) and used `continue` when hitting an already-assigned task — without decrementing the pre-incremented global counter. Fixed by pre-filtering `ready` to `unassigned_ready` before slicing, so the counter and the loop are always in sync.
- **Test isolation bug**: `_GLOBAL_ACTIVE_ACES` was never reset between tests, causing `test_skips_tasks_with_unmet_deps` and `test_respects_max_concurrent_limit` to fail when run as a suite (counter leaked from earlier spawns exhausted all slots). Fixed with an `autouse` fixture that resets the counter and lock before/after each test.
- **Dead field bug**: `test_respects_max_concurrent_limit` set `orchestrator._max_concurrent_aces = 2`, which is an unused dataclass field — the `ResourceGovernor` has its own `_max`. Fixed to set `orchestrator._governor._max` directly.

## Test plan

- [ ] `pytest tests/unit/test_leader_orchestrator.py` — all 27 tests pass
- [ ] New `test_counter_not_inflated_for_already_assigned`: verifies counter stays at 1 (not 2) when one of two ready tasks is already assigned
- [ ] New `test_counter_decremented_on_spawn_failure`: verifies counter returns to 0 after a failed spawn

🤖 Generated with [Claude Code](https://claude.com/claude-code)