### PR TITLE
fix: cost tracking returns null + oauth_mode flag for OAuth tokens (#128)

### DIFF
--- a/src/atc/api/routers/usage.py
+++ b/src/atc/api/routers/usage.py
@@ -11,6 +11,7 @@ Usage routes:
 from __future__ import annotations
 
 import logging
+import os
 from datetime import UTC, datetime, timedelta
 
 from fastapi import APIRouter, Request
@@ -67,10 +68,21 @@ class GitHubApiDataPoint(BaseModel):
 
 
 class UsageSummaryResponse(BaseModel):
-    today_cost: float
-    month_cost: float
+    today_cost: float | None
+    month_cost: float | None
     today_tokens: int
     month_tokens: int
+    oauth_mode: bool = False
+    message: str | None = None
+
+
+_OAUTH_KEY_PREFIXES = ("oat", "claude_")
+
+
+def _is_oauth_mode() -> bool:
+    """Return True if the Anthropic API key is an OAuth token, not a real API key."""
+    api_key = os.environ.get("ANTHROPIC_API_KEY", "")
+    return any(api_key.startswith(prefix) for prefix in _OAUTH_KEY_PREFIXES)
 
 
 # ---------------------------------------------------------------------------
@@ -81,6 +93,19 @@ class UsageSummaryResponse(BaseModel):
 @router.get("/summary", response_model=UsageSummaryResponse)
 async def get_usage_summary(request: Request) -> UsageSummaryResponse:
     """Aggregate cost and token totals across all projects for today and this month."""
+    if _is_oauth_mode():
+        return UsageSummaryResponse(
+            today_cost=None,
+            month_cost=None,
+            today_tokens=0,
+            month_tokens=0,
+            oauth_mode=True,
+            message=(
+                "Cost tracking unavailable — using OAuth authentication. "
+                "Add an Anthropic API key to enable."
+            ),
+        )
+
     db = request.app.state.db
     today = datetime.now(UTC).strftime("%Y-%m-%d")
     month_start = datetime.now(UTC).strftime("%Y-%m-01")
@@ -101,7 +126,7 @@ async def get_usage_summary(request: Request) -> UsageSummaryResponse:
     row = await cursor.fetchone()
     if row is None:
         return UsageSummaryResponse(
-            today_cost=0.0, month_cost=0.0, today_tokens=0, month_tokens=0
+            today_cost=0.0, month_cost=0.0, today_tokens=0, month_tokens=0, oauth_mode=False
         )
     return UsageSummaryResponse(
         today_cost=float(row[0]),

--- a/tests/unit/test_usage_oauth.py
+++ b/tests/unit/test_usage_oauth.py
@@ -1,0 +1,51 @@
+"""Tests for OAuth-mode cost tracking (Issue #128)."""
+
+from __future__ import annotations
+
+import pytest
+
+from atc.api.routers.usage import UsageSummaryResponse, _is_oauth_mode
+
+
+class TestIsOAuthMode:
+    def test_regular_api_key_is_not_oauth(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-abc123")
+        assert _is_oauth_mode() is False
+
+    def test_oat_prefix_is_oauth(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "oat01_sometoken")
+        assert _is_oauth_mode() is True
+
+    def test_claude_prefix_is_oauth(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "claude_abc123")
+        assert _is_oauth_mode() is True
+
+    def test_empty_key_is_not_oauth(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+        assert _is_oauth_mode() is False
+
+
+class TestUsageSummaryResponseModel:
+    def test_accepts_null_costs_in_oauth_mode(self) -> None:
+        resp = UsageSummaryResponse(
+            today_cost=None,
+            month_cost=None,
+            today_tokens=0,
+            month_tokens=0,
+            oauth_mode=True,
+            message="Cost tracking unavailable — using OAuth authentication. Add an Anthropic API key to enable.",
+        )
+        assert resp.today_cost is None
+        assert resp.month_cost is None
+        assert resp.oauth_mode is True
+        assert resp.message is not None
+
+    def test_defaults_oauth_mode_to_false(self) -> None:
+        resp = UsageSummaryResponse(
+            today_cost=1.23,
+            month_cost=4.56,
+            today_tokens=100,
+            month_tokens=500,
+        )
+        assert resp.oauth_mode is False
+        assert resp.message is None


### PR DESCRIPTION
## Summary
- Detects OAuth mode by checking if `ANTHROPIC_API_KEY` starts with `'oat'` or `'claude_'`
- When in OAuth mode, `/api/usage/summary` immediately returns `{today_cost: null, month_cost: null, oauth_mode: true, message: '...'}` without touching the billing API
- `UsageSummaryResponse` cost fields are now `float | None` to support null in OAuth mode

## Test plan
- [ ] `pytest tests/unit/test_usage_oauth.py` — 6 tests pass
- [ ] With `ANTHROPIC_API_KEY=oat01_foo`, GET /api/usage/summary returns `oauth_mode: true` and null costs

🤖 Generated with [Claude Code](https://claude.com/claude-code)