### PR TITLE
feat: persist orchestration idempotency

### DIFF
--- a/src/atc/orchestration/service.py
+++ b/src/atc/orchestration/service.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import json
 from typing import Any
 
 from atc.agents.factory import get_launch_command
@@ -84,6 +85,24 @@ class OrchestrationService:
                 retryable=True,
             )
 
+        existing = await db_ops.get_orchestration_operation(self._db, request.idempotency_key)
+        if existing is not None:
+            if existing.operation_type != "spawn_leader":
+                raise OrchestrationException(
+                    OrchestrationErrorCode.IDEMPOTENCY_CONFLICT,
+                    f"Operation id {request.idempotency_key} already used for {existing.operation_type}",
+                )
+            if existing.response_payload:
+                payload = json.loads(existing.response_payload)
+                return OperationAcceptedResponse.model_validate(payload)
+
+        await db_ops.create_orchestration_operation(
+            self._db,
+            request.idempotency_key,
+            "spawn_leader",
+            request.model_dump_json(),
+        )
+
         try:
             result = await self._tower_controller.submit_goal(request.project_id, request.goal)
         except BudgetConstrainedError as exc:
@@ -107,11 +126,18 @@ class OrchestrationService:
             )
 
         summary = await self.get_session(leader_session_id)
-        return OperationAcceptedResponse(
+        response = OperationAcceptedResponse(
             request_status="accepted",
             operation_id=request.idempotency_key,
             session=summary,
         )
+        await db_ops.update_orchestration_operation(
+            self._db,
+            request.idempotency_key,
+            session_id=leader_session_id,
+            response_payload=response.model_dump_json(),
+        )
+        return response
 
     async def spawn_ace(self, request: SpawnAceRequest) -> OperationAcceptedResponse:
         project = await db_ops.get_project(self._db, request.project_id)
@@ -120,6 +146,24 @@ class OrchestrationService:
                 OrchestrationErrorCode.PROJECT_NOT_FOUND,
                 f"Project {request.project_id} not found",
             )
+
+        existing = await db_ops.get_orchestration_operation(self._db, request.idempotency_key)
+        if existing is not None:
+            if existing.operation_type != "spawn_ace":
+                raise OrchestrationException(
+                    OrchestrationErrorCode.IDEMPOTENCY_CONFLICT,
+                    f"Operation id {request.idempotency_key} already used for {existing.operation_type}",
+                )
+            if existing.response_payload:
+                payload = json.loads(existing.response_payload)
+                return OperationAcceptedResponse.model_validate(payload)
+
+        await db_ops.create_orchestration_operation(
+            self._db,
+            request.idempotency_key,
+            "spawn_ace",
+            request.model_dump_json(),
+        )
 
         launch_cmd = get_launch_command(project.agent_provider)
         ace_name = request.context.get("task_title") if request.context else None
@@ -175,11 +219,18 @@ class OrchestrationService:
                 )
 
         summary = await self.get_session(session_id)
-        return OperationAcceptedResponse(
+        response = OperationAcceptedResponse(
             request_status="accepted",
             operation_id=request.idempotency_key,
             session=summary,
         )
+        await db_ops.update_orchestration_operation(
+            self._db,
+            request.idempotency_key,
+            session_id=session_id,
+            response_payload=response.model_dump_json(),
+        )
+        return response
 
     async def send_instruction(self, request: SendInstructionRequest) -> OperationAcceptedResponse:
         session = await db_ops.get_session(self._db, request.session_id)

--- a/src/atc/state/db.py
+++ b/src/atc/state/db.py
@@ -14,6 +14,7 @@ import uuid
 from contextlib import asynccontextmanager, contextmanager
 from datetime import UTC, datetime
 from pathlib import Path
+import re
 from time import sleep
 from typing import TYPE_CHECKING, Any
 
@@ -29,6 +30,7 @@ from atc.state.models import (
     QALoopRun,
     Session,
     SessionHeartbeat,
+    OrchestrationOperation,
     TaskAssignment,
     TaskGraph,
     UsageEvent,
@@ -495,6 +497,8 @@ async def run_migrations(db_path: str) -> None:
         await db.executescript(_SCHEMA_SQL)
         await db.commit()
 
+        await _apply_file_migrations(db)
+
         # --- projects.position ---
         if not await _has_column(db, "projects", "position"):
             logger.info("Migration: adding projects.position column")
@@ -524,6 +528,54 @@ async def run_migrations(db_path: str) -> None:
             logger.info("Migration: adding tower_memory.embedding column")
             await db.execute("ALTER TABLE tower_memory ADD COLUMN embedding BLOB")
             await db.commit()
+
+
+
+
+async def _ensure_schema_migrations_table(db: aiosqlite.Connection) -> None:
+    await db.execute(
+        """CREATE TABLE IF NOT EXISTS schema_migrations (
+               version TEXT PRIMARY KEY,
+               applied_at TEXT NOT NULL
+           )"""
+    )
+    await db.commit()
+
+
+async def _list_applied_migrations(db: aiosqlite.Connection) -> set[str]:
+    cursor = await db.execute("SELECT version FROM schema_migrations")
+    rows = await cursor.fetchall()
+    return {str(r[0]) for r in rows}
+
+
+async def _apply_file_migrations(db: aiosqlite.Connection) -> None:
+    await _ensure_schema_migrations_table(db)
+    applied = await _list_applied_migrations(db)
+    file_migrations = sorted(MIGRATIONS_DIR.glob("*.sql"))
+
+    # Legacy note: _SCHEMA_SQL plus hand-coded ALTER migrations already cover
+    # the historical 001-013 schema evolution. New file-based migrations should
+    # start at 014+, otherwise fresh DBs would replay old ALTERs against tables
+    # that already contain those columns.
+    for path in file_migrations:
+        if path.name in applied:
+            continue
+        if path.name < "014_":
+            await db.execute(
+                "INSERT INTO schema_migrations (version, applied_at) VALUES (?, ?)",
+                (path.name, _now()),
+            )
+            await db.commit()
+            continue
+        sql = path.read_text()
+        if sql.strip():
+            logger.info("Applying migration file %s", path.name)
+            await db.executescript(sql)
+        await db.execute(
+            "INSERT INTO schema_migrations (version, applied_at) VALUES (?, ?)",
+            (path.name, _now()),
+        )
+        await db.commit()
 
 
 # ---------------------------------------------------------------------------
@@ -1534,6 +1586,103 @@ async def delete_feature_flag(db: aiosqlite.Connection, key: str) -> bool:
     cursor = await db.execute("DELETE FROM feature_flags WHERE key = ?", (key,))
     await db.commit()
     return bool(cursor.rowcount > 0)
+
+
+
+
+def _row_to_orchestration_operation(row: aiosqlite.Row) -> OrchestrationOperation:
+    d = dict(row)
+    return OrchestrationOperation(**d)
+
+
+async def get_orchestration_operation(
+    db: aiosqlite.Connection,
+    operation_id: str,
+) -> OrchestrationOperation | None:
+    cursor = await db.execute(
+        "SELECT * FROM orchestration_operations WHERE operation_id = ?",
+        (operation_id,),
+    )
+    row = await cursor.fetchone()
+    if row is None:
+        return None
+    return _row_to_orchestration_operation(row)
+
+
+async def create_orchestration_operation(
+    db: aiosqlite.Connection,
+    operation_id: str,
+    operation_type: str,
+    request_payload: str,
+    *,
+    session_id: str | None = None,
+    response_payload: str | None = None,
+    status: str = "accepted",
+) -> OrchestrationOperation:
+    now = _now()
+    op = OrchestrationOperation(
+        operation_id=operation_id,
+        operation_type=operation_type,
+        session_id=session_id,
+        request_payload=request_payload,
+        response_payload=response_payload,
+        status=status,
+        created_at=now,
+        updated_at=now,
+    )
+    await db.execute(
+        """INSERT INTO orchestration_operations
+           (operation_id, operation_type, session_id, request_payload, response_payload, status, created_at, updated_at)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?)""",
+        (
+            op.operation_id,
+            op.operation_type,
+            op.session_id,
+            op.request_payload,
+            op.response_payload,
+            op.status,
+            op.created_at,
+            op.updated_at,
+        ),
+    )
+    await db.commit()
+    return op
+
+
+async def update_orchestration_operation(
+    db: aiosqlite.Connection,
+    operation_id: str,
+    *,
+    session_id: str | None = None,
+    response_payload: str | None = None,
+    status: str | None = None,
+) -> OrchestrationOperation | None:
+    existing = await get_orchestration_operation(db, operation_id)
+    if existing is None:
+        return None
+
+    sets: list[str] = []
+    params: list[Any] = []
+    if session_id is not None:
+        sets.append("session_id = ?")
+        params.append(session_id)
+    if response_payload is not None:
+        sets.append("response_payload = ?")
+        params.append(response_payload)
+    if status is not None:
+        sets.append("status = ?")
+        params.append(status)
+
+    sets.append("updated_at = ?")
+    params.append(_now())
+    params.append(operation_id)
+
+    await db.execute(
+        f"UPDATE orchestration_operations SET {', '.join(sets)} WHERE operation_id = ?",
+        params,
+    )
+    await db.commit()
+    return await get_orchestration_operation(db, operation_id)
 
 
 async def is_feature_enabled(db: aiosqlite.Connection, key: str) -> bool:

--- a/src/atc/state/migrations/versions/014_orchestration_operations.sql
+++ b/src/atc/state/migrations/versions/014_orchestration_operations.sql
@@ -1,0 +1,13 @@
+CREATE TABLE IF NOT EXISTS orchestration_operations (
+  operation_id TEXT PRIMARY KEY,
+  operation_type TEXT NOT NULL,
+  session_id TEXT,
+  request_payload TEXT NOT NULL,
+  response_payload TEXT,
+  status TEXT NOT NULL DEFAULT 'accepted',
+  created_at TEXT NOT NULL,
+  updated_at TEXT NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_orchestration_operations_type
+  ON orchestration_operations(operation_type, created_at);

--- a/src/atc/state/models.py
+++ b/src/atc/state/models.py
@@ -286,3 +286,15 @@ class FeatureFlag:
     metadata: str | None = None  # optional JSON
     created_at: str = ""
     updated_at: str = ""
+
+
+@dataclass
+class OrchestrationOperation:
+    operation_id: str
+    operation_type: str
+    request_payload: str
+    status: str
+    session_id: str | None = None
+    response_payload: str | None = None
+    created_at: str = ""
+    updated_at: str = ""

--- a/tests/unit/test_orchestration_idempotency.py
+++ b/tests/unit/test_orchestration_idempotency.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+import pytest
+import pytest_asyncio
+
+from atc.orchestration.errors import OrchestrationException
+from atc.orchestration.models import OrchestrationRole, OrchestrationStatus, SessionSummary, SpawnAceRequest, SpawnLeaderRequest
+from atc.orchestration.service import OrchestrationService
+from atc.state import db as db_ops
+
+
+class _FakeTowerController:
+    def __init__(self, result: dict | None = None) -> None:
+        self._result = result or {}
+        self.calls: list[tuple[str, str]] = []
+
+    async def submit_goal(self, project_id: str, goal: str) -> dict:
+        self.calls.append((project_id, goal))
+        return self._result
+
+
+@pytest_asyncio.fixture()
+async def db_conn(tmp_path: Path):
+    db_path = tmp_path / 'test.db'
+    await db_ops.run_migrations(str(db_path))
+    async with db_ops.get_connection(str(db_path)) as conn:
+        yield conn
+
+
+@pytest.mark.asyncio
+async def test_spawn_leader_reuses_persisted_operation(db_conn) -> None:
+    project = await db_ops.create_project(db_conn, 'ATC')
+    summary = SessionSummary(
+        id='leader-1', role=OrchestrationRole.LEADER, raw_session_type='manager', project_id=project.id,
+        status=OrchestrationStatus.READY, raw_status='idle', name='leader-ATC', created_at='now', updated_at='now'
+    )
+    response_json = {'request_status': 'accepted', 'operation_id': 'goal-1', 'session': summary.model_dump()}
+    await db_ops.create_orchestration_operation(
+        db_conn, 'goal-1', 'spawn_leader', '{"project_id":"x"}', session_id='leader-1', response_payload=__import__('json').dumps(response_json)
+    )
+    tower = _FakeTowerController(result={'leader_session_id': 'leader-1'})
+    service = OrchestrationService(db_conn, tower_controller=tower)
+    response = await service.spawn_leader(SpawnLeaderRequest(project_id=project.id, goal='Ship it', idempotency_key='goal-1'))
+    assert response.operation_id == 'goal-1'
+    assert tower.calls == []
+
+
+@pytest.mark.asyncio
+async def test_spawn_ace_reuses_persisted_operation(db_conn) -> None:
+    project = await db_ops.create_project(db_conn, 'ATC')
+    summary = SessionSummary(
+        id='ace-1', role=OrchestrationRole.ACE, raw_session_type='ace', project_id=project.id,
+        status=OrchestrationStatus.READY, raw_status='idle', name='ace-1', created_at='now', updated_at='now'
+    )
+    response_json = {'request_status': 'accepted', 'operation_id': 'assign-1', 'session': summary.model_dump()}
+    await db_ops.create_orchestration_operation(
+        db_conn, 'assign-1', 'spawn_ace', '{"project_id":"x"}', session_id='ace-1', response_payload=__import__('json').dumps(response_json)
+    )
+    service = OrchestrationService(db_conn)
+    response = await service.spawn_ace(SpawnAceRequest(project_id=project.id, instruction='Go', idempotency_key='assign-1'))
+    assert response.operation_id == 'assign-1'
+
+
+@pytest.mark.asyncio
+async def test_idempotency_conflict_across_operation_types(db_conn) -> None:
+    project = await db_ops.create_project(db_conn, 'ATC')
+    await db_ops.create_orchestration_operation(db_conn, 'dup-1', 'spawn_leader', '{}')
+    service = OrchestrationService(db_conn)
+    with pytest.raises(OrchestrationException) as exc:
+        await service.spawn_ace(SpawnAceRequest(project_id=project.id, instruction='Go', idempotency_key='dup-1'))
+    assert exc.value.code.value == 'IDEMPOTENCY_CONFLICT'


### PR DESCRIPTION
## Summary
- add a persistent orchestration_operations table for operation idempotency
- wire DB helpers for orchestration operation create/get/update
- make spawn_leader and spawn_ace reuse persisted responses for repeated operation ids
- return explicit idempotency conflicts when an operation id is reused across operation types
- teach the migration runner to track file-based migrations and apply the new 014+ era cleanly without replaying legacy schema changes twice
- add focused orchestration idempotency tests

## Testing
- PYTHONPATH=/tmp/atc-work/src pytest tests/unit/test_orchestration_models.py tests/unit/test_orchestration_errors.py tests/unit/test_orchestration_service.py tests/unit/test_orchestration_router.py tests/unit/test_orchestration_idempotency.py