### PR TITLE
feat: add MCP orchestration skeleton

### DIFF
--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -1,0 +1,36 @@
+# MCP Integration Plan
+
+ATC's MCP layer should sit on top of the orchestration boundary, not call session/tower internals directly.
+
+## Principles
+
+- MCP tools speak in orchestration models, roles, statuses, and errors.
+- MCP handlers should delegate to `atc.orchestration.service.OrchestrationService`.
+- The orchestration layer remains the normalization boundary between ATC product internals and external control surfaces.
+- Early MCP slices should prefer a stable skeleton over pretending the full protocol/tool catalog is complete.
+
+## Initial Tool Mapping
+
+The first MCP server slice should expose these orchestration-backed operations:
+
+- `list_sessions`
+- `get_session`
+- `spawn_leader`
+- `spawn_ace`
+- `send_instruction`
+- `wait_for_session`
+- `cancel_session`
+
+## Response Shape
+
+The MCP server should return JSON-serializable content based on orchestration models:
+
+- `SessionSummary`
+- `OperationAcceptedResponse`
+- orchestration error envelopes
+
+## Non-Goals for First Slice
+
+- full streaming/session event protocol
+- Tower lifecycle management beyond existing orchestration support
+- bespoke runtime logic outside the orchestration service

--- a/src/atc/mcp/__init__.py
+++ b/src/atc/mcp/__init__.py
@@ -1,0 +1,5 @@
+"""MCP integration layer for ATC.
+
+The first slice keeps this package intentionally small: a thin server skeleton
+that delegates tool execution to the orchestration service.
+"""

--- a/src/atc/mcp/server.py
+++ b/src/atc/mcp/server.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+from typing import Any
+
+from atc.orchestration.models import (
+    CancelSessionRequest,
+    ListSessionsRequest,
+    SendInstructionRequest,
+    SpawnAceRequest,
+    SpawnLeaderRequest,
+    WaitForSessionRequest,
+)
+from atc.orchestration.service import OrchestrationService
+
+
+class MCPServer:
+    """Minimal MCP-facing adapter over the orchestration service.
+
+    This is intentionally not a full protocol transport yet. It is the first
+    contract slice that defines the MCP tool surface ATC intends to expose.
+    """
+
+    def __init__(self, service: OrchestrationService) -> None:
+        self._service = service
+
+    def list_tools(self) -> list[dict[str, Any]]:
+        return [
+            {"name": "list_sessions", "description": "List normalized orchestration sessions"},
+            {"name": "get_session", "description": "Fetch a normalized orchestration session"},
+            {"name": "spawn_leader", "description": "Spawn a leader through Tower orchestration"},
+            {"name": "spawn_ace", "description": "Spawn an ace through orchestration"},
+            {"name": "send_instruction", "description": "Send an instruction to an orchestration session"},
+            {"name": "wait_for_session", "description": "Wait for a session to reach target orchestration statuses"},
+            {"name": "cancel_session", "description": "Cancel or stop an orchestration session"},
+        ]
+
+    async def call_tool(self, name: str, arguments: dict[str, Any]) -> dict[str, Any]:
+        if name == "list_sessions":
+            result = await self._service.list_sessions(ListSessionsRequest.model_validate(arguments))
+            return {"content": [item.model_dump(mode="json") for item in result]}
+        if name == "get_session":
+            result = await self._service.get_session(arguments["session_id"])
+            return {"content": result.model_dump(mode="json")}
+        if name == "spawn_leader":
+            result = await self._service.spawn_leader(SpawnLeaderRequest.model_validate(arguments))
+            return {"content": result.model_dump(mode="json")}
+        if name == "spawn_ace":
+            result = await self._service.spawn_ace(SpawnAceRequest.model_validate(arguments))
+            return {"content": result.model_dump(mode="json")}
+        if name == "send_instruction":
+            result = await self._service.send_instruction(SendInstructionRequest.model_validate(arguments))
+            return {"content": result.model_dump(mode="json")}
+        if name == "wait_for_session":
+            result = await self._service.wait_for_session(WaitForSessionRequest.model_validate(arguments))
+            return {"content": result.model_dump(mode="json")}
+        if name == "cancel_session":
+            result = await self._service.cancel_session(CancelSessionRequest.model_validate(arguments))
+            return {"content": None if result is None else result.model_dump(mode="json")}
+        raise ValueError(f"Unknown MCP tool: {name}")

--- a/tests/unit/test_mcp_server.py
+++ b/tests/unit/test_mcp_server.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from atc.mcp.server import MCPServer
+from atc.orchestration.models import OperationAcceptedResponse, OrchestrationRole, OrchestrationStatus, SessionSummary
+
+
+@pytest.mark.asyncio
+async def test_list_tools_includes_orchestration_surface() -> None:
+    service = AsyncMock()
+    server = MCPServer(service)
+    names = [tool['name'] for tool in server.list_tools()]
+    assert names == [
+        'list_sessions',
+        'get_session',
+        'spawn_leader',
+        'spawn_ace',
+        'send_instruction',
+        'wait_for_session',
+        'cancel_session',
+    ]
+
+
+@pytest.mark.asyncio
+async def test_call_tool_delegates_spawn_leader() -> None:
+    summary = SessionSummary(
+        id='leader-1', role=OrchestrationRole.LEADER, raw_session_type='manager', project_id='p1',
+        status=OrchestrationStatus.READY, raw_status='idle', name='leader-ATC', created_at='now', updated_at='now'
+    )
+    service = AsyncMock()
+    service.spawn_leader.return_value = OperationAcceptedResponse(
+        request_status='accepted', operation_id='goal-1', session=summary
+    )
+    server = MCPServer(service)
+    result = await server.call_tool('spawn_leader', {
+        'project_id': 'p1',
+        'goal': 'Ship it',
+        'idempotency_key': 'goal-1',
+    })
+    assert result['content']['operation_id'] == 'goal-1'
+    service.spawn_leader.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_call_tool_delegates_cancel_session() -> None:
+    summary = SessionSummary(
+        id='ace-1', role=OrchestrationRole.ACE, raw_session_type='ace', project_id='p1',
+        status=OrchestrationStatus.BLOCKED, raw_status='paused', name='ace-1', created_at='now', updated_at='now'
+    )
+    service = AsyncMock()
+    service.cancel_session.return_value = summary
+    server = MCPServer(service)
+    result = await server.call_tool('cancel_session', {
+        'session_id': 'ace-1',
+        'force': False,
+    })
+    assert result['content']['id'] == 'ace-1'
+    service.cancel_session.assert_awaited_once()


### PR DESCRIPTION
## Summary
- add initial MCP integration plan doc
- add an  package with a minimal server skeleton
- map the first MCP tool surface directly onto the orchestration service
- add unit tests proving the MCP adapter delegates to orchestration models and operations

## Testing
- PYTHONPATH=/tmp/atc-work/src pytest tests/unit/test_mcp_server.py tests/unit/test_orchestration_models.py tests/unit/test_orchestration_errors.py tests/unit/test_orchestration_service.py tests/unit/test_orchestration_router.py tests/unit/test_orchestration_idempotency.py