### PR TITLE
feat: add orchestration spawn-ace route

### DIFF
--- a/src/atc/api/routers/orchestration.py
+++ b/src/atc/api/routers/orchestration.py
@@ -8,6 +8,7 @@ from atc.orchestration.models import (
     OperationAcceptedResponse,
     SendInstructionRequest,
     SessionSummary,
+    SpawnAceRequest,
     SpawnLeaderRequest,
     WaitForSessionRequest,
 )
@@ -27,6 +28,15 @@ async def spawn_leader(body: SpawnLeaderRequest, request: Request) -> OperationA
     service = await _get_service(request)
     try:
         return await service.spawn_leader(body)
+    except OrchestrationException as exc:
+        raise HTTPException(status_code=exc.http_status, detail=exc.to_dict()) from None
+
+
+@router.post("/aces", response_model=OperationAcceptedResponse, status_code=202)
+async def spawn_ace(body: SpawnAceRequest, request: Request) -> OperationAcceptedResponse:
+    service = await _get_service(request)
+    try:
+        return await service.spawn_ace(body)
     except OrchestrationException as exc:
         raise HTTPException(status_code=exc.http_status, detail=exc.to_dict()) from None
 

--- a/src/atc/orchestration/service.py
+++ b/src/atc/orchestration/service.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 from typing import Any
 
+from atc.agents.factory import get_launch_command
 from atc.orchestration.errors import OrchestrationErrorCode, OrchestrationException
 from atc.orchestration.models import (
     ListSessionsRequest,
@@ -11,11 +12,13 @@ from atc.orchestration.models import (
     OrchestrationStatus,
     SendInstructionRequest,
     SessionSummary,
+    SpawnAceRequest,
     SpawnLeaderRequest,
     WaitForSessionRequest,
     normalize_role,
     normalize_status,
 )
+from atc.session import ace as ace_ops
 from atc.session.ace import _send_session_instruction
 from atc.state import db as db_ops
 from atc.tower.controller import BudgetConstrainedError, TowerBusyError, TowerController
@@ -102,6 +105,74 @@ class OrchestrationService:
             )
 
         summary = await self.get_session(leader_session_id)
+        return OperationAcceptedResponse(
+            request_status="accepted",
+            operation_id=request.idempotency_key,
+            session=summary,
+        )
+
+    async def spawn_ace(self, request: SpawnAceRequest) -> OperationAcceptedResponse:
+        project = await db_ops.get_project(self._db, request.project_id)
+        if project is None:
+            raise OrchestrationException(
+                OrchestrationErrorCode.PROJECT_NOT_FOUND,
+                f"Project {request.project_id} not found",
+            )
+
+        launch_cmd = get_launch_command(project.agent_provider)
+        ace_name = request.context.get("task_title") if request.context else None
+        ace_name = ace_name or (f"ace-{request.task_id[:8]}" if request.task_id else "ace-orchestration")
+
+        try:
+            session_id = await ace_ops.create_ace(
+                self._db,
+                request.project_id,
+                ace_name,
+                task_id=request.task_id,
+                host=request.host,
+                working_dir=project.repo_path,
+                launch_command=launch_cmd,
+                deploy_spec_kwargs={
+                    "project_name": project.name,
+                    "task_title": (request.context or {}).get("task_title") or ace_name,
+                    "task_description": request.instruction,
+                    "project_id": request.project_id,
+                    "repo_path": project.repo_path,
+                    "github_repo": project.github_repo,
+                    "context_entries": (request.context or {}).get("context_entries", []),
+                },
+            )
+        except Exception as exc:
+            raise OrchestrationException(
+                OrchestrationErrorCode.INTERNAL_STORAGE_ERROR,
+                f"Failed to spawn ace for project {request.project_id}",
+            ) from exc
+
+        if request.task_id:
+            try:
+                await db_ops.assign_task(
+                    self._db,
+                    request.task_id,
+                    session_id,
+                    request.idempotency_key,
+                )
+            except ValueError as exc:
+                raise OrchestrationException(
+                    OrchestrationErrorCode.INVALID_PARENT_RELATION,
+                    str(exc),
+                ) from exc
+
+        if request.instruction:
+            delivered = await _send_session_instruction(self._db, session_id, request.instruction)
+            if not delivered:
+                raise OrchestrationException(
+                    OrchestrationErrorCode.DELIVERY_FAILED,
+                    f"Ace {session_id} was created but initial instruction delivery was not accepted",
+                    retryable=True,
+                    details={"session_id": session_id},
+                )
+
+        summary = await self.get_session(session_id)
         return OperationAcceptedResponse(
             request_status="accepted",
             operation_id=request.idempotency_key,

--- a/tests/unit/test_orchestration_router.py
+++ b/tests/unit/test_orchestration_router.py
@@ -8,6 +8,7 @@ import pytest_asyncio
 from httpx import ASGITransport, AsyncClient
 
 from atc.api.app import create_app
+from atc.orchestration.models import OrchestrationRole, OrchestrationStatus, SessionSummary
 from atc.state import db as db_ops
 
 
@@ -97,6 +98,43 @@ async def test_spawn_orchestration_leader(app_and_db) -> None:
     assert body['operation_id'] == 'goal-1'
     assert body['session']['role'] == 'leader'
     assert body['session']['status'] == 'starting'
+
+
+@pytest.mark.asyncio
+async def test_spawn_orchestration_ace(app_and_db) -> None:
+    app, conn = app_and_db
+    project = await db_ops.create_project(conn, 'ATC', repo_path='/tmp/atc-repo')
+    task = await db_ops.create_task_graph(conn, project.id, 'Task 1')
+    fake_summary = SessionSummary(
+        id='session-123',
+        role=OrchestrationRole.ACE,
+        raw_session_type='ace',
+        project_id=project.id,
+        status=OrchestrationStatus.READY,
+        raw_status='idle',
+        name='ace-Task 1',
+        created_at='now',
+        updated_at='now',
+    )
+    with patch('atc.orchestration.service.ace_ops.create_ace', new=AsyncMock(return_value='session-123')), \
+         patch('atc.orchestration.service._send_session_instruction', new=AsyncMock(return_value=True)), \
+         patch('atc.orchestration.service.OrchestrationService.get_session', new=AsyncMock(return_value=fake_summary)):
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url='http://test') as client:
+            response = await client.post(
+                '/api/orchestration/aces',
+                json={
+                    'project_id': project.id,
+                    'task_id': task.id,
+                    'instruction': 'Start work',
+                    'idempotency_key': 'assign-1',
+                    'context': {'task_title': 'Task 1'},
+                },
+            )
+    assert response.status_code == 202
+    body = response.json()
+    assert body['operation_id'] == 'assign-1'
+    assert body['session']['id'] == 'session-123'
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_orchestration_service.py
+++ b/tests/unit/test_orchestration_service.py
@@ -13,6 +13,8 @@ from atc.orchestration.models import (
     OrchestrationRole,
     OrchestrationStatus,
     SendInstructionRequest,
+    SessionSummary,
+    SpawnAceRequest,
     SpawnLeaderRequest,
     WaitForSessionRequest,
 )
@@ -143,6 +145,49 @@ async def test_spawn_leader_maps_busy_error(db_conn) -> None:
         )
     assert exc.value.code.value == "CONCURRENCY_LIMIT_REACHED"
     assert exc.value.retryable is True
+
+
+@pytest.mark.asyncio
+async def test_spawn_ace_creates_session_and_assigns_task(db_conn) -> None:
+    project = await db_ops.create_project(db_conn, 'ATC', repo_path='/tmp/atc-repo')
+    task = await db_ops.create_task_graph(db_conn, project.id, 'Task 1')
+    fake_session_id = 'session-123'
+    await db_ops.create_session(
+        db_conn,
+        project_id=project.id,
+        session_type='ace',
+        name='ace-Task 1',
+        task_id=task.id,
+        status='idle',
+    )
+    fake_summary = SessionSummary(
+        id=fake_session_id,
+        role=OrchestrationRole.ACE,
+        raw_session_type='ace',
+        project_id=project.id,
+        status=OrchestrationStatus.READY,
+        raw_status='idle',
+        name='ace-Task 1',
+        created_at='now',
+        updated_at='now',
+    )
+    with patch('atc.orchestration.service.ace_ops.create_ace', new=AsyncMock(return_value=fake_session_id)), \
+         patch('atc.orchestration.service._send_session_instruction', new=AsyncMock(return_value=True)), \
+         patch.object(OrchestrationService, 'get_session', new=AsyncMock(return_value=fake_summary)):
+        service = OrchestrationService(db_conn)
+        response = await service.spawn_ace(
+            SpawnAceRequest(
+                project_id=project.id,
+                task_id=task.id,
+                instruction='Start work',
+                idempotency_key='assign-1',
+                context={'task_title': 'Task 1'},
+            )
+        )
+    assignment = await db_ops.get_task_assignment(db_conn, 'assign-1')
+    assert response.operation_id == 'assign-1'
+    assert assignment is not None
+    assert assignment.ace_session_id == fake_session_id
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- add orchestration service support for spawn_ace
- expose POST /api/orchestration/aces
- assign task graph entries via the orchestration idempotency key when task_id is provided
- optionally send the initial instruction through the existing provider-owned delivery path
- add service and router coverage for the new ace orchestration path

## Testing
- PYTHONPATH=/tmp/atc-work/src pytest tests/unit/test_orchestration_models.py tests/unit/test_orchestration_errors.py tests/unit/test_orchestration_service.py tests/unit/test_orchestration_router.py