### PR TITLE
fix: bridge retried leader tasks through assigned state

### DIFF
--- a/src/atc/leader/orchestrator.py
+++ b/src/atc/leader/orchestrator.py
@@ -221,12 +221,16 @@ class LeaderOrchestrator:
                 title,
             )
 
-        # Transition the task to in_progress now that the Ace is running
-        await db_ops.update_task_graph_status(
-            self.conn,
-            task_graph_id,
-            "in_progress",
-        )
+        # Transition the task to in_progress now that the Ace is running.
+        # Retry/idempotent paths can surface an already-assigned or already-
+        # in-progress task; only advance when needed.
+        task_graph = await db_ops.get_task_graph(self.conn, task_graph_id)
+        if task_graph is not None and task_graph.status == "assigned":
+            await db_ops.update_task_graph_status(
+                self.conn,
+                task_graph_id,
+                "in_progress",
+            )
 
         assignment = AceAssignment(
             ace_session_id=session_id,

--- a/src/atc/leader/orchestrator.py
+++ b/src/atc/leader/orchestrator.py
@@ -222,15 +222,23 @@ class LeaderOrchestrator:
             )
 
         # Transition the task to in_progress now that the Ace is running.
-        # Retry/idempotent paths can surface an already-assigned or already-
-        # in-progress task; only advance when needed.
+        # Retry/idempotent paths can reuse a terminal assignment row whose
+        # task_graph may already have been reset to todo, so bridge through
+        # assigned first when needed instead of tripping the state machine.
         task_graph = await db_ops.get_task_graph(self.conn, task_graph_id)
-        if task_graph is not None and task_graph.status == "assigned":
-            await db_ops.update_task_graph_status(
-                self.conn,
-                task_graph_id,
-                "in_progress",
-            )
+        if task_graph is not None:
+            if task_graph.status == "todo":
+                task_graph = await db_ops.update_task_graph_status(
+                    self.conn,
+                    task_graph_id,
+                    "assigned",
+                )
+            if task_graph is not None and task_graph.status == "assigned":
+                await db_ops.update_task_graph_status(
+                    self.conn,
+                    task_graph_id,
+                    "in_progress",
+                )
 
         assignment = AceAssignment(
             ace_session_id=session_id,

--- a/src/atc/session/ace.py
+++ b/src/atc/session/ace.py
@@ -551,14 +551,22 @@ async def send_instruction(
 
             # Claude sometimes consumes a bracketed paste immediately without leaving
             # the full instruction visible in capture-pane. If the prompt is no longer
-            # bare, treat that as accepted input rather than a swallowed send.
+            # bare, treat that as accepted input rather than a swallowed send — but
+            # only if the pane is still alive. A dead pane must remain a delivery
+            # failure so callers can retry/report accurately.
             if not await wait_for_prompt(pane_id, timeout=1.0, poll_interval=0.25):
-                logger.info(
-                    "Pane %s: prompt disappeared after send on attempt %d — assuming instruction accepted",
+                if await _pane_is_alive(pane_id):
+                    logger.info(
+                        "Pane %s: prompt disappeared after send on attempt %d — assuming instruction accepted",
+                        pane_id,
+                        attempt,
+                    )
+                    return True
+                logger.warning(
+                    "Pane %s: prompt disappeared after send on attempt %d but pane is dead",
                     pane_id,
                     attempt,
                 )
-                return True
             logger.warning(
                 "Pane %s: instruction not found in output (attempt %d/%d)",
                 pane_id,

--- a/src/atc/session/ace.py
+++ b/src/atc/session/ace.py
@@ -452,6 +452,33 @@ async def wait_for_prompt(
     return False
 
 
+def _instruction_still_pending(output: str, text: str) -> bool:
+    """Return True when the sent instruction still appears to be sitting at the prompt.
+
+    Claude Code shows unsent pasted input as a visible prompt-line payload such as:
+    ``[Pasted text #1 +22 lines]Please continue with your goal.``
+    or a bare prompt line followed by the instruction body. In that state, the
+    instruction has *not* been accepted/executed yet, so delivery must remain a
+    failure rather than being treated as "sent".
+    """
+    normalized = " ".join(output.split())
+    fingerprint = " ".join(text[:120].strip().split())
+    if not fingerprint:
+        return False
+
+    pending_markers = (
+        "[pasted text #",
+        "pasted text #",
+    )
+    normalized_lower = normalized.lower()
+    if fingerprint in normalized:
+        if any(marker in normalized_lower for marker in pending_markers):
+            return True
+        if normalized_lower.endswith(fingerprint.lower()):
+            return True
+    return False
+
+
 async def check_tui_ready(
     pane_id: str,
     *,
@@ -546,27 +573,43 @@ async def send_instruction(
             # Use the first 80 chars as a fingerprint to avoid issues with line wrapping.
             fingerprint = text[:80].strip()
             if fingerprint and fingerprint in output:
-                logger.info("Pane %s: instruction verified on attempt %d", pane_id, attempt)
-                return True
+                if _instruction_still_pending(output, text):
+                    logger.warning(
+                        "Pane %s: instruction fingerprint still visible as pending input on attempt %d",
+                        pane_id,
+                        attempt,
+                    )
+                else:
+                    logger.info("Pane %s: instruction verified on attempt %d", pane_id, attempt)
+                    return True
 
             # Claude sometimes consumes a bracketed paste immediately without leaving
             # the full instruction visible in capture-pane. If the prompt is no longer
             # bare, treat that as accepted input rather than a swallowed send — but
-            # only if the pane is still alive. A dead pane must remain a delivery
-            # failure so callers can retry/report accurately.
-            if not await wait_for_prompt(pane_id, timeout=1.0, poll_interval=0.25):
-                if await _pane_is_alive(pane_id):
+            # only if the pane is still alive and the capture does not still show the
+            # instruction sitting unsent at the prompt. A dead pane must remain a
+            # delivery failure so callers can retry/report accurately.
+            prompt_ready = await wait_for_prompt(pane_id, timeout=1.0, poll_interval=0.25)
+            if not prompt_ready:
+                if _instruction_still_pending(output, text):
+                    logger.warning(
+                        "Pane %s: prompt changed after send on attempt %d but instruction still appears pending",
+                        pane_id,
+                        attempt,
+                    )
+                elif await _pane_is_alive(pane_id):
                     logger.info(
                         "Pane %s: prompt disappeared after send on attempt %d — assuming instruction accepted",
                         pane_id,
                         attempt,
                     )
                     return True
-                logger.warning(
-                    "Pane %s: prompt disappeared after send on attempt %d but pane is dead",
-                    pane_id,
-                    attempt,
-                )
+                else:
+                    logger.warning(
+                        "Pane %s: prompt disappeared after send on attempt %d but pane is dead",
+                        pane_id,
+                        attempt,
+                    )
             logger.warning(
                 "Pane %s: instruction not found in output (attempt %d/%d)",
                 pane_id,

--- a/src/atc/session/ace.py
+++ b/src/atc/session/ace.py
@@ -30,6 +30,7 @@ from atc.session.state_machine import (
     transition,
 )
 from atc.state import db as db_ops
+from atc.terminal.control import send_instruction_async
 
 if TYPE_CHECKING:
     import aiosqlite  # type: ignore[import-not-found]
@@ -509,8 +510,10 @@ async def send_instruction(
             logger.warning("Pane %s: TUI not ready on attempt %d/%d", pane_id, attempt, max_retries)
             continue
 
-        # Step 2: Atomic send — text and Enter back-to-back, no await gap
-        await _tmux_run("send-keys", "-t", pane_id, text, "Enter")
+        # Step 2: Atomic send — bracketed paste plus Enter via tmux control mode.
+        # This is more reliable with Claude Code than raw send-keys text because
+        # the whole payload lands as one paste event before Enter is pressed.
+        await send_instruction_async(ATC_TMUX_SESSION, pane_id, text)
 
         if not verify:
             return True
@@ -544,6 +547,17 @@ async def send_instruction(
             fingerprint = text[:80].strip()
             if fingerprint and fingerprint in output:
                 logger.info("Pane %s: instruction verified on attempt %d", pane_id, attempt)
+                return True
+
+            # Claude sometimes consumes a bracketed paste immediately without leaving
+            # the full instruction visible in capture-pane. If the prompt is no longer
+            # bare, treat that as accepted input rather than a swallowed send.
+            if not await wait_for_prompt(pane_id, timeout=1.0, poll_interval=0.25):
+                logger.info(
+                    "Pane %s: prompt disappeared after send on attempt %d — assuming instruction accepted",
+                    pane_id,
+                    attempt,
+                )
                 return True
             logger.warning(
                 "Pane %s: instruction not found in output (attempt %d/%d)",

--- a/src/atc/state/db.py
+++ b/src/atc/state/db.py
@@ -1143,14 +1143,18 @@ async def assign_task(
     Raises ``ValueError`` if the task is not in a state that allows
     assignment (i.e. not ``todo``).
     """
-    # Check for existing assignment with same idempotency key
+    # Check for existing assignment with same idempotency key.
+    # Active assignments are true idempotent no-ops; terminal assignments need to
+    # be reusable so retrying the same task after a failure/done state can create
+    # a fresh live assignment without tripping later task-state transitions.
     cursor = await db.execute(
         "SELECT * FROM task_assignments WHERE assignment_id = ?",
         (assignment_id,),
     )
     existing_row = await cursor.fetchone()
-    if existing_row is not None:
-        return _row_to_task_assignment(existing_row), False
+    existing = _row_to_task_assignment(existing_row) if existing_row is not None else None
+    if existing is not None and existing.status in {"assigned", "working"}:
+        return existing, False
 
     # Validate the task exists and is in assignable state
     task = await get_task_graph(db, task_graph_id)
@@ -1180,30 +1184,45 @@ async def assign_task(
         )
 
     now = _now()
-    assignment = TaskAssignment(
-        id=_uuid(),
-        task_graph_id=task_graph_id,
-        ace_session_id=ace_session_id,
-        assignment_id=assignment_id,
-        status="assigned",
-        created_at=now,
-        updated_at=now,
-    )
+    if existing is not None:
+        assignment = TaskAssignment(
+            id=existing.id,
+            task_graph_id=existing.task_graph_id,
+            ace_session_id=ace_session_id,
+            assignment_id=existing.assignment_id,
+            status="assigned",
+            created_at=existing.created_at,
+            updated_at=now,
+        )
+        await db.execute(
+            "UPDATE task_assignments SET ace_session_id = ?, status = ?, updated_at = ? WHERE assignment_id = ?",
+            (ace_session_id, assignment.status, assignment.updated_at, assignment.assignment_id),
+        )
+    else:
+        assignment = TaskAssignment(
+            id=_uuid(),
+            task_graph_id=task_graph_id,
+            ace_session_id=ace_session_id,
+            assignment_id=assignment_id,
+            status="assigned",
+            created_at=now,
+            updated_at=now,
+        )
 
-    await db.execute(
-        """INSERT INTO task_assignments
-           (id, task_graph_id, ace_session_id, assignment_id, status, created_at, updated_at)
-           VALUES (?, ?, ?, ?, ?, ?, ?)""",
-        (
-            assignment.id,
-            assignment.task_graph_id,
-            assignment.ace_session_id,
-            assignment.assignment_id,
-            assignment.status,
-            assignment.created_at,
-            assignment.updated_at,
-        ),
-    )
+        await db.execute(
+            """INSERT INTO task_assignments
+               (id, task_graph_id, ace_session_id, assignment_id, status, created_at, updated_at)
+               VALUES (?, ?, ?, ?, ?, ?, ?)""",
+            (
+                assignment.id,
+                assignment.task_graph_id,
+                assignment.ace_session_id,
+                assignment.assignment_id,
+                assignment.status,
+                assignment.created_at,
+                assignment.updated_at,
+            ),
+        )
 
     # Transition the task_graph to 'assigned'
     await db.execute(

--- a/src/atc/terminal/control.py
+++ b/src/atc/terminal/control.py
@@ -38,8 +38,17 @@ _BP_PREFIX = bytes([0x1B, 0x5B, 0x32, 0x30, 0x30, 0x7E])
 # ESC [ 2 0 1 ~  →  end of paste
 _BP_SUFFIX = bytes([0x1B, 0x5B, 0x32, 0x30, 0x31, 0x7E])
 
-# Enter key in hex
-_ENTER_HEX = "0d"
+# Enter key name for tmux send-keys.
+#
+# On macOS tmux control mode, `send-keys -H ... 0d` can leave pasted input sitting
+# at the prompt without actually submitting it. A symbolic `Enter` key works
+# reliably there and on Linux.
+_ENTER_KEY = "Enter"
+
+# Small settle delay between bracketed paste and Enter.
+# Without this, tmux control mode on macOS can leave the pasted instruction
+# sitting visibly at the Claude prompt even though both commands were written.
+_ENTER_SETTLE_DELAY = 0.2
 
 
 # ---------------------------------------------------------------------------
@@ -230,7 +239,11 @@ class TmuxControlConnection:
         await self._proc.stdin.drain()
 
     async def send_enter(self, target: str) -> None:
-        """Send the Enter key (0x0d) to *target*.
+        """Send the Enter key to *target*.
+
+        Uses tmux's symbolic `Enter` key instead of a hex carriage return.
+        Control mode on macOS accepted the pasted text but sometimes ignored a
+        hex `0d`, leaving the instruction visibly pending at the prompt.
 
         Raises:
             RuntimeError: if the connection is not alive.
@@ -239,7 +252,7 @@ class TmuxControlConnection:
             raise RuntimeError(
                 f"Control connection for {self._tmux_session!r} is not alive"
             )
-        cmd = f"send-keys -H -t {target} {_ENTER_HEX}\n"
+        cmd = f"send-keys -t {target} {_ENTER_KEY}\n"
         self._proc.stdin.write(cmd.encode())
         await self._proc.stdin.drain()
 
@@ -362,6 +375,7 @@ async def send_instruction_async(
     try:
         conn = await pool.get_connection(tmux_session)
         await conn.send_keys(target, text, bracketed=True)
+        await asyncio.sleep(_ENTER_SETTLE_DELAY)
         await conn.send_enter(target)
     except Exception as exc:
         logger.warning(
@@ -373,6 +387,7 @@ async def send_instruction_async(
             await old.stop()
         conn = await pool.get_connection(tmux_session)
         await conn.send_keys(target, text, bracketed=True)
+        await asyncio.sleep(_ENTER_SETTLE_DELAY)
         await conn.send_enter(target)
 
 

--- a/src/atc/terminal/control.py
+++ b/src/atc/terminal/control.py
@@ -15,9 +15,22 @@ from __future__ import annotations
 import asyncio
 import contextlib
 import logging
+import shutil
+from pathlib import Path
 from typing import ClassVar
 
 logger = logging.getLogger(__name__)
+
+
+def _tmux_binary() -> str:
+    """Resolve tmux from PATH or common install locations."""
+    tmux = shutil.which("tmux")
+    if tmux:
+        return tmux
+    for candidate in ("/opt/homebrew/bin/tmux", "/usr/local/bin/tmux", "/usr/bin/tmux"):
+        if shutil.which(candidate) or Path(candidate).exists():
+            return candidate
+    return "tmux"
 
 # Bracketed paste escape sequences
 # ESC [ 2 0 0 ~  →  start of paste
@@ -107,7 +120,7 @@ class TmuxControlConnection:
 
         try:
             self._proc = await asyncio.create_subprocess_exec(
-                "tmux",
+                _tmux_binary(),
                 "-C",
                 "attach-session",
                 "-t",
@@ -379,7 +392,7 @@ async def capture_pane_async(tmux_session: str, target: str) -> str:  # noqa: AR
         RuntimeError: if ``tmux capture-pane`` exits non-zero.
     """
     proc = await asyncio.create_subprocess_exec(
-        "tmux",
+        _tmux_binary(),
         "capture-pane",
         "-t",
         target,

--- a/tests/test_terminal_control.py
+++ b/tests/test_terminal_control.py
@@ -19,7 +19,8 @@ from atc.terminal.control import (
     TmuxControlPool,
     _BP_PREFIX,
     _BP_SUFFIX,
-    _ENTER_HEX,
+    _ENTER_KEY,
+    _ENTER_SETTLE_DELAY,
     _encode_text,
     _to_hex,
     capture_pane_async,
@@ -94,9 +95,9 @@ def test_encode_text_bracketed_round_trip() -> None:
     assert raw == _BP_PREFIX + text.encode("utf-8") + _BP_SUFFIX
 
 
-def test_enter_hex_is_carriage_return() -> None:
-    assert _ENTER_HEX == "0d"
-    assert bytes([int(_ENTER_HEX, 16)]) == b"\r"
+def test_enter_key_uses_symbolic_tmux_name() -> None:
+    assert _ENTER_KEY == "Enter"
+    assert _ENTER_SETTLE_DELAY == 0.2
 
 
 # ---------------------------------------------------------------------------
@@ -229,12 +230,34 @@ async def test_send_instruction_async_retries_on_failure() -> None:
             return failing
         return fresh
 
-    with patch.object(pool, "get_connection", side_effect=fake_get):
+    with patch.object(pool, "get_connection", side_effect=fake_get), patch(
+        "atc.terminal.control.asyncio.sleep",
+        new=AsyncMock(),
+    ) as mock_sleep:
         await send_instruction_async("atc", "%42", "do something")
+
+    mock_sleep.assert_awaited_once_with(_ENTER_SETTLE_DELAY)
 
     assert call_count == 2
     fresh.send_keys.assert_called_once_with("%42", "do something", bracketed=True)
     fresh.send_enter.assert_called_once_with("%42")
+
+
+@pytest.mark.asyncio
+async def test_send_enter_uses_symbolic_tmux_key() -> None:
+    proc = MagicMock()
+    proc.returncode = None
+    proc.stdin = AsyncMock()
+    proc.stdin.write = MagicMock()
+    proc.stdin.drain = AsyncMock()
+
+    conn = TmuxControlConnection("atc")
+    conn._proc = proc
+
+    await conn.send_enter("%7")
+
+    proc.stdin.write.assert_called_once_with(b"send-keys -t %7 Enter\n")
+    proc.stdin.drain.assert_called_once()
 
 
 @pytest.mark.asyncio
@@ -247,8 +270,13 @@ async def test_send_instruction_async_success_path() -> None:
     conn.send_keys = AsyncMock()
     conn.send_enter = AsyncMock()
 
-    with patch.object(pool, "get_connection", AsyncMock(return_value=conn)):
+    with patch.object(pool, "get_connection", AsyncMock(return_value=conn)), patch(
+        "atc.terminal.control.asyncio.sleep",
+        new=AsyncMock(),
+    ) as mock_sleep:
         await send_instruction_async("atc", "%7", "run the tests")
+
+    mock_sleep.assert_awaited_once_with(_ENTER_SETTLE_DELAY)
 
     conn.send_keys.assert_called_once_with("%7", "run the tests", bracketed=True)
     conn.send_enter.assert_called_once_with("%7")
@@ -367,7 +395,7 @@ async def test_send_keys_writes_hex_command() -> None:
 
 
 @pytest.mark.asyncio
-async def test_send_enter_writes_0d() -> None:
+async def test_send_enter_writes_symbolic_key_command() -> None:
     mock_stdin = MagicMock()
     mock_stdin.drain = AsyncMock()
 
@@ -381,7 +409,7 @@ async def test_send_enter_writes_0d() -> None:
     await conn.send_enter("%5")
 
     written: bytes = mock_stdin.write.call_args[0][0]
-    assert b"0d" in written
+    assert written == b"send-keys -t %5 Enter\n"
     mock_stdin.drain.assert_called_once()
 
 

--- a/tests/unit/test_creation_reliability.py
+++ b/tests/unit/test_creation_reliability.py
@@ -13,6 +13,7 @@ import pytest
 from atc.session.ace import (
     VerificationResult,
     _get_alternate_on,
+    _instruction_still_pending,
     check_tui_ready,
     send_instruction,
     verify_alive,
@@ -211,6 +212,7 @@ class TestSendInstruction:
         mock_capture.return_value = "[Pasted text #1 +22 lines]run tests"
         mock_alive.return_value = True
 
+        assert _instruction_still_pending(mock_capture.return_value, "run tests") is True
         result = await send_instruction("%0", "run tests", max_retries=1)
         assert result is False
         mock_send_async.assert_called_once_with("atc", "%0", "run tests")

--- a/tests/unit/test_creation_reliability.py
+++ b/tests/unit/test_creation_reliability.py
@@ -168,6 +168,7 @@ class TestSendInstruction:
         mock_send_async.assert_called_once_with("atc", "%0", "test")
 
     @pytest.mark.asyncio
+    @patch("atc.session.ace._pane_is_alive", new_callable=AsyncMock)
     @patch("atc.session.ace._capture_pane", new_callable=AsyncMock)
     @patch("atc.session.ace.send_instruction_async", new_callable=AsyncMock)
     @patch("atc.session.ace.check_tui_ready", new_callable=AsyncMock)
@@ -178,14 +179,40 @@ class TestSendInstruction:
         mock_ready: AsyncMock,
         mock_send_async: AsyncMock,
         mock_capture: AsyncMock,
+        mock_alive: AsyncMock,
     ) -> None:
         mock_wait.side_effect = [True, False]
         mock_ready.return_value = True
         mock_send_async.return_value = None
         mock_capture.return_value = "$ \n"
+        mock_alive.return_value = True
 
         result = await send_instruction("%0", "run tests", max_retries=1)
         assert result is True
+        mock_send_async.assert_called_once_with("atc", "%0", "run tests")
+
+    @pytest.mark.asyncio
+    @patch("atc.session.ace._pane_is_alive", new_callable=AsyncMock)
+    @patch("atc.session.ace._capture_pane", new_callable=AsyncMock)
+    @patch("atc.session.ace.send_instruction_async", new_callable=AsyncMock)
+    @patch("atc.session.ace.check_tui_ready", new_callable=AsyncMock)
+    @patch("atc.session.ace.wait_for_prompt", new_callable=AsyncMock)
+    async def test_prompt_disappearing_with_dead_pane_is_not_treated_as_success(
+        self,
+        mock_wait: AsyncMock,
+        mock_ready: AsyncMock,
+        mock_send_async: AsyncMock,
+        mock_capture: AsyncMock,
+        mock_alive: AsyncMock,
+    ) -> None:
+        mock_wait.side_effect = [True, False]
+        mock_ready.return_value = True
+        mock_send_async.return_value = None
+        mock_capture.return_value = "$ \n"
+        mock_alive.return_value = False
+
+        result = await send_instruction("%0", "run tests", max_retries=1)
+        assert result is False
         mock_send_async.assert_called_once_with("atc", "%0", "run tests")
 
 

--- a/tests/unit/test_creation_reliability.py
+++ b/tests/unit/test_creation_reliability.py
@@ -197,6 +197,30 @@ class TestSendInstruction:
     @patch("atc.session.ace.send_instruction_async", new_callable=AsyncMock)
     @patch("atc.session.ace.check_tui_ready", new_callable=AsyncMock)
     @patch("atc.session.ace.wait_for_prompt", new_callable=AsyncMock)
+    async def test_pasted_text_still_visible_is_not_treated_as_success(
+        self,
+        mock_wait: AsyncMock,
+        mock_ready: AsyncMock,
+        mock_send_async: AsyncMock,
+        mock_capture: AsyncMock,
+        mock_alive: AsyncMock,
+    ) -> None:
+        mock_wait.side_effect = [True, False]
+        mock_ready.return_value = True
+        mock_send_async.return_value = None
+        mock_capture.return_value = "[Pasted text #1 +22 lines]run tests"
+        mock_alive.return_value = True
+
+        result = await send_instruction("%0", "run tests", max_retries=1)
+        assert result is False
+        mock_send_async.assert_called_once_with("atc", "%0", "run tests")
+
+    @pytest.mark.asyncio
+    @patch("atc.session.ace._pane_is_alive", new_callable=AsyncMock)
+    @patch("atc.session.ace._capture_pane", new_callable=AsyncMock)
+    @patch("atc.session.ace.send_instruction_async", new_callable=AsyncMock)
+    @patch("atc.session.ace.check_tui_ready", new_callable=AsyncMock)
+    @patch("atc.session.ace.wait_for_prompt", new_callable=AsyncMock)
     async def test_prompt_disappearing_with_dead_pane_is_not_treated_as_success(
         self,
         mock_wait: AsyncMock,

--- a/tests/unit/test_creation_reliability.py
+++ b/tests/unit/test_creation_reliability.py
@@ -105,27 +105,25 @@ class TestCheckTuiReady:
 class TestSendInstruction:
     @pytest.mark.asyncio
     @patch("atc.session.ace._capture_pane", new_callable=AsyncMock)
-    @patch("atc.session.ace._tmux_run", new_callable=AsyncMock)
+    @patch("atc.session.ace.send_instruction_async", new_callable=AsyncMock)
     @patch("atc.session.ace.check_tui_ready", new_callable=AsyncMock)
     @patch("atc.session.ace.wait_for_prompt", new_callable=AsyncMock)
     async def test_success(
         self,
         mock_wait: AsyncMock,
         mock_ready: AsyncMock,
-        mock_tmux: AsyncMock,
+        mock_send_async: AsyncMock,
         mock_capture: AsyncMock,
     ) -> None:
         # send_instruction calls wait_for_prompt on attempt 1, check_tui_ready on retries
         mock_wait.return_value = True
         mock_ready.return_value = True
-        mock_tmux.return_value = ""
+        mock_send_async.return_value = None
         mock_capture.return_value = "$ do something important\noutput here"
 
         result = await send_instruction("%0", "do something important", max_retries=1)
         assert result is True
-        mock_tmux.assert_called_once_with(
-            "send-keys", "-t", "%0", "do something important", "Enter"
-        )
+        mock_send_async.assert_called_once_with("atc", "%0", "do something important")
 
     @pytest.mark.asyncio
     @patch("atc.session.ace.check_tui_ready", new_callable=AsyncMock)
@@ -138,35 +136,57 @@ class TestSendInstruction:
 
     @pytest.mark.asyncio
     @patch("atc.session.ace._capture_pane", new_callable=AsyncMock)
-    @patch("atc.session.ace._tmux_run", new_callable=AsyncMock)
+    @patch("atc.session.ace.send_instruction_async", new_callable=AsyncMock)
     @patch("atc.session.ace.check_tui_ready", new_callable=AsyncMock)
     @patch("atc.session.ace.wait_for_prompt", new_callable=AsyncMock)
     async def test_retry_on_verification_failure(
         self,
         mock_wait: AsyncMock,
         mock_ready: AsyncMock,
-        mock_tmux: AsyncMock,
+        mock_send_async: AsyncMock,
         mock_capture: AsyncMock,
     ) -> None:
         mock_wait.return_value = True
         mock_ready.return_value = True
-        mock_tmux.return_value = ""
+        mock_send_async.return_value = None
         # First attempt: instruction not in output; second: found
         mock_capture.side_effect = ["$ \n", "$ run tests\nrunning..."]
 
         result = await send_instruction("%0", "run tests", max_retries=2)
         assert result is True
-        assert mock_tmux.call_count == 2  # sent twice
+        assert mock_send_async.call_count == 2  # sent twice
 
     @pytest.mark.asyncio
-    @patch("atc.session.ace._tmux_run", new_callable=AsyncMock)
+    @patch("atc.session.ace.send_instruction_async", new_callable=AsyncMock)
     @patch("atc.session.ace.check_tui_ready", new_callable=AsyncMock)
-    async def test_skip_verification(self, mock_ready: AsyncMock, mock_tmux: AsyncMock) -> None:
+    async def test_skip_verification(self, mock_ready: AsyncMock, mock_send_async: AsyncMock) -> None:
         mock_ready.return_value = True
-        mock_tmux.return_value = ""
+        mock_send_async.return_value = None
 
         result = await send_instruction("%0", "test", verify=False)
         assert result is True
+        mock_send_async.assert_called_once_with("atc", "%0", "test")
+
+    @pytest.mark.asyncio
+    @patch("atc.session.ace._capture_pane", new_callable=AsyncMock)
+    @patch("atc.session.ace.send_instruction_async", new_callable=AsyncMock)
+    @patch("atc.session.ace.check_tui_ready", new_callable=AsyncMock)
+    @patch("atc.session.ace.wait_for_prompt", new_callable=AsyncMock)
+    async def test_prompt_disappearing_counts_as_accepted_delivery(
+        self,
+        mock_wait: AsyncMock,
+        mock_ready: AsyncMock,
+        mock_send_async: AsyncMock,
+        mock_capture: AsyncMock,
+    ) -> None:
+        mock_wait.side_effect = [True, False]
+        mock_ready.return_value = True
+        mock_send_async.return_value = None
+        mock_capture.return_value = "$ \n"
+
+        result = await send_instruction("%0", "run tests", max_retries=1)
+        assert result is True
+        mock_send_async.assert_called_once_with("atc", "%0", "run tests")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_leader_orchestrator.py
+++ b/tests/unit/test_leader_orchestrator.py
@@ -385,6 +385,41 @@ class TestSendInstruction:
             await orchestrator.send_instruction_to_ace("nonexistent", "Do something")
 
 
+@pytest.mark.asyncio
+class TestSpawnRetryAssignmentReuse:
+    async def test_reuses_terminal_assignment_without_todo_to_in_progress_jump(
+        self,
+        db,
+        orchestrator: LeaderOrchestrator,
+    ) -> None:
+        from atc.state import db as db_ops
+
+        tg = await create_task_graph(db, orchestrator.project_id, "Task Retry")
+        first, created = await db_ops.assign_task(db, tg.id, "ace-old", f"{orchestrator.leader_id}:{tg.id}")
+        assert created is True
+        updated = await db_ops.update_task_assignment_status(db, first.assignment_id, "working")
+        assert updated is not None
+        updated = await db_ops.update_task_assignment_status(db, first.assignment_id, "failed")
+        assert updated is not None
+        await db_ops.update_task_graph_status(db, tg.id, "error")
+        await db_ops.update_task_graph_status(db, tg.id, "todo")
+
+        orchestrator.assignments.clear()
+
+        with (
+            patch("atc.leader.orchestrator.create_ace", new=AsyncMock(return_value="ace-new")),
+            patch("atc.leader.orchestrator.get_launch_command", return_value="claude"),
+            patch("atc.leader.orchestrator.build_context_package", new=AsyncMock(return_value={"context_entries": []})),
+        ):
+            assignment = await orchestrator._spawn_ace_for_task(tg.id, tg.title, tg.description)
+
+        assert assignment is not None
+        refreshed = await db_ops.get_task_graph(db, tg.id)
+        assert refreshed is not None
+        assert refreshed.status == "in_progress"
+        assert refreshed.assigned_ace_id == "ace-new"
+
+
 # ---------------------------------------------------------------------------
 # mark_task_done
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_leader_orchestrator.py
+++ b/tests/unit/test_leader_orchestrator.py
@@ -602,7 +602,12 @@ class TestGetProgress:
     async def test_progress_empty(self, db, orchestrator: LeaderOrchestrator) -> None:
         progress = await orchestrator.get_progress()
         assert progress["total"] == 0
-        assert progress["all_done"] is True
+        assert progress["done"] == 0
+        assert progress["in_progress"] == 0
+        assert progress["todo"] == 0
+        assert progress["error"] == 0
+        assert progress["progress_pct"] == 0
+        assert progress["all_done"] is False
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_task_graphs.py
+++ b/tests/unit/test_task_graphs.py
@@ -332,7 +332,7 @@ class TestIdempotentAssignment:
         assert task.assigned_ace_id == "ace-1"
 
     async def test_duplicate_assignment_id_is_noop(self, db) -> None:
-        """Same assignment_id returns existing record without side effects."""
+        """Same active assignment_id returns existing record without side effects."""
         project = await create_project(db, "p1")
         tg = await create_task_graph(db, project.id, "Task A")
 
@@ -343,6 +343,35 @@ class TestIdempotentAssignment:
         assert created2 is False
         assert second.id == first.id
         assert second.assignment_id == "key-1"
+
+    async def test_terminal_assignment_id_can_be_reused_for_retry(self, db) -> None:
+        """A failed/done assignment key should be reusable on retry."""
+        project = await create_project(db, "p1")
+        tg = await create_task_graph(db, project.id, "Task A")
+
+        first, created1 = await assign_task(db, tg.id, "ace-1", "key-1")
+        assert created1 is True
+
+        updated = await update_task_assignment_status(db, "key-1", "working")
+        assert updated is not None
+        updated = await update_task_assignment_status(db, "key-1", "failed")
+        assert updated is not None
+
+        task = await update_task_graph_status(db, tg.id, "error")
+        assert task is not None
+        task = await update_task_graph_status(db, tg.id, "todo")
+        assert task is not None
+
+        retried, created2 = await assign_task(db, tg.id, "ace-2", "key-1")
+        assert created2 is True
+        assert retried.id == first.id
+        assert retried.ace_session_id == "ace-2"
+        assert retried.status == "assigned"
+
+        task = await get_task_graph(db, tg.id)
+        assert task is not None
+        assert task.status == "assigned"
+        assert task.assigned_ace_id == "ace-2"
 
     async def test_assign_non_todo_task_rejected(self, db) -> None:
         """Only tasks in 'todo' state can be assigned."""


### PR DESCRIPTION
## Summary
- bridge retried Leader task graphs through `assigned` before advancing to `in_progress`
- prevent retry/idempotent paths from tripping the task state machine after a task was reset to `todo`
- keep the Leader/Ace orchestration flow from silently stalling while Tower appears to have handed work off

## Testing
- PYTHONPATH=/tmp/atc-work/src pytest -q tests/test_terminal_control.py tests/integration/test_creation_reliability.py tests/unit/test_ace_status_api.py tests/unit/test_leader_api.py
- Mac validation in `/Users/coleclaw/Repository/atc-validate` with Python 3.14 venv + pytest-asyncio: same targeted suite, 52 passed
