### PR TITLE
feat: startup smoke test for pane spawn validation (#130)

### DIFF
--- a/src/atc/api/app.py
+++ b/src/atc/api/app.py
@@ -233,6 +233,25 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
     except Exception:
         logger.exception("Startup cleanup failed — continuing")
 
+    # 6c. Run startup smoke test — validates pane spawn + instruction delivery
+    import time as _time
+
+    app.state.startup_at = _time.monotonic()
+    from atc.core.health import HealthResult as _HealthResult, run_startup_smoke_test
+
+    try:
+        health = await asyncio.wait_for(run_startup_smoke_test(), timeout=15.0)
+    except asyncio.TimeoutError:
+        health = _HealthResult(ok=False, message="smoke test timed out after 15s", duration_ms=15000.0)
+    except Exception as _exc:
+        health = _HealthResult(ok=False, message=f"smoke test error: {_exc}", duration_ms=0.0)
+
+    app.state.health = health
+    if health.ok:
+        logger.info("Startup smoke test passed (%.0fms)", health.duration_ms)
+    else:
+        logger.warning("Startup smoke test failed: %s (%.0fms)", health.message, health.duration_ms)
+
     # 7. Reconnect sessions that were active at last shutdown
     from atc.session.reconnect import reconnect_all
     from atc.state import db as db_ops
@@ -471,8 +490,18 @@ def create_app(settings: Settings | None = None) -> FastAPI:
     app.include_router(system.router, prefix="/api/system", tags=["system"])
 
     @app.get("/api/health")
-    async def health() -> dict[str, object]:
-        return {"ok": True, "version": __version__}
+    async def health(request: Request) -> dict[str, object]:
+        smoke: object = getattr(request.app.state, "health", None)
+        if smoke is None:
+            return {"status": "ok", "message": "startup in progress", "duration_ms": 0.0, "version": __version__}
+        from atc.core.health import HealthResult as _HR
+        assert isinstance(smoke, _HR)
+        return {
+            "status": "ok" if smoke.ok else "degraded",
+            "message": smoke.message,
+            "duration_ms": smoke.duration_ms,
+            "version": __version__,
+        }
 
     @app.websocket("/ws")
     async def websocket_endpoint(ws: WebSocket) -> None:

--- a/src/atc/core/health.py
+++ b/src/atc/core/health.py
@@ -1,0 +1,84 @@
+"""Startup smoke test — validates pane spawn + instruction delivery works."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+from dataclasses import dataclass
+
+from atc.session.ace import (
+    ATC_TMUX_SESSION,
+    _capture_pane,
+    _ensure_tmux_session,
+    _kill_pane,
+    _spawn_pane,
+    _tmux_run,
+)
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class HealthResult:
+    """Result of the startup smoke test."""
+
+    ok: bool
+    message: str
+    duration_ms: float
+
+
+async def run_startup_smoke_test() -> HealthResult:
+    """Spawn a temp tmux pane running bash, send echo ATC_HEALTH_OK, wait for output.
+
+    Returns a HealthResult indicating whether pane spawn and instruction delivery
+    work correctly. Kills the pane regardless of outcome.
+    """
+    start = time.monotonic()
+    pane_id: str | None = None
+
+    try:
+        await _ensure_tmux_session(ATC_TMUX_SESSION)
+        pane_id = await _spawn_pane(ATC_TMUX_SESSION, "bash")
+
+        # Give bash a moment to start
+        await asyncio.sleep(0.5)
+
+        # Send the health check command
+        await _tmux_run("send-keys", "-t", pane_id, "echo ATC_HEALTH_OK", "Enter")
+
+        # Wait up to 10s for ATC_HEALTH_OK in pane output
+        deadline = time.monotonic() + 10.0
+        found = False
+        while time.monotonic() < deadline:
+            try:
+                output = await _capture_pane(pane_id)
+                if "ATC_HEALTH_OK" in output:
+                    found = True
+                    break
+            except RuntimeError:
+                pass
+            await asyncio.sleep(0.5)
+
+        duration_ms = (time.monotonic() - start) * 1000
+        if found:
+            return HealthResult(ok=True, message="smoke test passed", duration_ms=duration_ms)
+        return HealthResult(
+            ok=False,
+            message="ATC_HEALTH_OK not seen in pane output within 10s",
+            duration_ms=duration_ms,
+        )
+
+    except Exception as exc:
+        duration_ms = (time.monotonic() - start) * 1000
+        return HealthResult(
+            ok=False,
+            message=f"smoke test error: {exc}",
+            duration_ms=duration_ms,
+        )
+    finally:
+        if pane_id is not None:
+            try:
+                await _kill_pane(pane_id)
+            except Exception:
+                pass

--- a/tests/unit/test_health.py
+++ b/tests/unit/test_health.py
@@ -1,0 +1,96 @@
+"""Unit tests for startup smoke test (Issue #130)."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from atc.core.health import HealthResult, run_startup_smoke_test
+
+
+@pytest.mark.asyncio
+async def test_smoke_test_passes_when_health_ok_appears() -> None:
+    """Smoke test returns ok=True when ATC_HEALTH_OK appears in pane output."""
+    with (
+        patch("atc.core.health._ensure_tmux_session", new=AsyncMock()),
+        patch("atc.core.health._spawn_pane", new=AsyncMock(return_value="%99")),
+        patch("atc.core.health._tmux_run", new=AsyncMock()),
+        patch("atc.core.health._capture_pane", new=AsyncMock(return_value="ATC_HEALTH_OK")),
+        patch("atc.core.health._kill_pane", new=AsyncMock()),
+    ):
+        result = await run_startup_smoke_test()
+
+    assert result.ok is True
+    assert "passed" in result.message
+    assert result.duration_ms >= 0
+
+
+@pytest.mark.asyncio
+async def test_smoke_test_fails_when_health_ok_never_appears() -> None:
+    """Smoke test returns ok=False when ATC_HEALTH_OK never appears (fast timeout)."""
+    with (
+        patch("atc.core.health._ensure_tmux_session", new=AsyncMock()),
+        patch("atc.core.health._spawn_pane", new=AsyncMock(return_value="%99")),
+        patch("atc.core.health._tmux_run", new=AsyncMock()),
+        patch(
+            "atc.core.health._capture_pane",
+            new=AsyncMock(return_value="$ bash-4.4"),
+        ),
+        patch("atc.core.health._kill_pane", new=AsyncMock()),
+        patch("atc.core.health.asyncio.sleep", new=AsyncMock()),
+        patch("atc.core.health.time") as mock_time,
+    ):
+        # start=0.0, deadline calc=0.0, while check=11.0 (past deadline), duration calc=11.0
+        mock_time.monotonic.side_effect = [0.0, 0.0, 11.0, 11.0]
+        result = await run_startup_smoke_test()
+
+    assert result.ok is False
+    assert "ATC_HEALTH_OK" in result.message
+
+
+@pytest.mark.asyncio
+async def test_smoke_test_fails_on_spawn_error() -> None:
+    """Smoke test returns ok=False when pane spawn raises an exception."""
+    with (
+        patch("atc.core.health._ensure_tmux_session", new=AsyncMock()),
+        patch(
+            "atc.core.health._spawn_pane",
+            new=AsyncMock(side_effect=RuntimeError("tmux not available")),
+        ),
+        patch("atc.core.health._kill_pane", new=AsyncMock()),
+        patch("atc.core.health.time") as mock_time,
+    ):
+        mock_time.monotonic.return_value = 0.0
+        result = await run_startup_smoke_test()
+
+    assert result.ok is False
+    assert "tmux not available" in result.message
+
+
+@pytest.mark.asyncio
+async def test_smoke_test_kills_pane_on_failure() -> None:
+    """Pane is killed even when the smoke test fails."""
+    kill_mock = AsyncMock()
+    with (
+        patch("atc.core.health._ensure_tmux_session", new=AsyncMock()),
+        patch("atc.core.health._spawn_pane", new=AsyncMock(return_value="%88")),
+        patch("atc.core.health._tmux_run", new=AsyncMock()),
+        patch("atc.core.health._capture_pane", new=AsyncMock(return_value="no health signal")),
+        patch("atc.core.health._kill_pane", kill_mock),
+        patch("atc.core.health.asyncio.sleep", new=AsyncMock()),
+        patch("atc.core.health.time") as mock_time,
+    ):
+        # start=0.0, deadline calc=0.0, while check=11.0 (past deadline), duration calc=11.0
+        mock_time.monotonic.side_effect = [0.0, 0.0, 11.0, 11.0]
+        await run_startup_smoke_test()
+
+    kill_mock.assert_called_once_with("%88")
+
+
+def test_health_result_dataclass() -> None:
+    """HealthResult dataclass has expected fields."""
+    r = HealthResult(ok=True, message="passed", duration_ms=42.5)
+    assert r.ok is True
+    assert r.message == "passed"
+    assert r.duration_ms == 42.5


### PR DESCRIPTION
## Summary
- Adds `src/atc/core/health.py` with `run_startup_smoke_test()` that spawns a temp bash pane and validates echo delivery
- Stores `HealthResult` on `app.state.health` after startup
- Updates `GET /api/health` to report `status: ok|degraded`, `message`, `duration_ms`
- Wrapped in 15s `asyncio.wait_for` — failure logs WARNING but does not abort startup

## Test plan
- [ ] `pytest tests/unit/test_health.py` passes
- [ ] Server starts normally if tmux is unavailable (WARNING logged, health=degraded)
- [ ] `GET /api/health` returns `{"status": "ok", ...}` after clean startup

🤖 Generated with [Claude Code](https://claude.ai/claude-code)