### PR TITLE
fix: global concurrent session limit (#127)

### DIFF
--- a/src/atc/api/routers/tower.py
+++ b/src/atc/api/routers/tower.py
@@ -51,6 +51,8 @@ class TowerStatusResponse(BaseModel):
     current_session_id: str | None
     leader_session_id: str | None
     output_line_count: int
+    active_ace_count: int
+    max_aces: int
 
 
 class TowerProgressResponse(BaseModel):
@@ -109,6 +111,8 @@ async def tower_status(request: Request) -> TowerStatusResponse:
         current_session_id=controller_status["current_session_id"],
         leader_session_id=controller_status.get("leader_session_id"),
         output_line_count=controller_status.get("output_line_count", 0),
+        active_ace_count=controller_status.get("active_ace_count", 0),
+        max_aces=controller_status.get("max_aces", 5),
     )
 
 

--- a/src/atc/config.py
+++ b/src/atc/config.py
@@ -24,6 +24,7 @@ class DatabaseConfig(BaseModel):
 class TowerConfig(BaseModel):
     enabled: bool = True
     auto_start: bool = False
+    max_concurrent_aces: int = 5
 
 
 class ResourceMonitorConfig(BaseModel):

--- a/src/atc/tower/controller.py
+++ b/src/atc/tower/controller.py
@@ -23,6 +23,7 @@ import json
 import logging
 from typing import TYPE_CHECKING, Any
 
+from atc.config import load_settings
 from atc.leader.context_package import build_context_package
 from atc.leader.leader import send_leader_message, start_leader, stop_leader
 from atc.state import db as db_ops
@@ -69,6 +70,7 @@ class TowerController:
         db: aiosqlite.Connection,
         event_bus: EventBus,
         ws_hub: WsHub | None = None,
+        max_concurrent_aces: int | None = None,
     ) -> None:
         self._db = db
         self._event_bus = event_bus
@@ -88,9 +90,19 @@ class TowerController:
         # Budget constraint flag — set when budget_warning fires, cleared on budget_ok
         self._budget_constrained = False
 
+        # Concurrent session limit — counts active leader + ace sessions
+        if max_concurrent_aces is None:
+            try:
+                max_concurrent_aces = load_settings().tower.max_concurrent_aces
+            except Exception:
+                max_concurrent_aces = 5
+        self._max_concurrent_aces: int = max_concurrent_aces
+        self._active_ace_count: int = 0
+
         # Subscribe to leader session events for monitoring
         self._event_bus.subscribe("session_status_changed", self._on_session_status_changed)
         self._event_bus.subscribe("pty_output", self._on_leader_output)
+        self._event_bus.subscribe("session_created", self._on_session_created)
 
         # Subscribe to budget events for proactive slowdown
         self._event_bus.subscribe("budget_warning", self._on_budget_warning)
@@ -231,6 +243,15 @@ class TowerController:
                 "Skipping new Ace spawn — budget constrained (project %s)", project_id
             )
             raise BudgetConstrainedError(project_id)
+
+        if self._active_ace_count >= self._max_concurrent_aces:
+            logger.warning(
+                "Skipping new session spawn — at capacity (active=%d, max=%d, project=%s)",
+                self._active_ace_count,
+                self._max_concurrent_aces,
+                project_id,
+            )
+            raise TowerBusyError(self._state, project_id, detail="at capacity")
 
         # Reset to idle first if coming from complete/error
         if self._state in (TowerState.COMPLETE, TowerState.ERROR):
@@ -421,6 +442,8 @@ class TowerController:
             "current_session_id": self._current_session_id,
             "leader_session_id": self._leader_session_id,
             "output_line_count": len(self._leader_output_lines),
+            "active_ace_count": self._active_ace_count,
+            "max_aces": self._max_concurrent_aces,
         }
 
     async def send_message(self, message: str) -> None:
@@ -668,6 +691,18 @@ class TowerController:
                     },
                 )
 
+    async def _on_session_created(self, data: dict[str, Any]) -> None:
+        """Increment active ace counter when a leader or ace session is created."""
+        session_type = data.get("session_type", "")
+        if session_type in ("leader", "ace"):
+            self._active_ace_count += 1
+            logger.debug(
+                "Session created (type=%s) — active_ace_count=%d/%d",
+                session_type,
+                self._active_ace_count,
+                self._max_concurrent_aces,
+            )
+
     async def _on_budget_warning(self, data: dict[str, Any]) -> None:
         """Handle budget_warning event — pause new Ace spawns."""
         project_id = data.get("project_id", "unknown")
@@ -682,9 +717,30 @@ class TowerController:
         logger.info("Budget back below threshold — resuming Ace spawns")
 
     async def _on_session_status_changed(self, data: dict[str, Any]) -> None:
-        """Monitor Leader session status changes for error detection."""
+        """Monitor Leader session status changes for error detection and counter updates."""
         session_id = data.get("session_id")
         new_status = data.get("new_status")
+
+        # Decrement active counter when any leader/ace session reaches a terminal status
+        _TERMINAL_STATUSES = {"disconnected", "error", "completed", "cancelled"}
+        if new_status in _TERMINAL_STATUSES:
+            # Look up session type to decide if this counts against our limit
+            try:
+                cursor = await self._db.execute(
+                    "SELECT session_type FROM sessions WHERE id = ?", (session_id,)
+                )
+                row = await cursor.fetchone()
+                if row and row[0] in ("leader", "ace"):
+                    self._active_ace_count = max(0, self._active_ace_count - 1)
+                    logger.debug(
+                        "Session %s terminal (status=%s) — active_ace_count=%d/%d",
+                        session_id,
+                        new_status,
+                        self._active_ace_count,
+                        self._max_concurrent_aces,
+                    )
+            except Exception:
+                logger.debug("Could not look up session type for %s during status change", session_id)
 
         if session_id != self._leader_session_id:
             return
@@ -721,12 +777,14 @@ class InvalidTowerTransitionError(Exception):
 class TowerBusyError(Exception):
     """Raised when a goal is submitted while the tower is busy."""
 
-    def __init__(self, state: TowerState, project_id: str) -> None:
+    def __init__(self, state: TowerState, project_id: str, detail: str | None = None) -> None:
         self.state = state
         self.project_id = project_id
-        super().__init__(
-            f"Tower is busy (state={state.value}), cannot accept goal for {project_id}"
-        )
+        self.detail = detail
+        msg = f"Tower is busy (state={state.value}), cannot accept goal for {project_id}"
+        if detail:
+            msg = f"{msg}: {detail}"
+        super().__init__(msg)
 
 
 class BudgetConstrainedError(Exception):

--- a/tests/unit/test_session_limit.py
+++ b/tests/unit/test_session_limit.py
@@ -1,0 +1,151 @@
+"""Tests for global concurrent session limit (Issue #127)."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from atc.core.events import EventBus
+from atc.state.db import (
+    _SCHEMA_SQL,
+    create_leader,
+    create_project,
+    create_session,
+    get_connection,
+    run_migrations,
+)
+from atc.tower.controller import (
+    TowerBusyError,
+    TowerController,
+    TowerState,
+)
+
+
+@pytest.fixture
+async def db():
+    """In-memory database with schema applied."""
+    await run_migrations(":memory:")
+    async with get_connection(":memory:") as conn:
+        await conn.executescript(_SCHEMA_SQL)
+        await conn.commit()
+        yield conn
+
+
+@pytest.fixture
+def event_bus() -> EventBus:
+    return EventBus()
+
+
+@pytest.mark.asyncio
+class TestSessionLimit:
+    def _make_tower(self, db, event_bus: EventBus, max_aces: int = 2) -> TowerController:
+        return TowerController(db, event_bus, max_concurrent_aces=max_aces)
+
+    async def test_status_exposes_active_ace_count_and_max_aces(
+        self, db, event_bus: EventBus
+    ) -> None:
+        tower = self._make_tower(db, event_bus, max_aces=3)
+        status = tower.get_status()
+        assert status["active_ace_count"] == 0
+        assert status["max_aces"] == 3
+
+    async def test_session_created_increments_counter_for_leader(
+        self, db, event_bus: EventBus
+    ) -> None:
+        tower = self._make_tower(db, event_bus)
+        await event_bus.publish(
+            "session_created",
+            {"session_id": "s1", "session_type": "leader", "project_id": "p1"},
+        )
+        assert tower._active_ace_count == 1
+
+    async def test_session_created_increments_counter_for_ace(
+        self, db, event_bus: EventBus
+    ) -> None:
+        tower = self._make_tower(db, event_bus)
+        await event_bus.publish(
+            "session_created",
+            {"session_id": "s1", "session_type": "ace", "project_id": "p1"},
+        )
+        assert tower._active_ace_count == 1
+
+    async def test_session_created_ignores_tower_type(
+        self, db, event_bus: EventBus
+    ) -> None:
+        tower = self._make_tower(db, event_bus)
+        await event_bus.publish(
+            "session_created",
+            {"session_id": "s1", "session_type": "tower", "project_id": "p1"},
+        )
+        assert tower._active_ace_count == 0
+
+    async def test_terminal_status_decrements_counter(self, db, event_bus: EventBus) -> None:
+        """When a leader/ace session reaches a terminal status, counter decrements."""
+        import uuid
+
+        project = await create_project(db, "test-proj")
+        sess = await create_session(
+            db,
+            project_id=project.id,
+            session_type="leader",
+            name="leader-test",
+            status="working",
+        )
+        await db.commit()
+
+        tower = self._make_tower(db, event_bus)
+        tower._active_ace_count = 2
+
+        await event_bus.publish(
+            "session_status_changed",
+            {"session_id": sess.id, "new_status": "disconnected"},
+        )
+        assert tower._active_ace_count == 1
+
+    async def test_counter_does_not_go_below_zero(self, db, event_bus: EventBus) -> None:
+        project = await create_project(db, "test-proj")
+        sess = await create_session(
+            db,
+            project_id=project.id,
+            session_type="ace",
+            name="ace-test",
+            status="working",
+        )
+        await db.commit()
+
+        tower = self._make_tower(db, event_bus)
+        tower._active_ace_count = 0
+
+        await event_bus.publish(
+            "session_status_changed",
+            {"session_id": sess.id, "new_status": "error"},
+        )
+        assert tower._active_ace_count == 0
+
+    @patch("atc.tower.controller.start_leader", new_callable=AsyncMock, return_value="l1")
+    async def test_submit_goal_raises_when_at_capacity(
+        self, mock_start: AsyncMock, db, event_bus: EventBus
+    ) -> None:
+        project = await create_project(db, "test-proj")
+        await create_leader(db, project.id)
+        tower = self._make_tower(db, event_bus, max_aces=2)
+        tower._active_ace_count = 2  # already at limit
+
+        with pytest.raises(TowerBusyError) as exc_info:
+            await tower.submit_goal(project.id, "Should be blocked")
+
+        assert "at capacity" in str(exc_info.value)
+        mock_start.assert_not_called()
+
+    @patch("atc.tower.controller.start_leader", new_callable=AsyncMock, return_value="l1")
+    async def test_submit_goal_succeeds_when_below_capacity(
+        self, mock_start: AsyncMock, db, event_bus: EventBus
+    ) -> None:
+        project = await create_project(db, "test-proj")
+        await create_leader(db, project.id)
+        tower = self._make_tower(db, event_bus, max_aces=5)
+        tower._active_ace_count = 3  # below limit
+
+        result = await tower.submit_goal(project.id, "Should succeed")
+        assert result["status"] == "accepted"


### PR DESCRIPTION
## Summary
- Adds `max_concurrent_aces: int = 5` to `TowerConfig` in `config.py`
- `TowerController` tracks active leader + ace sessions via `session_created` / `session_status_changed` events; never goes below 0
- `submit_goal` raises `TowerBusyError` (→ 409) with `detail='at capacity'` when `_active_ace_count >= _max_concurrent_aces`
- `/api/tower/status` now exposes `active_ace_count` and `max_aces`

## Test plan
- [ ] `pytest tests/unit/test_session_limit.py` — 8 tests pass
- [ ] `pytest tests/unit/test_tower_controller.py` — 33 existing tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)