### PR TITLE
feat: add orchestration wait-for-session route

### DIFF
--- a/src/atc/api/routers/orchestration.py
+++ b/src/atc/api/routers/orchestration.py
@@ -9,6 +9,7 @@ from atc.orchestration.models import (
     SendInstructionRequest,
     SessionSummary,
     SpawnLeaderRequest,
+    WaitForSessionRequest,
 )
 from atc.orchestration.service import OrchestrationService
 
@@ -40,6 +41,20 @@ async def send_instruction(
     try:
         payload = body.model_copy(update={"session_id": session_id})
         return await service.send_instruction(payload)
+    except OrchestrationException as exc:
+        raise HTTPException(status_code=exc.http_status, detail=exc.to_dict()) from None
+
+
+@router.post("/sessions/{session_id}/wait", response_model=SessionSummary)
+async def wait_for_session(
+    session_id: str,
+    body: WaitForSessionRequest,
+    request: Request,
+) -> SessionSummary:
+    service = await _get_service(request)
+    try:
+        payload = body.model_copy(update={"session_id": session_id})
+        return await service.wait_for_session(payload)
     except OrchestrationException as exc:
         raise HTTPException(status_code=exc.http_status, detail=exc.to_dict()) from None
 

--- a/src/atc/orchestration/service.py
+++ b/src/atc/orchestration/service.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 from typing import Any
 
 from atc.orchestration.errors import OrchestrationErrorCode, OrchestrationException
@@ -11,6 +12,7 @@ from atc.orchestration.models import (
     SendInstructionRequest,
     SessionSummary,
     SpawnLeaderRequest,
+    WaitForSessionRequest,
     normalize_role,
     normalize_status,
 )
@@ -145,6 +147,24 @@ class OrchestrationService:
             operation_id=request.idempotency_key,
             session=summary,
         )
+
+    async def wait_for_session(self, request: WaitForSessionRequest) -> SessionSummary:
+        timeout_s = max(request.timeout_ms, 0) / 1000
+        deadline = asyncio.get_running_loop().time() + timeout_s
+        target_statuses = set(request.target_statuses)
+
+        while True:
+            summary = await self.get_session(request.session_id)
+            if summary.status in target_statuses:
+                return summary
+            if asyncio.get_running_loop().time() >= deadline:
+                wanted = ", ".join(status.value for status in request.target_statuses)
+                raise OrchestrationException(
+                    OrchestrationErrorCode.SESSION_NOT_READY,
+                    f"Session {request.session_id} did not reach target statuses [{wanted}] before timeout",
+                    retryable=True,
+                )
+            await asyncio.sleep(0.5)
 
     async def _build_session_summary(self, session: Any) -> SessionSummary:
         role = normalize_role(session.session_type)

--- a/tests/unit/test_orchestration_router.py
+++ b/tests/unit/test_orchestration_router.py
@@ -125,3 +125,30 @@ async def test_send_instruction_route(app_and_db) -> None:
     body = response.json()
     assert body['operation_id'] == 'send-1'
     assert body['session']['id'] == session.id
+
+
+@pytest.mark.asyncio
+async def test_wait_for_session_route(app_and_db) -> None:
+    app, conn = app_and_db
+    project = await db_ops.create_project(conn, 'ATC')
+    session = await db_ops.create_session(
+        conn,
+        project_id=project.id,
+        session_type='ace',
+        name='ace-1',
+        status='idle',
+    )
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url='http://test') as client:
+        response = await client.post(
+            f'/api/orchestration/sessions/{session.id}/wait',
+            json={
+                'session_id': 'ignored-by-route',
+                'target_statuses': ['ready'],
+                'timeout_ms': 100,
+            },
+        )
+    assert response.status_code == 200
+    body = response.json()
+    assert body['id'] == session.id
+    assert body['status'] == 'ready'

--- a/tests/unit/test_orchestration_service.py
+++ b/tests/unit/test_orchestration_service.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 from pathlib import Path
 from unittest.mock import AsyncMock, patch
 
@@ -13,6 +14,7 @@ from atc.orchestration.models import (
     OrchestrationStatus,
     SendInstructionRequest,
     SpawnLeaderRequest,
+    WaitForSessionRequest,
 )
 from atc.orchestration.service import OrchestrationService
 from atc.state import db as db_ops
@@ -189,5 +191,57 @@ async def test_send_instruction_maps_rejected_delivery(db_conn) -> None:
                     idempotency_key='send-2',
                 )
             )
+    assert exc.value.code.value == 'SESSION_NOT_READY'
+    assert exc.value.retryable is True
+
+
+@pytest.mark.asyncio
+async def test_wait_for_session_returns_when_status_matches(db_conn) -> None:
+    project = await db_ops.create_project(db_conn, 'ATC')
+    session = await db_ops.create_session(
+        db_conn,
+        project_id=project.id,
+        session_type='ace',
+        name='ace-1',
+        status='connecting',
+    )
+    service = OrchestrationService(db_conn)
+
+    async def flip_status() -> None:
+        await asyncio.sleep(0.05)
+        await db_ops.update_session_status(db_conn, session.id, 'idle')
+
+    task = asyncio.create_task(flip_status())
+    summary = await service.wait_for_session(
+        WaitForSessionRequest(
+            session_id=session.id,
+            target_statuses=[OrchestrationStatus.READY],
+            timeout_ms=1000,
+        )
+    )
+    await task
+    assert summary.id == session.id
+    assert summary.status == OrchestrationStatus.READY
+
+
+@pytest.mark.asyncio
+async def test_wait_for_session_times_out(db_conn) -> None:
+    project = await db_ops.create_project(db_conn, 'ATC')
+    session = await db_ops.create_session(
+        db_conn,
+        project_id=project.id,
+        session_type='ace',
+        name='ace-1',
+        status='connecting',
+    )
+    service = OrchestrationService(db_conn)
+    with pytest.raises(OrchestrationException) as exc:
+        await service.wait_for_session(
+            WaitForSessionRequest(
+                session_id=session.id,
+                target_statuses=[OrchestrationStatus.READY],
+                timeout_ms=10,
+            )
+        )
     assert exc.value.code.value == 'SESSION_NOT_READY'
     assert exc.value.retryable is True


### PR DESCRIPTION
## Summary
- add orchestration service support for wait_for_session
- expose POST /api/orchestration/sessions/{session_id}/wait
- cover ready and timeout behavior in service and router tests

## Testing
- PYTHONPATH=/tmp/atc-work/src pytest tests/unit/test_orchestration_models.py tests/unit/test_orchestration_errors.py tests/unit/test_orchestration_service.py tests/unit/test_orchestration_router.py