### PR TITLE
feat: add MCP history and tool schemas

### DIFF
--- a/src/atc/mcp/server.py
+++ b/src/atc/mcp/server.py
@@ -6,6 +6,7 @@ from typing import Any, TextIO
 
 from atc.orchestration.models import (
     CancelSessionRequest,
+    ListOperationsRequest,
     ListSessionsRequest,
     SendInstructionRequest,
     SpawnAceRequest,
@@ -16,24 +17,23 @@ from atc.orchestration.service import OrchestrationService
 
 
 class MCPServer:
-    """Minimal MCP-facing adapter over the orchestration service.
-
-    This is intentionally not a full protocol transport yet. It is the first
-    contract slice that defines the MCP tool surface ATC intends to expose.
-    """
+    """Minimal MCP-facing adapter over the orchestration service."""
 
     def __init__(self, service: OrchestrationService) -> None:
         self._service = service
 
     def list_tools(self) -> list[dict[str, Any]]:
         return [
-            {"name": "list_sessions", "description": "List normalized orchestration sessions"},
-            {"name": "get_session", "description": "Fetch a normalized orchestration session"},
-            {"name": "spawn_leader", "description": "Spawn a leader through Tower orchestration"},
-            {"name": "spawn_ace", "description": "Spawn an ace through orchestration"},
-            {"name": "send_instruction", "description": "Send an instruction to an orchestration session"},
-            {"name": "wait_for_session", "description": "Wait for a session to reach target orchestration statuses"},
-            {"name": "cancel_session", "description": "Cancel or stop an orchestration session"},
+            {"name": "list_sessions", "description": "List normalized orchestration sessions", "inputSchema": {"type": "object", "properties": {"project_id": {"type": "string"}, "role": {"type": "string"}, "active_only": {"type": "boolean"}, "limit": {"type": "integer"}}}},
+            {"name": "get_session", "description": "Fetch a normalized orchestration session", "inputSchema": {"type": "object", "required": ["session_id"], "properties": {"session_id": {"type": "string"}}}},
+            {"name": "list_operations", "description": "List orchestration operations/history", "inputSchema": {"type": "object", "properties": {"operation_type": {"type": "string"}, "session_id": {"type": "string"}, "limit": {"type": "integer"}}}},
+            {"name": "get_operation", "description": "Fetch a single orchestration operation", "inputSchema": {"type": "object", "required": ["operation_id"], "properties": {"operation_id": {"type": "string"}}}},
+            {"name": "list_session_events", "description": "List app events for a session", "inputSchema": {"type": "object", "required": ["session_id"], "properties": {"session_id": {"type": "string"}, "limit": {"type": "integer"}}}},
+            {"name": "spawn_leader", "description": "Spawn a leader through Tower orchestration", "inputSchema": {"type": "object", "required": ["project_id", "goal", "idempotency_key"]}},
+            {"name": "spawn_ace", "description": "Spawn an ace through orchestration", "inputSchema": {"type": "object", "required": ["project_id", "instruction", "idempotency_key"]}},
+            {"name": "send_instruction", "description": "Send an instruction to an orchestration session", "inputSchema": {"type": "object", "required": ["session_id", "instruction", "idempotency_key"]}},
+            {"name": "wait_for_session", "description": "Wait for a session to reach target orchestration statuses", "inputSchema": {"type": "object", "required": ["session_id", "target_statuses"]}},
+            {"name": "cancel_session", "description": "Cancel or stop an orchestration session", "inputSchema": {"type": "object", "required": ["session_id"]}},
         ]
 
     async def call_tool(self, name: str, arguments: dict[str, Any]) -> dict[str, Any]:
@@ -43,6 +43,15 @@ class MCPServer:
         if name == "get_session":
             result = await self._service.get_session(arguments["session_id"])
             return {"content": result.model_dump(mode="json")}
+        if name == "list_operations":
+            result = await self._service.list_operations(ListOperationsRequest.model_validate(arguments))
+            return {"content": [item.model_dump(mode="json") for item in result]}
+        if name == "get_operation":
+            result = await self._service.get_operation(arguments["operation_id"])
+            return {"content": result.model_dump(mode="json")}
+        if name == "list_session_events":
+            result = await self._service.list_session_events(arguments["session_id"], limit=arguments.get("limit"))
+            return {"content": [item.model_dump(mode="json") for item in result]}
         if name == "spawn_leader":
             result = await self._service.spawn_leader(SpawnLeaderRequest.model_validate(arguments))
             return {"content": result.model_dump(mode="json")}
@@ -62,15 +71,6 @@ class MCPServer:
 
 
 class MCPStdioServer:
-    """Tiny stdio transport for the current MCP adapter.
-
-    Input lines are JSON objects with:
-    - {"method": "tools/list"}
-    - {"method": "tools/call", "params": {"name": ..., "arguments": {...}}}
-
-    Output is one JSON object per line.
-    """
-
     def __init__(self, server: MCPServer, *, stdin: TextIO | None = None, stdout: TextIO | None = None) -> None:
         self._server = server
         self._stdin = stdin or sys.stdin

--- a/src/atc/orchestration/models.py
+++ b/src/atc/orchestration/models.py
@@ -143,3 +143,31 @@ class SessionEvent(BaseModel):
     event_type: str
     created_at: str
     data: dict[str, Any] = Field(default_factory=dict)
+
+
+class ListOperationsRequest(BaseModel):
+    operation_type: str | None = None
+    session_id: str | None = None
+    limit: int | None = None
+
+
+class OperationRecord(BaseModel):
+    operation_id: str
+    operation_type: str
+    session_id: str | None = None
+    status: str
+    request_payload: dict[str, Any]
+    response_payload: dict[str, Any] | None = None
+    created_at: str
+    updated_at: str
+
+
+class SessionEventRecord(BaseModel):
+    id: str
+    level: str
+    category: str
+    message: str
+    created_at: str
+    detail: dict[str, Any] | None = None
+    project_id: str | None = None
+    session_id: str | None = None

--- a/src/atc/orchestration/service.py
+++ b/src/atc/orchestration/service.py
@@ -9,11 +9,14 @@ from atc.leader import leader as leader_ops
 from atc.orchestration.errors import OrchestrationErrorCode, OrchestrationException
 from atc.orchestration.models import (
     CancelSessionRequest,
+    ListOperationsRequest,
+    OperationRecord,
     ListSessionsRequest,
     OperationAcceptedResponse,
     OrchestrationRole,
     OrchestrationStatus,
     SendInstructionRequest,
+    SessionEventRecord,
     SessionSummary,
     SpawnAceRequest,
     SpawnLeaderRequest,
@@ -36,6 +39,63 @@ class OrchestrationService:
     ) -> None:
         self._db = db
         self._tower_controller = tower_controller
+
+
+    async def list_operations(self, request: ListOperationsRequest | None = None) -> list[OperationRecord]:
+        request = request or ListOperationsRequest()
+        ops = await db_ops.list_orchestration_operations(
+            self._db,
+            operation_type=request.operation_type,
+            session_id=request.session_id,
+            limit=request.limit,
+        )
+        return [
+            OperationRecord(
+                operation_id=op.operation_id,
+                operation_type=op.operation_type,
+                session_id=op.session_id,
+                status=op.status,
+                request_payload=json.loads(op.request_payload),
+                response_payload=(json.loads(op.response_payload) if op.response_payload else None),
+                created_at=op.created_at,
+                updated_at=op.updated_at,
+            )
+            for op in ops
+        ]
+
+    async def get_operation(self, operation_id: str) -> OperationRecord:
+        op = await db_ops.get_orchestration_operation(self._db, operation_id)
+        if op is None:
+            raise OrchestrationException(
+                OrchestrationErrorCode.SESSION_NOT_FOUND,
+                f"Operation {operation_id} not found",
+            )
+        return OperationRecord(
+            operation_id=op.operation_id,
+            operation_type=op.operation_type,
+            session_id=op.session_id,
+            status=op.status,
+            request_payload=json.loads(op.request_payload),
+            response_payload=(json.loads(op.response_payload) if op.response_payload else None),
+            created_at=op.created_at,
+            updated_at=op.updated_at,
+        )
+
+    async def list_session_events(self, session_id: str, *, limit: int | None = None) -> list[SessionEventRecord]:
+        events = await db_ops.list_app_events(self._db, session_id=session_id, limit=limit)
+        return [
+            SessionEventRecord(
+                id=event.id,
+                level=event.level,
+                category=event.category,
+                message=event.message,
+                created_at=event.created_at,
+                detail=(json.loads(event.detail) if event.detail else None),
+                project_id=event.project_id,
+                session_id=event.session_id,
+            )
+            for event in events
+        ]
 
     async def get_session(self, session_id: str) -> SessionSummary:
         session = await db_ops.get_session(self._db, session_id)

--- a/src/atc/state/db.py
+++ b/src/atc/state/db.py
@@ -21,6 +21,7 @@ from typing import TYPE_CHECKING, Any
 import aiosqlite  # type: ignore[import-not-found]
 
 from atc.state.models import (
+    AppEvent,
     ContextEntry,
     FeatureFlag,
     GitHubPR,
@@ -1683,6 +1684,52 @@ async def update_orchestration_operation(
     )
     await db.commit()
     return await get_orchestration_operation(db, operation_id)
+
+
+async def list_orchestration_operations(
+    db: aiosqlite.Connection,
+    *,
+    operation_type: str | None = None,
+    session_id: str | None = None,
+    limit: int | None = None,
+) -> list[OrchestrationOperation]:
+    clauses: list[str] = []
+    params: list[Any] = []
+    if operation_type is not None:
+        clauses.append("operation_type = ?")
+        params.append(operation_type)
+    if session_id is not None:
+        clauses.append("session_id = ?")
+        params.append(session_id)
+    where = f" WHERE {' AND '.join(clauses)}" if clauses else ""
+    sql = f"SELECT * FROM orchestration_operations{where} ORDER BY created_at DESC"
+    if limit is not None:
+        sql += " LIMIT ?"
+        params.append(limit)
+    cursor = await db.execute(sql, params)
+    rows = await cursor.fetchall()
+    return [_row_to_orchestration_operation(r) for r in rows]
+
+
+async def list_app_events(
+    db: aiosqlite.Connection,
+    *,
+    session_id: str | None = None,
+    limit: int | None = None,
+) -> list[AppEvent]:
+    clauses: list[str] = []
+    params: list[Any] = []
+    if session_id is not None:
+        clauses.append("session_id = ?")
+        params.append(session_id)
+    where = f" WHERE {' AND '.join(clauses)}" if clauses else ""
+    sql = f"SELECT * FROM app_events{where} ORDER BY created_at DESC"
+    if limit is not None:
+        sql += " LIMIT ?"
+        params.append(limit)
+    cursor = await db.execute(sql, params)
+    rows = await cursor.fetchall()
+    return [AppEvent(**dict(r)) for r in rows]
 
 
 async def is_feature_enabled(db: aiosqlite.Connection, key: str) -> bool:

--- a/tests/unit/test_mcp_server.py
+++ b/tests/unit/test_mcp_server.py
@@ -16,12 +16,16 @@ async def test_list_tools_includes_orchestration_surface() -> None:
     assert names == [
         'list_sessions',
         'get_session',
+        'list_operations',
+        'get_operation',
+        'list_session_events',
         'spawn_leader',
         'spawn_ace',
         'send_instruction',
         'wait_for_session',
         'cancel_session',
     ]
+    assert all('inputSchema' in tool for tool in server.list_tools())
 
 
 @pytest.mark.asyncio
@@ -59,3 +63,13 @@ async def test_call_tool_delegates_cancel_session() -> None:
     })
     assert result['content']['id'] == 'ace-1'
     service.cancel_session.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_call_tool_delegates_list_operations() -> None:
+    service = AsyncMock()
+    service.list_operations.return_value = []
+    server = MCPServer(service)
+    result = await server.call_tool('list_operations', {'limit': 5})
+    assert result['content'] == []
+    service.list_operations.assert_awaited_once()

--- a/tests/unit/test_orchestration_history.py
+++ b/tests/unit/test_orchestration_history.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+import pytest_asyncio
+
+from atc.orchestration.service import OrchestrationService
+from atc.state import db as db_ops
+
+
+@pytest_asyncio.fixture()
+async def db_conn(tmp_path: Path):
+    db_path = tmp_path / 'test.db'
+    await db_ops.run_migrations(str(db_path))
+    async with db_ops.get_connection(str(db_path)) as conn:
+        yield conn
+
+
+@pytest.mark.asyncio
+async def test_list_operations_returns_records(db_conn) -> None:
+    await db_ops.create_orchestration_operation(
+        db_conn,
+        'op-1',
+        'spawn_leader',
+        json.dumps({'project_id': 'p1'}),
+        session_id='s1',
+        response_payload=json.dumps({'ok': True}),
+    )
+    service = OrchestrationService(db_conn)
+    records = await service.list_operations()
+    assert len(records) == 1
+    assert records[0].operation_id == 'op-1'
+    assert records[0].request_payload['project_id'] == 'p1'
+
+
+@pytest.mark.asyncio
+async def test_get_operation_returns_record(db_conn) -> None:
+    await db_ops.create_orchestration_operation(
+        db_conn,
+        'op-1',
+        'spawn_leader',
+        json.dumps({'project_id': 'p1'}),
+        session_id='s1',
+    )
+    service = OrchestrationService(db_conn)
+    record = await service.get_operation('op-1')
+    assert record.operation_id == 'op-1'
+    assert record.session_id == 's1'


### PR DESCRIPTION
## Summary
- add orchestration history accessors for operations and session events
- expose operation/session-history tools through the MCP layer
- enrich MCP tool metadata with input schemas for the current surface

## Testing
- PYTHONPATH=/tmp/atc-work/src pytest tests/unit/test_mcp_server.py tests/unit/test_mcp_stdio.py tests/unit/test_orchestration_models.py tests/unit/test_orchestration_errors.py tests/unit/test_orchestration_service.py tests/unit/test_orchestration_router.py tests/unit/test_orchestration_idempotency.py tests/unit/test_orchestration_history.py