### PR TITLE
docs: document orchestration surface

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -60,6 +60,21 @@ GET    /api/tower/memory                      → list tower memory entries
 DELETE /api/tower/memory/{key}                → forget a memory entry
 ```
 
+## Orchestration
+
+```
+GET    /api/orchestration/sessions                     → list normalized sessions
+GET    /api/orchestration/sessions/{id}                → normalized single session view
+POST   /api/orchestration/leaders                      → spawn leader via Tower goal path
+POST   /api/orchestration/sessions/{id}/instruction    → send provider-owned instruction to a session
+POST   /api/orchestration/sessions/{id}/wait           → wait until session reaches target normalized status
+```
+
+Notes:
+- This surface exposes normalized orchestration roles (`tower`, `leader`, `ace`) and statuses (`starting`, `ready`, `running`, etc.) rather than raw internal DB strings.
+- `send_instruction` deliberately reuses the existing provider-owned delivery path instead of creating a second prompt-delivery implementation.
+- `wait` is currently a polling contract over session state, which keeps the API stable while backend event plumbing evolves.
+
 ## Usage & Budget
 
 ```

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -20,10 +20,23 @@ User → Tower → Leader → Ace
 
 FastAPI application with:
 - **App factory** (`app.py`): `create_app()` with lifespan management
-- **REST routers** (`routers/`): tower, projects, tasks, aces, usage, settings
+- **REST routers** (`routers/`): tower, projects, tasks, aces, orchestration, usage, settings
 - **WebSocket hub** (`ws/`): channel-based pub/sub for real-time state
 
 ### Domain Layer
+
+### Orchestration Boundary (`src/atc/orchestration/`)
+
+The new orchestration package is an internal normalization boundary that sits between ATC's product-specific internals and future external control surfaces like MCP.
+
+Current responsibilities:
+- normalize raw session types/statuses into orchestration roles and statuses
+- expose session-oriented service methods (`get_session`, `list_sessions`, `spawn_leader`, `send_instruction`, `wait_for_session`)
+- translate Tower/provider/runtime failures into a stable orchestration error vocabulary
+- back the first orchestration REST routes under `/api/orchestration/*`
+
+Design rule:
+- Orchestration should wrap existing high-level flows where they already exist, not duplicate runtime behavior. For example, `spawn_leader` goes through Tower's submit-goal path, and `send_instruction` goes through the existing provider-owned delivery path.
 
 | Package | Responsibility |
 |---|---|


### PR DESCRIPTION
## Summary
- document the new orchestration REST surface in API.md
- describe the orchestration boundary and design rules in ARCHITECTURE.md

## Testing
- PYTHONPATH=/tmp/atc-work/src pytest tests/unit/test_orchestration_models.py tests/unit/test_orchestration_errors.py tests/unit/test_orchestration_service.py tests/unit/test_orchestration_router.py