### PR TITLE
refactor: move session spawn into providers

### DIFF
--- a/src/atc/agents/base.py
+++ b/src/atc/agents/base.py
@@ -11,6 +11,8 @@ import enum
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
 
+from atc.state.models import Project, Session
+
 if TYPE_CHECKING:
     from collections.abc import AsyncIterator
     from pathlib import Path
@@ -83,6 +85,19 @@ class ProviderMetadata:
     version: str = "0.0.0"
     description: str = ""
     author: str = ""
+
+
+@dataclass(frozen=True)
+class ProviderSpawnRequest:
+    """Provider-owned spawn request for lifecycle operations."""
+
+    session: Session
+    project: Project | None = None
+    working_dir: str | None = None
+    launch_command: str | None = None
+    env: dict[str, str] = field(default_factory=dict)
+    context_file: Path | None = None
+    role: str = "ace"
 
 
 @runtime_checkable
@@ -162,6 +177,10 @@ class AgentProvider(Protocol):
         perform other provider-specific initialization needed before the
         session is considered ready.
         """
+        ...
+
+    async def spawn_for_session(self, request: ProviderSpawnRequest) -> SessionInfo:
+        """Spawn a runtime pane/process for an existing ATC session row."""
         ...
 
     async def send_prompt(self, session_id: str, prompt: str) -> PromptResult:

--- a/src/atc/agents/claude_provider.py
+++ b/src/atc/agents/claude_provider.py
@@ -21,6 +21,7 @@ from atc.agents.base import (
     PromptResult,
     ProviderCapabilities,
     ProviderError,
+    ProviderSpawnRequest,
     SessionInfo,
     SessionStatus,
 )
@@ -147,6 +148,18 @@ class ClaudeCodeProvider:
 
         logger.info("Spawned Claude Code session %s in pane %s", session_id, pane_id)
         return tracked.to_info()
+
+    async def spawn_for_session(self, request: ProviderSpawnRequest) -> SessionInfo:
+        """Spawn a Claude runtime pane for an existing ATC session row."""
+        info = await self.spawn_session(
+            request.session.id,
+            working_dir=request.working_dir,
+            env=request.env,
+            context_file=request.context_file,
+            role=request.role,
+        )
+        await self.handle_startup(request.session.id)
+        return info
 
     async def handle_startup(self, session_id: str) -> None:
         """Handle Claude-specific startup dialogs for a tracked session."""

--- a/src/atc/agents/factory.py
+++ b/src/atc/agents/factory.py
@@ -17,6 +17,7 @@ from pathlib import Path
 from typing import Any
 
 from atc.agents.base import AgentProvider, ProviderError, ProviderMetadata
+from atc.config import load_settings
 
 logger = logging.getLogger(__name__)
 
@@ -56,6 +57,12 @@ def create_provider(name: str, **kwargs: Any) -> AgentProvider:
             "factory",
             f"Unknown provider {name!r}. Available: {available}",
         )
+    if not kwargs and name == "claude_code":
+        try:
+            settings = load_settings()
+            kwargs = {"claude_command": settings.agent_provider.claude_command}
+        except Exception:
+            kwargs = {}
     provider: AgentProvider = cls(**kwargs)
     logger.info("Created agent provider: %s (%s)", name, cls.__name__)
     return provider

--- a/src/atc/agents/opencode_provider.py
+++ b/src/atc/agents/opencode_provider.py
@@ -23,6 +23,7 @@ from atc.agents.base import (
     PromptResult,
     ProviderCapabilities,
     ProviderError,
+    ProviderSpawnRequest,
     SessionInfo,
     SessionStatus,
 )
@@ -203,6 +204,15 @@ class OpenCodeProvider:
         """OpenCode has no tmux/TUI startup dialog flow."""
         self._require_tracked(session_id)
         return None
+
+    async def spawn_for_session(self, request: ProviderSpawnRequest) -> SessionInfo:
+        return await self.spawn_session(
+            request.session.id,
+            working_dir=request.working_dir,
+            env=request.env,
+            context_file=request.context_file,
+            role=request.role,
+        )
 
     async def send_prompt(self, session_id: str, prompt: str) -> PromptResult:
         self._require_tracked(session_id)

--- a/src/atc/core/health.py
+++ b/src/atc/core/health.py
@@ -10,7 +10,6 @@ from dataclasses import dataclass
 from atc.session.ace import (
     ATC_TMUX_SESSION,
     _capture_pane,
-    _ensure_tmux_session,
     _kill_pane,
     _spawn_pane,
     _tmux_run,
@@ -38,7 +37,6 @@ async def run_startup_smoke_test() -> HealthResult:
     pane_id: str | None = None
 
     try:
-        await _ensure_tmux_session(ATC_TMUX_SESSION)
         pane_id = await _spawn_pane(ATC_TMUX_SESSION, "bash")
 
         # Give bash a moment to start

--- a/src/atc/leader/leader.py
+++ b/src/atc/leader/leader.py
@@ -19,11 +19,11 @@ from typing import TYPE_CHECKING, Any
 from atc.agents.deploy import ManagerDeploySpec, deploy_manager_files
 from atc.agents.factory import get_launch_command
 from atc.session.ace import (
-    ATC_TMUX_SESSION,
     _accept_trust_dialog,
     _ensure_tmux_session,
     _kill_pane,
     _spawn_pane,
+    _spawn_provider_session,
     send_instruction,
 )
 from atc.session.state_machine import SessionStatus, transition
@@ -195,22 +195,16 @@ async def start_leader(
                 _prep_exc,
             )
 
-        await _ensure_tmux_session(ATC_TMUX_SESSION)
-        pane_id = await _spawn_pane(
-            ATC_TMUX_SESSION,
-            launch_cmd,
+        tmux_session, pane_id = await _spawn_provider_session(
+            conn,
+            session.id,
+            project_id=project_id,
+            session_type="manager",
             working_dir=working_dir,
+            context_file=deployed.claude_md_path if deployed.claude_md_path.exists() else None,
+            launch_command=launch_cmd,
         )
-        try:
-            from atc.agents.factory import create_provider
-
-            provider = create_provider(project.agent_provider if project else "claude_code")
-            if hasattr(provider, "_sessions"):
-                provider._sessions[session.id] = type("Tracked", (), {"pane_id": pane_id, "status": None})()
-            await provider.handle_startup(session.id)
-        except Exception:
-            await _accept_trust_dialog(pane_id)
-        await db_ops.update_session_tmux(conn, session.id, ATC_TMUX_SESSION, pane_id)
+        await db_ops.update_session_tmux(conn, session.id, tmux_session, pane_id)
 
         await transition(session.id, SessionStatus.CONNECTING, SessionStatus.IDLE, event_bus)
         await db_ops.update_session_status(conn, session.id, SessionStatus.IDLE.value)

--- a/src/atc/session/ace.py
+++ b/src/atc/session/ace.py
@@ -25,6 +25,7 @@ from dataclasses import dataclass
 from pathlib import Path as _Path
 from typing import TYPE_CHECKING, Any
 
+from atc.agents.base import ProviderSpawnRequest
 from atc.agents.claude_runtime import (
     INSTRUCTION_MAX_RETRIES,
     TUI_READY_POLL_INTERVAL,
@@ -343,6 +344,49 @@ async def _send_keys(pane_id: str, keys: str) -> None:
 # ---------------------------------------------------------------------------
 
 
+async def _spawn_provider_session(
+    conn: aiosqlite.Connection,
+    session_id: str,
+    *,
+    project_id: str | None,
+    session_type: str,
+    working_dir: str | None,
+    context_file: _Path | None = None,
+    launch_command: str | None = None,
+) -> tuple[str, str]:
+    from atc.agents.factory import create_provider
+
+    project = await db_ops.get_project(conn, project_id) if project_id else None
+    provider_name = project.agent_provider if project and project.agent_provider else "claude_code"
+    provider = create_provider(provider_name)
+
+    session = await db_ops.get_session(conn, session_id)
+    if session is None:
+        raise ValueError(f"Session {session_id} not found")
+
+    role = {
+        "ace": "ace",
+        "manager": "leader",
+        "tower": "tower",
+    }.get(session_type, "ace")
+
+    info = await provider.spawn_for_session(
+        ProviderSpawnRequest(
+            session=session,
+            project=project,
+            working_dir=working_dir,
+            launch_command=launch_command,
+            context_file=context_file,
+            role=role,
+        )
+    )
+    pane_id = str(info.metadata.get("pane_id") or "")
+    tmux_session = str(info.metadata.get("tmux_session") or ATC_TMUX_SESSION)
+    if not pane_id:
+        raise RuntimeError(f"Provider {provider_name} did not return a pane_id for {session_id}")
+    return tmux_session, pane_id
+
+
 async def create_ace(
     conn: aiosqlite.Connection,
     project_id: str,
@@ -381,6 +425,7 @@ async def create_ace(
     # Step 1b: Deploy config files with the real session_id so hooks,
     # CLAUDE.md, and heartbeat all reference the correct ID.
     effective_working_dir = working_dir
+    deployed = None
     if deploy_spec_kwargs is not None:
         from atc.agents.deploy import AceDeploySpec, deploy_ace_files
 
@@ -419,27 +464,16 @@ async def create_ace(
                     _prep_exc,
                 )
 
-        await _ensure_tmux_session(ATC_TMUX_SESSION)
-        pane_id = await _spawn_pane(
-            ATC_TMUX_SESSION,
-            launch_command,
+        tmux_session, pane_id = await _spawn_provider_session(
+            conn,
+            session.id,
+            project_id=project_id,
+            session_type="ace",
             working_dir=effective_working_dir,
+            context_file=deployed.claude_md_path if deployed and deployed.claude_md_path.exists() else None,
+            launch_command=launch_command,
         )
-        try:
-            from atc.agents.factory import create_provider
-
-            provider_name = "claude_code"
-            if project_id:
-                project = await db_ops.get_project(conn, project_id)
-                if project and project.agent_provider:
-                    provider_name = project.agent_provider
-            provider = create_provider(provider_name)
-            if hasattr(provider, "_sessions"):
-                provider._sessions[session.id] = type("Tracked", (), {"pane_id": pane_id, "status": None})()
-            await provider.handle_startup(session.id)
-        except Exception:
-            await _accept_trust_dialog(pane_id)
-        await db_ops.update_session_tmux(conn, session.id, ATC_TMUX_SESSION, pane_id)
+        await db_ops.update_session_tmux(conn, session.id, tmux_session, pane_id)
 
         # Step 4a: success → idle
         await transition(session.id, SessionStatus.CONNECTING, SessionStatus.IDLE, event_bus)

--- a/src/atc/session/reconnect.py
+++ b/src/atc/session/reconnect.py
@@ -14,14 +14,7 @@ from typing import TYPE_CHECKING
 from atc.agents.deploy import TowerDeploySpec, deploy_tower_files
 from atc.agents.factory import get_launch_command
 from atc.leader.leader import _build_manager_deploy_spec
-from atc.session.ace import (
-    ATC_TMUX_SESSION,
-    _accept_trust_dialog,
-    _ensure_tmux_session,
-    _kill_pane,
-    _pane_is_alive,
-    _spawn_pane,
-)
+from atc.session.ace import _kill_pane, _pane_is_alive, _spawn_provider_session
 from atc.session.state_machine import SessionStatus, transition
 from atc.state import db as db_ops
 
@@ -173,23 +166,24 @@ async def reconnect_session(
         if working_dir:
             _log_reconnect_working_dir(working_dir, session_id)
 
-        await _ensure_tmux_session(ATC_TMUX_SESSION)
-        pane_id = await _spawn_pane(
-            ATC_TMUX_SESSION,
-            launch_cmd,
-            working_dir=working_dir,
-        )
-        try:
-            from atc.agents.factory import create_provider
+        context_file = None
+        if getattr(session, "session_type", None) == "tower" and project:
+            _candidate = deployed.root / "CLAUDE.md"
+            context_file = _candidate if _candidate.exists() else None
+        elif getattr(session, "session_type", None) == "manager" and project:
+            _candidate = deployed.root / "CLAUDE.md"
+            context_file = _candidate if _candidate.exists() else None
 
-            provider_name = project.agent_provider or "claude_code" if project else "claude_code"
-            provider = create_provider(provider_name)
-            if hasattr(provider, "_sessions"):
-                provider._sessions[session_id] = type("Tracked", (), {"pane_id": pane_id, "status": None})()
-            await provider.handle_startup(session_id)
-        except Exception:
-            await _accept_trust_dialog(pane_id)
-        await db_ops.update_session_tmux(conn, session_id, ATC_TMUX_SESSION, pane_id)
+        tmux_session, pane_id = await _spawn_provider_session(
+            conn,
+            session_id,
+            project_id=session.project_id,
+            session_type=getattr(session, "session_type", "ace"),
+            working_dir=working_dir,
+            context_file=context_file,
+            launch_command=launch_cmd,
+        )
+        await db_ops.update_session_tmux(conn, session_id, tmux_session, pane_id)
 
         await transition(session_id, SessionStatus.CONNECTING, SessionStatus.IDLE, event_bus)
         await db_ops.update_session_status(conn, session_id, SessionStatus.IDLE.value)

--- a/src/atc/tower/session.py
+++ b/src/atc/tower/session.py
@@ -17,13 +17,13 @@ from typing import TYPE_CHECKING
 from atc.agents.deploy import _DEFAULT_STAGING_ROOT, TowerDeploySpec, deploy_tower_files
 from atc.agents.factory import get_launch_command
 from atc.session.ace import (
-    ATC_TMUX_SESSION,
     _accept_trust_dialog,
     _ensure_tmux_session,
     _kill_pane,
     _pane_is_alive,
     _send_keys,
     _spawn_pane,
+    _spawn_provider_session,
 )
 from atc.session.state_machine import SessionStatus, transition
 from atc.state import db as db_ops
@@ -160,18 +160,16 @@ async def start_tower_session(
             try:
                 provider = project.agent_provider if project else "claude_code"
                 launch_cmd = get_launch_command(provider)
-                await _ensure_tmux_session(ATC_TMUX_SESSION)
-                pane_id = await _spawn_pane(ATC_TMUX_SESSION, launch_cmd, working_dir=working_dir)
-                try:
-                    from atc.agents.factory import create_provider
-
-                    provider_obj = create_provider(provider)
-                    if hasattr(provider_obj, "_sessions"):
-                        provider_obj._sessions[sess.id] = type("Tracked", (), {"pane_id": pane_id, "status": None})()
-                    await provider_obj.handle_startup(sess.id)
-                except Exception:
-                    await _accept_trust_dialog(pane_id)
-                await db_ops.update_session_tmux(conn, sess.id, ATC_TMUX_SESSION, pane_id)
+                tmux_session, pane_id = await _spawn_provider_session(
+                    conn,
+                    sess.id,
+                    project_id=project_id,
+                    session_type="tower",
+                    working_dir=working_dir,
+                    context_file=staging_dir / "CLAUDE.md" if (staging_dir / "CLAUDE.md").is_file() else None,
+                    launch_command=launch_cmd,
+                )
+                await db_ops.update_session_tmux(conn, sess.id, tmux_session, pane_id)
                 await transition(sess.id, SessionStatus.CONNECTING, SessionStatus.IDLE, event_bus)
                 await db_ops.update_session_status(conn, sess.id, SessionStatus.IDLE.value)
             except Exception as exc:
@@ -228,22 +226,16 @@ async def start_tower_session(
         # --- Runtime debug: verify CLAUDE.md is present at working_dir ---
         _log_working_dir_contents(working_dir, session.id, "start_tower_session")
 
-        await _ensure_tmux_session(ATC_TMUX_SESSION)
-        pane_id = await _spawn_pane(
-            ATC_TMUX_SESSION,
-            launch_cmd,
+        tmux_session, pane_id = await _spawn_provider_session(
+            conn,
+            session.id,
+            project_id=project_id,
+            session_type="tower",
             working_dir=working_dir,
+            context_file=deployed.claude_md_path if deployed.claude_md_path.exists() else None,
+            launch_command=launch_cmd,
         )
-        try:
-            from atc.agents.factory import create_provider
-
-            provider_obj = create_provider(provider)
-            if hasattr(provider_obj, "_sessions"):
-                provider_obj._sessions[session.id] = type("Tracked", (), {"pane_id": pane_id, "status": None})()
-            await provider_obj.handle_startup(session.id)
-        except Exception:
-            await _accept_trust_dialog(pane_id)
-        await db_ops.update_session_tmux(conn, session.id, ATC_TMUX_SESSION, pane_id)
+        await db_ops.update_session_tmux(conn, session.id, tmux_session, pane_id)
 
         await transition(session.id, SessionStatus.CONNECTING, SessionStatus.IDLE, event_bus)
         await db_ops.update_session_status(conn, session.id, SessionStatus.IDLE.value)

--- a/tests/integration/test_creation_reliability.py
+++ b/tests/integration/test_creation_reliability.py
@@ -39,12 +39,10 @@ class TestDBFirstCreation:
     """Verify that the DB row is written before tmux operations."""
 
     @pytest.mark.asyncio
-    @patch("atc.session.ace._spawn_pane", new_callable=AsyncMock)
-    @patch("atc.session.ace._ensure_tmux_session", new_callable=AsyncMock)
+    @patch("atc.session.ace._spawn_provider_session", new_callable=AsyncMock)
     async def test_session_row_created_before_tmux(
         self,
-        mock_ensure: AsyncMock,
-        mock_spawn: AsyncMock,
+        mock_spawn_provider: AsyncMock,
         conn,
         event_bus: EventBus,
     ) -> None:
@@ -59,13 +57,13 @@ class TestDBFirstCreation:
             call_order.append("db_create")
             return result
 
-        mock_spawn.return_value = "%1"
+        mock_spawn_provider.return_value = ("atc", "%1")
 
         async def tracking_spawn(*args, **kwargs):
             call_order.append("tmux_spawn")
-            return "%1"
+            return ("atc", "%1")
 
-        mock_spawn.side_effect = tracking_spawn
+        mock_spawn_provider.side_effect = tracking_spawn
 
         # Create project first
         project = await db_ops.create_project(conn, "test-project")
@@ -81,16 +79,13 @@ class TestDBFirstCreation:
         assert session is not None
 
     @pytest.mark.asyncio
-    @patch("atc.session.ace._spawn_pane", new_callable=AsyncMock)
-    @patch("atc.session.ace._ensure_tmux_session", new_callable=AsyncMock)
+    @patch("atc.session.ace._spawn_provider_session", new_callable=AsyncMock, return_value=("atc", "%2"))
     async def test_session_moves_to_idle_on_success(
         self,
-        mock_ensure: AsyncMock,
-        mock_spawn: AsyncMock,
+        mock_spawn_provider: AsyncMock,
         conn,
         event_bus: EventBus,
     ) -> None:
-        mock_spawn.return_value = "%2"
         project = await db_ops.create_project(conn, "test-project")
 
         session_id = await create_ace(conn, project.id, "test-ace", event_bus=event_bus)
@@ -101,22 +96,17 @@ class TestDBFirstCreation:
         assert session.tmux_pane == "%2"
 
     @pytest.mark.asyncio
-    @patch("atc.session.ace._ensure_tmux_session", new_callable=AsyncMock)
+    @patch("atc.session.ace._spawn_provider_session", new_callable=AsyncMock, side_effect=RuntimeError("tmux not available"))
     async def test_session_moves_to_error_on_failure(
         self,
-        mock_ensure: AsyncMock,
+        mock_spawn_provider: AsyncMock,
         conn,
         event_bus: EventBus,
     ) -> None:
         """If tmux spawn fails, the session row should still exist with error status."""
         project = await db_ops.create_project(conn, "test-project")
 
-        # _spawn_pane is not mocked, so it will fail (no tmux)
-        with patch(
-            "atc.session.ace._spawn_pane",
-            new_callable=AsyncMock,
-            side_effect=RuntimeError("tmux not available"),
-        ), pytest.raises(RuntimeError, match="tmux not available"):
+        with pytest.raises(RuntimeError, match="tmux not available"):
             await create_ace(conn, project.id, "test-ace", event_bus=event_bus)
 
         # Session must exist with error status — no ghost session
@@ -125,16 +115,13 @@ class TestDBFirstCreation:
         assert sessions[0].status == SessionStatus.ERROR.value
 
     @pytest.mark.asyncio
-    @patch("atc.session.ace._spawn_pane", new_callable=AsyncMock)
-    @patch("atc.session.ace._ensure_tmux_session", new_callable=AsyncMock)
+    @patch("atc.session.ace._spawn_provider_session", new_callable=AsyncMock, return_value=("atc", "%3"))
     async def test_creation_event_published(
         self,
-        mock_ensure: AsyncMock,
-        mock_spawn: AsyncMock,
+        mock_spawn_provider: AsyncMock,
         conn,
         event_bus: EventBus,
     ) -> None:
-        mock_spawn.return_value = "%3"
         received: list[dict] = []
 
         async def handler(data: dict) -> None:
@@ -155,17 +142,14 @@ class TestAtomicInstructionSending:
 
     @pytest.mark.asyncio
     @patch("atc.session.ace.send_instruction", new_callable=AsyncMock)
-    @patch("atc.session.ace._spawn_pane", new_callable=AsyncMock)
-    @patch("atc.session.ace._ensure_tmux_session", new_callable=AsyncMock)
+    @patch("atc.session.ace._spawn_provider_session", new_callable=AsyncMock, return_value=("atc", "%4"))
     async def test_start_ace_uses_send_instruction(
         self,
-        mock_ensure: AsyncMock,
-        mock_spawn: AsyncMock,
+        mock_spawn_provider: AsyncMock,
         mock_send: AsyncMock,
         conn,
         event_bus: EventBus,
     ) -> None:
-        mock_spawn.return_value = "%4"
         mock_send.return_value = True
 
         project = await db_ops.create_project(conn, "test-project")
@@ -177,17 +161,14 @@ class TestAtomicInstructionSending:
 
     @pytest.mark.asyncio
     @patch("atc.session.ace.send_instruction", new_callable=AsyncMock)
-    @patch("atc.session.ace._spawn_pane", new_callable=AsyncMock)
-    @patch("atc.session.ace._ensure_tmux_session", new_callable=AsyncMock)
+    @patch("atc.session.ace._spawn_provider_session", new_callable=AsyncMock, return_value=("atc", "%5"))
     async def test_start_ace_errors_on_failed_delivery(
         self,
-        mock_ensure: AsyncMock,
-        mock_spawn: AsyncMock,
+        mock_spawn_provider: AsyncMock,
         mock_send: AsyncMock,
         conn,
         event_bus: EventBus,
     ) -> None:
-        mock_spawn.return_value = "%5"
         mock_send.return_value = False  # delivery failed
 
         project = await db_ops.create_project(conn, "test-project")
@@ -207,17 +188,14 @@ class TestVerificationChecks:
 
     @pytest.mark.asyncio
     @patch("atc.session.ace._pane_is_alive", new_callable=AsyncMock)
-    @patch("atc.session.ace._spawn_pane", new_callable=AsyncMock)
-    @patch("atc.session.ace._ensure_tmux_session", new_callable=AsyncMock)
+    @patch("atc.session.ace._spawn_provider_session", new_callable=AsyncMock, return_value=("atc", "%6"))
     async def test_verify_session_alive(
         self,
-        mock_ensure: AsyncMock,
-        mock_spawn: AsyncMock,
+        mock_spawn_provider: AsyncMock,
         mock_alive: AsyncMock,
         conn,
         event_bus: EventBus,
     ) -> None:
-        mock_spawn.return_value = "%6"
         mock_alive.return_value = True
 
         project = await db_ops.create_project(conn, "test-project")
@@ -227,17 +205,14 @@ class TestVerificationChecks:
 
     @pytest.mark.asyncio
     @patch("atc.session.ace._pane_is_alive", new_callable=AsyncMock)
-    @patch("atc.session.ace._spawn_pane", new_callable=AsyncMock)
-    @patch("atc.session.ace._ensure_tmux_session", new_callable=AsyncMock)
+    @patch("atc.session.ace._spawn_provider_session", new_callable=AsyncMock, return_value=("atc", "%7"))
     async def test_verify_session_dead_pane(
         self,
-        mock_ensure: AsyncMock,
-        mock_spawn: AsyncMock,
+        mock_spawn_provider: AsyncMock,
         mock_alive: AsyncMock,
         conn,
         event_bus: EventBus,
     ) -> None:
-        mock_spawn.return_value = "%7"
         mock_alive.return_value = False
 
         project = await db_ops.create_project(conn, "test-project")

--- a/tests/unit/test_e2e_wiring.py
+++ b/tests/unit/test_e2e_wiring.py
@@ -138,14 +138,12 @@ class TestTowerToLeaderWiring:
         assert spec.goal == "Build feature X"
         assert spec.project_name == "test-proj"
 
-    @patch("atc.leader.leader._spawn_pane", new_callable=AsyncMock, return_value="%1")
-    @patch("atc.leader.leader._ensure_tmux_session", new_callable=AsyncMock)
+    @patch("atc.leader.leader._spawn_provider_session", new_callable=AsyncMock, return_value=("atc", "%1"))
     @patch("atc.leader.leader.deploy_manager_files")
     async def test_start_leader_launches_claude(
         self,
         mock_deploy: AsyncMock,
-        mock_ensure: AsyncMock,
-        mock_spawn: AsyncMock,
+        mock_spawn_provider: AsyncMock,
         db,
         event_bus: EventBus,
     ) -> None:
@@ -160,23 +158,18 @@ class TestTowerToLeaderWiring:
 
         await start_leader(db, project.id, goal="Build it", event_bus=event_bus)
 
-        # Verify tmux pane was spawned with claude command and working_dir
-        mock_spawn.assert_called_once()
-        args, kwargs = mock_spawn.call_args
-        assert args[0] == "atc"  # tmux session name
-        assert args[1] == get_launch_command("claude_code")
-        # Leader uses repo_path when set (so Claude works in the actual repo);
-        # falls back to staging dir only when repo_path is None.
-        assert kwargs.get("working_dir") == "/tmp/repo"
+        mock_spawn_provider.assert_called_once()
+        _, kwargs = mock_spawn_provider.call_args
+        assert kwargs["session_type"] == "manager"
+        assert kwargs["launch_command"] == get_launch_command("claude_code")
+        assert kwargs["working_dir"] == "/tmp/repo"
 
-    @patch("atc.leader.leader._spawn_pane", new_callable=AsyncMock, return_value="%1")
-    @patch("atc.leader.leader._ensure_tmux_session", new_callable=AsyncMock)
+    @patch("atc.leader.leader._spawn_provider_session", new_callable=AsyncMock, return_value=("atc", "%1"))
     @patch("atc.leader.leader.deploy_manager_files")
     async def test_start_leader_uses_deploy_root_when_no_repo(
         self,
         mock_deploy: AsyncMock,
-        mock_ensure: AsyncMock,
-        mock_spawn: AsyncMock,
+        mock_spawn_provider: AsyncMock,
         db,
         event_bus: EventBus,
     ) -> None:
@@ -191,18 +184,15 @@ class TestTowerToLeaderWiring:
 
         await start_leader(db, project.id, goal="Test", event_bus=event_bus)
 
-        # Without repo_path, should fall back to deployed root
-        _, kwargs = mock_spawn.call_args
-        assert kwargs.get("working_dir") == "/tmp/atc-agents/leader-1"
+        _, kwargs = mock_spawn_provider.call_args
+        assert kwargs["working_dir"] == "/tmp/atc-agents/leader-1"
 
-    @patch("atc.leader.leader._spawn_pane", new_callable=AsyncMock, return_value="%1")
-    @patch("atc.leader.leader._ensure_tmux_session", new_callable=AsyncMock)
+    @patch("atc.leader.leader._spawn_provider_session", new_callable=AsyncMock, return_value=("atc", "%1"))
     @patch("atc.leader.leader.deploy_manager_files")
     async def test_start_leader_uses_project_agent_provider(
         self,
         mock_deploy: AsyncMock,
-        mock_ensure: AsyncMock,
-        mock_spawn: AsyncMock,
+        mock_spawn_provider: AsyncMock,
         db,
         event_bus: EventBus,
     ) -> None:
@@ -224,10 +214,10 @@ class TestTowerToLeaderWiring:
 
         await start_leader(db, project.id, goal="Build it", event_bus=event_bus)
 
-        mock_spawn.assert_called_once()
-        args, _ = mock_spawn.call_args
-        assert args[1] == get_launch_command("opencode")
-        assert args[1] == "opencode"
+        mock_spawn_provider.assert_called_once()
+        _, kwargs = mock_spawn_provider.call_args
+        assert kwargs["launch_command"] == get_launch_command("opencode")
+        assert kwargs["launch_command"] == "opencode"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_tower_session_reuse.py
+++ b/tests/unit/test_tower_session_reuse.py
@@ -60,13 +60,11 @@ async def test_reuses_most_recent_disconnected_session_with_valid_staging_dir(
             "atc.tower.session._DEFAULT_STAGING_ROOT",
             str(tmp_path),
         ),
-        patch("atc.tower.session._ensure_tmux_session", new_callable=AsyncMock),
         patch(
-            "atc.tower.session._spawn_pane",
+            "atc.tower.session._spawn_provider_session",
             new_callable=AsyncMock,
-            return_value=mock_pane_id,
+            return_value=("atc", mock_pane_id),
         ),
-        patch("atc.tower.session._accept_trust_dialog", new_callable=AsyncMock),
         patch("atc.tower.session._pane_is_alive", new_callable=AsyncMock, return_value=False),
         patch("atc.tower.session.get_launch_command", return_value="claude"),
         patch("atc.tower.session.transition", new_callable=AsyncMock),
@@ -107,13 +105,11 @@ async def test_creates_new_session_when_no_valid_staging_dir(db, tmp_path: Path)
             "atc.tower.session._DEFAULT_STAGING_ROOT",
             str(tmp_path),
         ),
-        patch("atc.tower.session._ensure_tmux_session", new_callable=AsyncMock),
         patch(
-            "atc.tower.session._spawn_pane",
+            "atc.tower.session._spawn_provider_session",
             new_callable=AsyncMock,
-            return_value=mock_pane_id,
+            return_value=("atc", mock_pane_id),
         ),
-        patch("atc.tower.session._accept_trust_dialog", new_callable=AsyncMock),
         patch("atc.tower.session._pane_is_alive", new_callable=AsyncMock, return_value=False),
         patch("atc.tower.session.get_launch_command", return_value="claude"),
         patch("atc.tower.session.transition", new_callable=AsyncMock),
@@ -123,8 +119,11 @@ async def test_creates_new_session_when_no_valid_staging_dir(db, tmp_path: Path)
         mock_root = tmp_path / "new-sess"
         mock_root.mkdir()
         (mock_root / "CLAUDE.md").write_text("# Tower\n")
-        mock_deployed = AsyncMock()
+        from unittest.mock import Mock
+
+        mock_deployed = Mock()
         mock_deployed.root = mock_root
+        mock_deployed.claude_md_path = mock_root / "CLAUDE.md"
         mock_deploy.return_value = mock_deployed
 
         returned_id = await start_tower_session(db, project.id)


### PR DESCRIPTION
## Summary
- move ace, leader, tower, and reconnect spawn through provider-owned lifecycle hooks
- add provider spawn request/startup helpers and factor Claude runtime startup+prompt logic into a shared module
- update regression coverage to assert the provider boundary instead of raw tmux internals

## Testing
- PYTHONPATH=src pytest tests/unit/test_agent_provider.py tests/unit/test_provider_abstraction.py tests/unit/test_creation_reliability.py tests/unit/test_welcome_hardening.py tests/unit/test_tower_session_reuse.py tests/unit/test_leader_orchestrator.py tests/unit/test_e2e_wiring.py tests/integration/test_creation_reliability.py -q