### PR TITLE
feat: atc-agent wrapper script for guaranteed workspace setup (#134)

### DIFF
--- a/scripts/atc-agent
+++ b/scripts/atc-agent
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# atc-agent — thin wrapper that guarantees workspace setup before exec-ing claude.
+#
+# Env vars:
+#   ATC_SESSION_ID   — session identifier (informational)
+#   ATC_ROLE         — tower | leader | ace
+#   ATC_REPO_PATH    — path to the repository working directory
+#   ATC_STAGING_DIR  — path to the staging directory
+#
+# Extra args ($@) are passed through to claude.
+
+set -euo pipefail
+
+# 1. Ensure repo directory exists.
+if [[ -n "${ATC_REPO_PATH:-}" ]]; then
+    mkdir -p "${ATC_REPO_PATH}"
+fi
+
+# 2. Copy CLAUDE.md from staging to repo dir if not already present.
+if [[ -n "${ATC_STAGING_DIR:-}" && -n "${ATC_REPO_PATH:-}" ]]; then
+    if [[ -f "${ATC_STAGING_DIR}/CLAUDE.md" && ! -f "${ATC_REPO_PATH}/CLAUDE.md" ]]; then
+        cp "${ATC_STAGING_DIR}/CLAUDE.md" "${ATC_REPO_PATH}/CLAUDE.md"
+    fi
+fi
+
+# 3. cd into the appropriate directory.
+if [[ -n "${ATC_REPO_PATH:-}" ]]; then
+    cd "${ATC_REPO_PATH}"
+elif [[ -n "${ATC_STAGING_DIR:-}" ]]; then
+    cd "${ATC_STAGING_DIR}"
+fi
+
+# 4. Hand off to claude.
+exec claude --dangerously-skip-permissions "$@"

--- a/src/atc/agents/factory.py
+++ b/src/atc/agents/factory.py
@@ -77,7 +77,16 @@ def get_provider_info(name: str) -> ProviderMetadata | None:
 
 
 def get_launch_command(provider_name: str) -> str:
-    """Return the shell launch command for a given provider name."""
+    """Return the shell launch command for a given provider name.
+
+    For the ``claude_code`` provider, if the bundled ``scripts/atc-agent``
+    wrapper exists it is returned instead of the bare ``claude`` command so
+    that workspace setup is guaranteed before Claude starts.
+    """
+    if provider_name == "claude_code":
+        script = Path(__file__).parent.parent.parent.parent / "scripts" / "atc-agent"
+        if script.exists():
+            return str(script)
     return _LAUNCH_COMMANDS.get(provider_name, _LAUNCH_COMMANDS["claude_code"])
 
 

--- a/tests/unit/test_agent_provider.py
+++ b/tests/unit/test_agent_provider.py
@@ -625,8 +625,23 @@ class TestConfigIntegration:
 
 
 class TestGetLaunchCommand:
-    def test_claude_code_returns_claude_cmd(self) -> None:
+    def test_claude_code_returns_atc_agent_when_present(self) -> None:
+        # atc-agent exists in scripts/, so get_launch_command should prefer it.
+        from pathlib import Path
+
+        script = Path(__file__).parent.parent.parent / "scripts" / "atc-agent"
         cmd = get_launch_command("claude_code")
+        if script.exists():
+            assert cmd == str(script)
+        else:
+            assert cmd == "claude --dangerously-skip-permissions"
+
+    def test_claude_code_falls_back_without_script(self) -> None:
+        from pathlib import Path
+        from unittest.mock import patch
+
+        with patch.object(Path, "exists", return_value=False):
+            cmd = get_launch_command("claude_code")
         assert cmd == "claude --dangerously-skip-permissions"
 
     def test_opencode_returns_opencode_cmd(self) -> None:
@@ -634,7 +649,11 @@ class TestGetLaunchCommand:
         assert cmd == "opencode"
 
     def test_unknown_falls_back_to_claude(self) -> None:
-        cmd = get_launch_command("unknown_provider")
+        from pathlib import Path
+        from unittest.mock import patch
+
+        with patch.object(Path, "exists", return_value=False):
+            cmd = get_launch_command("unknown_provider")
         assert cmd == "claude --dangerously-skip-permissions"
 
     def test_launch_commands_registry_has_both(self) -> None:

--- a/tests/unit/test_atc_agent.py
+++ b/tests/unit/test_atc_agent.py
@@ -1,0 +1,175 @@
+"""Tests for atc-agent script and the get_launch_command factory integration."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from atc.agents.factory import get_launch_command
+
+# Absolute path to the atc-agent script in the project root.
+_SCRIPT = Path(__file__).parent.parent.parent / "scripts" / "atc-agent"
+
+
+# ---------------------------------------------------------------------------
+# get_launch_command — atc-agent integration
+# ---------------------------------------------------------------------------
+
+
+class TestGetLaunchCommandAtcAgent:
+    def test_returns_script_when_exists(self) -> None:
+        """When atc-agent exists on disk, claude_code should use it."""
+        assert _SCRIPT.exists(), f"atc-agent not found at {_SCRIPT}"
+        cmd = get_launch_command("claude_code")
+        assert cmd == str(_SCRIPT)
+
+    def test_falls_back_when_script_missing(self, tmp_path: Path) -> None:
+        """When atc-agent is absent, fall back to bare claude command."""
+        # Patch Path.exists on the computed script path inside get_launch_command.
+        with patch.object(Path, "exists", return_value=False):
+            cmd = get_launch_command("claude_code")
+        assert cmd == "claude --dangerously-skip-permissions"
+
+    def test_opencode_unaffected(self) -> None:
+        """opencode provider is not affected by atc-agent presence."""
+        cmd = get_launch_command("opencode")
+        assert cmd == "opencode"
+
+    def test_unknown_falls_back_to_claude(self) -> None:
+        """Unknown providers still fall back to the claude_code default."""
+        with patch.object(Path, "exists", return_value=False):
+            cmd = get_launch_command("unknown_provider")
+        assert cmd == "claude --dangerously-skip-permissions"
+
+
+# ---------------------------------------------------------------------------
+# atc-agent script behaviour (subprocess tests)
+# ---------------------------------------------------------------------------
+
+
+def _run_agent(
+    env: dict[str, str], extra_args: list[str] | None = None
+) -> subprocess.CompletedProcess[str]:
+    """Run atc-agent with a minimal env, replacing exec'd claude with 'true'."""
+    # We cannot actually exec claude, so override PATH so that 'claude' resolves
+    # to a no-op script we create inline via a wrapper.
+    cmd = [str(_SCRIPT)] + (extra_args or [])
+    return subprocess.run(
+        cmd,
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+
+
+@pytest.fixture()
+def base_env() -> dict[str, str]:
+    """Minimal env with PATH pointing at a fake 'claude' that just exits 0."""
+    # Build a minimal PATH that includes a directory with a stub 'claude'.
+    # We use a shell trick: inject a function override via a wrapper script
+    # stored in a temp dir.
+    return {}
+
+
+class TestAtcAgentScript:
+    """Run the atc-agent script in a subprocess with a stub 'claude' binary."""
+
+    @pytest.fixture(autouse=True)
+    def stub_claude(self, tmp_path: Path) -> Path:
+        """Create a stub 'claude' script that records its invocation and exits 0."""
+        bin_dir = tmp_path / "bin"
+        bin_dir.mkdir()
+        stub = bin_dir / "claude"
+        stub.write_text("#!/usr/bin/env bash\nexit 0\n")
+        stub.chmod(0o755)
+        self._bin_dir = bin_dir
+        return bin_dir
+
+    def _env(self, extra: dict[str, str] | None = None) -> dict[str, str]:
+        env = {
+            "PATH": f"{self._bin_dir}:{os.environ.get('PATH', '')}",
+            "HOME": os.environ.get("HOME", "/tmp"),
+        }
+        if extra:
+            env.update(extra)
+        return env
+
+    def test_script_is_executable(self) -> None:
+        assert os.access(_SCRIPT, os.X_OK), "atc-agent must be executable"
+
+    def test_no_env_vars_exits_zero(self) -> None:
+        result = subprocess.run(
+            [str(_SCRIPT)],
+            env=self._env(),
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 0, result.stderr
+
+    def test_creates_repo_path(self, tmp_path: Path) -> None:
+        repo = tmp_path / "repo" / "subdir"
+        assert not repo.exists()
+        result = subprocess.run(
+            [str(_SCRIPT)],
+            env=self._env({"ATC_REPO_PATH": str(repo)}),
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 0, result.stderr
+        assert repo.is_dir(), "ATC_REPO_PATH should have been created"
+
+    def test_copies_claude_md_from_staging(self, tmp_path: Path) -> None:
+        staging = tmp_path / "staging"
+        staging.mkdir()
+        repo = tmp_path / "repo"
+        # Write a CLAUDE.md in staging; repo does not exist yet.
+        (staging / "CLAUDE.md").write_text("# project instructions\n")
+
+        result = subprocess.run(
+            [str(_SCRIPT)],
+            env=self._env({
+                "ATC_REPO_PATH": str(repo),
+                "ATC_STAGING_DIR": str(staging),
+            }),
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 0, result.stderr
+        assert (repo / "CLAUDE.md").exists(), "CLAUDE.md should be copied from staging"
+        assert (repo / "CLAUDE.md").read_text() == "# project instructions\n"
+
+    def test_does_not_overwrite_existing_claude_md(self, tmp_path: Path) -> None:
+        staging = tmp_path / "staging"
+        staging.mkdir()
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        (staging / "CLAUDE.md").write_text("staging version\n")
+        (repo / "CLAUDE.md").write_text("existing version\n")
+
+        result = subprocess.run(
+            [str(_SCRIPT)],
+            env=self._env({
+                "ATC_REPO_PATH": str(repo),
+                "ATC_STAGING_DIR": str(staging),
+            }),
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 0, result.stderr
+        assert (repo / "CLAUDE.md").read_text() == "existing version\n"
+
+    def test_staging_only_no_crash(self, tmp_path: Path) -> None:
+        """ATC_STAGING_DIR set but no ATC_REPO_PATH — should cd into staging."""
+        staging = tmp_path / "staging"
+        staging.mkdir()
+        result = subprocess.run(
+            [str(_SCRIPT)],
+            env=self._env({"ATC_STAGING_DIR": str(staging)}),
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 0, result.stderr


### PR DESCRIPTION
## Summary

- Adds `scripts/atc-agent`: executable bash wrapper that guarantees workspace setup before handing off to `claude --dangerously-skip-permissions`
  - Creates `ATC_REPO_PATH` via `mkdir -p` if set
  - Copies `CLAUDE.md` from `ATC_STAGING_DIR` → `ATC_REPO_PATH` if not already present
  - `cd`s into `ATC_REPO_PATH` → `ATC_STAGING_DIR` → cwd (in that order of preference)
  - `exec`s `claude --dangerously-skip-permissions "$@"` passing through all extra args
- Updates `get_launch_command()` in `factory.py` to use `scripts/atc-agent` when it exists on disk, falling back to the bare `claude` command otherwise — no config change required
- Adds `tests/unit/test_atc_agent.py` with subprocess tests for script behaviour and factory fallback logic
- Updates `TestGetLaunchCommand` in `test_agent_provider.py` to match the new script-aware behaviour

## Test plan

- [ ] `pytest tests/unit/test_atc_agent.py` — 10 tests covering script executable bit, dir creation, CLAUDE.md copy, no-overwrite guard, staging-only path, and factory fallback
- [ ] `pytest tests/unit/test_agent_provider.py::TestGetLaunchCommand` — 5 tests covering script-present, script-absent, opencode, unknown provider
- [ ] `ruff check src/atc/agents/factory.py tests/unit/test_atc_agent.py` passes clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)