### PR TITLE
feat: add orchestration send-instruction route

### DIFF
--- a/src/atc/api/routers/orchestration.py
+++ b/src/atc/api/routers/orchestration.py
@@ -6,6 +6,7 @@ from atc.orchestration.errors import OrchestrationException
 from atc.orchestration.models import (
     ListSessionsRequest,
     OperationAcceptedResponse,
+    SendInstructionRequest,
     SessionSummary,
     SpawnLeaderRequest,
 )
@@ -25,6 +26,20 @@ async def spawn_leader(body: SpawnLeaderRequest, request: Request) -> OperationA
     service = await _get_service(request)
     try:
         return await service.spawn_leader(body)
+    except OrchestrationException as exc:
+        raise HTTPException(status_code=exc.http_status, detail=exc.to_dict()) from None
+
+
+@router.post("/sessions/{session_id}/instruction", response_model=OperationAcceptedResponse, status_code=202)
+async def send_instruction(
+    session_id: str,
+    body: SendInstructionRequest,
+    request: Request,
+) -> OperationAcceptedResponse:
+    service = await _get_service(request)
+    try:
+        payload = body.model_copy(update={"session_id": session_id})
+        return await service.send_instruction(payload)
     except OrchestrationException as exc:
         raise HTTPException(status_code=exc.http_status, detail=exc.to_dict()) from None
 

--- a/src/atc/orchestration/service.py
+++ b/src/atc/orchestration/service.py
@@ -8,11 +8,13 @@ from atc.orchestration.models import (
     OperationAcceptedResponse,
     OrchestrationRole,
     OrchestrationStatus,
+    SendInstructionRequest,
     SessionSummary,
     SpawnLeaderRequest,
     normalize_role,
     normalize_status,
 )
+from atc.session.ace import _send_session_instruction
 from atc.state import db as db_ops
 from atc.tower.controller import BudgetConstrainedError, TowerBusyError, TowerController
 
@@ -98,6 +100,46 @@ class OrchestrationService:
             )
 
         summary = await self.get_session(leader_session_id)
+        return OperationAcceptedResponse(
+            request_status="accepted",
+            operation_id=request.idempotency_key,
+            session=summary,
+        )
+
+    async def send_instruction(self, request: SendInstructionRequest) -> OperationAcceptedResponse:
+        session = await db_ops.get_session(self._db, request.session_id)
+        if session is None:
+            raise OrchestrationException(
+                OrchestrationErrorCode.SESSION_NOT_FOUND,
+                f"Session {request.session_id} not found",
+            )
+
+        try:
+            delivered = await _send_session_instruction(
+                self._db,
+                request.session_id,
+                request.instruction,
+            )
+        except ValueError as exc:
+            raise OrchestrationException(
+                OrchestrationErrorCode.SESSION_NOT_READY,
+                str(exc),
+                retryable=True,
+            ) from exc
+        except Exception as exc:
+            raise OrchestrationException(
+                OrchestrationErrorCode.INTERNAL_STORAGE_ERROR,
+                f"Instruction delivery failed for session {request.session_id}",
+            ) from exc
+
+        if not delivered:
+            raise OrchestrationException(
+                OrchestrationErrorCode.SESSION_NOT_READY,
+                f"Instruction delivery was not accepted for session {request.session_id}",
+                retryable=True,
+            )
+
+        summary = await self.get_session(request.session_id)
         return OperationAcceptedResponse(
             request_status="accepted",
             operation_id=request.idempotency_key,

--- a/tests/unit/test_orchestration_router.py
+++ b/tests/unit/test_orchestration_router.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+from unittest.mock import AsyncMock, patch
 
 import pytest
 import pytest_asyncio
@@ -8,7 +9,6 @@ from httpx import ASGITransport, AsyncClient
 
 from atc.api.app import create_app
 from atc.state import db as db_ops
-from atc.tower.controller import TowerState
 
 
 class _FakeTowerController:
@@ -97,3 +97,31 @@ async def test_spawn_orchestration_leader(app_and_db) -> None:
     assert body['operation_id'] == 'goal-1'
     assert body['session']['role'] == 'leader'
     assert body['session']['status'] == 'starting'
+
+
+@pytest.mark.asyncio
+async def test_send_instruction_route(app_and_db) -> None:
+    app, conn = app_and_db
+    project = await db_ops.create_project(conn, 'ATC')
+    session = await db_ops.create_session(
+        conn,
+        project_id=project.id,
+        session_type='ace',
+        name='ace-1',
+        status='working',
+    )
+    transport = ASGITransport(app=app)
+    with patch('atc.orchestration.service._send_session_instruction', new=AsyncMock(return_value=True)):
+        async with AsyncClient(transport=transport, base_url='http://test') as client:
+            response = await client.post(
+                f'/api/orchestration/sessions/{session.id}/instruction',
+                json={
+                    'session_id': 'ignored-by-route',
+                    'instruction': 'Do the thing',
+                    'idempotency_key': 'send-1',
+                },
+            )
+    assert response.status_code == 202
+    body = response.json()
+    assert body['operation_id'] == 'send-1'
+    assert body['session']['id'] == session.id

--- a/tests/unit/test_orchestration_service.py
+++ b/tests/unit/test_orchestration_service.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+from unittest.mock import AsyncMock, patch
 
 import pytest
 import pytest_asyncio
@@ -10,6 +11,7 @@ from atc.orchestration.models import (
     ListSessionsRequest,
     OrchestrationRole,
     OrchestrationStatus,
+    SendInstructionRequest,
     SpawnLeaderRequest,
 )
 from atc.orchestration.service import OrchestrationService
@@ -138,4 +140,54 @@ async def test_spawn_leader_maps_busy_error(db_conn) -> None:
             SpawnLeaderRequest(project_id=project.id, goal="Ship it", idempotency_key="goal-2")
         )
     assert exc.value.code.value == "CONCURRENCY_LIMIT_REACHED"
+    assert exc.value.retryable is True
+
+
+@pytest.mark.asyncio
+async def test_send_instruction_returns_accepted_response(db_conn) -> None:
+    project = await db_ops.create_project(db_conn, "ATC")
+    session = await db_ops.create_session(
+        db_conn,
+        project_id=project.id,
+        session_type="ace",
+        name="ace-1",
+        status="working",
+    )
+    service = OrchestrationService(db_conn)
+    with patch('atc.orchestration.service._send_session_instruction', new=AsyncMock(return_value=True)) as mock_send:
+        response = await service.send_instruction(
+            SendInstructionRequest(
+                session_id=session.id,
+                instruction='Do the thing',
+                idempotency_key='send-1',
+            )
+        )
+    assert response.request_status == 'accepted'
+    assert response.operation_id == 'send-1'
+    assert response.session is not None
+    assert response.session.id == session.id
+    mock_send.assert_awaited_once_with(db_conn, session.id, 'Do the thing')
+
+
+@pytest.mark.asyncio
+async def test_send_instruction_maps_rejected_delivery(db_conn) -> None:
+    project = await db_ops.create_project(db_conn, "ATC")
+    session = await db_ops.create_session(
+        db_conn,
+        project_id=project.id,
+        session_type="ace",
+        name="ace-1",
+        status="working",
+    )
+    service = OrchestrationService(db_conn)
+    with patch('atc.orchestration.service._send_session_instruction', new=AsyncMock(return_value=False)):
+        with pytest.raises(OrchestrationException) as exc:
+            await service.send_instruction(
+                SendInstructionRequest(
+                    session_id=session.id,
+                    instruction='Do the thing',
+                    idempotency_key='send-2',
+                )
+            )
+    assert exc.value.code.value == 'SESSION_NOT_READY'
     assert exc.value.retryable is True


### PR DESCRIPTION
## Summary
- add orchestration service support for send_instruction
- expose POST /api/orchestration/sessions/{session_id}/instruction
- cover accepted and rejected delivery behavior in service and router tests

## Testing
- PYTHONPATH=/tmp/atc-work/src pytest tests/unit/test_orchestration_models.py tests/unit/test_orchestration_errors.py tests/unit/test_orchestration_service.py tests/unit/test_orchestration_router.py