### PR TITLE
fix: auto-scroll Tower terminal to bottom on new output

### DIFF
--- a/frontend/src/hooks/useTerminal.ts
+++ b/frontend/src/hooks/useTerminal.ts
@@ -174,7 +174,9 @@ export function useTerminal({ channel, enabled = true }: UseTerminalOptions) {
             // Buffer writes if terminal isn't opened yet to avoid xterm.js
             // "dimensions" error from syncScrollArea on unopened terminals.
             if (termOpenRef.current && termRef.current) {
-              termRef.current.write(transformed);
+              termRef.current.write(transformed, () => {
+                termRef.current?.scrollToBottom();
+              });
             } else {
               pendingWritesRef.current.push(transformed);
             }
@@ -278,6 +280,7 @@ export function useTerminal({ channel, enabled = true }: UseTerminalOptions) {
               termRef.current.write(data);
             }
             pendingWritesRef.current = [];
+            termRef.current?.scrollToBottom();
           }
         });
       });


### PR DESCRIPTION
## Problem
Tower terminal was scrolling to the top on load and staying there — newest output was off-screen unless you manually scrolled down.

## Root Cause
`xterm.js` does **not** auto-scroll when new data is written — it only follows new output if the viewport is already at the bottom. The `useTerminal` hook was calling `term.write(data)` without any scroll step, so after the initial backlog of terminal history was flushed, the viewport stayed at position 0.

## Fix
- Pass a write callback to `term.write()` that calls `term.scrollToBottom()` after each incoming PTY chunk
- Also call `scrollToBottom()` after flushing the pending-writes buffer on terminal mount

Both touch points in `useTerminal.ts` — no other files changed.