### PR TITLE
fix: resolve tmux binary for control-mode attach on macOS

### DIFF
--- a/src/atc/api/app.py
+++ b/src/atc/api/app.py
@@ -452,8 +452,6 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
         except Exception:
             logger.exception("Tower auto-start failed — Tower will start in idle state")
 
-    asyncio.create_task(_auto_start_tower())
-
     # 9. Start resource monitor
     from atc.tracking.resources import ResourceMonitor
 
@@ -541,6 +539,7 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
     _resolve_claude_binary(settings)
 
     logger.info("ATC startup complete")
+    asyncio.create_task(_auto_start_tower())
     await memory_cron.start()
     yield
 

--- a/src/atc/api/app.py
+++ b/src/atc/api/app.py
@@ -486,6 +486,10 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
     memory_cron = MemoryCron(db_path, event_bus, ws_hub=ws_hub)
     app.state.memory_cron = memory_cron
 
+    # Startup DB-heavy background jobs only after init work is complete.
+    await memory_cron.start()
+    asyncio.create_task(_auto_start_tower())
+
     # 14. Start backup service
     from pathlib import Path as _Path
 

--- a/src/atc/api/app.py
+++ b/src/atc/api/app.py
@@ -48,9 +48,10 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
     # 3. Open a persistent DB connection for the app
     import aiosqlite
 
-    db = await aiosqlite.connect(db_path)
+    db = await aiosqlite.connect(db_path, timeout=30.0)
     await db.execute("PRAGMA journal_mode=WAL")
     await db.execute("PRAGMA foreign_keys=ON")
+    await db.execute("PRAGMA busy_timeout=30000")
     db.row_factory = aiosqlite.Row
     app.state.db = db
 
@@ -484,7 +485,7 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
     # 13. Start memory consolidation cron
     from atc.memory.cron import MemoryCron
 
-    memory_cron = MemoryCron(db, event_bus, ws_hub=ws_hub)
+    memory_cron = MemoryCron(db_path, event_bus, ws_hub=ws_hub)
     await memory_cron.start()
     app.state.memory_cron = memory_cron
 

--- a/src/atc/api/app.py
+++ b/src/atc/api/app.py
@@ -486,7 +486,6 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
     from atc.memory.cron import MemoryCron
 
     memory_cron = MemoryCron(db_path, event_bus, ws_hub=ws_hub)
-    await memory_cron.start()
     app.state.memory_cron = memory_cron
 
     # 14. Start backup service
@@ -542,6 +541,7 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
     _resolve_claude_binary(settings)
 
     logger.info("ATC startup complete")
+    await memory_cron.start()
     yield
 
     # Shutdown

--- a/src/atc/api/app.py
+++ b/src/atc/api/app.py
@@ -539,8 +539,6 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
     _resolve_claude_binary(settings)
 
     logger.info("ATC startup complete")
-    asyncio.create_task(_auto_start_tower())
-    await memory_cron.start()
     yield
 
     # Shutdown

--- a/src/atc/memory/cron.py
+++ b/src/atc/memory/cron.py
@@ -25,6 +25,8 @@ from typing import TYPE_CHECKING
 from atc.memory.consolidation import MemoryConsolidation
 
 if TYPE_CHECKING:
+    from collections.abc import AsyncIterator
+
     import aiosqlite
 
     from atc.api.ws.hub import WsHub
@@ -40,13 +42,13 @@ class MemoryCron:
 
     def __init__(
         self,
-        db: aiosqlite.Connection,
+        db_path: str,
         event_bus: EventBus,
         *,
         ws_hub: WsHub | None = None,
         check_interval: float = _CHECK_INTERVAL,
     ) -> None:
-        self._db = db
+        self._db_path = db_path
         self._event_bus = event_bus
         self._ws_hub = ws_hub
         self._check_interval = check_interval
@@ -60,9 +62,10 @@ class MemoryCron:
 
         # On startup: trigger immediately if no run today
         try:
-            if await MemoryConsolidation.should_run_for_day(self._db):
-                logger.info("Memory cron: first run of day — triggering consolidation now")
-                self._running_job = asyncio.create_task(self._run_job("startup"))
+            async with self._connection() as db:
+                if await MemoryConsolidation.should_run_for_day(db):
+                    logger.info("Memory cron: first run of day — triggering consolidation now")
+                    self._running_job = asyncio.create_task(self._run_job("startup"))
         except Exception:
             logger.exception("Memory cron: startup check failed")
 
@@ -115,9 +118,10 @@ class MemoryCron:
             logger.debug("Memory cron: consolidation already running, skipping check")
             return
 
-        if not await MemoryConsolidation.should_run(self._db):
-            logger.debug("Memory cron: skipping — consolidation not yet due")
-            return
+        async with self._connection() as db:
+            if not await MemoryConsolidation.should_run(db):
+                logger.debug("Memory cron: skipping — consolidation not yet due")
+                return
 
         logger.info("Memory cron: consolidation is due — launching job")
         self._running_job = asyncio.create_task(self._run_job("scheduled"))
@@ -126,9 +130,10 @@ class MemoryCron:
         """Execute consolidation and log result."""
         logger.info("Memory cron: starting consolidation (trigger=%s)", trigger)
         try:
-            result = await MemoryConsolidation.run_consolidation(
-                self._db, self._event_bus, self._ws_hub
-            )
+            async with self._connection() as db:
+                result = await MemoryConsolidation.run_consolidation(
+                    db, self._event_bus, self._ws_hub
+                )
             logger.info(
                 "Memory cron: consolidation done (trigger=%s status=%s written=%d)",
                 trigger,
@@ -149,14 +154,22 @@ class MemoryCron:
     async def last_run_at(self) -> str | None:
         """Return ISO-8601 timestamp of the last finished consolidation run, or None."""
         try:
-            cursor = await self._db.execute(
-                """SELECT finished_at FROM memory_consolidation_runs
+            async with self._connection() as db:
+                cursor = await db.execute(
+                    """SELECT finished_at FROM memory_consolidation_runs
                    WHERE status = 'done' ORDER BY finished_at DESC LIMIT 1"""
-            )
-            row = await cursor.fetchone()
-            return str(row["finished_at"]) if row and row["finished_at"] else None
+                )
+                row = await cursor.fetchone()
+                return str(row["finished_at"]) if row and row["finished_at"] else None
         except Exception:
             return None
+
+    @contextlib.asynccontextmanager
+    async def _connection(self) -> "AsyncIterator[aiosqlite.Connection]":
+        from atc.state.db import get_connection
+
+        async with get_connection(self._db_path) as db:
+            yield db
 
     async def next_run_at(self) -> str | None:
         """Return the estimated ISO-8601 timestamp for the next scheduled run."""

--- a/src/atc/state/db.py
+++ b/src/atc/state/db.py
@@ -190,10 +190,11 @@ def _uuid() -> str:
 @asynccontextmanager
 async def get_connection(db_path: str) -> AsyncIterator[aiosqlite.Connection]:
     """Yield an aiosqlite connection with WAL mode and foreign keys enabled."""
-    db = await aiosqlite.connect(db_path)
+    db = await aiosqlite.connect(db_path, timeout=30.0)
     try:
         await db.execute("PRAGMA journal_mode=WAL")
         await db.execute("PRAGMA foreign_keys=ON")
+        await db.execute("PRAGMA busy_timeout=30000")
         db.row_factory = aiosqlite.Row
         yield db
     finally:

--- a/src/atc/terminal/control.py
+++ b/src/atc/terminal/control.py
@@ -20,6 +20,17 @@ from typing import ClassVar
 
 logger = logging.getLogger(__name__)
 
+
+def _tmux_binary() -> str:
+    """Resolve tmux path consistently across Linux/macOS and sparse PATHs."""
+    tmux = shutil.which("tmux")
+    if tmux:
+        return tmux
+    for candidate in ("/usr/local/bin/tmux", "/opt/homebrew/bin/tmux", "/usr/bin/tmux"):
+        if shutil.which(candidate):
+            return candidate
+    return "tmux"
+
 # Bracketed paste escape sequences
 # ESC [ 2 0 0 ~  →  start of paste
 _BP_PREFIX = bytes([0x1B, 0x5B, 0x32, 0x30, 0x30, 0x7E])

--- a/src/atc/tower/controller.py
+++ b/src/atc/tower/controller.py
@@ -798,6 +798,61 @@ class TowerController:
                 exc,
             )
 
+    async def _on_leader_output(self, data: dict[str, Any]) -> None:
+        """Capture PTY output from the Leader session for monitoring.
+
+        After submit_goal() starts a Leader, Tower's Claude session needs to
+        know the goal and leader session ID so it can begin monitoring.
+        This is fire-and-forget: if Tower's terminal isn't ready, we log and move on.
+        """
+        if not self._current_session_id:
+            return
+
+        # Wait briefly for Tower's pane to be ready before sending
+        await asyncio.sleep(3.0)
+
+        # Look up the project name for a friendlier message
+        try:
+            cursor = await self._db.execute(
+                "SELECT name FROM projects WHERE id = ?",
+                (project_id,),
+            )
+            row = await cursor.fetchone()
+            project_name = row[0] if row else project_id[:8]
+        except Exception:
+            project_name = project_id[:8]
+
+        notification = (
+            f"[ATC] Leader started for project '{project_name}'.\n"
+            f"Goal: {goal}\n"
+            f"Leader session: {leader_session_id}\n"
+            f"Project ID: {project_id}\n\n"
+            f"Begin monitoring. Check progress with:\n"
+            f"  curl -s http://127.0.0.1:8420/api/projects/{project_id}/leader/progress\n"
+            f"Send nudges if stuck:\n"
+            f"  atc leader message --project-id {project_id} --message 'Please continue with your goal.'\n"
+            f"\nDo NOT write code or create files yourself — delegate to the Leader only."
+        )
+
+        try:
+            await send_tower_message(
+                self._db,
+                self._current_session_id,
+                notification,
+                event_bus=self._event_bus,
+            )
+            logger.info(
+                "Sent goal notification to Tower session %s (project %s)",
+                self._current_session_id,
+                project_id,
+            )
+        except Exception as exc:
+            logger.warning(
+                "Could not notify Tower session %s of new goal: %s",
+                self._current_session_id,
+                exc,
+            )
+
     @staticmethod
     def _extract_auth_blocker(text: str) -> str | None:
         """Return a human-readable auth blocker when Claude is not usable."""

--- a/tests/unit/test_memory.py
+++ b/tests/unit/test_memory.py
@@ -345,7 +345,7 @@ class TestMemoryCron:
         from atc.memory.cron import MemoryCron
 
         mock_bus = MagicMock()
-        cron = MemoryCron(db, mock_bus)
+        cron = MemoryCron(":memory:", mock_bus)
 
         with patch(
             "atc.memory.cron.MemoryConsolidation.run_consolidation",
@@ -367,7 +367,7 @@ class TestMemoryCron:
         from atc.memory.cron import MemoryCron
 
         mock_bus = MagicMock()
-        cron = MemoryCron(db, mock_bus)
+        cron = MemoryCron(":memory:", mock_bus)
 
         async def _slow_job(*args, **kwargs):  # type: ignore[no-untyped-def]
             import asyncio


### PR DESCRIPTION
## Summary
- resolve tmux path in terminal/control.py the same way other tmux helpers already do
- fix macOS SSH/backend environments where panes can spawn but control-mode attach fails because bare  is not on PATH
- keep Leader/Ace instruction delivery from failing after successful pane creation

## Validation
- pytest -q tests/unit/test_leader_orchestrator.py tests/unit/test_leader_api.py tests/unit/test_e2e_wiring.py
