### PR TITLE
fix: harden welcome screen detection with prompt-ready polling (#131)

### DIFF
--- a/src/atc/session/ace.py
+++ b/src/atc/session/ace.py
@@ -221,7 +221,21 @@ async def _accept_trust_dialog(pane_id: str, *, timeout: float = 20.0) -> bool:
                 await _tmux_run("send-keys", "-t", pane_id, "Escape")
                 logger.info("Pane %s: dismissed welcome/tips screen", pane_id)
                 dismissed.add("welcome_screen")
-                await asyncio.sleep(1.5)  # wait for overlay to animate out
+                # Poll for up to 3s until the tips panel text is gone from output
+                _clear_elapsed = 0.0
+                while _clear_elapsed < 3.0:
+                    await asyncio.sleep(0.3)
+                    _clear_elapsed += 0.3
+                    try:
+                        _check = await _capture_pane(pane_id)
+                        _check_lower = _check.lower()
+                        if (
+                            "tips for getting started" not in _check_lower
+                            and "welcome to claude code" not in _check_lower
+                        ):
+                            break
+                    except RuntimeError:
+                        break
                 continue
 
             # Claude Code TUI is running — all dialogs cleared.
@@ -279,6 +293,45 @@ async def _get_alternate_on(pane_id: str) -> bool:
 # ---------------------------------------------------------------------------
 
 
+async def wait_for_prompt(
+    pane_id: str,
+    *,
+    timeout: float = 10.0,
+    poll_interval: float = 0.5,
+) -> bool:
+    """Wait until the pane shows an empty prompt with alternate_on == 0.
+
+    Checks two conditions simultaneously:
+    1. alternate_on == 0 (no full-screen TUI active)
+    2. A bare prompt line: starts with '❯' or '> ' with nothing after it
+
+    Returns True when both conditions are met within *timeout* seconds,
+    False otherwise.
+    """
+    import re as _re
+
+    _PROMPT_RE = _re.compile(r"^[❯>]\s*$", _re.MULTILINE)
+
+    elapsed = 0.0
+    while elapsed < timeout:
+        try:
+            alt_on = await _get_alternate_on(pane_id)
+            if not alt_on:
+                output = await _capture_pane(pane_id)
+                if _PROMPT_RE.search(output):
+                    return True
+        except RuntimeError:
+            return False
+        await asyncio.sleep(poll_interval)
+        elapsed += poll_interval
+    logger.warning(
+        "Pane %s: prompt not ready after %.1fs (wait_for_prompt timed out)",
+        pane_id,
+        timeout,
+    )
+    return False
+
+
 async def check_tui_ready(
     pane_id: str,
     *,
@@ -327,8 +380,12 @@ async def send_instruction(
     Returns ``True`` if the instruction was verified (or verification skipped).
     """
     for attempt in range(1, max_retries + 1):
-        # Step 1: TUI readiness
-        ready = await check_tui_ready(pane_id)
+        # Step 1: TUI readiness — use prompt-ready polling for first attempt
+        # to ensure the welcome screen has fully cleared before sending.
+        if attempt == 1:
+            ready = await wait_for_prompt(pane_id)
+        else:
+            ready = await check_tui_ready(pane_id)
         if not ready:
             logger.warning("Pane %s: TUI not ready on attempt %d/%d", pane_id, attempt, max_retries)
             continue

--- a/tests/unit/test_trust_dialog.py
+++ b/tests/unit/test_trust_dialog.py
@@ -180,9 +180,9 @@ async def test_returns_false_when_already_running() -> None:
 
     The 'already running' output must NOT contain any dialog trigger strings —
     otherwise the guard would not fire. This tests clean TUI output with no
-    dialog keywords present.
+    dialog keywords present (e.g. a Claude Code prompt after startup).
     """
-    with _patch_tmux() as mock_run, _patch_pane("Welcome to Claude Code v2.1\n> "):
+    with _patch_tmux() as mock_run, _patch_pane("Claude Code v2.1 ready\n❯ "):
         result = await _accept_trust_dialog("pane-5")
 
     assert result is False

--- a/tests/unit/test_welcome_hardening.py
+++ b/tests/unit/test_welcome_hardening.py
@@ -1,0 +1,125 @@
+"""Unit tests for welcome screen hardening (Issue #131)."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from atc.session.ace import _accept_trust_dialog, wait_for_prompt
+
+
+# ---------------------------------------------------------------------------
+# wait_for_prompt tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_wait_for_prompt_returns_true_on_bare_prompt() -> None:
+    """wait_for_prompt returns True when alternate_on=0 and bare '❯' prompt found."""
+    with (
+        patch("atc.session.ace._get_alternate_on", new=AsyncMock(return_value=False)),
+        patch("atc.session.ace._capture_pane", new=AsyncMock(return_value="❯")),
+    ):
+        result = await wait_for_prompt("pane-1", timeout=2.0)
+
+    assert result is True
+
+
+@pytest.mark.asyncio
+async def test_wait_for_prompt_returns_true_on_gt_prompt() -> None:
+    """wait_for_prompt returns True on '> ' bare prompt (alternate style)."""
+    with (
+        patch("atc.session.ace._get_alternate_on", new=AsyncMock(return_value=False)),
+        patch("atc.session.ace._capture_pane", new=AsyncMock(return_value="> ")),
+    ):
+        result = await wait_for_prompt("pane-2", timeout=2.0)
+
+    assert result is True
+
+
+@pytest.mark.asyncio
+async def test_wait_for_prompt_waits_while_alternate_on() -> None:
+    """wait_for_prompt keeps polling while alternate_on == 1."""
+    alt_on_values = [True, True, False]
+    with (
+        patch(
+            "atc.session.ace._get_alternate_on",
+            new=AsyncMock(side_effect=alt_on_values),
+        ),
+        patch("atc.session.ace._capture_pane", new=AsyncMock(return_value="❯")),
+    ):
+        result = await wait_for_prompt("pane-3", timeout=5.0)
+
+    assert result is True
+
+
+@pytest.mark.asyncio
+async def test_wait_for_prompt_returns_false_on_timeout() -> None:
+    """wait_for_prompt returns False when prompt never appears."""
+    with (
+        patch("atc.session.ace._get_alternate_on", new=AsyncMock(return_value=False)),
+        patch("atc.session.ace._capture_pane", new=AsyncMock(return_value="some output without prompt")),
+    ):
+        result = await wait_for_prompt("pane-4", timeout=0.1)
+
+    assert result is False
+
+
+@pytest.mark.asyncio
+async def test_wait_for_prompt_returns_false_on_runtime_error() -> None:
+    """wait_for_prompt returns False if pane dies (RuntimeError)."""
+    with patch(
+        "atc.session.ace._get_alternate_on",
+        new=AsyncMock(side_effect=RuntimeError("pane dead")),
+    ):
+        result = await wait_for_prompt("pane-5", timeout=2.0)
+
+    assert result is False
+
+
+# ---------------------------------------------------------------------------
+# _accept_trust_dialog welcome screen clearing tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_welcome_screen_clears_before_returning() -> None:
+    """After sending Escape for welcome screen, polls until tips text is gone."""
+    # First call: welcome screen; subsequent calls: cleared
+    pane_outputs = [
+        "Welcome to Claude Code\nTips for getting started",
+        "Welcome to Claude Code\nTips for getting started",  # still visible
+        "Claude Code ready\n❯",  # cleared
+        "Claude Code ready\n❯",  # final check: no dialog triggers → exits
+    ]
+    with patch("atc.session.ace._tmux_run", new=AsyncMock()) as mock_run, patch(
+        "atc.session.ace._capture_pane",
+        new=AsyncMock(side_effect=pane_outputs),
+    ):
+        result = await _accept_trust_dialog("pane-w1", timeout=5.0)
+
+    assert result is True
+    # Escape must have been sent
+    send_keys = [c for c in mock_run.call_args_list if "send-keys" in c.args]
+    assert any("Escape" in c.args for c in send_keys)
+
+
+@pytest.mark.asyncio
+async def test_welcome_screen_not_retriggered_after_dismiss() -> None:
+    """Welcome screen dismiss is tracked — same output doesn't retrigger Escape."""
+    pane_outputs = [
+        "Welcome to Claude Code\nTips for getting started",
+        "Welcome to Claude Code\nTips for getting started",  # still visible (polling)
+        "Claude Code ready\n❯",  # cleared
+        "Claude Code ready\n❯",  # main loop: exits clean
+    ]
+    with patch("atc.session.ace._tmux_run", new=AsyncMock()) as mock_run, patch(
+        "atc.session.ace._capture_pane",
+        new=AsyncMock(side_effect=pane_outputs),
+    ):
+        await _accept_trust_dialog("pane-w2", timeout=5.0)
+
+    send_keys = [c for c in mock_run.call_args_list if "send-keys" in c.args]
+    escape_count = sum(1 for c in send_keys if "Escape" in c.args)
+    assert escape_count == 1


### PR DESCRIPTION
## Summary

- Adds `wait_for_prompt()` helper in `src/atc/session/ace.py` that checks both `alternate_on == 0` **and** a bare prompt line (`❯` or `> `) before treating the pane as ready for input — stronger than the previous `check_tui_ready` which only checked `alternate_on`
- After dismissing the welcome/tips screen with Escape, replaces the fixed `asyncio.sleep(1.5)` with a poll loop (up to 3s, 0.3s intervals) that exits as soon as the tips panel text is gone from pane output
- `send_instruction` now uses `wait_for_prompt` on the **first attempt** to ensure the welcome screen has fully cleared before the instruction is sent; subsequent retry attempts fall back to `check_tui_ready` for speed

## Test plan

- [ ] `tests/unit/test_welcome_hardening.py` — 7 new tests covering `wait_for_prompt` (true on bare prompt, timeout, RuntimeError, alternate_on polling) and `_accept_trust_dialog` polling behaviour
- [ ] `tests/unit/test_trust_dialog.py` — existing 9 tests still pass; updated `test_returns_false_when_already_running` fixture to use output that doesn't contain welcome screen trigger strings
- [ ] Run `python3 -m pytest tests/unit/test_welcome_hardening.py tests/unit/test_trust_dialog.py -v` → 16 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)