### PR TITLE
fix: stabilize leader-spawned Ace startup

### DIFF
--- a/src/atc/api/routers/aces.py
+++ b/src/atc/api/routers/aces.py
@@ -13,6 +13,7 @@ Routes:
 
 from __future__ import annotations
 
+import logging
 from typing import Any
 
 from fastapi import APIRouter, HTTPException, Request
@@ -25,6 +26,7 @@ from atc.session.state_machine import InvalidTransitionError
 from atc.state import db as db_ops
 
 router = APIRouter()
+logger = logging.getLogger(__name__)
 
 
 # ---------------------------------------------------------------------------
@@ -206,6 +208,15 @@ async def update_ace_status(
         await transition(session.id, current, target, event_bus)
         await db_ops.update_session_status(db, session.id, target.value)
     except InvalidTransitionError as exc:
+        if target in {SessionStatus.WORKING, SessionStatus.WAITING}:
+            logger.info(
+                "Ignoring stale hook status for ace %s: %s -> %s (%s)",
+                session.id,
+                current.value,
+                target.value,
+                exc,
+            )
+            return {"status": current.value}
         raise SessionStaleError(str(exc)) from None
 
     return {"status": target.value}

--- a/src/atc/leader/orchestrator.py
+++ b/src/atc/leader/orchestrator.py
@@ -15,11 +15,11 @@ from __future__ import annotations
 
 import contextlib
 import logging
-import uuid
 from dataclasses import dataclass, field
+from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
-from atc.agents.deploy import AceDeploySpec, cleanup_deployed_files, deploy_ace_files
+from atc.agents.deploy import AceDeploySpec, cleanup_deployed_files
 from atc.agents.factory import get_launch_command
 from atc.leader.context_package import build_context_package
 from atc.leader.decomposer import get_completion_status, get_ready_tasks
@@ -152,52 +152,20 @@ class LeaderOrchestrator:
             repo_path = project.repo_path if project else None
             github_repo = project.github_repo if project else None
 
-            # Generate a stable session id up-front so deploy can use it
-            session_id_preview = str(uuid.uuid4())
-
-            # Fetch inherited context entries for the Ace
+            # Fetch inherited context entries for the Ace. Use a preview id only
+            # for context assembly; create_ace will deploy hooks/config with the real
+            # session id so callbacks target the live session instead of a ghost id.
             context_entries: list[dict[str, Any]] = []
             with contextlib.suppress(Exception):
                 ctx = await build_context_package(
                     self.conn,
                     self.project_id,
                     title,
-                    session_id=session_id_preview,
+                    session_id=f"preview:{task_graph_id}",
                     parent_session_id=self.leader_id,
                     scope="ace",
                 )
                 context_entries = ctx.get("context_entries", [])
-
-            # Deploy config files before launching the session
-            spec = AceDeploySpec(
-                session_id=session_id_preview,
-                project_name=project_name,
-                task_title=title,
-                task_description=description,
-                project_id=self.project_id,
-                repo_path=repo_path,
-                github_repo=github_repo,
-                context_entries=context_entries,
-            )
-            deployed = deploy_ace_files(spec)
-            logger.info("Deployed ace config for task '%s' → %s", title, deployed.root)
-
-            working_dir = repo_path or str(deployed.root)
-
-            # Bug #162: if the Ace runs in repo_path, the Leader's CLAUDE.md is already
-            # there and the Ace will think it is a Leader (refusing to create files).
-            # Fix: copy the Ace's CLAUDE.md into repo_path, overwriting the Leader's.
-            if repo_path:
-                import shutil as _shutil
-                from pathlib import Path as _Path
-                ace_claude_md_src = deployed.root / "CLAUDE.md"
-                ace_claude_md_dst = _Path(repo_path) / "CLAUDE.md"
-                if ace_claude_md_src.exists():
-                    _shutil.copy2(str(ace_claude_md_src), str(ace_claude_md_dst))
-                    logger.info(
-                        "Copied Ace CLAUDE.md to repo_path %s (overwrites Leader copy)",
-                        ace_claude_md_dst,
-                    )
 
             launch_cmd = get_launch_command(
                 project.agent_provider if project else "claude_code",
@@ -209,8 +177,17 @@ class LeaderOrchestrator:
                 ace_name,
                 task_id=task_graph_id,
                 event_bus=self.event_bus,
-                working_dir=working_dir,
+                working_dir=repo_path,
                 launch_command=launch_cmd,
+                deploy_spec_kwargs={
+                    "project_name": project_name,
+                    "task_title": title,
+                    "task_description": description,
+                    "project_id": self.project_id,
+                    "repo_path": repo_path,
+                    "github_repo": github_repo,
+                    "context_entries": context_entries,
+                },
             )
         except Exception:
             logger.exception(
@@ -257,7 +234,7 @@ class LeaderOrchestrator:
             task_title=title,
             assignment_id=idempotency_key,
             status="assigned",
-            deployed_root=deployed.root,
+            deployed_root=Path("/tmp/atc-agents") / session_id,
         )
         self.assignments[task_graph_id] = assignment
 

--- a/tests/unit/test_ace_status_api.py
+++ b/tests/unit/test_ace_status_api.py
@@ -113,6 +113,23 @@ class TestPatchAceStatus:
         assert updated is not None
         assert updated.status == "idle"
 
+    @pytest.mark.asyncio
+    async def test_stale_waiting_hook_is_ignored(self, project_and_session) -> None:
+        from types import SimpleNamespace
+
+        from atc.api.routers.aces import StatusUpdateRequest, update_ace_status
+        from atc.state import db as db_ops
+
+        _project, session, db, event_bus = project_and_session
+        request = SimpleNamespace(app=SimpleNamespace(state=SimpleNamespace(db=db, event_bus=event_bus)))
+
+        result = await update_ace_status(session.id, StatusUpdateRequest(status="waiting"), request)
+
+        assert result == {"status": "idle"}
+        updated = await db_ops.get_session(db, session.id)
+        assert updated is not None
+        assert updated.status == "idle"
+
 
 class TestNotifyEndpoint:
     @pytest.mark.asyncio

--- a/tests/unit/test_leader_orchestrator.py
+++ b/tests/unit/test_leader_orchestrator.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from pathlib import Path
 from unittest.mock import AsyncMock, patch
 
 import pytest
@@ -310,6 +311,26 @@ class TestSpawnAces:
         assignments = await orchestrator.spawn_aces_for_ready_tasks()
         assert len(assignments) == 0
         assert orch_mod._GLOBAL_ACTIVE_ACES == 0
+
+    async def test_deploy_uses_real_session_id_for_staging_root(
+        self,
+        mock_create: AsyncMock,
+        db,
+        orchestrator: LeaderOrchestrator,
+    ) -> None:
+        await create_task_graph(db, orchestrator.project_id, "Task Deploy")
+
+        assignments = await orchestrator.spawn_aces_for_ready_tasks()
+
+        assert len(assignments) == 1
+        assert assignments[0].deployed_root == Path("/tmp/atc-agents/ace-session-1")
+
+        call_kwargs = mock_create.call_args
+        assert call_kwargs is not None
+        deploy_kwargs = call_kwargs.kwargs.get("deploy_spec_kwargs")
+        assert deploy_kwargs is not None
+        assert deploy_kwargs["task_title"] == "Task Deploy"
+        assert deploy_kwargs["project_id"] == orchestrator.project_id
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- deploy leader-spawned Ace files via create_ace so hooks use the real session id
- keep assignment cleanup rooted to the real Ace staging directory
- ignore stale working/waiting hook transitions instead of surfacing noisy 422s

## Testing
- ./.venv/bin/python -m pytest tests/unit/test_leader_orchestrator.py tests/unit/test_ace_status_api.py -q
- restarted backend on mac and validated project -> leader -> spawn ace -> instruct flow via API
