### PR TITLE
fix: bridge retried leader tasks through assigned state

### DIFF
--- a/src/atc/leader/orchestrator.py
+++ b/src/atc/leader/orchestrator.py
@@ -222,15 +222,23 @@ class LeaderOrchestrator:
             )
 
         # Transition the task to in_progress now that the Ace is running.
-        # Retry/idempotent paths can surface an already-assigned or already-
-        # in-progress task; only advance when needed.
+        # Retry/idempotent paths can reuse a terminal assignment row whose
+        # task_graph may already have been reset to todo, so bridge through
+        # assigned first when needed instead of tripping the state machine.
         task_graph = await db_ops.get_task_graph(self.conn, task_graph_id)
-        if task_graph is not None and task_graph.status == "assigned":
-            await db_ops.update_task_graph_status(
-                self.conn,
-                task_graph_id,
-                "in_progress",
-            )
+        if task_graph is not None:
+            if task_graph.status == "todo":
+                task_graph = await db_ops.update_task_graph_status(
+                    self.conn,
+                    task_graph_id,
+                    "assigned",
+                )
+            if task_graph is not None and task_graph.status == "assigned":
+                await db_ops.update_task_graph_status(
+                    self.conn,
+                    task_graph_id,
+                    "in_progress",
+                )
 
         deployed = deploy_ace_files(
             AceDeploySpec(


### PR DESCRIPTION
## Summary
- bridge retried Leader task graphs through `assigned` before advancing to `in_progress`
- prevent retry/idempotent paths from tripping the task state machine after a task was reset to `todo`
- keep the Leader/Ace orchestration flow from silently stalling while Tower appears to have handed work off

## Testing
- PYTHONPATH=/tmp/atc-work/src pytest -q tests/test_terminal_control.py tests/integration/test_creation_reliability.py tests/unit/test_ace_status_api.py tests/unit/test_leader_api.py
- Mac validation in `/Users/coleclaw/Repository/atc-validate` with Python 3.14 venv + pytest-asyncio: same targeted suite, 52 passed
