### PR TITLE
feat: add orchestration contract foundation

### DIFF
--- a/src/atc/api/app.py
+++ b/src/atc/api/app.py
@@ -662,6 +662,7 @@ def create_app(settings: Settings | None = None) -> FastAPI:
         heartbeat,
         leader,
         memory,
+        orchestration,
         projects,
         qa,
         system,
@@ -685,6 +686,7 @@ def create_app(settings: Settings | None = None) -> FastAPI:
     app.include_router(feature_flags.router, prefix="/api/feature-flags", tags=["feature_flags"])
     app.include_router(context.router, prefix="/api", tags=["context"])
     app.include_router(memory.router, prefix="/api/memory", tags=["memory"])
+    app.include_router(orchestration.router, prefix="/api/orchestration", tags=["orchestration"])
     app.include_router(backup.router, prefix="/api/backup", tags=["backup"])
     app.include_router(qa.router, prefix="/api/qa", tags=["qa"])
     app.include_router(system.router, prefix="/api/system", tags=["system"])

--- a/src/atc/api/routers/orchestration.py
+++ b/src/atc/api/routers/orchestration.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+from fastapi import APIRouter, HTTPException, Request
+
+from atc.orchestration.errors import OrchestrationException
+from atc.orchestration.models import (
+    ListSessionsRequest,
+    OperationAcceptedResponse,
+    SessionSummary,
+    SpawnLeaderRequest,
+)
+from atc.orchestration.service import OrchestrationService
+
+router = APIRouter()
+
+
+async def _get_service(request: Request) -> OrchestrationService:
+    db = request.app.state.db
+    tower_controller = getattr(request.app.state, "tower_controller", None)
+    return OrchestrationService(db, tower_controller=tower_controller)
+
+
+@router.post("/leaders", response_model=OperationAcceptedResponse, status_code=202)
+async def spawn_leader(body: SpawnLeaderRequest, request: Request) -> OperationAcceptedResponse:
+    service = await _get_service(request)
+    try:
+        return await service.spawn_leader(body)
+    except OrchestrationException as exc:
+        raise HTTPException(status_code=exc.http_status, detail=exc.to_dict()) from None
+
+
+@router.get("/sessions/{session_id}", response_model=SessionSummary)
+async def get_session(session_id: str, request: Request) -> SessionSummary:
+    service = await _get_service(request)
+    try:
+        return await service.get_session(session_id)
+    except OrchestrationException as exc:
+        raise HTTPException(status_code=exc.http_status, detail=exc.to_dict()) from None
+
+
+@router.get("/sessions", response_model=list[SessionSummary])
+async def list_sessions(
+    request: Request,
+    project_id: str | None = None,
+    role: str | None = None,
+    active_only: bool = False,
+    limit: int | None = None,
+) -> list[SessionSummary]:
+    service = await _get_service(request)
+    try:
+        model = ListSessionsRequest(
+            project_id=project_id,
+            role=role,
+            active_only=active_only,
+            limit=limit,
+        )
+        return await service.list_sessions(model)
+    except OrchestrationException as exc:
+        raise HTTPException(status_code=exc.http_status, detail=exc.to_dict()) from None

--- a/src/atc/orchestration/__init__.py
+++ b/src/atc/orchestration/__init__.py
@@ -1,0 +1,31 @@
+from atc.orchestration.models import (
+    CancelSessionRequest,
+    ListSessionsRequest,
+    OperationAcceptedResponse,
+    OrchestrationRole,
+    OrchestrationStatus,
+    SendInstructionRequest,
+    SessionEvent,
+    SessionSummary,
+    SpawnAceRequest,
+    SpawnLeaderRequest,
+    WaitForSessionRequest,
+    normalize_role,
+    normalize_status,
+)
+
+__all__ = [
+    "CancelSessionRequest",
+    "ListSessionsRequest",
+    "OperationAcceptedResponse",
+    "OrchestrationRole",
+    "OrchestrationStatus",
+    "SendInstructionRequest",
+    "SessionEvent",
+    "SessionSummary",
+    "SpawnAceRequest",
+    "SpawnLeaderRequest",
+    "WaitForSessionRequest",
+    "normalize_role",
+    "normalize_status",
+]

--- a/src/atc/orchestration/errors.py
+++ b/src/atc/orchestration/errors.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+from enum import Enum
+from typing import Any
+
+
+class OrchestrationErrorCode(str, Enum):
+    PROJECT_NOT_FOUND = "PROJECT_NOT_FOUND"
+    SESSION_NOT_FOUND = "SESSION_NOT_FOUND"
+    TASK_NOT_FOUND = "TASK_NOT_FOUND"
+    INVALID_ROLE = "INVALID_ROLE"
+    INVALID_REQUEST = "INVALID_REQUEST"
+    INVALID_PARENT_RELATION = "INVALID_PARENT_RELATION"
+    SESSION_NOT_READY = "SESSION_NOT_READY"
+    SESSION_NOT_ACTIVE = "SESSION_NOT_ACTIVE"
+    DELIVERY_FAILED = "DELIVERY_FAILED"
+    VERIFICATION_FAILED = "VERIFICATION_FAILED"
+    PROVIDER_UNAVAILABLE = "PROVIDER_UNAVAILABLE"
+    PROVIDER_AUTH_FAILED = "PROVIDER_AUTH_FAILED"
+    CONCURRENCY_LIMIT_REACHED = "CONCURRENCY_LIMIT_REACHED"
+    BUDGET_BLOCKED = "BUDGET_BLOCKED"
+    SESSION_FAILED = "SESSION_FAILED"
+    DUPLICATE_IDEMPOTENCY_KEY = "DUPLICATE_IDEMPOTENCY_KEY"
+    IDEMPOTENCY_CONFLICT = "IDEMPOTENCY_CONFLICT"
+    SQLITE_LOCK_TIMEOUT = "SQLITE_LOCK_TIMEOUT"
+    INTERNAL_STORAGE_ERROR = "INTERNAL_STORAGE_ERROR"
+
+
+_DEFAULT_HTTP_STATUS: dict[OrchestrationErrorCode, int] = {
+    OrchestrationErrorCode.PROJECT_NOT_FOUND: 404,
+    OrchestrationErrorCode.SESSION_NOT_FOUND: 404,
+    OrchestrationErrorCode.TASK_NOT_FOUND: 404,
+    OrchestrationErrorCode.INVALID_ROLE: 400,
+    OrchestrationErrorCode.INVALID_REQUEST: 400,
+    OrchestrationErrorCode.INVALID_PARENT_RELATION: 409,
+    OrchestrationErrorCode.SESSION_NOT_READY: 409,
+    OrchestrationErrorCode.SESSION_NOT_ACTIVE: 409,
+    OrchestrationErrorCode.DELIVERY_FAILED: 409,
+    OrchestrationErrorCode.VERIFICATION_FAILED: 409,
+    OrchestrationErrorCode.PROVIDER_UNAVAILABLE: 503,
+    OrchestrationErrorCode.PROVIDER_AUTH_FAILED: 503,
+    OrchestrationErrorCode.CONCURRENCY_LIMIT_REACHED: 409,
+    OrchestrationErrorCode.BUDGET_BLOCKED: 409,
+    OrchestrationErrorCode.SESSION_FAILED: 409,
+    OrchestrationErrorCode.DUPLICATE_IDEMPOTENCY_KEY: 200,
+    OrchestrationErrorCode.IDEMPOTENCY_CONFLICT: 409,
+    OrchestrationErrorCode.SQLITE_LOCK_TIMEOUT: 503,
+    OrchestrationErrorCode.INTERNAL_STORAGE_ERROR: 500,
+}
+
+
+class OrchestrationException(Exception):
+    def __init__(
+        self,
+        code: OrchestrationErrorCode,
+        message: str,
+        *,
+        retryable: bool = False,
+        details: dict[str, Any] | None = None,
+        http_status: int | None = None,
+    ) -> None:
+        self.code = code
+        self.message = message
+        self.retryable = retryable
+        self.details = details or {}
+        self.http_status = http_status if http_status is not None else _DEFAULT_HTTP_STATUS[code]
+        super().__init__(message)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "code": self.code.value,
+            "message": self.message,
+            "retryable": self.retryable,
+            "details": self.details,
+        }

--- a/src/atc/orchestration/models.py
+++ b/src/atc/orchestration/models.py
@@ -1,0 +1,145 @@
+from __future__ import annotations
+
+from enum import Enum
+from typing import Any, Literal
+
+from pydantic import BaseModel, Field
+
+
+class OrchestrationRole(str, Enum):
+    TOWER = "tower"
+    LEADER = "leader"
+    ACE = "ace"
+
+
+class OrchestrationStatus(str, Enum):
+    PENDING = "pending"
+    STARTING = "starting"
+    READY = "ready"
+    RUNNING = "running"
+    WAITING_INPUT = "waiting_input"
+    WAITING_BACKGROUND = "waiting_background"
+    BLOCKED = "blocked"
+    STOPPING = "stopping"
+    STOPPED = "stopped"
+    FAILED = "failed"
+
+
+_ROLE_MAP: dict[str, OrchestrationRole] = {
+    "tower": OrchestrationRole.TOWER,
+    "manager": OrchestrationRole.LEADER,
+    "leader": OrchestrationRole.LEADER,
+    "ace": OrchestrationRole.ACE,
+}
+
+_STATUS_MAP: dict[str, OrchestrationStatus] = {
+    "connecting": OrchestrationStatus.STARTING,
+    "idle": OrchestrationStatus.READY,
+    "working": OrchestrationStatus.RUNNING,
+    "waiting": OrchestrationStatus.WAITING_INPUT,
+    "paused": OrchestrationStatus.BLOCKED,
+    "disconnected": OrchestrationStatus.FAILED,
+    "error": OrchestrationStatus.FAILED,
+}
+
+
+def normalize_role(raw_session_type: str) -> OrchestrationRole:
+    try:
+        return _ROLE_MAP[raw_session_type]
+    except KeyError as exc:
+        raise ValueError(f"Unknown session type for orchestration role mapping: {raw_session_type}") from exc
+
+
+
+def normalize_status(raw_status: str) -> OrchestrationStatus:
+    try:
+        return _STATUS_MAP[raw_status]
+    except KeyError as exc:
+        raise ValueError(f"Unknown session status for orchestration status mapping: {raw_status}") from exc
+
+
+class SpawnLeaderRequest(BaseModel):
+    project_id: str
+    goal: str
+    provider: str | None = None
+    parent_session_id: str | None = None
+    idempotency_key: str
+    reuse_existing_idle: bool = True
+    require_clean_scope: bool = False
+    context: dict[str, Any] | None = None
+
+
+class SpawnAceRequest(BaseModel):
+    project_id: str
+    instruction: str
+    idempotency_key: str
+    task_id: str | None = None
+    parent_session_id: str | None = None
+    provider: str | None = None
+    host: str | None = None
+    context: dict[str, Any] | None = None
+
+
+class SendInstructionRequest(BaseModel):
+    session_id: str
+    instruction: str
+    idempotency_key: str
+    await_delivery: bool = True
+
+
+class ListSessionsRequest(BaseModel):
+    project_id: str | None = None
+    role: OrchestrationRole | None = None
+    parent_session_id: str | None = None
+    status_in: list[OrchestrationStatus] | None = None
+    active_only: bool = False
+    limit: int | None = None
+
+
+class WaitForSessionRequest(BaseModel):
+    session_id: str
+    target_statuses: list[OrchestrationStatus]
+    timeout_ms: int = 120_000
+
+
+class CancelSessionRequest(BaseModel):
+    session_id: str
+    force: bool = False
+    reason: str | None = None
+
+
+class SessionSummary(BaseModel):
+    id: str
+    role: OrchestrationRole
+    raw_session_type: str
+    project_id: str
+    task_id: str | None = None
+    parent_session_id: str | None = None
+    provider: str | None = None
+    status: OrchestrationStatus
+    raw_status: str
+    name: str
+    goal: str | None = None
+    summary: str | None = None
+    host: str | None = None
+    created_at: str
+    updated_at: str
+    last_activity_at: str | None = None
+    tmux_session: str | None = None
+    tmux_pane: str | None = None
+    verification: dict[str, bool] | None = None
+    metadata: dict[str, Any] = Field(default_factory=dict)
+
+
+class OperationAcceptedResponse(BaseModel):
+    request_status: Literal["accepted"]
+    operation_id: str
+    session: SessionSummary | None = None
+
+
+class SessionEvent(BaseModel):
+    id: str
+    session_id: str
+    event_type: str
+    created_at: str
+    data: dict[str, Any] = Field(default_factory=dict)

--- a/src/atc/orchestration/service.py
+++ b/src/atc/orchestration/service.py
@@ -1,0 +1,151 @@
+from __future__ import annotations
+
+from typing import Any
+
+from atc.orchestration.errors import OrchestrationErrorCode, OrchestrationException
+from atc.orchestration.models import (
+    ListSessionsRequest,
+    OperationAcceptedResponse,
+    OrchestrationRole,
+    OrchestrationStatus,
+    SessionSummary,
+    SpawnLeaderRequest,
+    normalize_role,
+    normalize_status,
+)
+from atc.state import db as db_ops
+from atc.tower.controller import BudgetConstrainedError, TowerBusyError, TowerController
+
+
+class OrchestrationService:
+    def __init__(
+        self,
+        db: Any,
+        *,
+        tower_controller: TowerController | None = None,
+    ) -> None:
+        self._db = db
+        self._tower_controller = tower_controller
+
+    async def get_session(self, session_id: str) -> SessionSummary:
+        session = await db_ops.get_session(self._db, session_id)
+        if session is None:
+            raise OrchestrationException(
+                OrchestrationErrorCode.SESSION_NOT_FOUND,
+                f"Session {session_id} not found",
+            )
+        return await self._build_session_summary(session)
+
+    async def list_sessions(self, request: ListSessionsRequest | None = None) -> list[SessionSummary]:
+        request = request or ListSessionsRequest()
+        raw_session_type = self._session_type_for_role(request.role)
+        sessions = await db_ops.list_sessions(
+            self._db,
+            project_id=request.project_id,
+            session_type=raw_session_type,
+        )
+
+        summaries = [await self._build_session_summary(session) for session in sessions]
+
+        if request.status_in:
+            allowed = set(request.status_in)
+            summaries = [summary for summary in summaries if summary.status in allowed]
+
+        if request.active_only:
+            terminal = {OrchestrationStatus.STOPPED, OrchestrationStatus.FAILED}
+            summaries = [summary for summary in summaries if summary.status not in terminal]
+
+        if request.limit is not None:
+            summaries = summaries[: request.limit]
+
+        return summaries
+
+    async def spawn_leader(self, request: SpawnLeaderRequest) -> OperationAcceptedResponse:
+        project = await db_ops.get_project(self._db, request.project_id)
+        if project is None:
+            raise OrchestrationException(
+                OrchestrationErrorCode.PROJECT_NOT_FOUND,
+                f"Project {request.project_id} not found",
+            )
+
+        if self._tower_controller is None:
+            raise OrchestrationException(
+                OrchestrationErrorCode.PROVIDER_UNAVAILABLE,
+                "Tower controller not available for leader orchestration",
+                retryable=True,
+            )
+
+        try:
+            result = await self._tower_controller.submit_goal(request.project_id, request.goal)
+        except BudgetConstrainedError as exc:
+            raise OrchestrationException(
+                OrchestrationErrorCode.BUDGET_BLOCKED,
+                str(exc),
+            ) from exc
+        except TowerBusyError as exc:
+            code = (
+                OrchestrationErrorCode.CONCURRENCY_LIMIT_REACHED
+                if getattr(exc, "detail", None) == "at capacity"
+                else OrchestrationErrorCode.SESSION_NOT_READY
+            )
+            raise OrchestrationException(code, str(exc), retryable=True) from exc
+
+        leader_session_id = result.get("leader_session_id")
+        if not leader_session_id:
+            raise OrchestrationException(
+                OrchestrationErrorCode.INTERNAL_STORAGE_ERROR,
+                "Tower goal submission did not return a leader session id",
+            )
+
+        summary = await self.get_session(leader_session_id)
+        return OperationAcceptedResponse(
+            request_status="accepted",
+            operation_id=request.idempotency_key,
+            session=summary,
+        )
+
+    async def _build_session_summary(self, session: Any) -> SessionSummary:
+        role = normalize_role(session.session_type)
+        status = normalize_status(session.status)
+        goal = None
+        metadata: dict[str, Any] = {}
+
+        if role == OrchestrationRole.LEADER:
+            leader = await db_ops.get_leader_by_project(self._db, session.project_id)
+            if leader and leader.session_id == session.id:
+                goal = leader.goal
+                metadata["leader_status"] = leader.status
+
+        project = await db_ops.get_project(self._db, session.project_id)
+        provider = project.agent_provider if project else None
+
+        return SessionSummary(
+            id=session.id,
+            role=role,
+            raw_session_type=session.session_type,
+            project_id=session.project_id,
+            task_id=session.task_id,
+            provider=provider,
+            status=status,
+            raw_status=session.status,
+            name=session.name,
+            goal=goal,
+            host=session.host,
+            created_at=session.created_at,
+            updated_at=session.updated_at,
+            tmux_session=session.tmux_session,
+            tmux_pane=session.tmux_pane,
+            metadata=metadata,
+        )
+
+    @staticmethod
+    def _session_type_for_role(role: OrchestrationRole | None) -> str | None:
+        if role is None:
+            return None
+        if role == OrchestrationRole.TOWER:
+            return "tower"
+        if role == OrchestrationRole.LEADER:
+            return "manager"
+        if role == OrchestrationRole.ACE:
+            return "ace"
+        return None

--- a/tests/unit/test_orchestration_errors.py
+++ b/tests/unit/test_orchestration_errors.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+from atc.orchestration.errors import OrchestrationErrorCode, OrchestrationException
+
+
+def test_orchestration_exception_serializes() -> None:
+    exc = OrchestrationException(
+        OrchestrationErrorCode.PROJECT_NOT_FOUND,
+        "Project missing",
+        details={"project_id": "proj_123"},
+    )
+    assert exc.to_dict() == {
+        "code": "PROJECT_NOT_FOUND",
+        "message": "Project missing",
+        "retryable": False,
+        "details": {"project_id": "proj_123"},
+    }
+
+
+def test_retryable_error_preserved() -> None:
+    exc = OrchestrationException(
+        OrchestrationErrorCode.PROVIDER_UNAVAILABLE,
+        "Provider offline",
+        retryable=True,
+    )
+    assert exc.retryable is True
+    assert exc.http_status == 503
+
+
+def test_details_default_empty() -> None:
+    exc = OrchestrationException(
+        OrchestrationErrorCode.INVALID_REQUEST,
+        "Bad request",
+    )
+    assert exc.details == {}
+
+
+def test_error_code_values_stable() -> None:
+    assert OrchestrationErrorCode.IDEMPOTENCY_CONFLICT.value == "IDEMPOTENCY_CONFLICT"
+    assert OrchestrationErrorCode.BUDGET_BLOCKED.value == "BUDGET_BLOCKED"

--- a/tests/unit/test_orchestration_models.py
+++ b/tests/unit/test_orchestration_models.py
@@ -1,0 +1,155 @@
+from __future__ import annotations
+
+import pytest
+
+from atc.orchestration.models import (
+    CancelSessionRequest,
+    ListSessionsRequest,
+    OperationAcceptedResponse,
+    OrchestrationRole,
+    OrchestrationStatus,
+    SendInstructionRequest,
+    SessionEvent,
+    SessionSummary,
+    SpawnAceRequest,
+    SpawnLeaderRequest,
+    WaitForSessionRequest,
+    normalize_role,
+    normalize_status,
+)
+
+
+def test_normalize_role_tower() -> None:
+    assert normalize_role("tower") == OrchestrationRole.TOWER
+
+
+def test_normalize_role_manager_to_leader() -> None:
+    assert normalize_role("manager") == OrchestrationRole.LEADER
+
+
+def test_normalize_role_ace() -> None:
+    assert normalize_role("ace") == OrchestrationRole.ACE
+
+
+def test_normalize_role_unknown_raises() -> None:
+    with pytest.raises(ValueError):
+        normalize_role("unknown")
+
+
+def test_normalize_status_connecting() -> None:
+    assert normalize_status("connecting") == OrchestrationStatus.STARTING
+
+
+def test_normalize_status_idle() -> None:
+    assert normalize_status("idle") == OrchestrationStatus.READY
+
+
+def test_normalize_status_working() -> None:
+    assert normalize_status("working") == OrchestrationStatus.RUNNING
+
+
+def test_normalize_status_waiting() -> None:
+    assert normalize_status("waiting") == OrchestrationStatus.WAITING_INPUT
+
+
+def test_normalize_status_paused() -> None:
+    assert normalize_status("paused") == OrchestrationStatus.BLOCKED
+
+
+def test_normalize_status_disconnected() -> None:
+    assert normalize_status("disconnected") == OrchestrationStatus.FAILED
+
+
+def test_normalize_status_error() -> None:
+    assert normalize_status("error") == OrchestrationStatus.FAILED
+
+
+def test_normalize_status_unknown_raises() -> None:
+    with pytest.raises(ValueError):
+        normalize_status("weird")
+
+
+def test_spawn_leader_request_minimal() -> None:
+    model = SpawnLeaderRequest(
+        project_id="proj_123",
+        goal="Ship thing",
+        idempotency_key="op-1",
+    )
+    assert model.reuse_existing_idle is True
+    assert model.require_clean_scope is False
+
+
+def test_spawn_ace_request_minimal() -> None:
+    model = SpawnAceRequest(
+        project_id="proj_123",
+        instruction="Implement feature",
+        idempotency_key="op-2",
+    )
+    assert model.task_id is None
+
+
+def test_send_instruction_request_minimal() -> None:
+    model = SendInstructionRequest(
+        session_id="sess_123",
+        instruction="Continue",
+        idempotency_key="msg-1",
+    )
+    assert model.await_delivery is True
+
+
+def test_list_sessions_request_with_filters() -> None:
+    model = ListSessionsRequest(
+        project_id="proj_123",
+        role=OrchestrationRole.LEADER,
+        status_in=[OrchestrationStatus.READY, OrchestrationStatus.RUNNING],
+        active_only=True,
+        limit=5,
+    )
+    assert model.active_only is True
+    assert model.limit == 5
+
+
+def test_wait_for_session_request_default_timeout() -> None:
+    model = WaitForSessionRequest(
+        session_id="sess_123",
+        target_statuses=[OrchestrationStatus.READY],
+    )
+    assert model.timeout_ms == 120_000
+
+
+def test_cancel_session_request_defaults() -> None:
+    model = CancelSessionRequest(session_id="sess_123")
+    assert model.force is False
+    assert model.reason is None
+
+
+def test_session_summary_accepts_raw_and_normalized_fields() -> None:
+    model = SessionSummary(
+        id="sess_123",
+        role=OrchestrationRole.LEADER,
+        raw_session_type="manager",
+        project_id="proj_123",
+        status=OrchestrationStatus.READY,
+        raw_status="idle",
+        name="leader-ATC",
+        created_at="2026-05-25T05:48:00Z",
+        updated_at="2026-05-25T05:49:00Z",
+    )
+    assert model.raw_session_type == "manager"
+    assert model.status == OrchestrationStatus.READY
+
+
+def test_operation_accepted_response_minimal() -> None:
+    model = OperationAcceptedResponse(request_status="accepted", operation_id="op_123")
+    assert model.operation_id == "op_123"
+
+
+def test_session_event_shape() -> None:
+    model = SessionEvent(
+        id="evt_123",
+        session_id="sess_123",
+        event_type="session_created",
+        created_at="2026-05-25T05:50:00Z",
+        data={"k": "v"},
+    )
+    assert model.data == {"k": "v"}

--- a/tests/unit/test_orchestration_router.py
+++ b/tests/unit/test_orchestration_router.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import pytest_asyncio
+from httpx import ASGITransport, AsyncClient
+
+from atc.api.app import create_app
+from atc.state import db as db_ops
+from atc.tower.controller import TowerState
+
+
+class _FakeTowerController:
+    def __init__(self, result: dict | None = None) -> None:
+        self._result = result or {}
+        self.calls: list[tuple[str, str]] = []
+
+    async def submit_goal(self, project_id: str, goal: str) -> dict:
+        self.calls.append((project_id, goal))
+        return self._result
+
+
+@pytest_asyncio.fixture()
+async def app_and_db(tmp_path: Path):
+    db_path = tmp_path / 'test.db'
+    await db_ops.run_migrations(str(db_path))
+    async with db_ops.get_connection(str(db_path)) as conn:
+        app = create_app()
+        app.state.db = conn
+        app.state.tower_controller = _FakeTowerController()
+        yield app, conn
+
+
+@pytest.mark.asyncio
+async def test_get_orchestration_session_not_found(app_and_db) -> None:
+    app, _conn = app_and_db
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url='http://test') as client:
+        response = await client.get('/api/orchestration/sessions/missing')
+    assert response.status_code == 404
+    assert response.json()['detail']['code'] == 'SESSION_NOT_FOUND'
+
+
+@pytest.mark.asyncio
+async def test_list_orchestration_sessions(app_and_db) -> None:
+    app, conn = app_and_db
+    project = await db_ops.create_project(conn, 'ATC')
+    await db_ops.create_session(
+        conn,
+        project_id=project.id,
+        session_type='ace',
+        name='ace-1',
+        status='working',
+    )
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url='http://test') as client:
+        response = await client.get('/api/orchestration/sessions')
+    assert response.status_code == 200
+    body = response.json()
+    assert len(body) == 1
+    assert body[0]['role'] == 'ace'
+    assert body[0]['status'] == 'running'
+
+
+@pytest.mark.asyncio
+async def test_spawn_orchestration_leader(app_and_db) -> None:
+    app, conn = app_and_db
+    project = await db_ops.create_project(conn, 'ATC')
+    leader = await db_ops.create_leader(conn, project.id, goal='Ship it')
+    session = await db_ops.create_session(
+        conn,
+        project_id=project.id,
+        session_type='manager',
+        name='leader-ATC',
+        status='connecting',
+    )
+    await conn.execute(
+        "UPDATE leaders SET session_id = ?, goal = ?, status = 'managing' WHERE id = ?",
+        (session.id, 'Ship it', leader.id),
+    )
+    await conn.commit()
+    app.state.tower_controller = _FakeTowerController(result={'leader_session_id': session.id})
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url='http://test') as client:
+        response = await client.post(
+            '/api/orchestration/leaders',
+            json={
+                'project_id': project.id,
+                'goal': 'Ship it',
+                'idempotency_key': 'goal-1',
+            },
+        )
+    assert response.status_code == 202
+    body = response.json()
+    assert body['operation_id'] == 'goal-1'
+    assert body['session']['role'] == 'leader'
+    assert body['session']['status'] == 'starting'

--- a/tests/unit/test_orchestration_service.py
+++ b/tests/unit/test_orchestration_service.py
@@ -1,0 +1,141 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import pytest_asyncio
+
+from atc.orchestration.errors import OrchestrationException
+from atc.orchestration.models import (
+    ListSessionsRequest,
+    OrchestrationRole,
+    OrchestrationStatus,
+    SpawnLeaderRequest,
+)
+from atc.orchestration.service import OrchestrationService
+from atc.state import db as db_ops
+from atc.tower.controller import TowerBusyError, TowerState
+
+
+class _FakeTowerController:
+    def __init__(self, result: dict | None = None, exc: Exception | None = None) -> None:
+        self._result = result or {}
+        self._exc = exc
+        self.calls: list[tuple[str, str]] = []
+
+    async def submit_goal(self, project_id: str, goal: str) -> dict:
+        self.calls.append((project_id, goal))
+        if self._exc:
+            raise self._exc
+        return self._result
+
+
+@pytest_asyncio.fixture()
+async def db_conn(tmp_path: Path):
+    db_path = tmp_path / "test.db"
+    await db_ops.run_migrations(str(db_path))
+    async with db_ops.get_connection(str(db_path)) as conn:
+        yield conn
+
+
+@pytest.mark.asyncio
+async def test_get_session_not_found(db_conn) -> None:
+    service = OrchestrationService(db_conn)
+    with pytest.raises(OrchestrationException) as exc:
+        await service.get_session("missing")
+    assert exc.value.code.value == "SESSION_NOT_FOUND"
+
+
+@pytest.mark.asyncio
+async def test_list_sessions_normalizes_role_and_status(db_conn) -> None:
+    project = await db_ops.create_project(db_conn, "ATC")
+    session = await db_ops.create_session(
+        db_conn,
+        project_id=project.id,
+        session_type="manager",
+        name="leader-ATC",
+        status="idle",
+    )
+    leader = await db_ops.create_leader(db_conn, project.id, goal="Ship it")
+    await db_conn.execute(
+        "UPDATE leaders SET session_id = ?, goal = ?, status = 'managing' WHERE id = ?",
+        (session.id, "Ship it", leader.id),
+    )
+    await db_conn.commit()
+
+    service = OrchestrationService(db_conn)
+    summaries = await service.list_sessions(ListSessionsRequest(role=OrchestrationRole.LEADER))
+    assert len(summaries) == 1
+    assert summaries[0].role == OrchestrationRole.LEADER
+    assert summaries[0].status == OrchestrationStatus.READY
+    assert summaries[0].goal == "Ship it"
+
+
+@pytest.mark.asyncio
+async def test_list_sessions_active_only_filters_failed(db_conn) -> None:
+    project = await db_ops.create_project(db_conn, "ATC")
+    await db_ops.create_session(
+        db_conn,
+        project_id=project.id,
+        session_type="ace",
+        name="ace-1",
+        status="error",
+    )
+    await db_ops.create_session(
+        db_conn,
+        project_id=project.id,
+        session_type="ace",
+        name="ace-2",
+        status="working",
+    )
+    service = OrchestrationService(db_conn)
+    summaries = await service.list_sessions(ListSessionsRequest(active_only=True))
+    assert len(summaries) == 1
+    assert summaries[0].name == "ace-2"
+
+
+@pytest.mark.asyncio
+async def test_spawn_leader_wraps_tower_controller(db_conn) -> None:
+    project = await db_ops.create_project(db_conn, "ATC")
+    leader = await db_ops.create_leader(db_conn, project.id, goal="Ship it")
+    session = await db_ops.create_session(
+        db_conn,
+        project_id=project.id,
+        session_type="manager",
+        name="leader-ATC",
+        status="connecting",
+    )
+    await db_conn.execute(
+        "UPDATE leaders SET session_id = ?, goal = ?, status = 'managing' WHERE id = ?",
+        (session.id, "Ship it", leader.id),
+    )
+    await db_conn.commit()
+
+    tower = _FakeTowerController(result={"leader_session_id": session.id})
+    service = OrchestrationService(db_conn, tower_controller=tower)
+    response = await service.spawn_leader(
+        SpawnLeaderRequest(
+            project_id=project.id,
+            goal="Ship it",
+            idempotency_key="goal-1",
+        )
+    )
+    assert response.operation_id == "goal-1"
+    assert response.session is not None
+    assert response.session.status == OrchestrationStatus.STARTING
+    assert tower.calls == [(project.id, "Ship it")]
+
+
+@pytest.mark.asyncio
+async def test_spawn_leader_maps_busy_error(db_conn) -> None:
+    project = await db_ops.create_project(db_conn, "ATC")
+    tower = _FakeTowerController(
+        exc=TowerBusyError(state=TowerState.MANAGING, project_id=project.id, detail="at capacity")
+    )
+    service = OrchestrationService(db_conn, tower_controller=tower)
+    with pytest.raises(OrchestrationException) as exc:
+        await service.spawn_leader(
+            SpawnLeaderRequest(project_id=project.id, goal="Ship it", idempotency_key="goal-2")
+        )
+    assert exc.value.code.value == "CONCURRENCY_LIMIT_REACHED"
+    assert exc.value.retryable is True


### PR DESCRIPTION
## Summary
- add orchestration contract models and normalized role/status helpers
- add orchestration error vocabulary and initial docs notes
- add initial orchestration service plus first orchestration API routes
- add unit coverage for models, errors, service, and router slices

## Testing
- PYTHONPATH=/tmp/atc-work/src pytest tests/unit/test_orchestration_models.py tests/unit/test_orchestration_errors.py tests/unit/test_orchestration_service.py tests/unit/test_orchestration_router.py