### PR TITLE
Fix silent leader auth stalls and surface real progress

### DIFF
--- a/src/atc/api/routers/leader.py
+++ b/src/atc/api/routers/leader.py
@@ -93,6 +93,14 @@ def _get_event_bus(request: Request) -> Any:
     return getattr(request.app.state, "event_bus", None)
 
 
+async def _broadcast_tower_progress(request: Request) -> None:
+    tower = getattr(request.app.state, "tower_controller", None)
+    if tower is None:
+        return
+    with __import__("contextlib").suppress(Exception):
+        await tower.get_progress()
+
+
 async def _get_or_create_orchestrator(
     request: Request,
     project_id: str,
@@ -212,6 +220,8 @@ async def decompose(
             {"task_graphs_updated": True, "project_id": project_id, "task_graphs": tg_data},
         )
 
+    await _broadcast_tower_progress(request)
+
     return DecomposeResponse(
         project_id=result.project_id,
         goal=result.goal,
@@ -239,6 +249,7 @@ async def spawn_aces(
     """Spawn Ace sessions for all ready (unblocked) tasks."""
     orch = await _get_or_create_orchestrator(request, project_id)
     assignments = await orch.spawn_aces_for_ready_tasks()
+    await _broadcast_tower_progress(request)
 
     return SpawnAcesResponse(
         spawned=[
@@ -281,6 +292,7 @@ async def task_done(
     """Mark a task graph entry as done and clean up its Ace."""
     orch = await _get_or_create_orchestrator(request, project_id)
     await orch.mark_task_done(body.task_graph_id)
+    await _broadcast_tower_progress(request)
     return {"status": "done"}
 
 
@@ -293,6 +305,7 @@ async def task_failed(
     """Mark a task graph entry as failed and allow retry."""
     orch = await _get_or_create_orchestrator(request, project_id)
     await orch.mark_task_failed(body.task_graph_id, reason=body.reason)
+    await _broadcast_tower_progress(request)
     return {"status": "failed"}
 
 

--- a/src/atc/leader/decomposer.py
+++ b/src/atc/leader/decomposer.py
@@ -208,8 +208,9 @@ def get_completion_status(task_graphs: list[TaskGraph]) -> dict[str, Any]:
             "done": 0,
             "in_progress": 0,
             "todo": 0,
-            "all_done": True,
-            "progress_pct": 100,
+            "error": 0,
+            "all_done": False,
+            "progress_pct": 0,
         }
 
     done = sum(1 for tg in task_graphs if tg.status == "done")

--- a/src/atc/tower/controller.py
+++ b/src/atc/tower/controller.py
@@ -27,6 +27,7 @@ from atc.config import load_settings
 from atc.leader.context_package import build_context_package
 from atc.leader.leader import send_leader_message, start_leader, stop_leader
 from atc.state import db as db_ops
+from atc.session.state_machine import SessionStatus
 from atc.tower.session import send_tower_message, start_tower_session, stop_tower_session
 
 if TYPE_CHECKING:
@@ -101,7 +102,7 @@ class TowerController:
 
         # Subscribe to leader session events for monitoring
         self._event_bus.subscribe("session_status_changed", self._on_session_status_changed)
-        self._event_bus.subscribe("pty_output", self._on_leader_output)
+        self._event_bus.subscribe("pty_output", self._on_agent_output)
         self._event_bus.subscribe("session_created", self._on_session_created)
 
         # Subscribe to budget events for proactive slowdown
@@ -797,29 +798,72 @@ class TowerController:
                 exc,
             )
 
-    async def _on_leader_output(self, data: dict[str, Any]) -> None:
-        """Capture PTY output from the Leader session for monitoring.
+    @staticmethod
+    def _extract_auth_blocker(text: str) -> str | None:
+        """Return a human-readable auth blocker when Claude is not usable."""
+        lowered = text.lower()
+        if "not logged in" in lowered and "/login" in lowered:
+            return "Claude Code is not logged in on the host. Run /login in the affected pane."
+        if "run in another terminal: security unlock-keychain" in lowered:
+            return "Claude Code cannot access macOS keychain; unlock the keychain on the host."
+        return None
 
-        Only captures output from the current Leader session. Stores
-        recent lines for the Tower to inspect and broadcasts a summary
-        event so the frontend can show activity indicators.
-        """
+    async def _mark_session_error(self, session_id: str, reason: str) -> None:
+        session = await db_ops.get_session(self._db, session_id)
+        if session is None or session.status == SessionStatus.ERROR.value:
+            return
+
+        await db_ops.update_session_status(self._db, session_id, SessionStatus.ERROR.value)
+        await self._event_bus.publish(
+            "session_status_changed",
+            {
+                "session_id": session_id,
+                "previous_status": session.status,
+                "new_status": SessionStatus.ERROR.value,
+                "reason": reason,
+            },
+        )
+
+    async def _handle_auth_blocked_session(self, session_id: str, reason: str) -> None:
+        await self._mark_session_error(session_id, reason)
+
+        if self._ws_hub is not None and session_id == self._leader_session_id:
+            await self._ws_hub.broadcast(
+                "tower",
+                {
+                    "type": "leader_activity",
+                    "session_id": session_id,
+                    "preview": reason,
+                },
+            )
+
+        if session_id in {self._leader_session_id, self._current_session_id}:
+            logger.error("Tower session %s blocked by auth issue: %s", session_id, reason)
+            if self._state in (TowerState.PLANNING, TowerState.MANAGING):
+                await self._transition(TowerState.ERROR)
+
+    async def _on_agent_output(self, data: dict[str, Any]) -> None:
+        """Capture PTY output from current Tower/Leader sessions for monitoring."""
         session_id = data.get("session_id")
-        if session_id != self._leader_session_id:
+        if session_id not in {self._leader_session_id, self._current_session_id}:
             return
 
         raw = data.get("data", b"")
         text = raw.decode("utf-8", errors="replace") if isinstance(raw, bytes) else str(raw)
 
-        # Store output lines (ring buffer)
+        reason = self._extract_auth_blocker(text)
+        if reason is not None:
+            await self._handle_auth_blocked_session(session_id, reason)
+
+        if session_id != self._leader_session_id:
+            return
+
         lines = text.splitlines()
         self._leader_output_lines.extend(lines)
         if len(self._leader_output_lines) > self._max_output_lines:
             self._leader_output_lines = self._leader_output_lines[-self._max_output_lines :]
 
-        # Broadcast a lightweight activity event for the Tower UI
         if self._ws_hub is not None:
-            # Only broadcast non-empty, visible text
             stripped = text.strip()
             if stripped:
                 await self._ws_hub.broadcast(

--- a/tests/unit/test_decomposer.py
+++ b/tests/unit/test_decomposer.py
@@ -253,8 +253,9 @@ class TestGetCompletionStatus:
     def test_empty(self) -> None:
         status = get_completion_status([])
         assert status["total"] == 0
-        assert status["all_done"] is True
-        assert status["progress_pct"] == 100
+        assert status["error"] == 0
+        assert status["all_done"] is False
+        assert status["progress_pct"] == 0
 
     def test_all_done(self) -> None:
         tasks = [self._make_tg("1", "done"), self._make_tg("2", "done")]

--- a/tests/unit/test_leader_api.py
+++ b/tests/unit/test_leader_api.py
@@ -70,6 +70,8 @@ def mock_request(db, event_bus):
     # settings=None so _get_or_create_orchestrator uses defaults (avoids MagicMock
     # leaking into ResourceGovernor float comparisons)
     request.app.state.settings = None
+    request.app.state.tower_controller = MagicMock()
+    request.app.state.tower_controller.get_progress = AsyncMock(return_value={})
     return request
 
 
@@ -98,6 +100,7 @@ class TestDecomposeEndpoint:
         assert result.error is None
         assert result.project_id == project.id
         assert len(result.task_graphs) == 2
+        mock_request.app.state.tower_controller.get_progress.assert_awaited()
 
     async def test_decompose_no_leader_returns_404(
         self, db, mock_request,
@@ -165,6 +168,7 @@ class TestSpawnAcesEndpoint:
 
         assert len(result.spawned) == 1
         assert result.spawned[0]["task_title"] == "Ready Task"
+        mock_request.app.state.tower_controller.get_progress.assert_awaited()
 
     async def test_spawn_with_no_ready_tasks(
         self, mock_create: AsyncMock, db, project_with_leader, mock_request,
@@ -238,6 +242,7 @@ class TestTaskLifecycleEndpoints:
         result = await task_done(project.id, body, mock_request)
 
         assert result["status"] == "done"
+        mock_request.app.state.tower_controller.get_progress.assert_awaited()
 
     async def test_task_failed(
         self, mock_create: AsyncMock, mock_destroy: AsyncMock,
@@ -255,6 +260,7 @@ class TestTaskLifecycleEndpoints:
         result = await task_failed(project.id, body, mock_request)
 
         assert result["status"] == "failed"
+        mock_request.app.state.tower_controller.get_progress.assert_awaited()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_tower_controller.py
+++ b/tests/unit/test_tower_controller.py
@@ -12,6 +12,7 @@ from atc.state.db import (
     create_leader,
     create_project,
     get_connection,
+    get_session,
     run_migrations,
 )
 from atc.tower.controller import (
@@ -641,3 +642,36 @@ class TestNotifyTowerGoalStarted:
             await tower._notify_tower_goal_started(project.id, "leader-sess-1", "Build X")
 
         mock_send.assert_called_once()
+
+
+@pytest.mark.asyncio
+class TestAuthBlockDetection:
+    @patch("atc.tower.controller.start_leader", new_callable=AsyncMock, return_value="leader-sess-1")
+    async def test_leader_auth_block_marks_session_error_and_transitions_tower(
+        self, mock_start: AsyncMock, db, event_bus: EventBus
+    ) -> None:
+        project = await create_project(db, "test-proj")
+        await create_leader(db, project.id)
+        tower = TowerController(db, event_bus)
+
+        await tower.submit_goal(project.id, "Blocked goal")
+        await db.execute(
+            "INSERT INTO sessions (id, project_id, session_type, name, status, created_at, updated_at) VALUES (?, ?, 'manager', 'leader', 'working', datetime('now'), datetime('now'))",
+            ("leader-sess-1", project.id),
+        )
+        await db.commit()
+
+        await tower._on_agent_output({
+            "session_id": "leader-sess-1",
+            "data": "Not logged in · Please run /login\n".encode("utf-8"),
+        })
+
+        session = await get_session(db, "leader-sess-1")
+        assert session is not None
+        assert session.status == "error"
+        assert tower.state == TowerState.ERROR
+
+    async def test_extract_auth_blocker_detects_login_and_keychain_hints(self, tower: TowerController) -> None:
+        assert tower._extract_auth_blocker("Not logged in · Please run /login") is not None
+        assert tower._extract_auth_blocker("Run in another terminal: security unlock-keychain") is not None
+        assert tower._extract_auth_blocker("All good, working normally") is None


### PR DESCRIPTION
## Summary
- detect Claude Code auth/keychain blockers from Tower/Leader PTY output and mark blocked sessions as error instead of leaving Tower stuck in managing
- broadcast Tower progress whenever Leader task graph state changes so the UI gets live task counts without needing a manual /api/tower/progress poll
- treat zero-task leader progress as 0% / not done instead of 100% complete

## Validation
- pytest tests/unit/test_tower_controller.py tests/unit/test_leader_api.py tests/unit/test_decomposer.py -q
- live repro on the Mac-hosted ATC deployment after restarting uvicorn from this branch:
  - created fresh projects authstall-e2e / authstall-e2e-2
  - submitted a Tower goal
  - confirmed the Leader pane shows Claude Code blocked at `Not logged in · Please run /login`
  - confirmed Tower now transitions to `error` and the Leader session row becomes `error` instead of sitting in misleading `managing`/`working`
  - confirmed `/api/projects/<id>/leader/progress` now reports `all_done: false` and `progress_pct: 0` while zero tasks exist

## Notes
- This is distinct from #189. #189 fixed Ace startup / kickoff delivery; this follow-up fixes a separate silent-stall path where Leader/Tower could not act because Claude auth was unavailable, while ATC still presented the run as active.
