### PR TITLE
feat: add MCP stdio entrypoint

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,7 @@ backup = [
 [project.scripts]
 atc-server = "atc.api.app:main"
 atc = "atc.cli.main:main"
+atc-mcp = "atc.mcp.cli:main"
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/atc"]

--- a/src/atc/mcp/cli.py
+++ b/src/atc/mcp/cli.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+import asyncio
+import os
+
+from atc.config import load_settings
+from atc.mcp.server import MCPServer, MCPStdioServer
+from atc.orchestration.service import OrchestrationService
+from atc.state.db import get_connection, run_migrations
+
+
+async def _run() -> None:
+    settings = load_settings()
+    db_path = os.environ.get('ATC_DB_PATH', settings.database.path)
+    await run_migrations(db_path)
+    async with get_connection(db_path) as db:
+        service = OrchestrationService(db)
+        stdio = MCPStdioServer(MCPServer(service))
+        while await stdio.run_once():
+            pass
+
+
+def main() -> None:
+    asyncio.run(_run())

--- a/src/atc/mcp/server.py
+++ b/src/atc/mcp/server.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
-from typing import Any
+import json
+import sys
+from typing import Any, TextIO
 
 from atc.orchestration.models import (
     CancelSessionRequest,
@@ -57,3 +59,44 @@ class MCPServer:
             result = await self._service.cancel_session(CancelSessionRequest.model_validate(arguments))
             return {"content": None if result is None else result.model_dump(mode="json")}
         raise ValueError(f"Unknown MCP tool: {name}")
+
+
+class MCPStdioServer:
+    """Tiny stdio transport for the current MCP adapter.
+
+    Input lines are JSON objects with:
+    - {"method": "tools/list"}
+    - {"method": "tools/call", "params": {"name": ..., "arguments": {...}}}
+
+    Output is one JSON object per line.
+    """
+
+    def __init__(self, server: MCPServer, *, stdin: TextIO | None = None, stdout: TextIO | None = None) -> None:
+        self._server = server
+        self._stdin = stdin or sys.stdin
+        self._stdout = stdout or sys.stdout
+
+    async def handle_message(self, message: dict[str, Any]) -> dict[str, Any]:
+        method = message.get("method")
+        if method == "tools/list":
+            return {"tools": self._server.list_tools()}
+        if method == "tools/call":
+            params = message.get("params") or {}
+            name = params.get("name")
+            arguments = params.get("arguments") or {}
+            if not name:
+                raise ValueError("tools/call requires params.name")
+            return await self._server.call_tool(name, arguments)
+        raise ValueError(f"Unknown MCP method: {method}")
+
+    async def run_once(self) -> bool:
+        line = self._stdin.readline()
+        if line == "":
+            return False
+        line = line.strip()
+        if not line:
+            return True
+        response = await self.handle_message(json.loads(line))
+        self._stdout.write(json.dumps(response) + "\n")
+        self._stdout.flush()
+        return True

--- a/tests/unit/test_mcp_stdio.py
+++ b/tests/unit/test_mcp_stdio.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+import io
+from unittest.mock import AsyncMock
+
+import pytest
+
+from atc.mcp.server import MCPServer, MCPStdioServer
+from atc.orchestration.models import OperationAcceptedResponse, OrchestrationRole, OrchestrationStatus, SessionSummary
+
+
+@pytest.mark.asyncio
+async def test_stdio_server_lists_tools() -> None:
+    service = AsyncMock()
+    server = MCPStdioServer(MCPServer(service), stdin=io.StringIO('{"method":"tools/list"}\n'), stdout=io.StringIO())
+    assert await server.run_once() is True
+    output = server._stdout.getvalue()
+    assert 'list_sessions' in output
+    assert 'cancel_session' in output
+
+
+@pytest.mark.asyncio
+async def test_stdio_server_calls_tool() -> None:
+    summary = SessionSummary(
+        id='leader-1', role=OrchestrationRole.LEADER, raw_session_type='manager', project_id='p1',
+        status=OrchestrationStatus.READY, raw_status='idle', name='leader-ATC', created_at='now', updated_at='now'
+    )
+    service = AsyncMock()
+    service.spawn_leader.return_value = OperationAcceptedResponse(
+        request_status='accepted', operation_id='goal-1', session=summary
+    )
+    input_data = io.StringIO('{"method":"tools/call","params":{"name":"spawn_leader","arguments":{"project_id":"p1","goal":"Ship it","idempotency_key":"goal-1"}}}\n')
+    output_data = io.StringIO()
+    server = MCPStdioServer(MCPServer(service), stdin=input_data, stdout=output_data)
+    assert await server.run_once() is True
+    assert 'goal-1' in output_data.getvalue()
+    service.spawn_leader.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_stdio_server_eof_returns_false() -> None:
+    service = AsyncMock()
+    server = MCPStdioServer(MCPServer(service), stdin=io.StringIO(''), stdout=io.StringIO())
+    assert await server.run_once() is False


### PR DESCRIPTION
## Summary
- add a minimal stdio transport for the MCP orchestration adapter
- add an  CLI entrypoint that boots the MCP stdio server against the ATC database
- add focused stdio transport tests while keeping the MCP layer delegated to orchestration service methods

## Testing
- PYTHONPATH=/tmp/atc-work/src pytest tests/unit/test_mcp_server.py tests/unit/test_mcp_stdio.py tests/unit/test_orchestration_models.py tests/unit/test_orchestration_errors.py tests/unit/test_orchestration_service.py tests/unit/test_orchestration_router.py tests/unit/test_orchestration_idempotency.py