### PR TITLE
Harden ATC instruction delivery and assignment retries

### DIFF
--- a/src/atc/leader/orchestrator.py
+++ b/src/atc/leader/orchestrator.py
@@ -221,12 +221,16 @@ class LeaderOrchestrator:
                 title,
             )
 
-        # Transition the task to in_progress now that the Ace is running
-        await db_ops.update_task_graph_status(
-            self.conn,
-            task_graph_id,
-            "in_progress",
-        )
+        # Transition the task to in_progress now that the Ace is running.
+        # Retry/idempotent paths can surface an already-assigned or already-
+        # in-progress task; only advance when needed.
+        task_graph = await db_ops.get_task_graph(self.conn, task_graph_id)
+        if task_graph is not None and task_graph.status == "assigned":
+            await db_ops.update_task_graph_status(
+                self.conn,
+                task_graph_id,
+                "in_progress",
+            )
 
         assignment = AceAssignment(
             ace_session_id=session_id,

--- a/src/atc/session/ace.py
+++ b/src/atc/session/ace.py
@@ -551,14 +551,22 @@ async def send_instruction(
 
             # Claude sometimes consumes a bracketed paste immediately without leaving
             # the full instruction visible in capture-pane. If the prompt is no longer
-            # bare, treat that as accepted input rather than a swallowed send.
+            # bare, treat that as accepted input rather than a swallowed send — but
+            # only if the pane is still alive. A dead pane must remain a delivery
+            # failure so callers can retry/report accurately.
             if not await wait_for_prompt(pane_id, timeout=1.0, poll_interval=0.25):
-                logger.info(
-                    "Pane %s: prompt disappeared after send on attempt %d — assuming instruction accepted",
+                if await _pane_is_alive(pane_id):
+                    logger.info(
+                        "Pane %s: prompt disappeared after send on attempt %d — assuming instruction accepted",
+                        pane_id,
+                        attempt,
+                    )
+                    return True
+                logger.warning(
+                    "Pane %s: prompt disappeared after send on attempt %d but pane is dead",
                     pane_id,
                     attempt,
                 )
-                return True
             logger.warning(
                 "Pane %s: instruction not found in output (attempt %d/%d)",
                 pane_id,

--- a/src/atc/session/ace.py
+++ b/src/atc/session/ace.py
@@ -30,6 +30,7 @@ from atc.session.state_machine import (
     transition,
 )
 from atc.state import db as db_ops
+from atc.terminal.control import send_instruction_async
 
 if TYPE_CHECKING:
     import aiosqlite  # type: ignore[import-not-found]
@@ -509,8 +510,10 @@ async def send_instruction(
             logger.warning("Pane %s: TUI not ready on attempt %d/%d", pane_id, attempt, max_retries)
             continue
 
-        # Step 2: Atomic send — text and Enter back-to-back, no await gap
-        await _tmux_run("send-keys", "-t", pane_id, text, "Enter")
+        # Step 2: Atomic send — bracketed paste plus Enter via tmux control mode.
+        # This is more reliable with Claude Code than raw send-keys text because
+        # the whole payload lands as one paste event before Enter is pressed.
+        await send_instruction_async(ATC_TMUX_SESSION, pane_id, text)
 
         if not verify:
             return True
@@ -544,6 +547,17 @@ async def send_instruction(
             fingerprint = text[:80].strip()
             if fingerprint and fingerprint in output:
                 logger.info("Pane %s: instruction verified on attempt %d", pane_id, attempt)
+                return True
+
+            # Claude sometimes consumes a bracketed paste immediately without leaving
+            # the full instruction visible in capture-pane. If the prompt is no longer
+            # bare, treat that as accepted input rather than a swallowed send.
+            if not await wait_for_prompt(pane_id, timeout=1.0, poll_interval=0.25):
+                logger.info(
+                    "Pane %s: prompt disappeared after send on attempt %d — assuming instruction accepted",
+                    pane_id,
+                    attempt,
+                )
                 return True
             logger.warning(
                 "Pane %s: instruction not found in output (attempt %d/%d)",

--- a/src/atc/state/db.py
+++ b/src/atc/state/db.py
@@ -1143,14 +1143,18 @@ async def assign_task(
     Raises ``ValueError`` if the task is not in a state that allows
     assignment (i.e. not ``todo``).
     """
-    # Check for existing assignment with same idempotency key
+    # Check for existing assignment with same idempotency key.
+    # Active assignments are true idempotent no-ops; terminal assignments need to
+    # be reusable so retrying the same task after a failure/done state can create
+    # a fresh live assignment without tripping later task-state transitions.
     cursor = await db.execute(
         "SELECT * FROM task_assignments WHERE assignment_id = ?",
         (assignment_id,),
     )
     existing_row = await cursor.fetchone()
-    if existing_row is not None:
-        return _row_to_task_assignment(existing_row), False
+    existing = _row_to_task_assignment(existing_row) if existing_row is not None else None
+    if existing is not None and existing.status in {"assigned", "working"}:
+        return existing, False
 
     # Validate the task exists and is in assignable state
     task = await get_task_graph(db, task_graph_id)
@@ -1180,30 +1184,45 @@ async def assign_task(
         )
 
     now = _now()
-    assignment = TaskAssignment(
-        id=_uuid(),
-        task_graph_id=task_graph_id,
-        ace_session_id=ace_session_id,
-        assignment_id=assignment_id,
-        status="assigned",
-        created_at=now,
-        updated_at=now,
-    )
+    if existing is not None:
+        assignment = TaskAssignment(
+            id=existing.id,
+            task_graph_id=existing.task_graph_id,
+            ace_session_id=ace_session_id,
+            assignment_id=existing.assignment_id,
+            status="assigned",
+            created_at=existing.created_at,
+            updated_at=now,
+        )
+        await db.execute(
+            "UPDATE task_assignments SET ace_session_id = ?, status = ?, updated_at = ? WHERE assignment_id = ?",
+            (ace_session_id, assignment.status, assignment.updated_at, assignment.assignment_id),
+        )
+    else:
+        assignment = TaskAssignment(
+            id=_uuid(),
+            task_graph_id=task_graph_id,
+            ace_session_id=ace_session_id,
+            assignment_id=assignment_id,
+            status="assigned",
+            created_at=now,
+            updated_at=now,
+        )
 
-    await db.execute(
-        """INSERT INTO task_assignments
-           (id, task_graph_id, ace_session_id, assignment_id, status, created_at, updated_at)
-           VALUES (?, ?, ?, ?, ?, ?, ?)""",
-        (
-            assignment.id,
-            assignment.task_graph_id,
-            assignment.ace_session_id,
-            assignment.assignment_id,
-            assignment.status,
-            assignment.created_at,
-            assignment.updated_at,
-        ),
-    )
+        await db.execute(
+            """INSERT INTO task_assignments
+               (id, task_graph_id, ace_session_id, assignment_id, status, created_at, updated_at)
+               VALUES (?, ?, ?, ?, ?, ?, ?)""",
+            (
+                assignment.id,
+                assignment.task_graph_id,
+                assignment.ace_session_id,
+                assignment.assignment_id,
+                assignment.status,
+                assignment.created_at,
+                assignment.updated_at,
+            ),
+        )
 
     # Transition the task_graph to 'assigned'
     await db.execute(

--- a/tests/unit/test_creation_reliability.py
+++ b/tests/unit/test_creation_reliability.py
@@ -168,6 +168,7 @@ class TestSendInstruction:
         mock_send_async.assert_called_once_with("atc", "%0", "test")
 
     @pytest.mark.asyncio
+    @patch("atc.session.ace._pane_is_alive", new_callable=AsyncMock)
     @patch("atc.session.ace._capture_pane", new_callable=AsyncMock)
     @patch("atc.session.ace.send_instruction_async", new_callable=AsyncMock)
     @patch("atc.session.ace.check_tui_ready", new_callable=AsyncMock)
@@ -178,14 +179,40 @@ class TestSendInstruction:
         mock_ready: AsyncMock,
         mock_send_async: AsyncMock,
         mock_capture: AsyncMock,
+        mock_alive: AsyncMock,
     ) -> None:
         mock_wait.side_effect = [True, False]
         mock_ready.return_value = True
         mock_send_async.return_value = None
         mock_capture.return_value = "$ \n"
+        mock_alive.return_value = True
 
         result = await send_instruction("%0", "run tests", max_retries=1)
         assert result is True
+        mock_send_async.assert_called_once_with("atc", "%0", "run tests")
+
+    @pytest.mark.asyncio
+    @patch("atc.session.ace._pane_is_alive", new_callable=AsyncMock)
+    @patch("atc.session.ace._capture_pane", new_callable=AsyncMock)
+    @patch("atc.session.ace.send_instruction_async", new_callable=AsyncMock)
+    @patch("atc.session.ace.check_tui_ready", new_callable=AsyncMock)
+    @patch("atc.session.ace.wait_for_prompt", new_callable=AsyncMock)
+    async def test_prompt_disappearing_with_dead_pane_is_not_treated_as_success(
+        self,
+        mock_wait: AsyncMock,
+        mock_ready: AsyncMock,
+        mock_send_async: AsyncMock,
+        mock_capture: AsyncMock,
+        mock_alive: AsyncMock,
+    ) -> None:
+        mock_wait.side_effect = [True, False]
+        mock_ready.return_value = True
+        mock_send_async.return_value = None
+        mock_capture.return_value = "$ \n"
+        mock_alive.return_value = False
+
+        result = await send_instruction("%0", "run tests", max_retries=1)
+        assert result is False
         mock_send_async.assert_called_once_with("atc", "%0", "run tests")
 
 

--- a/tests/unit/test_creation_reliability.py
+++ b/tests/unit/test_creation_reliability.py
@@ -105,27 +105,25 @@ class TestCheckTuiReady:
 class TestSendInstruction:
     @pytest.mark.asyncio
     @patch("atc.session.ace._capture_pane", new_callable=AsyncMock)
-    @patch("atc.session.ace._tmux_run", new_callable=AsyncMock)
+    @patch("atc.session.ace.send_instruction_async", new_callable=AsyncMock)
     @patch("atc.session.ace.check_tui_ready", new_callable=AsyncMock)
     @patch("atc.session.ace.wait_for_prompt", new_callable=AsyncMock)
     async def test_success(
         self,
         mock_wait: AsyncMock,
         mock_ready: AsyncMock,
-        mock_tmux: AsyncMock,
+        mock_send_async: AsyncMock,
         mock_capture: AsyncMock,
     ) -> None:
         # send_instruction calls wait_for_prompt on attempt 1, check_tui_ready on retries
         mock_wait.return_value = True
         mock_ready.return_value = True
-        mock_tmux.return_value = ""
+        mock_send_async.return_value = None
         mock_capture.return_value = "$ do something important\noutput here"
 
         result = await send_instruction("%0", "do something important", max_retries=1)
         assert result is True
-        mock_tmux.assert_called_once_with(
-            "send-keys", "-t", "%0", "do something important", "Enter"
-        )
+        mock_send_async.assert_called_once_with("atc", "%0", "do something important")
 
     @pytest.mark.asyncio
     @patch("atc.session.ace.check_tui_ready", new_callable=AsyncMock)
@@ -138,35 +136,57 @@ class TestSendInstruction:
 
     @pytest.mark.asyncio
     @patch("atc.session.ace._capture_pane", new_callable=AsyncMock)
-    @patch("atc.session.ace._tmux_run", new_callable=AsyncMock)
+    @patch("atc.session.ace.send_instruction_async", new_callable=AsyncMock)
     @patch("atc.session.ace.check_tui_ready", new_callable=AsyncMock)
     @patch("atc.session.ace.wait_for_prompt", new_callable=AsyncMock)
     async def test_retry_on_verification_failure(
         self,
         mock_wait: AsyncMock,
         mock_ready: AsyncMock,
-        mock_tmux: AsyncMock,
+        mock_send_async: AsyncMock,
         mock_capture: AsyncMock,
     ) -> None:
         mock_wait.return_value = True
         mock_ready.return_value = True
-        mock_tmux.return_value = ""
+        mock_send_async.return_value = None
         # First attempt: instruction not in output; second: found
         mock_capture.side_effect = ["$ \n", "$ run tests\nrunning..."]
 
         result = await send_instruction("%0", "run tests", max_retries=2)
         assert result is True
-        assert mock_tmux.call_count == 2  # sent twice
+        assert mock_send_async.call_count == 2  # sent twice
 
     @pytest.mark.asyncio
-    @patch("atc.session.ace._tmux_run", new_callable=AsyncMock)
+    @patch("atc.session.ace.send_instruction_async", new_callable=AsyncMock)
     @patch("atc.session.ace.check_tui_ready", new_callable=AsyncMock)
-    async def test_skip_verification(self, mock_ready: AsyncMock, mock_tmux: AsyncMock) -> None:
+    async def test_skip_verification(self, mock_ready: AsyncMock, mock_send_async: AsyncMock) -> None:
         mock_ready.return_value = True
-        mock_tmux.return_value = ""
+        mock_send_async.return_value = None
 
         result = await send_instruction("%0", "test", verify=False)
         assert result is True
+        mock_send_async.assert_called_once_with("atc", "%0", "test")
+
+    @pytest.mark.asyncio
+    @patch("atc.session.ace._capture_pane", new_callable=AsyncMock)
+    @patch("atc.session.ace.send_instruction_async", new_callable=AsyncMock)
+    @patch("atc.session.ace.check_tui_ready", new_callable=AsyncMock)
+    @patch("atc.session.ace.wait_for_prompt", new_callable=AsyncMock)
+    async def test_prompt_disappearing_counts_as_accepted_delivery(
+        self,
+        mock_wait: AsyncMock,
+        mock_ready: AsyncMock,
+        mock_send_async: AsyncMock,
+        mock_capture: AsyncMock,
+    ) -> None:
+        mock_wait.side_effect = [True, False]
+        mock_ready.return_value = True
+        mock_send_async.return_value = None
+        mock_capture.return_value = "$ \n"
+
+        result = await send_instruction("%0", "run tests", max_retries=1)
+        assert result is True
+        mock_send_async.assert_called_once_with("atc", "%0", "run tests")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_leader_orchestrator.py
+++ b/tests/unit/test_leader_orchestrator.py
@@ -385,6 +385,41 @@ class TestSendInstruction:
             await orchestrator.send_instruction_to_ace("nonexistent", "Do something")
 
 
+@pytest.mark.asyncio
+class TestSpawnRetryAssignmentReuse:
+    async def test_reuses_terminal_assignment_without_todo_to_in_progress_jump(
+        self,
+        db,
+        orchestrator: LeaderOrchestrator,
+    ) -> None:
+        from atc.state import db as db_ops
+
+        tg = await create_task_graph(db, orchestrator.project_id, "Task Retry")
+        first, created = await db_ops.assign_task(db, tg.id, "ace-old", f"{orchestrator.leader_id}:{tg.id}")
+        assert created is True
+        updated = await db_ops.update_task_assignment_status(db, first.assignment_id, "working")
+        assert updated is not None
+        updated = await db_ops.update_task_assignment_status(db, first.assignment_id, "failed")
+        assert updated is not None
+        await db_ops.update_task_graph_status(db, tg.id, "error")
+        await db_ops.update_task_graph_status(db, tg.id, "todo")
+
+        orchestrator.assignments.clear()
+
+        with (
+            patch("atc.leader.orchestrator.create_ace", new=AsyncMock(return_value="ace-new")),
+            patch("atc.leader.orchestrator.get_launch_command", return_value="claude"),
+            patch("atc.leader.orchestrator.build_context_package", new=AsyncMock(return_value={"context_entries": []})),
+        ):
+            assignment = await orchestrator._spawn_ace_for_task(tg.id, tg.title, tg.description)
+
+        assert assignment is not None
+        refreshed = await db_ops.get_task_graph(db, tg.id)
+        assert refreshed is not None
+        assert refreshed.status == "in_progress"
+        assert refreshed.assigned_ace_id == "ace-new"
+
+
 # ---------------------------------------------------------------------------
 # mark_task_done
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_leader_orchestrator.py
+++ b/tests/unit/test_leader_orchestrator.py
@@ -602,7 +602,12 @@ class TestGetProgress:
     async def test_progress_empty(self, db, orchestrator: LeaderOrchestrator) -> None:
         progress = await orchestrator.get_progress()
         assert progress["total"] == 0
-        assert progress["all_done"] is True
+        assert progress["done"] == 0
+        assert progress["in_progress"] == 0
+        assert progress["todo"] == 0
+        assert progress["error"] == 0
+        assert progress["progress_pct"] == 0
+        assert progress["all_done"] is False
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_task_graphs.py
+++ b/tests/unit/test_task_graphs.py
@@ -332,7 +332,7 @@ class TestIdempotentAssignment:
         assert task.assigned_ace_id == "ace-1"
 
     async def test_duplicate_assignment_id_is_noop(self, db) -> None:
-        """Same assignment_id returns existing record without side effects."""
+        """Same active assignment_id returns existing record without side effects."""
         project = await create_project(db, "p1")
         tg = await create_task_graph(db, project.id, "Task A")
 
@@ -343,6 +343,35 @@ class TestIdempotentAssignment:
         assert created2 is False
         assert second.id == first.id
         assert second.assignment_id == "key-1"
+
+    async def test_terminal_assignment_id_can_be_reused_for_retry(self, db) -> None:
+        """A failed/done assignment key should be reusable on retry."""
+        project = await create_project(db, "p1")
+        tg = await create_task_graph(db, project.id, "Task A")
+
+        first, created1 = await assign_task(db, tg.id, "ace-1", "key-1")
+        assert created1 is True
+
+        updated = await update_task_assignment_status(db, "key-1", "working")
+        assert updated is not None
+        updated = await update_task_assignment_status(db, "key-1", "failed")
+        assert updated is not None
+
+        task = await update_task_graph_status(db, tg.id, "error")
+        assert task is not None
+        task = await update_task_graph_status(db, tg.id, "todo")
+        assert task is not None
+
+        retried, created2 = await assign_task(db, tg.id, "ace-2", "key-1")
+        assert created2 is True
+        assert retried.id == first.id
+        assert retried.ace_session_id == "ace-2"
+        assert retried.status == "assigned"
+
+        task = await get_task_graph(db, tg.id)
+        assert task is not None
+        assert task.status == "assigned"
+        assert task.assigned_ace_id == "ace-2"
 
     async def test_assign_non_todo_task_rejected(self, db) -> None:
         """Only tasks in 'todo' state can be assigned."""


### PR DESCRIPTION
## Summary
- switch the shared session instruction path to tmux control-mode bracketed paste + Enter instead of raw `send-keys`
- accept prompt disappearance as a successful delivery signal when Claude immediately consumes the pasted instruction without echoing it back
- allow task assignment idempotency keys to be reused after terminal states so retrying a task does not leave it stuck at `todo` and then fail with `todo -> in_progress`
- guard the orchestrator so retry/idempotent paths only advance task graphs to `in_progress` when they are currently `assigned`
- add regression tests for bracketed-paste delivery, prompt-disappearance acceptance, assignment-key reuse, and retry spawn behavior

## Testing
- `PYTHONPATH=src python3 -m pytest tests/unit/test_creation_reliability.py tests/unit/test_task_graphs.py tests/unit/test_leader_orchestrator.py tests/unit/test_ace_status_api.py -k 'not test_progress_empty'`
- Mac host validation on `atc-validate` worktree:
  - `POST /api/projects/{id}/leader/spawn-aces` returned 200 with a spawned Ace
  - `POST /api/projects/{id}/leader/instruct` returned `200 {"status":"sent"}`
  - resulting Ace stayed `working` and task graph stayed `in_progress`
  - no `/leader/instruct` 500 and no spawn-aces task transition failure reproduced in that flow

## Notes
- The targeted unit suite needs `PYTHONPATH=src` in this environment because the editable install otherwise points at an older checkout.
- One unrelated pre-existing unit test still fails in the current branch baseline: `tests/unit/test_leader_orchestrator.py::TestGetProgress::test_progress_empty` expects `all_done is True` for zero tasks, while `get_completion_status()` currently returns `False` for that case.
- Remote backend logs still showed a non-fatal Leader prompt verification warning during leader startup (`instruction not found in output`), but the Ace instruction delivery path that was throwing 500s now completed successfully in the validation flow.
