### PR TITLE
fix: startup cleanup of orphaned sessions and staging dirs (#129)

### DIFF
--- a/src/atc/api/app.py
+++ b/src/atc/api/app.py
@@ -224,6 +224,15 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
 
     ws_hub.on_heartbeat(_on_ws_heartbeat)
 
+    # 6b. Run startup cleanup — remove orphaned sessions and staging dirs
+    from atc.core.cleanup import run_startup_cleanup
+
+    try:
+        cleanup_totals = await run_startup_cleanup(db)
+        logger.info("Startup cleanup: %s", cleanup_totals)
+    except Exception:
+        logger.exception("Startup cleanup failed — continuing")
+
     # 7. Reconnect sessions that were active at last shutdown
     from atc.session.reconnect import reconnect_all
     from atc.state import db as db_ops
@@ -436,6 +445,7 @@ def create_app(settings: Settings | None = None) -> FastAPI:
         memory,
         projects,
         qa,
+        system,
         task_graphs,
         tasks,
         tower,
@@ -458,6 +468,7 @@ def create_app(settings: Settings | None = None) -> FastAPI:
     app.include_router(memory.router, prefix="/api/memory", tags=["memory"])
     app.include_router(backup.router, prefix="/api/backup", tags=["backup"])
     app.include_router(qa.router, prefix="/api/qa", tags=["qa"])
+    app.include_router(system.router, prefix="/api/system", tags=["system"])
 
     @app.get("/api/health")
     async def health() -> dict[str, object]:

--- a/src/atc/api/routers/system.py
+++ b/src/atc/api/routers/system.py
@@ -1,0 +1,32 @@
+"""System maintenance endpoints.
+
+Routes:
+  GET /api/system/cleanup  → run orphan session + staging dir cleanup
+"""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Request
+from pydantic import BaseModel
+
+from atc.core.cleanup import run_startup_cleanup
+
+router = APIRouter()
+
+
+class CleanupResult(BaseModel):
+    ace: int
+    manager: int
+    tower: int
+
+
+@router.get("/cleanup", response_model=CleanupResult)
+async def trigger_cleanup(request: Request) -> CleanupResult:
+    """Manually trigger orphan session and staging directory cleanup.
+
+    Runs the same cleanup logic as startup: deletes stale ace/manager/tower
+    sessions from the DB and removes their /tmp/atc-agents/ directories.
+    """
+    db = request.app.state.db
+    totals = await run_startup_cleanup(db)
+    return CleanupResult(**totals)

--- a/src/atc/core/cleanup.py
+++ b/src/atc/core/cleanup.py
@@ -1,0 +1,114 @@
+"""Startup and on-demand cleanup of orphaned sessions and staging directories.
+
+Prevents unbounded accumulation of DB rows and /tmp/atc-agents/ directories
+across server restarts and extended E2E test sessions.
+"""
+
+from __future__ import annotations
+
+import logging
+import shutil
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import aiosqlite
+
+logger = logging.getLogger(__name__)
+
+_STAGING_ROOT = Path("/tmp/atc-agents")
+
+# Statuses that indicate a session is fully done and safe to delete
+_TERMINAL_STATUSES = ("disconnected", "error", "completed", "cancelled")
+
+# Number of tower sessions to retain per project
+_KEEP_TOWER_SESSIONS = 5
+
+# Age threshold (days) for terminal ace sessions
+_ACE_MAX_AGE_DAYS = 7
+
+
+def _remove_staging_dir(session_id: str) -> None:
+    """Remove /tmp/atc-agents/<session_id>/ if it exists."""
+    staging = _STAGING_ROOT / session_id
+    if staging.exists():
+        try:
+            shutil.rmtree(staging)
+            logger.info("Removed staging dir %s", staging)
+        except OSError as exc:
+            logger.warning("Failed to remove staging dir %s: %s", staging, exc)
+
+
+async def run_startup_cleanup(db: "aiosqlite.Connection") -> dict[str, int]:
+    """Remove orphaned sessions and staging dirs on startup.
+
+    Steps:
+    1. Delete ace sessions older than 7 days in terminal statuses.
+    2. Delete manager sessions that are disconnected and not referenced by any
+       active leader.
+    3. Keep only the 5 most recent tower sessions per project; delete the rest.
+    4. For every deleted session, remove /tmp/atc-agents/<session_id>/.
+
+    Returns a summary dict with counts of deleted sessions per category.
+    """
+    totals: dict[str, int] = {"ace": 0, "manager": 0, "tower": 0}
+
+    # ── Step 1: stale ace sessions ──────────────────────────────────────────
+    placeholders = ",".join("?" * len(_TERMINAL_STATUSES))
+    cursor = await db.execute(
+        f"""SELECT id FROM sessions
+            WHERE session_type = 'ace'
+              AND status IN ({placeholders})
+              AND created_at < datetime('now', '-{_ACE_MAX_AGE_DAYS} days')""",
+        _TERMINAL_STATUSES,
+    )
+    ace_rows = await cursor.fetchall()
+    for (session_id,) in ace_rows:
+        await db.execute("DELETE FROM sessions WHERE id = ?", (session_id,))
+        _remove_staging_dir(session_id)
+        totals["ace"] += 1
+
+    # ── Step 2: orphaned manager sessions ──────────────────────────────────
+    # A manager session is orphaned when it is disconnected AND no leader row
+    # holds a reference to its session_id as an active session.
+    cursor = await db.execute(
+        """SELECT s.id FROM sessions s
+           WHERE s.session_type = 'manager'
+             AND s.status = 'disconnected'
+             AND NOT EXISTS (
+                 SELECT 1 FROM leaders l
+                 WHERE l.session_id = s.id
+                   AND l.status NOT IN ('idle', 'error')
+             )"""
+    )
+    manager_rows = await cursor.fetchall()
+    for (session_id,) in manager_rows:
+        await db.execute("DELETE FROM sessions WHERE id = ?", (session_id,))
+        _remove_staging_dir(session_id)
+        totals["manager"] += 1
+
+    # ── Step 3: excess tower sessions (keep 5 most recent per project) ──────
+    cursor = await db.execute("SELECT DISTINCT project_id FROM sessions WHERE session_type = 'tower'")
+    project_rows = await cursor.fetchall()
+    for (project_id,) in project_rows:
+        cursor2 = await db.execute(
+            """SELECT id FROM sessions
+               WHERE session_type = 'tower' AND project_id = ?
+               ORDER BY created_at DESC""",
+            (project_id,),
+        )
+        tower_rows = await cursor2.fetchall()
+        for (session_id,) in tower_rows[_KEEP_TOWER_SESSIONS:]:
+            await db.execute("DELETE FROM sessions WHERE id = ?", (session_id,))
+            _remove_staging_dir(session_id)
+            totals["tower"] += 1
+
+    await db.commit()
+
+    logger.info(
+        "Startup cleanup complete — deleted ace=%d manager=%d tower=%d sessions",
+        totals["ace"],
+        totals["manager"],
+        totals["tower"],
+    )
+    return totals

--- a/tests/unit/test_cleanup.py
+++ b/tests/unit/test_cleanup.py
@@ -1,0 +1,143 @@
+"""Tests for orphan session + staging dir cleanup (Issue #129)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from atc.state.db import (
+    _SCHEMA_SQL,
+    create_project,
+    create_session,
+    get_connection,
+    run_migrations,
+)
+from atc.core.cleanup import run_startup_cleanup
+
+
+@pytest.fixture
+async def db():
+    """In-memory database with schema applied."""
+    await run_migrations(":memory:")
+    async with get_connection(":memory:") as conn:
+        await conn.executescript(_SCHEMA_SQL)
+        await conn.commit()
+        yield conn
+
+
+async def _count_sessions(db, session_type: str | None = None) -> int:
+    if session_type:
+        cursor = await db.execute(
+            "SELECT COUNT(*) FROM sessions WHERE session_type = ?", (session_type,)
+        )
+    else:
+        cursor = await db.execute("SELECT COUNT(*) FROM sessions")
+    row = await cursor.fetchone()
+    return row[0]
+
+
+@pytest.mark.asyncio
+async def test_deletes_old_ace_sessions_in_terminal_status(db) -> None:
+    """Ace sessions older than 7 days in terminal status are deleted."""
+    project = await create_project(db, "proj")
+
+    # Old ace session in terminal status
+    await db.execute(
+        "INSERT INTO sessions (id, project_id, session_type, name, status, created_at, updated_at)"
+        " VALUES ('old-ace', ?, 'ace', 'old', 'disconnected',"
+        " datetime('now', '-8 days'), datetime('now', '-8 days'))",
+        (project.id,),
+    )
+    # Recent ace session — should be kept
+    await create_session(db, project_id=project.id, session_type="ace", name="new", status="disconnected")
+    await db.commit()
+
+    totals = await run_startup_cleanup(db)
+
+    assert totals["ace"] == 1
+    assert await _count_sessions(db, "ace") == 1  # only the recent one remains
+
+
+@pytest.mark.asyncio
+async def test_keeps_active_ace_sessions(db) -> None:
+    """Ace sessions that are recent or not in terminal status are kept."""
+    project = await create_project(db, "proj")
+    await create_session(db, project_id=project.id, session_type="ace", name="active", status="working")
+    await db.commit()
+
+    totals = await run_startup_cleanup(db)
+
+    assert totals["ace"] == 0
+    assert await _count_sessions(db, "ace") == 1
+
+
+@pytest.mark.asyncio
+async def test_deletes_orphaned_manager_sessions(db) -> None:
+    """Disconnected manager sessions not referenced by any active leader are deleted."""
+    project = await create_project(db, "proj")
+    sess = await create_session(
+        db, project_id=project.id, session_type="manager", name="mgr", status="disconnected"
+    )
+    await db.commit()
+
+    totals = await run_startup_cleanup(db)
+
+    assert totals["manager"] == 1
+    assert await _count_sessions(db, "manager") == 0
+
+
+@pytest.mark.asyncio
+async def test_keeps_excess_tower_sessions_up_to_limit(db) -> None:
+    """Only keeps 5 most recent tower sessions per project; deletes the rest."""
+    project = await create_project(db, "proj")
+
+    for i in range(8):
+        await db.execute(
+            "INSERT INTO sessions (id, project_id, session_type, name, status, created_at, updated_at)"
+            " VALUES (?, ?, 'tower', 'tower', 'disconnected',"
+            " datetime('now', ? || ' seconds'), datetime('now'))",
+            (f"tower-{i}", project.id, f"-{100 - i}"),
+        )
+    await db.commit()
+
+    totals = await run_startup_cleanup(db)
+
+    assert totals["tower"] == 3
+    assert await _count_sessions(db, "tower") == 5
+
+
+@pytest.mark.asyncio
+async def test_removes_staging_dir_for_deleted_sessions(db, tmp_path: Path) -> None:
+    """Staging dirs are removed when their session is deleted."""
+    project = await create_project(db, "proj")
+
+    # Old ace session with a staging dir
+    staging = tmp_path / "old-ace"
+    staging.mkdir()
+    (staging / "CLAUDE.md").write_text("# test\n")
+
+    await db.execute(
+        "INSERT INTO sessions (id, project_id, session_type, name, status, created_at, updated_at)"
+        " VALUES ('old-ace', ?, 'ace', 'old', 'error',"
+        " datetime('now', '-8 days'), datetime('now', '-8 days'))",
+        (project.id,),
+    )
+    await db.commit()
+
+    with patch("atc.core.cleanup._STAGING_ROOT", tmp_path):
+        await run_startup_cleanup(db)
+
+    assert not staging.exists()
+
+
+@pytest.mark.asyncio
+async def test_cleanup_returns_zero_counts_when_nothing_to_clean(db) -> None:
+    project = await create_project(db, "proj")
+    await create_session(db, project_id=project.id, session_type="ace", name="a", status="working")
+    await db.commit()
+
+    totals = await run_startup_cleanup(db)
+
+    assert totals == {"ace": 0, "manager": 0, "tower": 0}


### PR DESCRIPTION
## Summary
- Creates `src/atc/core/cleanup.py` with `run_startup_cleanup(db)`:
  1. Deletes ace sessions **older than 7 days** with status in `(disconnected, error, completed, cancelled)`
  2. Deletes **disconnected manager sessions** not referenced by any active leader
  3. Keeps only **5 most recent tower sessions per project**, deletes older ones
  4. Removes `/tmp/atc-agents/<session_id>/` for every deleted session
- Wires `run_startup_cleanup` into app lifespan (step 6b, after migrations, before reconnect)
- Adds `GET /api/system/cleanup` endpoint for manual on-demand cleanup

## Test plan
- [ ] `pytest tests/unit/test_cleanup.py` — 6 tests pass
- [ ] After restart, check `SELECT COUNT(*) FROM sessions` drops from 33+

🤖 Generated with [Claude Code](https://claude.com/claude-code)