### PR TITLE
Fix leader instruction submit after login

### DIFF
--- a/src/atc/leader/leader.py
+++ b/src/atc/leader/leader.py
@@ -304,4 +304,16 @@ async def send_leader_message(
     if not await _pane_is_alive(session.tmux_pane):
         raise ValueError("Leader tmux pane is dead — stop and restart the leader")
 
-    await send_instruction(session.tmux_pane, message)
+    delivered = await send_instruction(session.tmux_pane, message)
+    if not delivered:
+        logger.error(
+            "Leader %s: instruction delivery failed for project %s",
+            session.id,
+            project_id,
+        )
+        await db_ops.update_session_status(conn, session.id, SessionStatus.ERROR.value)
+        try:
+            await transition(session.id, SessionStatus.WORKING, SessionStatus.ERROR, event_bus)
+        except Exception:
+            pass
+        raise ValueError("Leader instruction delivery failed — restart the leader after Claude login if needed")

--- a/src/atc/session/ace.py
+++ b/src/atc/session/ace.py
@@ -567,6 +567,41 @@ async def send_instruction(
                     pane_id,
                     attempt,
                 )
+
+            # Live macOS repro: after /login recovery, bracketed paste can land
+            # in the Claude prompt while the submit keystroke is effectively lost.
+            # When we can still see the full instruction sitting at a bare prompt,
+            # send one extra plain Enter before declaring delivery failure.
+            prompt_lines = [line.rstrip() for line in output.splitlines() if line.strip()]
+            last_line = prompt_lines[-1] if prompt_lines else ""
+            at_bare_prompt = last_line.startswith("❯") or last_line.startswith(">")
+            if at_bare_prompt and fingerprint and fingerprint in output:
+                logger.info(
+                    "Pane %s: instruction still visible at prompt on attempt %d; sending extra Enter",
+                    pane_id,
+                    attempt,
+                )
+                await _tmux_run("send-keys", "-t", pane_id, "Enter")
+                await asyncio.sleep(1.0)
+                follow_up = await _capture_pane(pane_id)
+                follow_lines = [line.rstrip() for line in follow_up.splitlines() if line.strip()]
+                follow_last = follow_lines[-1] if follow_lines else ""
+                if not (follow_last.startswith("❯") or follow_last.startswith(">")):
+                    logger.info(
+                        "Pane %s: extra Enter cleared bare prompt on attempt %d",
+                        pane_id,
+                        attempt,
+                    )
+                    return True
+                if not await wait_for_prompt(pane_id, timeout=1.0, poll_interval=0.25):
+                    if await _pane_is_alive(pane_id):
+                        logger.info(
+                            "Pane %s: extra Enter caused prompt to disappear on attempt %d",
+                            pane_id,
+                            attempt,
+                        )
+                        return True
+
             logger.warning(
                 "Pane %s: instruction not found in output (attempt %d/%d)",
                 pane_id,


### PR DESCRIPTION
## Summary
- retry instruction submission with one extra Enter when login recovery leaves the full instruction sitting at a bare Claude prompt
- treat failed leader instruction delivery as an error instead of reporting success
- log the failure and move the leader session to error so callers can surface the problem

## Context
Live macOS repro showed the Leader instruction text pasted into the Claude prompt without execution after /login recovery, while backend logs already indicated delivery failure.