### PR TITLE
refactor: move Claude startup flow into provider

### DIFF
--- a/src/atc/agents/base.py
+++ b/src/atc/agents/base.py
@@ -155,6 +155,15 @@ class AgentProvider(Protocol):
         """
         ...
 
+    async def handle_startup(self, session_id: str) -> None:
+        """Handle provider-specific startup flows after spawn.
+
+        Examples: dismiss trust dialogs, accept permission prompts, or
+        perform other provider-specific initialization needed before the
+        session is considered ready.
+        """
+        ...
+
     async def send_prompt(self, session_id: str, prompt: str) -> PromptResult:
         """Send a prompt/instruction to an existing session.
 

--- a/src/atc/agents/claude_provider.py
+++ b/src/atc/agents/claude_provider.py
@@ -9,15 +9,12 @@ from __future__ import annotations
 
 import asyncio
 import logging
-import re
 import shutil
 from pathlib import Path
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from collections.abc import AsyncIterator
-
-from atc.terminal.control import send_instruction_async
 
 from atc.agents.base import (
     OutputChunk,
@@ -27,6 +24,12 @@ from atc.agents.base import (
     SessionInfo,
     SessionStatus,
 )
+from atc.agents.claude_runtime import (
+    accept_startup_dialogs,
+    send_instruction as claude_send_instruction,
+    wait_for_prompt as claude_wait_for_prompt,
+)
+from atc.terminal.control import send_instruction_async
 
 logger = logging.getLogger(__name__)
 
@@ -37,8 +40,8 @@ class ClaudeCodeProvider:
     """Agent provider using Claude Code in tmux panes.
 
     Sessions are spawned as tmux new-window commands. Prompts are delivered
-    via ``tmux send-keys``. Status is tracked internally (future: via PTY
-    monitor). Output streaming delegates to the terminal/pty_stream module.
+    through Claude-specific runtime helpers. Output streaming delegates to a
+    capture-pane fallback for now.
 
     Implements :class:`AgentProvider` protocol.
     """
@@ -79,13 +82,11 @@ class ClaudeCodeProvider:
 
         self._check_tmux_available()
 
-        # Prepare workspace if requested
         if working_dir:
             await self.prepare_workspace(
                 session_id, working_dir=working_dir, context_file=context_file
             )
 
-        # Build the claude command, prepending ANTHROPIC_API_KEY if available
         import shlex as _shlex
 
         from atc.agents.auth import resolve_agent_api_key
@@ -108,14 +109,13 @@ class ClaudeCodeProvider:
         shell_cmd = f"{env_prefix}{' '.join(cmd_parts)}"
         logger.debug("spawn_session role=%s session=%s", role, session_id)
 
-        # Spawn in a new tmux window (avoids 'no space for new pane' in small terminals)
         tmux_args = [
             _TMUX_CMD,
             "new-window",
             "-t",
             self._tmux_session,
             "-d",
-            "-P",  # print pane info
+            "-P",
             "-F",
             "#{pane_id}",
         ]
@@ -148,71 +148,53 @@ class ClaudeCodeProvider:
         logger.info("Spawned Claude Code session %s in pane %s", session_id, pane_id)
         return tracked.to_info()
 
+    async def handle_startup(self, session_id: str) -> None:
+        """Handle Claude-specific startup dialogs for a tracked session."""
+        tracked = self._get_tracked(session_id)
+        await accept_startup_dialogs(
+            tracked.pane_id,
+            capture_pane=self._capture_pane,
+            get_alternate_on=self._get_alternate_on,
+            tmux_run=self._tmux_run,
+        )
+
     async def send_prompt(self, session_id: str, prompt: str) -> PromptResult:
         tracked = self._get_tracked(session_id)
 
+        import atc.agents.claude_runtime as _claude_runtime
+
+        original_send = _claude_runtime.send_instruction_async
+        _claude_runtime.send_instruction_async = send_instruction_async
         try:
-            await send_instruction_async(
-                self._tmux_session, tracked.pane_id, prompt
+            accepted = await claude_send_instruction(
+                tracked.pane_id,
+                prompt,
+                capture_pane=self._capture_pane,
+                pane_is_alive=self._pane_is_alive,
+                wait_for_prompt_fn=self._wait_for_prompt,
+                check_tui_ready_fn=self.is_ready,
             )
         except Exception as exc:
             raise ProviderError(self.name, f"send-keys failed: {exc}") from exc
+        finally:
+            _claude_runtime.send_instruction_async = original_send
 
-        tracked.status = SessionStatus.BUSY
+        tracked.status = SessionStatus.BUSY if accepted else SessionStatus.ERROR
         logger.info("Sent prompt to session %s (pane %s)", session_id, tracked.pane_id)
-        return PromptResult(session_id=session_id, accepted=True)
+        return PromptResult(session_id=session_id, accepted=accepted)
 
     async def get_status(self, session_id: str) -> SessionInfo:
         tracked = self._get_tracked(session_id)
 
-        # Verify the tmux pane still exists
-        check_cmd = [
-            _TMUX_CMD,
-            "has-session",
-            "-t",
-            tracked.pane_id,
-        ]
         try:
-            proc = await asyncio.create_subprocess_exec(
-                *check_cmd,
-                stdout=asyncio.subprocess.PIPE,
-                stderr=asyncio.subprocess.PIPE,
-            )
-            await proc.communicate()
-        except OSError:
-            tracked.status = SessionStatus.ERROR
-            return tracked.to_info()
-
-        if proc.returncode != 0:
+            await self._tmux_query("has-session", "-t", tracked.pane_id)
+        except ProviderError:
             tracked.status = SessionStatus.STOPPED
         return tracked.to_info()
 
     async def stream_output(self, session_id: str) -> AsyncIterator[OutputChunk]:
-        """Stream output via PTY pipe-pane.
-
-        NOTE: Full implementation depends on the terminal/pty_stream module
-        (ATC-5). This provides a basic capture-pane fallback.
-        """
         tracked = self._get_tracked(session_id)
-
-        capture_cmd = [
-            _TMUX_CMD,
-            "capture-pane",
-            "-t",
-            tracked.pane_id,
-            "-p",  # print to stdout
-        ]
-        try:
-            proc = await asyncio.create_subprocess_exec(
-                *capture_cmd,
-                stdout=asyncio.subprocess.PIPE,
-                stderr=asyncio.subprocess.PIPE,
-            )
-            stdout, _ = await proc.communicate()
-        except OSError as exc:
-            raise ProviderError(self.name, f"capture-pane failed: {exc}") from exc
-
-        content = stdout.decode()
+        content = await self._capture_pane(tracked.pane_id, lines=200)
         yield OutputChunk(
             session_id=session_id,
             content=content,
@@ -222,15 +204,12 @@ class ClaudeCodeProvider:
     async def stop_session(self, session_id: str) -> None:
         tracked = self._get_tracked(session_id)
 
-        kill_cmd = [
-            _TMUX_CMD,
-            "kill-pane",
-            "-t",
-            tracked.pane_id,
-        ]
         try:
             proc = await asyncio.create_subprocess_exec(
-                *kill_cmd,
+                _TMUX_CMD,
+                "kill-pane",
+                "-t",
+                tracked.pane_id,
                 stdout=asyncio.subprocess.PIPE,
                 stderr=asyncio.subprocess.PIPE,
             )
@@ -286,60 +265,58 @@ class ClaudeCodeProvider:
                 )
 
     async def is_ready(self, session_id: str) -> bool:
-        """Return True when the session's tmux pane shows an idle ❯ prompt.
-
-        Polls capture-pane for up to 10 seconds looking for a bare prompt
-        line (alternate_on == 0 and a line matching ``^[❯>]\\s*$``).
-        """
+        """Return True when the session's tmux pane shows an idle Claude prompt."""
         tracked = self._sessions.get(session_id)
         if tracked is None:
             return False
+        return await self._wait_for_prompt(tracked.pane_id)
 
-        _prompt_re = re.compile(r"^[❯>]\s*$", re.MULTILINE)
-        timeout = 10.0
-        poll_interval = 0.5
-        elapsed = 0.0
+    async def _tmux_query(self, *args: str) -> str:
+        try:
+            proc = await asyncio.create_subprocess_exec(
+                _TMUX_CMD,
+                *args,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+            )
+            stdout, stderr = await proc.communicate()
+        except OSError as exc:
+            raise ProviderError(self.name, f"tmux command failed: {exc}") from exc
+        if proc.returncode != 0:
+            raise ProviderError(self.name, stderr.decode().strip() or "tmux query failed")
+        return stdout.decode()
 
-        while elapsed < timeout:
-            try:
-                alt_proc = await asyncio.create_subprocess_exec(
-                    _TMUX_CMD,
-                    "display-message",
-                    "-t",
-                    tracked.pane_id,
-                    "-p",
-                    "#{alternate_on}",
-                    stdout=asyncio.subprocess.PIPE,
-                    stderr=asyncio.subprocess.PIPE,
-                )
-                alt_stdout, _ = await alt_proc.communicate()
-                if alt_stdout.decode().strip() == "1":
-                    await asyncio.sleep(poll_interval)
-                    elapsed += poll_interval
-                    continue
+    async def _capture_pane(self, pane_id: str, *, lines: int = 50) -> str:
+        return await self._tmux_query("capture-pane", "-t", pane_id, "-p", "-S", f"-{lines}")
 
-                cap_proc = await asyncio.create_subprocess_exec(
-                    _TMUX_CMD,
-                    "capture-pane",
-                    "-t",
-                    tracked.pane_id,
-                    "-p",
-                    "-S",
-                    "-50",
-                    stdout=asyncio.subprocess.PIPE,
-                    stderr=asyncio.subprocess.PIPE,
-                )
-                cap_stdout, _ = await cap_proc.communicate()
-                if _prompt_re.search(cap_stdout.decode()):
-                    return True
-            except OSError:
-                return False
+    async def _get_alternate_on(self, pane_id: str) -> bool:
+        result = await self._tmux_query("display-message", "-t", pane_id, "-p", "#{alternate_on}")
+        return result.strip() == "1"
 
-            await asyncio.sleep(poll_interval)
-            elapsed += poll_interval
+    async def _pane_is_alive(self, pane_id: str) -> bool:
+        try:
+            await self._tmux_query("has-session", "-t", pane_id)
+            return True
+        except ProviderError:
+            return False
 
-        logger.warning("is_ready: session %s not ready after %.1fs", session_id, timeout)
-        return False
+    async def _wait_for_prompt(
+        self,
+        pane_id: str,
+        *,
+        timeout: float = 10.0,
+        poll_interval: float = 0.5,
+    ) -> bool:
+        return await claude_wait_for_prompt(
+            pane_id,
+            get_alternate_on=self._get_alternate_on,
+            capture_pane=self._capture_pane,
+            timeout=timeout,
+            poll_interval=poll_interval,
+        )
+
+    async def _tmux_run(self, *args: str) -> str:
+        return (await self._tmux_query(*args)).strip()
 
     def _get_tracked(self, session_id: str) -> _TrackedSession:
         tracked = self._sessions.get(session_id)

--- a/src/atc/agents/claude_runtime.py
+++ b/src/atc/agents/claude_runtime.py
@@ -1,0 +1,284 @@
+"""Claude-specific runtime helpers for tmux-backed sessions.
+
+This module holds startup-dialog handling, readiness checks, and
+instruction-delivery verification that are specific to Claude Code's TUI.
+Shared session orchestration should call into this module rather than
+embedding Claude-specific behavior directly.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import re
+from typing import Final
+
+from atc.terminal.control import send_instruction_async
+
+logger = logging.getLogger(__name__)
+
+# Default tmux session name used for ATC panes
+ATC_TMUX_SESSION: Final[str] = "atc"
+
+# TUI readiness: max seconds to wait for alternate_on == False
+TUI_READY_TIMEOUT: Final[float] = 10.0
+TUI_READY_POLL_INTERVAL: Final[float] = 0.5
+
+# Instruction verification: seconds to wait before capture-pane check
+INSTRUCTION_VERIFY_DELAY: Final[float] = 2.0
+INSTRUCTION_MAX_RETRIES: Final[int] = 3
+
+# Strings that indicate a known startup dialog is on screen.
+_DIALOG_TRIGGERS: Final[tuple[str, ...]] = (
+    "enter to confirm",
+    "trust this folder",
+    "do you trust",
+    "bypass permissions",
+    "bypass permissions on",
+    "yes, i accept",
+    "do you want to use this api key",
+    "will be able to read",
+    "'ll be able to read",
+    "able to read, edit",
+    "yes, i trust this folder",
+    "no, exit",
+    "security guide",
+    "is this a project you created",
+    "one you trust",
+    "tips for getting started",
+    "welcome to claude code",
+    "welcome back",
+)
+
+_WELCOME_TRIGGERS: Final[tuple[str, ...]] = (
+    "tips for getting started",
+    "welcome to claude code",
+    "welcome back",
+)
+
+_BARE_PROMPT_RE: Final[re.Pattern[str]] = re.compile(r"^[❯>]\s*$", re.MULTILINE)
+
+
+async def accept_startup_dialogs(
+    pane_id: str,
+    *,
+    capture_pane,
+    get_alternate_on,
+    tmux_run,
+    timeout: float = 10.0,
+) -> bool:
+    """Accept Claude Code startup confirmation dialogs for a tmux pane."""
+    from atc.agents.auth import is_oauth_key, resolve_agent_api_key
+
+    key = resolve_agent_api_key()
+    use_api_key = bool(key and not is_oauth_key(key))
+
+    poll_interval = 0.5
+    elapsed = 0.0
+    dismissed: set[str] = set()
+
+    while elapsed < timeout:
+        try:
+            output = await capture_pane(pane_id)
+            lowered = output.lower()
+
+            if "api_key_selector" not in dismissed and (
+                "do you want to use this api key" in lowered
+                or ("detected" in lowered and "api key" in lowered)
+            ):
+                if use_api_key:
+                    await tmux_run("send-keys", "-t", pane_id, "Up")
+                    await asyncio.sleep(0.1)
+                    logger.info("Pane %s: accepted API key selector (real key configured)", pane_id)
+                else:
+                    logger.info("Pane %s: dismissed API key selector dialog (OAuth mode)", pane_id)
+                await tmux_run("send-keys", "-t", pane_id, "Enter")
+                dismissed.add("api_key_selector")
+                await asyncio.sleep(1.0)
+                continue
+
+            if "bypass_permissions" not in dismissed and (
+                "bypass permissions" in lowered
+                or ("yes, i accept" in lowered and "no, exit" in lowered)
+            ):
+                await tmux_run("send-keys", "-t", pane_id, "Down")
+                await asyncio.sleep(0.1)
+                await tmux_run("send-keys", "-t", pane_id, "Enter")
+                logger.info("Pane %s: accepted bypass permissions dialog", pane_id)
+                dismissed.add("bypass_permissions")
+                await asyncio.sleep(1.0)
+                continue
+
+            if "trust_folder" not in dismissed and (
+                "trust this folder" in lowered
+                or "do you trust" in lowered
+                or "yes, i trust this folder" in lowered
+                or "will be able to read" in lowered
+                or "'ll be able to read" in lowered
+                or "able to read, edit" in lowered
+                or "is this a project you created" in lowered
+            ):
+                await tmux_run("send-keys", "-t", pane_id, "Enter")
+                logger.info("Pane %s: accepted trust-folder dialog", pane_id)
+                dismissed.add("trust_folder")
+                await asyncio.sleep(1.0)
+                continue
+
+            if "claude code" in lowered and not any(t in lowered for t in _DIALOG_TRIGGERS):
+                logger.debug("Pane %s: Claude Code ready (text match, %.1fs)", pane_id, elapsed)
+                return bool(dismissed)
+
+            try:
+                alt_on = await get_alternate_on(pane_id)
+                if not alt_on and _BARE_PROMPT_RE.search(output):
+                    if not any(t in lowered for t in _DIALOG_TRIGGERS):
+                        logger.debug("Pane %s: prompt visible (alternate_on=0, %.1fs)", pane_id, elapsed)
+                        return bool(dismissed)
+            except RuntimeError:
+                pass
+
+        except RuntimeError:
+            pass
+        await asyncio.sleep(poll_interval)
+        elapsed += poll_interval
+
+    logger.debug("Pane %s: dialog handling finished after %.1fs", pane_id, timeout)
+    return bool(dismissed)
+
+
+async def wait_for_prompt(
+    pane_id: str,
+    *,
+    get_alternate_on,
+    capture_pane,
+    timeout: float = 10.0,
+    poll_interval: float = 0.5,
+) -> bool:
+    """Wait until the pane shows an empty Claude prompt with alternate_on == 0."""
+    elapsed = 0.0
+    while elapsed < timeout:
+        try:
+            alt_on = await get_alternate_on(pane_id)
+            if not alt_on:
+                output = await capture_pane(pane_id)
+                lowered = output.lower()
+                if any(trigger in lowered for trigger in _DIALOG_TRIGGERS):
+                    logger.debug(
+                        "Pane %s: prompt suppressed because startup dialog is still visible",
+                        pane_id,
+                    )
+                elif _BARE_PROMPT_RE.search(output):
+                    return True
+        except RuntimeError:
+            return False
+        await asyncio.sleep(poll_interval)
+        elapsed += poll_interval
+
+    logger.warning("Pane %s: prompt not ready after %.1fs (wait_for_prompt timed out)", pane_id, timeout)
+    return False
+
+
+async def check_tui_ready(
+    pane_id: str,
+    *,
+    get_alternate_on,
+    timeout: float = TUI_READY_TIMEOUT,
+    poll_interval: float = TUI_READY_POLL_INTERVAL,
+) -> bool:
+    """Wait until the Claude pane exits alternate screen mode."""
+    elapsed = 0.0
+    while elapsed < timeout:
+        try:
+            if not await get_alternate_on(pane_id):
+                return True
+        except RuntimeError:
+            return False
+        await asyncio.sleep(poll_interval)
+        elapsed += poll_interval
+
+    logger.warning("Pane %s: TUI still active after %.1fs, alternate_on not cleared", pane_id, timeout)
+    return False
+
+
+async def send_instruction(
+    pane_id: str,
+    text: str,
+    *,
+    capture_pane,
+    pane_is_alive,
+    wait_for_prompt_fn,
+    check_tui_ready_fn,
+    verify: bool = True,
+    max_retries: int = INSTRUCTION_MAX_RETRIES,
+) -> bool:
+    """Send instruction text + Enter atomically, with Claude-specific verification."""
+    for attempt in range(1, max_retries + 1):
+        if attempt == 1:
+            ready = await wait_for_prompt_fn(pane_id)
+        else:
+            ready = await check_tui_ready_fn(pane_id)
+        if not ready:
+            logger.warning("Pane %s: TUI not ready on attempt %d/%d", pane_id, attempt, max_retries)
+            continue
+
+        await send_instruction_async(ATC_TMUX_SESSION, pane_id, text)
+
+        if not verify:
+            return True
+
+        await asyncio.sleep(INSTRUCTION_VERIFY_DELAY)
+        try:
+            output = await capture_pane(pane_id)
+            output_lower = output.lower()
+
+            if any(t in output_lower for t in _WELCOME_TRIGGERS):
+                logger.info(
+                    "Pane %s: welcome screen visible on attempt %d — assuming instruction delivered",
+                    pane_id,
+                    attempt,
+                )
+                return True
+
+            fingerprint = text[:80].strip()
+            if fingerprint and fingerprint in output:
+                logger.info("Pane %s: instruction verified on attempt %d", pane_id, attempt)
+                return True
+
+            if not await wait_for_prompt_fn(pane_id, timeout=1.0, poll_interval=0.25):
+                latest_output = await capture_pane(pane_id)
+                latest_lower = latest_output.lower()
+                if any(trigger in latest_lower for trigger in _DIALOG_TRIGGERS):
+                    logger.warning(
+                        "Pane %s: startup dialog still visible after send on attempt %d",
+                        pane_id,
+                        attempt,
+                    )
+                elif await pane_is_alive(pane_id):
+                    logger.info(
+                        "Pane %s: prompt disappeared after send on attempt %d — assuming instruction accepted",
+                        pane_id,
+                        attempt,
+                    )
+                    return True
+                else:
+                    logger.warning(
+                        "Pane %s: prompt disappeared after send on attempt %d but pane is dead",
+                        pane_id,
+                        attempt,
+                    )
+            logger.warning(
+                "Pane %s: instruction not found in output (attempt %d/%d)",
+                pane_id,
+                attempt,
+                max_retries,
+            )
+        except RuntimeError:
+            logger.warning(
+                "Pane %s: capture-pane failed on attempt %d/%d",
+                pane_id,
+                attempt,
+                max_retries,
+            )
+
+    logger.error("Pane %s: instruction delivery failed after %d attempts", pane_id, max_retries)
+    return False

--- a/src/atc/agents/opencode_provider.py
+++ b/src/atc/agents/opencode_provider.py
@@ -150,6 +150,8 @@ class OpenCodeProvider:
         *,
         working_dir: str | None = None,
         env: dict[str, str] | None = None,
+        context_file: Path | None = None,
+        role: str = "ace",
     ) -> SessionInfo:
         if session_id in self._pane_ids:
             raise ProviderError(self.name, f"Session {session_id} already tracked")
@@ -178,6 +180,29 @@ class OpenCodeProvider:
             status=SessionStatus.IDLE,
             metadata={"pane_id": pane_id, "base_url": self._base_url},
         )
+
+    async def prepare_workspace(
+        self,
+        session_id: str,
+        *,
+        working_dir: str,
+        context_file: Path | None = None,
+    ) -> None:
+        """OpenCode does not require provider-managed workspace prep."""
+        return None
+
+    async def is_ready(self, session_id: str) -> bool:
+        """OpenCode sessions are ready once the API reports them reachable."""
+        try:
+            status = await self.get_status(session_id)
+        except ProviderError:
+            return False
+        return status.status in {SessionStatus.IDLE, SessionStatus.BUSY}
+
+    async def handle_startup(self, session_id: str) -> None:
+        """OpenCode has no tmux/TUI startup dialog flow."""
+        self._require_tracked(session_id)
+        return None
 
     async def send_prompt(self, session_id: str, prompt: str) -> PromptResult:
         self._require_tracked(session_id)

--- a/src/atc/leader/leader.py
+++ b/src/atc/leader/leader.py
@@ -201,7 +201,15 @@ async def start_leader(
             launch_cmd,
             working_dir=working_dir,
         )
-        await _accept_trust_dialog(pane_id)
+        try:
+            from atc.agents.factory import create_provider
+
+            provider = create_provider(project.agent_provider if project else "claude_code")
+            if hasattr(provider, "_sessions"):
+                provider._sessions[session.id] = type("Tracked", (), {"pane_id": pane_id, "status": None})()
+            await provider.handle_startup(session.id)
+        except Exception:
+            await _accept_trust_dialog(pane_id)
         await db_ops.update_session_tmux(conn, session.id, ATC_TMUX_SESSION, pane_id)
 
         await transition(session.id, SessionStatus.CONNECTING, SessionStatus.IDLE, event_bus)

--- a/src/atc/session/ace.py
+++ b/src/atc/session/ace.py
@@ -25,6 +25,15 @@ from dataclasses import dataclass
 from pathlib import Path as _Path
 from typing import TYPE_CHECKING, Any
 
+from atc.agents.claude_runtime import (
+    INSTRUCTION_MAX_RETRIES,
+    TUI_READY_POLL_INTERVAL,
+    TUI_READY_TIMEOUT,
+    accept_startup_dialogs,
+    check_tui_ready as claude_check_tui_ready,
+    send_instruction as claude_send_instruction,
+    wait_for_prompt as claude_wait_for_prompt,
+)
 from atc.session.state_machine import (
     SessionStatus,
     transition,
@@ -41,42 +50,6 @@ logger = logging.getLogger(__name__)
 
 # Default tmux session name used for ATC panes
 ATC_TMUX_SESSION = "atc"
-
-# TUI readiness: max seconds to wait for alternate_on == False
-TUI_READY_TIMEOUT = 10.0
-TUI_READY_POLL_INTERVAL = 0.5
-
-# Instruction verification: seconds to wait before capture-pane check
-INSTRUCTION_VERIFY_DELAY = 2.0
-INSTRUCTION_MAX_RETRIES = 3
-
-# Strings that indicate a known startup dialog is on screen.
-# Used to guard against false-positive "Claude is running" detection —
-# the trust dialog body itself contains "Claude Code will be able to..."
-# which would otherwise trigger the early-exit before any dialog is handled.
-_DIALOG_TRIGGERS: tuple[str, ...] = (
-    "enter to confirm",
-    "trust this folder",
-    "do you trust",
-    "bypass permissions",
-    "bypass permissions on",
-    "yes, i accept",
-    "do you want to use this api key",
-    "will be able to read",
-    # Claude Code v2+ uses contraction: "Claude Code'll be able to read..."
-    "'ll be able to read",
-    "able to read, edit",
-    "yes, i trust this folder",
-    "no, exit",
-    "security guide",
-    "is this a project you created",
-    "one you trust",
-    # Welcome/tips screen — Claude is running but not yet in the interactive
-    # prompt.  Listed here so the "claude code" fast-exit doesn't fire early.
-    "tips for getting started",
-    "welcome to claude code",
-    "welcome back",
-)
 
 
 # ---------------------------------------------------------------------------
@@ -247,133 +220,14 @@ async def _spawn_pane(
 
 
 async def _accept_trust_dialog(pane_id: str, *, timeout: float = 10.0) -> bool:
-    """Accept all Claude Code startup confirmation dialogs.
-
-    Claude Code (v2+) shows up to two dialogs before becoming interactive:
-
-    Dialog 1 — API key selector (when ANTHROPIC_API_KEY is set):
-        "Detected a custom API key in your environment"
-        "Do you want to use this API key?"
-        ❯ 2. No (recommended)  ← default cursor position
-        → Send Enter to dismiss (keeps OAuth login, ignores the env key)
-
-    Dialog 2 — Bypass permissions confirmation (with --dangerously-skip-permissions):
-        "By proceeding, you accept all responsibility..."
-        ❯ 1. No, exit          ← default cursor position
-          2. Yes, I accept
-        → Send Down then Enter to select "Yes, I accept"
-
-    Legacy dialog — trust this folder:
-        → Send Enter to accept
-
-    Returns True if any dialog was detected and dismissed, False if Claude
-    started without showing any dialog within *timeout* seconds.
-    """
-    from atc.agents.auth import is_oauth_key, resolve_agent_api_key
-
-    _key = resolve_agent_api_key()
-    _use_api_key = bool(_key and not is_oauth_key(_key))
-
-    poll_interval = 0.5
-    elapsed = 0.0
-    # Track which dialog types we've already handled to avoid re-triggering on
-    # the same pane output while waiting for the screen to clear.
-    dismissed: set[str] = set()
-
-    while elapsed < timeout:
-        try:
-            output = await _capture_pane(pane_id)
-            lowered = output.lower()
-
-            # Dialog 1: API key selector — Enter dismisses (selects "No")
-            if "api_key_selector" not in dismissed and (
-                "do you want to use this api key" in lowered
-                or ("detected" in lowered and "api key" in lowered)
-            ):
-                if _use_api_key:
-                    # Option 1 "Yes" is above the pre-selected option 2 "No"
-                    await _tmux_run("send-keys", "-t", pane_id, "Up")
-                    await asyncio.sleep(0.1)
-                    logger.info("Pane %s: accepted API key selector (real key configured)", pane_id)
-                else:
-                    logger.info("Pane %s: dismissed API key selector dialog (OAuth mode)", pane_id)
-                await _tmux_run("send-keys", "-t", pane_id, "Enter")
-                dismissed.add("api_key_selector")
-                await asyncio.sleep(1.0)  # wait for next dialog to appear
-                continue
-
-            # Dialog 2: bypass permissions confirmation — Down then Enter selects "Yes"
-            if "bypass_permissions" not in dismissed and (
-                "bypass permissions" in lowered
-                or ("yes, i accept" in lowered and "no, exit" in lowered)
-            ):
-                await _tmux_run("send-keys", "-t", pane_id, "Down")
-                await asyncio.sleep(0.1)
-                await _tmux_run("send-keys", "-t", pane_id, "Enter")
-                logger.info("Pane %s: accepted bypass permissions dialog", pane_id)
-                dismissed.add("bypass_permissions")
-                await asyncio.sleep(1.0)
-                continue
-
-            # Dialog 3: security guide / trust-folder (new variant, v2+)
-            #   Body: "Claude Code will be able to read, edit, and execute files here."
-            #   ❯ 1. Yes, I trust this folder   ← pre-selected
-            #     2. No, exit
-            #   Enter to confirm · Esc to cancel
-            # Option 1 is pre-selected — Enter accepts without arrow keys.
-            if "trust_folder" not in dismissed and (
-                "trust this folder" in lowered
-                or "do you trust" in lowered
-                or "yes, i trust this folder" in lowered
-                or "will be able to read" in lowered
-                or "'ll be able to read" in lowered  # v2+ contraction form
-                or "able to read, edit" in lowered
-                or "is this a project you created" in lowered
-            ):
-                await _tmux_run("send-keys", "-t", pane_id, "Enter")
-                logger.info("Pane %s: accepted trust-folder dialog", pane_id)
-                dismissed.add("trust_folder")
-                await asyncio.sleep(1.0)
-                continue
-
-            # Claude Code TUI is running — all dialogs cleared.
-            # NOTE: must run AFTER dialog checks. The trust dialog body text
-            # contains "Claude Code will be able to..." which would cause a
-            # false-positive early-exit if this check ran first.
-            # Guard: only exit early when no known dialog trigger strings present.
-            if "claude code" in lowered and not any(t in lowered for t in _DIALOG_TRIGGERS):
-                logger.debug("Pane %s: Claude Code ready (text match, %.1fs)", pane_id, elapsed)
-                return bool(dismissed)
-
-            # Fast-exit: pane left alternate-screen mode (TUI exited) and the
-            # interactive ❯ prompt is visible.  This fires on Mac where the
-            # alternate_on flag goes False as soon as dialogs clear.
-            #
-            # IMPORTANT: The trust dialog also uses ❯ for menu items (❯ 1. Yes…).
-            # Only treat ❯ as the interactive prompt when it appears on a line by
-            # itself (bare ❯ or "> "), NOT as a menu item prefix like "❯ 1.".
-            try:
-                alt_on = await _get_alternate_on(pane_id)
-                if not alt_on:
-                    # Check for bare prompt line: "❯" or "> " alone, not "❯ 1."
-                    import re as _re_mod
-                    _bare_prompt = _re_mod.compile(r"^[❯>]\s*$", _re_mod.MULTILINE)
-                    if _bare_prompt.search(output):
-                        # Extra guard: ensure no dialog triggers are still visible
-                        if not any(t in lowered for t in _DIALOG_TRIGGERS):
-                            logger.debug(
-                                "Pane %s: prompt visible (alternate_on=0, %.1fs)", pane_id, elapsed
-                            )
-                            return bool(dismissed)
-            except RuntimeError:
-                pass
-
-        except RuntimeError:
-            pass
-        await asyncio.sleep(poll_interval)
-        elapsed += poll_interval
-    logger.debug("Pane %s: dialog handling finished after %.1fs", pane_id, timeout)
-    return bool(dismissed)
+    """Backward-compatible wrapper around Claude-specific startup handling."""
+    return await accept_startup_dialogs(
+        pane_id,
+        capture_pane=_capture_pane,
+        get_alternate_on=_get_alternate_on,
+        tmux_run=_tmux_run,
+        timeout=timeout,
+    )
 
 
 async def _kill_pane(pane_id: str) -> None:
@@ -421,43 +275,14 @@ async def wait_for_prompt(
     timeout: float = 10.0,
     poll_interval: float = 0.5,
 ) -> bool:
-    """Wait until the pane shows an empty prompt with alternate_on == 0.
-
-    Checks two conditions simultaneously:
-    1. alternate_on == 0 (no full-screen TUI active)
-    2. A bare prompt line: starts with '❯' or '> ' with nothing after it
-
-    Returns True when both conditions are met within *timeout* seconds,
-    False otherwise.
-    """
-    import re as _re
-
-    _prompt_re = _re.compile(r"^[❯>]\s*$", _re.MULTILINE)
-
-    elapsed = 0.0
-    while elapsed < timeout:
-        try:
-            alt_on = await _get_alternate_on(pane_id)
-            if not alt_on:
-                output = await _capture_pane(pane_id)
-                lowered = output.lower()
-                if any(trigger in lowered for trigger in _DIALOG_TRIGGERS):
-                    logger.debug(
-                        "Pane %s: prompt suppressed because startup dialog is still visible",
-                        pane_id,
-                    )
-                elif _prompt_re.search(output):
-                    return True
-        except RuntimeError:
-            return False
-        await asyncio.sleep(poll_interval)
-        elapsed += poll_interval
-    logger.warning(
-        "Pane %s: prompt not ready after %.1fs (wait_for_prompt timed out)",
+    """Backward-compatible wrapper around Claude-specific prompt readiness."""
+    return await claude_wait_for_prompt(
         pane_id,
-        timeout,
+        get_alternate_on=_get_alternate_on,
+        capture_pane=_capture_pane,
+        timeout=timeout,
+        poll_interval=poll_interval,
     )
-    return False
 
 
 async def check_tui_ready(
@@ -466,25 +291,13 @@ async def check_tui_ready(
     timeout: float = TUI_READY_TIMEOUT,
     poll_interval: float = TUI_READY_POLL_INTERVAL,
 ) -> bool:
-    """Wait until the pane exits alternate screen mode (TUI not active).
-
-    Returns ``True`` if the pane is ready for input within *timeout* seconds,
-    ``False`` if it timed out (TUI still active).
-    """
-    elapsed = 0.0
-    while elapsed < timeout:
-        try:
-            if not await _get_alternate_on(pane_id):
-                return True
-        except RuntimeError:
-            # Pane may have died
-            return False
-        await asyncio.sleep(poll_interval)
-        elapsed += poll_interval
-    logger.warning(
-        "Pane %s: TUI still active after %.1fs, alternate_on not cleared", pane_id, timeout
+    """Backward-compatible wrapper around Claude-specific TUI readiness."""
+    return await claude_check_tui_ready(
+        pane_id,
+        get_alternate_on=_get_alternate_on,
+        timeout=timeout,
+        poll_interval=poll_interval,
     )
-    return False
 
 
 # ---------------------------------------------------------------------------
@@ -499,108 +312,24 @@ async def send_instruction(
     verify: bool = True,
     max_retries: int = INSTRUCTION_MAX_RETRIES,
 ) -> bool:
-    """Send instruction text + Enter atomically, with optional verification.
+    """Backward-compatible wrapper around Claude-specific instruction delivery."""
+    import atc.agents.claude_runtime as _claude_runtime
 
-    1. Check TUI readiness (alternate_on == False)
-    2. Send text + Enter with no await gap between them
-    3. Verify instruction appears in capture-pane output
-
-    Returns ``True`` if the instruction was verified (or verification skipped).
-    """
-    for attempt in range(1, max_retries + 1):
-        # Step 1: TUI readiness — use prompt-ready polling for first attempt
-        # to ensure the welcome screen has fully cleared before sending.
-        if attempt == 1:
-            ready = await wait_for_prompt(pane_id)
-        else:
-            ready = await check_tui_ready(pane_id)
-        if not ready:
-            logger.warning("Pane %s: TUI not ready on attempt %d/%d", pane_id, attempt, max_retries)
-            continue
-
-        # Step 2: Atomic send — bracketed paste plus Enter via tmux control mode.
-        # This is more reliable with Claude Code than raw send-keys text because
-        # the whole payload lands as one paste event before Enter is pressed.
-        await send_instruction_async(ATC_TMUX_SESSION, pane_id, text)
-
-        if not verify:
-            return True
-
-        # Step 3: Verify instruction was received
-        await asyncio.sleep(INSTRUCTION_VERIFY_DELAY)
-        try:
-            output = await _capture_pane(pane_id)
-            output_lower = output.lower()
-
-            # If the welcome/tips overlay is still visible, the instruction text
-            # is hidden behind it — skip retry and treat as delivered.  The
-            # overlay is purely cosmetic and does not block input; Claude is
-            # already processing the instruction.
-            _welcome_triggers = (
-                "tips for getting started",
-                "welcome to claude code",
-                "welcome back",
-            )
-            if any(t in output_lower for t in _welcome_triggers):
-                logger.info(
-                    "Pane %s: welcome screen visible on attempt %d"
-                    " — assuming instruction delivered",
-                    pane_id,
-                    attempt,
-                )
-                return True
-
-            # Check if any significant portion of the instruction appears in output.
-            # Use the first 80 chars as a fingerprint to avoid issues with line wrapping.
-            fingerprint = text[:80].strip()
-            if fingerprint and fingerprint in output:
-                logger.info("Pane %s: instruction verified on attempt %d", pane_id, attempt)
-                return True
-
-            # Claude sometimes consumes a bracketed paste immediately without leaving
-            # the full instruction visible in capture-pane. If the prompt is no longer
-            # bare, treat that as accepted input rather than a swallowed send — but
-            # only if the pane is still alive and not sitting on a startup dialog.
-            # A dead pane or visible dialog must remain a delivery failure so callers
-            # can retry/report accurately.
-            if not await wait_for_prompt(pane_id, timeout=1.0, poll_interval=0.25):
-                latest_output = await _capture_pane(pane_id)
-                latest_lower = latest_output.lower()
-                if any(trigger in latest_lower for trigger in _DIALOG_TRIGGERS):
-                    logger.warning(
-                        "Pane %s: startup dialog still visible after send on attempt %d",
-                        pane_id,
-                        attempt,
-                    )
-                elif await _pane_is_alive(pane_id):
-                    logger.info(
-                        "Pane %s: prompt disappeared after send on attempt %d — assuming instruction accepted",
-                        pane_id,
-                        attempt,
-                    )
-                    return True
-                else:
-                    logger.warning(
-                        "Pane %s: prompt disappeared after send on attempt %d but pane is dead",
-                        pane_id,
-                        attempt,
-                    )
-            logger.warning(
-                "Pane %s: instruction not found in output (attempt %d/%d)",
-                pane_id,
-                attempt,
-                max_retries,
-            )
-        except RuntimeError:
-            logger.warning(
-                "Pane %s: capture-pane failed on attempt %d/%d",
-                pane_id,
-                attempt,
-                max_retries,
-            )
-
-    logger.error("Pane %s: instruction delivery failed after %d attempts", pane_id, max_retries)
-    return False
+    original_send = _claude_runtime.send_instruction_async
+    _claude_runtime.send_instruction_async = send_instruction_async
+    try:
+        return await claude_send_instruction(
+            pane_id,
+            text,
+            capture_pane=_capture_pane,
+            pane_is_alive=_pane_is_alive,
+            wait_for_prompt_fn=wait_for_prompt,
+            check_tui_ready_fn=check_tui_ready,
+            verify=verify,
+            max_retries=max_retries,
+        )
+    finally:
+        _claude_runtime.send_instruction_async = original_send
 
 
 # Legacy wrapper kept for backward compatibility with existing callers
@@ -696,7 +425,20 @@ async def create_ace(
             launch_command,
             working_dir=effective_working_dir,
         )
-        await _accept_trust_dialog(pane_id)
+        try:
+            from atc.agents.factory import create_provider
+
+            provider_name = "claude_code"
+            if project_id:
+                project = await db_ops.get_project(conn, project_id)
+                if project and project.agent_provider:
+                    provider_name = project.agent_provider
+            provider = create_provider(provider_name)
+            if hasattr(provider, "_sessions"):
+                provider._sessions[session.id] = type("Tracked", (), {"pane_id": pane_id, "status": None})()
+            await provider.handle_startup(session.id)
+        except Exception:
+            await _accept_trust_dialog(pane_id)
         await db_ops.update_session_tmux(conn, session.id, ATC_TMUX_SESSION, pane_id)
 
         # Step 4a: success → idle

--- a/src/atc/session/reconnect.py
+++ b/src/atc/session/reconnect.py
@@ -179,7 +179,16 @@ async def reconnect_session(
             launch_cmd,
             working_dir=working_dir,
         )
-        await _accept_trust_dialog(pane_id)
+        try:
+            from atc.agents.factory import create_provider
+
+            provider_name = project.agent_provider or "claude_code" if project else "claude_code"
+            provider = create_provider(provider_name)
+            if hasattr(provider, "_sessions"):
+                provider._sessions[session_id] = type("Tracked", (), {"pane_id": pane_id, "status": None})()
+            await provider.handle_startup(session_id)
+        except Exception:
+            await _accept_trust_dialog(pane_id)
         await db_ops.update_session_tmux(conn, session_id, ATC_TMUX_SESSION, pane_id)
 
         await transition(session_id, SessionStatus.CONNECTING, SessionStatus.IDLE, event_bus)

--- a/src/atc/tower/session.py
+++ b/src/atc/tower/session.py
@@ -162,7 +162,15 @@ async def start_tower_session(
                 launch_cmd = get_launch_command(provider)
                 await _ensure_tmux_session(ATC_TMUX_SESSION)
                 pane_id = await _spawn_pane(ATC_TMUX_SESSION, launch_cmd, working_dir=working_dir)
-                await _accept_trust_dialog(pane_id)
+                try:
+                    from atc.agents.factory import create_provider
+
+                    provider_obj = create_provider(provider)
+                    if hasattr(provider_obj, "_sessions"):
+                        provider_obj._sessions[sess.id] = type("Tracked", (), {"pane_id": pane_id, "status": None})()
+                    await provider_obj.handle_startup(sess.id)
+                except Exception:
+                    await _accept_trust_dialog(pane_id)
                 await db_ops.update_session_tmux(conn, sess.id, ATC_TMUX_SESSION, pane_id)
                 await transition(sess.id, SessionStatus.CONNECTING, SessionStatus.IDLE, event_bus)
                 await db_ops.update_session_status(conn, sess.id, SessionStatus.IDLE.value)
@@ -226,7 +234,15 @@ async def start_tower_session(
             launch_cmd,
             working_dir=working_dir,
         )
-        await _accept_trust_dialog(pane_id)
+        try:
+            from atc.agents.factory import create_provider
+
+            provider_obj = create_provider(provider)
+            if hasattr(provider_obj, "_sessions"):
+                provider_obj._sessions[session.id] = type("Tracked", (), {"pane_id": pane_id, "status": None})()
+            await provider_obj.handle_startup(session.id)
+        except Exception:
+            await _accept_trust_dialog(pane_id)
         await db_ops.update_session_tmux(conn, session.id, ATC_TMUX_SESSION, pane_id)
 
         await transition(session.id, SessionStatus.CONNECTING, SessionStatus.IDLE, event_bus)

--- a/tests/unit/test_agent_provider.py
+++ b/tests/unit/test_agent_provider.py
@@ -262,8 +262,13 @@ class TestClaudeCodeProvider:
         mock_exec.return_value = _make_process(stdout=b"%42\n")
         await provider.spawn_session("s1")
 
-        # send_instruction_async is mocked so no real tmux call is made
-        result = await provider.send_prompt("s1", "Write hello world")
+        with (
+            patch.object(provider, "_wait_for_prompt", new=AsyncMock(return_value=True)),
+            patch.object(provider, "is_ready", new=AsyncMock(return_value=True)),
+            patch.object(provider, "_capture_pane", new=AsyncMock(return_value="Write hello world")),
+        ):
+            # send_instruction_async is mocked so no real tmux call is made
+            result = await provider.send_prompt("s1", "Write hello world")
 
         assert result.accepted is True
         assert result.session_id == "s1"

--- a/tests/unit/test_provider_abstraction.py
+++ b/tests/unit/test_provider_abstraction.py
@@ -3,6 +3,7 @@
 Covers:
 - ClaudeCodeProvider.prepare_workspace: creates dirs, copies context file
 - ClaudeCodeProvider.is_ready: returns True when pane shows ❯ prompt
+- ClaudeCodeProvider.handle_startup: Claude startup dialogs are provider-owned
 """
 
 from __future__ import annotations
@@ -17,15 +18,10 @@ if TYPE_CHECKING:
 
 from atc.agents.claude_provider import ClaudeCodeProvider
 
-# ---------------------------------------------------------------------------
-# prepare_workspace
-# ---------------------------------------------------------------------------
-
 
 class TestPrepareWorkspace:
     @pytest.mark.asyncio
     async def test_creates_working_dir(self, tmp_path: Path) -> None:
-        """prepare_workspace creates the working directory if missing."""
         provider = ClaudeCodeProvider()
         target = tmp_path / "new_dir" / "nested"
 
@@ -35,7 +31,6 @@ class TestPrepareWorkspace:
 
     @pytest.mark.asyncio
     async def test_copies_context_file(self, tmp_path: Path) -> None:
-        """prepare_workspace copies context_file to working_dir/CLAUDE.md."""
         provider = ClaudeCodeProvider()
         context_file = tmp_path / "src_CLAUDE.md"
         context_file.write_text("# Leader instructions\n")
@@ -54,7 +49,6 @@ class TestPrepareWorkspace:
 
     @pytest.mark.asyncio
     async def test_does_not_overwrite_existing_claude_md(self, tmp_path: Path) -> None:
-        """prepare_workspace skips copy when CLAUDE.md already exists."""
         provider = ClaudeCodeProvider()
         working_dir = tmp_path / "workspace"
         working_dir.mkdir()
@@ -71,12 +65,10 @@ class TestPrepareWorkspace:
             context_file=context_file,
         )
 
-        # Original content must be preserved
         assert existing.read_text() == "# Existing instructions\n"
 
     @pytest.mark.asyncio
     async def test_no_context_file_still_creates_dir(self, tmp_path: Path) -> None:
-        """prepare_workspace succeeds with context_file=None."""
         provider = ClaudeCodeProvider()
         target = tmp_path / "just_dir"
 
@@ -86,25 +78,17 @@ class TestPrepareWorkspace:
         assert not (target / "CLAUDE.md").exists()
 
 
-# ---------------------------------------------------------------------------
-# is_ready
-# ---------------------------------------------------------------------------
-
-
 class TestIsReady:
     @pytest.mark.asyncio
     async def test_returns_false_for_unknown_session(self) -> None:
-        """is_ready returns False immediately for an untracked session."""
         provider = ClaudeCodeProvider()
         result = await provider.is_ready("does-not-exist")
         assert result is False
 
     @pytest.mark.asyncio
     async def test_returns_true_when_prompt_detected(self) -> None:
-        """is_ready returns True when capture-pane shows a bare ❯ prompt."""
         provider = ClaudeCodeProvider()
 
-        # Inject a fake tracked session
         from atc.agents.base import SessionStatus
         from atc.agents.claude_provider import _TrackedSession
 
@@ -114,15 +98,11 @@ class TestIsReady:
             status=SessionStatus.IDLE,
         )
 
-        # Simulate: alternate_on == 0, then pane output with bare ❯ prompt
         async def _fake_subproc(*args: str, **kwargs: object) -> MagicMock:
             proc = MagicMock()
             if "display-message" in args:
-                # alternate_on = 0
                 proc.communicate = AsyncMock(return_value=(b"0\n", b""))
             else:
-                # capture-pane output with a bare prompt line
-                # Use ASCII '>' prompt since bytes literals can't contain ❯
                 proc.communicate = AsyncMock(return_value=(b"some output\n>\n", b""))
             proc.returncode = 0
             return proc
@@ -134,7 +114,6 @@ class TestIsReady:
 
     @pytest.mark.asyncio
     async def test_returns_false_when_tui_fullscreen(self) -> None:
-        """is_ready returns False while alternate_on == 1 (TUI fullscreen)."""
         provider = ClaudeCodeProvider()
 
         from atc.agents.base import SessionStatus
@@ -146,40 +125,37 @@ class TestIsReady:
             status=SessionStatus.STARTING,
         )
 
-        call_count = 0
-
         async def _always_alt_on(*args: str, **kwargs: object) -> MagicMock:
-            nonlocal call_count
-            call_count += 1
             proc = MagicMock()
             proc.communicate = AsyncMock(return_value=(b"1\n", b""))
             proc.returncode = 0
             return proc
 
-        # Patch sleep to avoid slow tests and cap iterations
         with (
             patch("asyncio.create_subprocess_exec", side_effect=_always_alt_on),
             patch("asyncio.sleep", new_callable=AsyncMock) as mock_sleep,
         ):
-            # Accelerate by making sleep advance time instantly
-            # is_ready polls until 10s elapsed; we patch sleep but the
-            # elapsed counter only advances by poll_interval (0.5) each loop.
-            # Override timeout via monkeypatching the local variable is not
-            # possible cleanly, so instead we just let the function run a
-            # few iterations and confirm False is returned.
-            # We reduce test duration by patching sleep to be instant and
-            # asserting at least one poll happened.
-            mock_sleep.side_effect = None  # non-blocking
-
-            # Limit to a small number of real iterations by patching the
-            # time boundary — simplest approach: raise after N calls.
-            _iters = 0
-            _original = provider.is_ready
-
-            async def _limited(*a: object, **kw: object) -> bool:
-                return await _original(*a, **kw)  # type: ignore[arg-type]
-
+            mock_sleep.side_effect = None
             result = await provider.is_ready("sess-tui")
 
-        # alternate_on never cleared → not ready
         assert result is False
+
+
+class TestHandleStartup:
+    @pytest.mark.asyncio
+    async def test_calls_claude_runtime_startup_handler(self) -> None:
+        provider = ClaudeCodeProvider()
+
+        from atc.agents.base import SessionStatus
+        from atc.agents.claude_provider import _TrackedSession
+
+        provider._sessions["sess-start"] = _TrackedSession(
+            session_id="sess-start",
+            pane_id="%77",
+            status=SessionStatus.STARTING,
+        )
+
+        with patch("atc.agents.claude_provider.accept_startup_dialogs", new_callable=AsyncMock) as mock_startup:
+            await provider.handle_startup("sess-start")
+
+        mock_startup.assert_awaited_once()


### PR DESCRIPTION
## Summary
- move Claude startup dialog handling, readiness checks, and instruction verification into provider-owned runtime helpers
- route ace, leader, tower, and reconnect startup flows through provider.handle_startup with Claude fallback only as a guard
- align provider tests and protocol coverage with the new boundary, including OpenCode protocol compliance

## Testing
- PYTHONPATH=src pytest tests/unit/test_agent_provider.py tests/unit/test_provider_abstraction.py tests/unit/test_creation_reliability.py tests/unit/test_welcome_hardening.py tests/unit/test_tower_session_reuse.py tests/unit/test_leader_orchestrator.py tests/unit/test_e2e_wiring.py tests/integration/test_creation_reliability.py -q