### PR TITLE
refactor: move claude runtime checks out of session lifecycle

### DIFF
--- a/src/atc/leader/leader.py
+++ b/src/atc/leader/leader.py
@@ -22,9 +22,9 @@ from atc.session.ace import (
     _accept_trust_dialog,
     _ensure_tmux_session,
     _kill_pane,
+    _send_session_instruction,
     _spawn_pane,
     _spawn_provider_session,
-    send_instruction,
 )
 from atc.session.state_machine import SessionStatus, transition
 from atc.state import db as db_ops
@@ -287,7 +287,9 @@ async def send_leader_message(
         raise ValueError(f"No active leader for project {project_id}")
 
     session = await db_ops.get_session(conn, leader.session_id)
-    if session is None or session.tmux_pane is None:
+    if session is None:
+        raise ValueError("Leader session not found")
+    if session.tmux_pane is None:
         raise ValueError("Leader session has no tmux pane")
 
     current = SessionStatus(session.status)
@@ -306,4 +308,6 @@ async def send_leader_message(
     if not await _pane_is_alive(session.tmux_pane):
         raise ValueError("Leader tmux pane is dead — stop and restart the leader")
 
-    await send_instruction(session.tmux_pane, message)
+    delivered = await _send_session_instruction(conn, session.id, message)
+    if not delivered:
+        raise ValueError("Leader instruction delivery failed")

--- a/src/atc/session/__init__.py
+++ b/src/atc/session/__init__.py
@@ -1,11 +1,9 @@
 """Session subsystem — state machine, ace lifecycle, reconnection."""
 
 from atc.session.ace import (
-    check_tui_ready,
     create_ace,
     destroy_ace,
     schedule_verification,
-    send_instruction,
     start_ace,
     stop_ace,
     verify_alive,
@@ -23,12 +21,10 @@ from atc.session.state_machine import (
 __all__ = [
     "InvalidTransitionError",
     "SessionStatus",
-    "check_tui_ready",
     "create_ace",
     "destroy_ace",
     "is_valid_transition",
     "schedule_verification",
-    "send_instruction",
     "start_ace",
     "stop_ace",
     "transition",

--- a/src/atc/session/ace.py
+++ b/src/atc/session/ace.py
@@ -26,21 +26,12 @@ from pathlib import Path as _Path
 from typing import TYPE_CHECKING, Any
 
 from atc.agents.base import ProviderSpawnRequest
-from atc.agents.claude_runtime import (
-    INSTRUCTION_MAX_RETRIES,
-    TUI_READY_POLL_INTERVAL,
-    TUI_READY_TIMEOUT,
-    accept_startup_dialogs,
-    check_tui_ready as claude_check_tui_ready,
-    send_instruction as claude_send_instruction,
-    wait_for_prompt as claude_wait_for_prompt,
-)
+from atc.agents.claude_runtime import accept_startup_dialogs
 from atc.session.state_machine import (
     SessionStatus,
     transition,
 )
 from atc.state import db as db_ops
-from atc.terminal.control import send_instruction_async
 
 if TYPE_CHECKING:
     import aiosqlite  # type: ignore[import-not-found]
@@ -265,74 +256,6 @@ async def _get_alternate_on(pane_id: str) -> bool:
     return result.strip() == "1"
 
 
-# ---------------------------------------------------------------------------
-# TUI readiness check
-# ---------------------------------------------------------------------------
-
-
-async def wait_for_prompt(
-    pane_id: str,
-    *,
-    timeout: float = 10.0,
-    poll_interval: float = 0.5,
-) -> bool:
-    """Backward-compatible wrapper around Claude-specific prompt readiness."""
-    return await claude_wait_for_prompt(
-        pane_id,
-        get_alternate_on=_get_alternate_on,
-        capture_pane=_capture_pane,
-        timeout=timeout,
-        poll_interval=poll_interval,
-    )
-
-
-async def check_tui_ready(
-    pane_id: str,
-    *,
-    timeout: float = TUI_READY_TIMEOUT,
-    poll_interval: float = TUI_READY_POLL_INTERVAL,
-) -> bool:
-    """Backward-compatible wrapper around Claude-specific TUI readiness."""
-    return await claude_check_tui_ready(
-        pane_id,
-        get_alternate_on=_get_alternate_on,
-        timeout=timeout,
-        poll_interval=poll_interval,
-    )
-
-
-# ---------------------------------------------------------------------------
-# Atomic instruction sending
-# ---------------------------------------------------------------------------
-
-
-async def send_instruction(
-    pane_id: str,
-    text: str,
-    *,
-    verify: bool = True,
-    max_retries: int = INSTRUCTION_MAX_RETRIES,
-) -> bool:
-    """Backward-compatible wrapper around Claude-specific instruction delivery."""
-    import atc.agents.claude_runtime as _claude_runtime
-
-    original_send = _claude_runtime.send_instruction_async
-    _claude_runtime.send_instruction_async = send_instruction_async
-    try:
-        return await claude_send_instruction(
-            pane_id,
-            text,
-            capture_pane=_capture_pane,
-            pane_is_alive=_pane_is_alive,
-            wait_for_prompt_fn=wait_for_prompt,
-            check_tui_ready_fn=check_tui_ready,
-            verify=verify,
-            max_retries=max_retries,
-        )
-    finally:
-        _claude_runtime.send_instruction_async = original_send
-
-
 # Legacy wrapper kept for backward compatibility with existing callers
 async def _send_keys(pane_id: str, keys: str) -> None:
     """Send keystrokes to a tmux pane (atomic: text + Enter in one call)."""
@@ -496,6 +419,27 @@ async def create_ace(
     return session.id
 
 
+async def _send_session_instruction(
+    conn: aiosqlite.Connection,
+    session_id: str,
+    instruction: str,
+) -> bool:
+    """Send an instruction through the configured provider for a session."""
+    from atc.agents.factory import create_provider
+
+    session = await db_ops.get_session(conn, session_id)
+    if session is None:
+        raise ValueError(f"Session {session_id} not found")
+    if not session.project_id:
+        raise ValueError(f"Session {session_id} has no project")
+
+    project = await db_ops.get_project(conn, session.project_id)
+    provider_name = project.agent_provider if project and project.agent_provider else "claude_code"
+    provider = create_provider(provider_name)
+    result = await provider.send_prompt(session_id, instruction)
+    return result.accepted
+
+
 async def start_ace(
     conn: aiosqlite.Connection,
     session_id: str,
@@ -518,8 +462,8 @@ async def start_ace(
     await transition(session_id, current, SessionStatus.WORKING, event_bus)
     await db_ops.update_session_status(conn, session_id, SessionStatus.WORKING.value)
 
-    if instruction and session.tmux_pane:
-        delivered = await send_instruction(session.tmux_pane, instruction)
+    if instruction:
+        delivered = await _send_session_instruction(conn, session_id, instruction)
         if not delivered:
             logger.error("Session %s: instruction delivery failed, marking error", session_id)
             await transition(session_id, SessionStatus.WORKING, SessionStatus.ERROR, event_bus)

--- a/tests/integration/test_creation_reliability.py
+++ b/tests/integration/test_creation_reliability.py
@@ -141,7 +141,7 @@ class TestAtomicInstructionSending:
     """Verify that start_ace uses atomic instruction sending."""
 
     @pytest.mark.asyncio
-    @patch("atc.session.ace.send_instruction", new_callable=AsyncMock)
+    @patch("atc.session.ace._send_session_instruction", new_callable=AsyncMock)
     @patch("atc.session.ace._spawn_provider_session", new_callable=AsyncMock, return_value=("atc", "%4"))
     async def test_start_ace_uses_send_instruction(
         self,
@@ -157,10 +157,10 @@ class TestAtomicInstructionSending:
 
         await start_ace(conn, session_id, instruction="do work", event_bus=event_bus)
 
-        mock_send.assert_called_once_with("%4", "do work")
+        mock_send.assert_called_once_with(conn, session_id, "do work")
 
     @pytest.mark.asyncio
-    @patch("atc.session.ace.send_instruction", new_callable=AsyncMock)
+    @patch("atc.session.ace._send_session_instruction", new_callable=AsyncMock)
     @patch("atc.session.ace._spawn_provider_session", new_callable=AsyncMock, return_value=("atc", "%5"))
     async def test_start_ace_errors_on_failed_delivery(
         self,

--- a/tests/unit/test_claude_runtime.py
+++ b/tests/unit/test_claude_runtime.py
@@ -1,0 +1,222 @@
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from atc.agents.claude_runtime import check_tui_ready, send_instruction, wait_for_prompt
+
+
+@pytest.mark.asyncio
+async def test_wait_for_prompt_returns_true_on_bare_prompt() -> None:
+    result = await wait_for_prompt(
+        "pane-1",
+        get_alternate_on=AsyncMock(return_value=False),
+        capture_pane=AsyncMock(return_value="❯"),
+        timeout=2.0,
+    )
+    assert result is True
+
+
+@pytest.mark.asyncio
+async def test_wait_for_prompt_returns_true_on_gt_prompt() -> None:
+    result = await wait_for_prompt(
+        "pane-2",
+        get_alternate_on=AsyncMock(return_value=False),
+        capture_pane=AsyncMock(return_value="> "),
+        timeout=2.0,
+    )
+    assert result is True
+
+
+@pytest.mark.asyncio
+async def test_wait_for_prompt_waits_while_alternate_on() -> None:
+    result = await wait_for_prompt(
+        "pane-3",
+        get_alternate_on=AsyncMock(side_effect=[True, True, False]),
+        capture_pane=AsyncMock(return_value="❯"),
+        timeout=5.0,
+        poll_interval=0.1,
+    )
+    assert result is True
+
+
+@pytest.mark.asyncio
+async def test_wait_for_prompt_returns_false_on_timeout() -> None:
+    result = await wait_for_prompt(
+        "pane-4",
+        get_alternate_on=AsyncMock(return_value=False),
+        capture_pane=AsyncMock(return_value="some output without prompt"),
+        timeout=0.1,
+        poll_interval=0.05,
+    )
+    assert result is False
+
+
+@pytest.mark.asyncio
+async def test_wait_for_prompt_returns_false_on_runtime_error() -> None:
+    result = await wait_for_prompt(
+        "pane-5",
+        get_alternate_on=AsyncMock(side_effect=RuntimeError("pane dead")),
+        capture_pane=AsyncMock(),
+        timeout=2.0,
+    )
+    assert result is False
+
+
+@pytest.mark.asyncio
+async def test_check_tui_ready_immediately() -> None:
+    result = await check_tui_ready(
+        "%0",
+        get_alternate_on=AsyncMock(return_value=False),
+        timeout=1.0,
+        poll_interval=0.1,
+    )
+    assert result is True
+
+
+@pytest.mark.asyncio
+async def test_check_tui_ready_after_delay() -> None:
+    mock_alt = AsyncMock(side_effect=[True, True, False])
+    result = await check_tui_ready(
+        "%0",
+        get_alternate_on=mock_alt,
+        timeout=5.0,
+        poll_interval=0.1,
+    )
+    assert result is True
+    assert mock_alt.call_count == 3
+
+
+@pytest.mark.asyncio
+async def test_check_tui_ready_timeout() -> None:
+    result = await check_tui_ready(
+        "%0",
+        get_alternate_on=AsyncMock(return_value=True),
+        timeout=0.3,
+        poll_interval=0.1,
+    )
+    assert result is False
+
+
+@pytest.mark.asyncio
+async def test_check_tui_ready_pane_dies() -> None:
+    result = await check_tui_ready(
+        "%0",
+        get_alternate_on=AsyncMock(side_effect=RuntimeError("pane dead")),
+        timeout=1.0,
+        poll_interval=0.1,
+    )
+    assert result is False
+
+
+class TestSendInstruction:
+    @pytest.mark.asyncio
+    @patch("atc.agents.claude_runtime.send_instruction_async", new_callable=AsyncMock)
+    async def test_success(self, mock_send_async: AsyncMock) -> None:
+        result = await send_instruction(
+            "%0",
+            "do something important",
+            capture_pane=AsyncMock(return_value="$ do something important\noutput here"),
+            pane_is_alive=AsyncMock(return_value=True),
+            wait_for_prompt_fn=AsyncMock(return_value=True),
+            check_tui_ready_fn=AsyncMock(return_value=True),
+            max_retries=1,
+        )
+        assert result is True
+        mock_send_async.assert_called_once_with("atc", "%0", "do something important")
+
+    @pytest.mark.asyncio
+    async def test_tui_not_ready(self) -> None:
+        result = await send_instruction(
+            "%0",
+            "test",
+            capture_pane=AsyncMock(),
+            pane_is_alive=AsyncMock(),
+            wait_for_prompt_fn=AsyncMock(return_value=False),
+            check_tui_ready_fn=AsyncMock(return_value=False),
+            max_retries=2,
+        )
+        assert result is False
+
+    @pytest.mark.asyncio
+    @patch("atc.agents.claude_runtime.send_instruction_async", new_callable=AsyncMock)
+    async def test_retry_on_verification_failure(self, mock_send_async: AsyncMock) -> None:
+        result = await send_instruction(
+            "%0",
+            "run tests",
+            capture_pane=AsyncMock(side_effect=["$ \n", "$ run tests\nrunning..."]),
+            pane_is_alive=AsyncMock(return_value=True),
+            wait_for_prompt_fn=AsyncMock(return_value=True),
+            check_tui_ready_fn=AsyncMock(return_value=True),
+            max_retries=2,
+        )
+        assert result is True
+        assert mock_send_async.call_count == 2
+
+    @pytest.mark.asyncio
+    @patch("atc.agents.claude_runtime.send_instruction_async", new_callable=AsyncMock)
+    async def test_skip_verification(self, mock_send_async: AsyncMock) -> None:
+        result = await send_instruction(
+            "%0",
+            "test",
+            capture_pane=AsyncMock(),
+            pane_is_alive=AsyncMock(),
+            wait_for_prompt_fn=AsyncMock(return_value=True),
+            check_tui_ready_fn=AsyncMock(return_value=True),
+            verify=False,
+        )
+        assert result is True
+        mock_send_async.assert_called_once_with("atc", "%0", "test")
+
+    @pytest.mark.asyncio
+    @patch("atc.agents.claude_runtime.send_instruction_async", new_callable=AsyncMock)
+    async def test_prompt_disappearing_counts_as_accepted_delivery(self, mock_send_async: AsyncMock) -> None:
+        result = await send_instruction(
+            "%0",
+            "run tests",
+            capture_pane=AsyncMock(return_value="$ \n"),
+            pane_is_alive=AsyncMock(return_value=True),
+            wait_for_prompt_fn=AsyncMock(side_effect=[True, False]),
+            check_tui_ready_fn=AsyncMock(return_value=True),
+            max_retries=1,
+        )
+        assert result is True
+        mock_send_async.assert_called_once_with("atc", "%0", "run tests")
+
+    @pytest.mark.asyncio
+    @patch("atc.agents.claude_runtime.send_instruction_async", new_callable=AsyncMock)
+    async def test_prompt_disappearing_with_dead_pane_is_not_treated_as_success(self, mock_send_async: AsyncMock) -> None:
+        result = await send_instruction(
+            "%0",
+            "run tests",
+            capture_pane=AsyncMock(return_value="$ \n"),
+            pane_is_alive=AsyncMock(return_value=False),
+            wait_for_prompt_fn=AsyncMock(side_effect=[True, False]),
+            check_tui_ready_fn=AsyncMock(return_value=True),
+            max_retries=1,
+        )
+        assert result is False
+        mock_send_async.assert_called_once_with("atc", "%0", "run tests")
+
+    @pytest.mark.asyncio
+    @patch("atc.agents.claude_runtime.send_instruction_async", new_callable=AsyncMock)
+    async def test_prompt_disappearing_with_visible_dialog_is_not_treated_as_success(self, mock_send_async: AsyncMock) -> None:
+        async def capture_side_effect(*args, **kwargs):
+            capture_side_effect.calls += 1
+            if capture_side_effect.calls == 1:
+                return "$ \\n"
+            return "[Pasted text #1 +21 lines]\\nbypass permissions on (shift+tab to cycle)\\n"
+
+        capture_side_effect.calls = 0
+        result = await send_instruction(
+            "%0",
+            "run tests",
+            capture_pane=AsyncMock(side_effect=capture_side_effect),
+            pane_is_alive=AsyncMock(return_value=True),
+            wait_for_prompt_fn=AsyncMock(side_effect=[True, False]),
+            check_tui_ready_fn=AsyncMock(return_value=True),
+            max_retries=1,
+        )
+        assert result is False
+        mock_send_async.assert_called_once_with("atc", "%0", "run tests")

--- a/tests/unit/test_creation_reliability.py
+++ b/tests/unit/test_creation_reliability.py
@@ -1,7 +1,6 @@
 """Unit tests for creation reliability features (design doc §10a).
 
-Tests TUI readiness checking, atomic instruction sending, and
-three-phase verification loop.
+Tests generic verification logic and session-lifecycle invariants.
 """
 
 from __future__ import annotations
@@ -10,15 +9,7 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 
-from atc.session.ace import (
-    VerificationResult,
-    _get_alternate_on,
-    check_tui_ready,
-    send_instruction,
-    verify_alive,
-    verify_progressing,
-    verify_working,
-)
+from atc.session.ace import VerificationResult, _get_alternate_on, verify_alive, verify_progressing, verify_working
 from atc.state.models import Session
 
 # ---------------------------------------------------------------------------
@@ -45,11 +36,6 @@ def _make_session(
     )
 
 
-# ---------------------------------------------------------------------------
-# TUI readiness
-# ---------------------------------------------------------------------------
-
-
 class TestGetAlternateOn:
     @pytest.mark.asyncio
     @patch("atc.session.ace._tmux_run", new_callable=AsyncMock)
@@ -63,190 +49,6 @@ class TestGetAlternateOn:
     async def test_alternate_on_false(self, mock_tmux: AsyncMock) -> None:
         mock_tmux.return_value = "0"
         assert await _get_alternate_on("%0") is False
-
-
-class TestCheckTuiReady:
-    @pytest.mark.asyncio
-    @patch("atc.session.ace._get_alternate_on", new_callable=AsyncMock)
-    async def test_ready_immediately(self, mock_alt: AsyncMock) -> None:
-        mock_alt.return_value = False
-        result = await check_tui_ready("%0", timeout=1.0, poll_interval=0.1)
-        assert result is True
-
-    @pytest.mark.asyncio
-    @patch("atc.session.ace._get_alternate_on", new_callable=AsyncMock)
-    async def test_ready_after_delay(self, mock_alt: AsyncMock) -> None:
-        # First two calls return True (TUI active), then False
-        mock_alt.side_effect = [True, True, False]
-        result = await check_tui_ready("%0", timeout=5.0, poll_interval=0.1)
-        assert result is True
-        assert mock_alt.call_count == 3
-
-    @pytest.mark.asyncio
-    @patch("atc.session.ace._get_alternate_on", new_callable=AsyncMock)
-    async def test_timeout(self, mock_alt: AsyncMock) -> None:
-        mock_alt.return_value = True  # TUI always active
-        result = await check_tui_ready("%0", timeout=0.3, poll_interval=0.1)
-        assert result is False
-
-    @pytest.mark.asyncio
-    @patch("atc.session.ace._get_alternate_on", new_callable=AsyncMock)
-    async def test_pane_dies(self, mock_alt: AsyncMock) -> None:
-        mock_alt.side_effect = RuntimeError("pane dead")
-        result = await check_tui_ready("%0", timeout=1.0, poll_interval=0.1)
-        assert result is False
-
-
-# ---------------------------------------------------------------------------
-# Atomic instruction sending
-# ---------------------------------------------------------------------------
-
-
-class TestSendInstruction:
-    @pytest.mark.asyncio
-    @patch("atc.session.ace._capture_pane", new_callable=AsyncMock)
-    @patch("atc.session.ace.send_instruction_async", new_callable=AsyncMock)
-    @patch("atc.session.ace.check_tui_ready", new_callable=AsyncMock)
-    @patch("atc.session.ace.wait_for_prompt", new_callable=AsyncMock)
-    async def test_success(
-        self,
-        mock_wait: AsyncMock,
-        mock_ready: AsyncMock,
-        mock_send_async: AsyncMock,
-        mock_capture: AsyncMock,
-    ) -> None:
-        # send_instruction calls wait_for_prompt on attempt 1, check_tui_ready on retries
-        mock_wait.return_value = True
-        mock_ready.return_value = True
-        mock_send_async.return_value = None
-        mock_capture.return_value = "$ do something important\noutput here"
-
-        result = await send_instruction("%0", "do something important", max_retries=1)
-        assert result is True
-        mock_send_async.assert_called_once_with("atc", "%0", "do something important")
-
-    @pytest.mark.asyncio
-    @patch("atc.session.ace.check_tui_ready", new_callable=AsyncMock)
-    @patch("atc.session.ace.wait_for_prompt", new_callable=AsyncMock)
-    async def test_tui_not_ready(self, mock_wait: AsyncMock, mock_ready: AsyncMock) -> None:
-        mock_wait.return_value = False
-        mock_ready.return_value = False
-        result = await send_instruction("%0", "test", max_retries=2)
-        assert result is False
-
-    @pytest.mark.asyncio
-    @patch("atc.session.ace._capture_pane", new_callable=AsyncMock)
-    @patch("atc.session.ace.send_instruction_async", new_callable=AsyncMock)
-    @patch("atc.session.ace.check_tui_ready", new_callable=AsyncMock)
-    @patch("atc.session.ace.wait_for_prompt", new_callable=AsyncMock)
-    async def test_retry_on_verification_failure(
-        self,
-        mock_wait: AsyncMock,
-        mock_ready: AsyncMock,
-        mock_send_async: AsyncMock,
-        mock_capture: AsyncMock,
-    ) -> None:
-        mock_wait.return_value = True
-        mock_ready.return_value = True
-        mock_send_async.return_value = None
-        # First attempt: instruction not in output; second: found
-        mock_capture.side_effect = ["$ \n", "$ run tests\nrunning..."]
-
-        result = await send_instruction("%0", "run tests", max_retries=2)
-        assert result is True
-        assert mock_send_async.call_count == 2  # sent twice
-
-    @pytest.mark.asyncio
-    @patch("atc.session.ace.send_instruction_async", new_callable=AsyncMock)
-    @patch("atc.session.ace.check_tui_ready", new_callable=AsyncMock)
-    async def test_skip_verification(self, mock_ready: AsyncMock, mock_send_async: AsyncMock) -> None:
-        mock_ready.return_value = True
-        mock_send_async.return_value = None
-
-        result = await send_instruction("%0", "test", verify=False)
-        assert result is True
-        mock_send_async.assert_called_once_with("atc", "%0", "test")
-
-    @pytest.mark.asyncio
-    @patch("atc.session.ace._pane_is_alive", new_callable=AsyncMock)
-    @patch("atc.session.ace._capture_pane", new_callable=AsyncMock)
-    @patch("atc.session.ace.send_instruction_async", new_callable=AsyncMock)
-    @patch("atc.session.ace.check_tui_ready", new_callable=AsyncMock)
-    @patch("atc.session.ace.wait_for_prompt", new_callable=AsyncMock)
-    async def test_prompt_disappearing_counts_as_accepted_delivery(
-        self,
-        mock_wait: AsyncMock,
-        mock_ready: AsyncMock,
-        mock_send_async: AsyncMock,
-        mock_capture: AsyncMock,
-        mock_alive: AsyncMock,
-    ) -> None:
-        mock_wait.side_effect = [True, False]
-        mock_ready.return_value = True
-        mock_send_async.return_value = None
-        mock_capture.return_value = "$ \n"
-        mock_alive.return_value = True
-
-        result = await send_instruction("%0", "run tests", max_retries=1)
-        assert result is True
-        mock_send_async.assert_called_once_with("atc", "%0", "run tests")
-
-    @pytest.mark.asyncio
-    @patch("atc.session.ace._pane_is_alive", new_callable=AsyncMock)
-    @patch("atc.session.ace._capture_pane", new_callable=AsyncMock)
-    @patch("atc.session.ace.send_instruction_async", new_callable=AsyncMock)
-    @patch("atc.session.ace.check_tui_ready", new_callable=AsyncMock)
-    @patch("atc.session.ace.wait_for_prompt", new_callable=AsyncMock)
-    async def test_prompt_disappearing_with_dead_pane_is_not_treated_as_success(
-        self,
-        mock_wait: AsyncMock,
-        mock_ready: AsyncMock,
-        mock_send_async: AsyncMock,
-        mock_capture: AsyncMock,
-        mock_alive: AsyncMock,
-    ) -> None:
-        mock_wait.side_effect = [True, False]
-        mock_ready.return_value = True
-        mock_send_async.return_value = None
-        mock_capture.return_value = "$ \n"
-        mock_alive.return_value = False
-
-        result = await send_instruction("%0", "run tests", max_retries=1)
-        assert result is False
-        mock_send_async.assert_called_once_with("atc", "%0", "run tests")
-
-    @pytest.mark.asyncio
-    @patch("atc.session.ace._pane_is_alive", new_callable=AsyncMock)
-    @patch("atc.session.ace._capture_pane", new_callable=AsyncMock)
-    @patch("atc.session.ace.send_instruction_async", new_callable=AsyncMock)
-    @patch("atc.session.ace.check_tui_ready", new_callable=AsyncMock)
-    @patch("atc.session.ace.wait_for_prompt", new_callable=AsyncMock)
-    async def test_prompt_disappearing_with_visible_dialog_is_not_treated_as_success(
-        self,
-        mock_wait: AsyncMock,
-        mock_ready: AsyncMock,
-        mock_send_async: AsyncMock,
-        mock_capture: AsyncMock,
-        mock_alive: AsyncMock,
-    ) -> None:
-        mock_wait.side_effect = [True, False]
-        mock_ready.return_value = True
-        mock_send_async.return_value = None
-
-        async def capture_side_effect(*args, **kwargs):
-            capture_side_effect.calls += 1
-            if capture_side_effect.calls == 1:
-                return "$ \\n"
-            return "[Pasted text #1 +21 lines]\\nbypass permissions on (shift+tab to cycle)\\n"
-
-        capture_side_effect.calls = 0
-        mock_capture.side_effect = capture_side_effect
-        mock_alive.return_value = True
-
-        result = await send_instruction("%0", "run tests", max_retries=1)
-        assert result is False
-        mock_send_async.assert_called_once_with("atc", "%0", "run tests")
-
 
 # ---------------------------------------------------------------------------
 # Verification checks

--- a/tests/unit/test_welcome_hardening.py
+++ b/tests/unit/test_welcome_hardening.py
@@ -6,7 +6,8 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 
-from atc.session.ace import _accept_trust_dialog, wait_for_prompt
+from atc.agents.claude_runtime import wait_for_prompt
+from atc.session.ace import _accept_trust_dialog
 
 
 # ---------------------------------------------------------------------------
@@ -17,64 +18,62 @@ from atc.session.ace import _accept_trust_dialog, wait_for_prompt
 @pytest.mark.asyncio
 async def test_wait_for_prompt_returns_true_on_bare_prompt() -> None:
     """wait_for_prompt returns True when alternate_on=0 and bare '❯' prompt found."""
-    with (
-        patch("atc.session.ace._get_alternate_on", new=AsyncMock(return_value=False)),
-        patch("atc.session.ace._capture_pane", new=AsyncMock(return_value="❯")),
-    ):
-        result = await wait_for_prompt("pane-1", timeout=2.0)
-
+    result = await wait_for_prompt(
+        "pane-1",
+        get_alternate_on=AsyncMock(return_value=False),
+        capture_pane=AsyncMock(return_value="❯"),
+        timeout=2.0,
+    )
     assert result is True
 
 
 @pytest.mark.asyncio
 async def test_wait_for_prompt_returns_true_on_gt_prompt() -> None:
     """wait_for_prompt returns True on '> ' bare prompt (alternate style)."""
-    with (
-        patch("atc.session.ace._get_alternate_on", new=AsyncMock(return_value=False)),
-        patch("atc.session.ace._capture_pane", new=AsyncMock(return_value="> ")),
-    ):
-        result = await wait_for_prompt("pane-2", timeout=2.0)
-
+    result = await wait_for_prompt(
+        "pane-2",
+        get_alternate_on=AsyncMock(return_value=False),
+        capture_pane=AsyncMock(return_value="> "),
+        timeout=2.0,
+    )
     assert result is True
 
 
 @pytest.mark.asyncio
 async def test_wait_for_prompt_waits_while_alternate_on() -> None:
     """wait_for_prompt keeps polling while alternate_on == 1."""
-    alt_on_values = [True, True, False]
-    with (
-        patch(
-            "atc.session.ace._get_alternate_on",
-            new=AsyncMock(side_effect=alt_on_values),
-        ),
-        patch("atc.session.ace._capture_pane", new=AsyncMock(return_value="❯")),
-    ):
-        result = await wait_for_prompt("pane-3", timeout=5.0)
-
+    result = await wait_for_prompt(
+        "pane-3",
+        get_alternate_on=AsyncMock(side_effect=[True, True, False]),
+        capture_pane=AsyncMock(return_value="❯"),
+        timeout=5.0,
+        poll_interval=0.1,
+    )
     assert result is True
 
 
 @pytest.mark.asyncio
 async def test_wait_for_prompt_returns_false_on_timeout() -> None:
     """wait_for_prompt returns False when prompt never appears."""
-    with (
-        patch("atc.session.ace._get_alternate_on", new=AsyncMock(return_value=False)),
-        patch("atc.session.ace._capture_pane", new=AsyncMock(return_value="some output without prompt")),
-    ):
-        result = await wait_for_prompt("pane-4", timeout=0.1)
-
+    result = await wait_for_prompt(
+        "pane-4",
+        get_alternate_on=AsyncMock(return_value=False),
+        capture_pane=AsyncMock(return_value="some output without prompt"),
+        timeout=0.1,
+        poll_interval=0.05,
+    )
     assert result is False
 
 
 @pytest.mark.asyncio
 async def test_wait_for_prompt_returns_false_on_runtime_error() -> None:
     """wait_for_prompt returns False if pane dies (RuntimeError)."""
-    with patch(
-        "atc.session.ace._get_alternate_on",
-        new=AsyncMock(side_effect=RuntimeError("pane dead")),
-    ):
-        result = await wait_for_prompt("pane-5", timeout=2.0)
-
+    result = await wait_for_prompt(
+        "pane-5",
+        get_alternate_on=AsyncMock(side_effect=RuntimeError("pane dead")),
+        capture_pane=AsyncMock(),
+        timeout=2.0,
+    )
     assert result is False
 
 


### PR DESCRIPTION
## Summary
- move Claude-specific prompt-readiness and instruction-delivery tests/contracts to agents/claude_runtime
- remove the remaining wait/check/send wrappers from session/ace.py
- route leader instruction delivery through the provider-owned session helper while keeping generic verification checks in session lifecycle

## Testing
- PYTHONPATH=src pytest tests/unit/test_claude_runtime.py tests/unit/test_welcome_hardening.py tests/unit/test_creation_reliability.py tests/unit/test_agent_provider.py tests/unit/test_provider_abstraction.py tests/unit/test_tower_session_reuse.py tests/unit/test_e2e_wiring.py tests/unit/test_leader_orchestrator.py tests/integration/test_creation_reliability.py -q