### PR TITLE
feat: add MCP protocol envelopes

### DIFF
--- a/src/atc/mcp/server.py
+++ b/src/atc/mcp/server.py
@@ -4,6 +4,7 @@ import json
 import sys
 from typing import Any, TextIO
 
+from atc.orchestration.errors import OrchestrationException
 from atc.orchestration.models import (
     CancelSessionRequest,
     ListOperationsRequest,
@@ -36,37 +37,37 @@ class MCPServer:
             {"name": "cancel_session", "description": "Cancel or stop an orchestration session", "inputSchema": {"type": "object", "required": ["session_id"]}},
         ]
 
-    async def call_tool(self, name: str, arguments: dict[str, Any]) -> dict[str, Any]:
+    async def call_tool(self, name: str, arguments: dict[str, Any]) -> Any:
         if name == "list_sessions":
             result = await self._service.list_sessions(ListSessionsRequest.model_validate(arguments))
-            return {"content": [item.model_dump(mode="json") for item in result]}
+            return [item.model_dump(mode="json") for item in result]
         if name == "get_session":
             result = await self._service.get_session(arguments["session_id"])
-            return {"content": result.model_dump(mode="json")}
+            return result.model_dump(mode="json")
         if name == "list_operations":
             result = await self._service.list_operations(ListOperationsRequest.model_validate(arguments))
-            return {"content": [item.model_dump(mode="json") for item in result]}
+            return [item.model_dump(mode="json") for item in result]
         if name == "get_operation":
             result = await self._service.get_operation(arguments["operation_id"])
-            return {"content": result.model_dump(mode="json")}
+            return result.model_dump(mode="json")
         if name == "list_session_events":
             result = await self._service.list_session_events(arguments["session_id"], limit=arguments.get("limit"))
-            return {"content": [item.model_dump(mode="json") for item in result]}
+            return [item.model_dump(mode="json") for item in result]
         if name == "spawn_leader":
             result = await self._service.spawn_leader(SpawnLeaderRequest.model_validate(arguments))
-            return {"content": result.model_dump(mode="json")}
+            return result.model_dump(mode="json")
         if name == "spawn_ace":
             result = await self._service.spawn_ace(SpawnAceRequest.model_validate(arguments))
-            return {"content": result.model_dump(mode="json")}
+            return result.model_dump(mode="json")
         if name == "send_instruction":
             result = await self._service.send_instruction(SendInstructionRequest.model_validate(arguments))
-            return {"content": result.model_dump(mode="json")}
+            return result.model_dump(mode="json")
         if name == "wait_for_session":
             result = await self._service.wait_for_session(WaitForSessionRequest.model_validate(arguments))
-            return {"content": result.model_dump(mode="json")}
+            return result.model_dump(mode="json")
         if name == "cancel_session":
             result = await self._service.cancel_session(CancelSessionRequest.model_validate(arguments))
-            return {"content": None if result is None else result.model_dump(mode="json")}
+            return None if result is None else result.model_dump(mode="json")
         raise ValueError(f"Unknown MCP tool: {name}")
 
 
@@ -76,18 +77,41 @@ class MCPStdioServer:
         self._stdin = stdin or sys.stdin
         self._stdout = stdout or sys.stdout
 
+    def _success_response(self, request_id: Any, result: Any) -> dict[str, Any]:
+        return {"jsonrpc": "2.0", "id": request_id, "result": result}
+
+    def _error_response(self, request_id: Any, code: int, message: str, data: dict[str, Any] | None = None) -> dict[str, Any]:
+        payload: dict[str, Any] = {"jsonrpc": "2.0", "id": request_id, "error": {"code": code, "message": message}}
+        if data is not None:
+            payload["error"]["data"] = data
+        return payload
+
     async def handle_message(self, message: dict[str, Any]) -> dict[str, Any]:
+        request_id = message.get("id")
         method = message.get("method")
-        if method == "tools/list":
-            return {"tools": self._server.list_tools()}
-        if method == "tools/call":
-            params = message.get("params") or {}
-            name = params.get("name")
-            arguments = params.get("arguments") or {}
-            if not name:
-                raise ValueError("tools/call requires params.name")
-            return await self._server.call_tool(name, arguments)
-        raise ValueError(f"Unknown MCP method: {method}")
+        try:
+            if method == "tools/list":
+                return self._success_response(request_id, {"tools": self._server.list_tools()})
+            if method == "tools/call":
+                params = message.get("params") or {}
+                name = params.get("name")
+                arguments = params.get("arguments") or {}
+                if not name:
+                    return self._error_response(request_id, -32602, "tools/call requires params.name")
+                result = await self._server.call_tool(name, arguments)
+                return self._success_response(request_id, {"content": result})
+            return self._error_response(request_id, -32601, f"Unknown MCP method: {method}")
+        except OrchestrationException as exc:
+            return self._error_response(
+                request_id,
+                -32001,
+                exc.message,
+                {"code": str(exc.code.value).lower(), "retryable": exc.retryable, "details": exc.details},
+            )
+        except ValueError as exc:
+            return self._error_response(request_id, -32602, str(exc))
+        except Exception as exc:
+            return self._error_response(request_id, -32000, str(exc))
 
     async def run_once(self) -> bool:
         line = self._stdin.readline()

--- a/tests/unit/test_mcp_server.py
+++ b/tests/unit/test_mcp_server.py
@@ -44,7 +44,7 @@ async def test_call_tool_delegates_spawn_leader() -> None:
         'goal': 'Ship it',
         'idempotency_key': 'goal-1',
     })
-    assert result['content']['operation_id'] == 'goal-1'
+    assert result['operation_id'] == 'goal-1'
     service.spawn_leader.assert_awaited_once()
 
 
@@ -61,7 +61,7 @@ async def test_call_tool_delegates_cancel_session() -> None:
         'session_id': 'ace-1',
         'force': False,
     })
-    assert result['content']['id'] == 'ace-1'
+    assert result['id'] == 'ace-1'
     service.cancel_session.assert_awaited_once()
 
 
@@ -71,5 +71,5 @@ async def test_call_tool_delegates_list_operations() -> None:
     service.list_operations.return_value = []
     server = MCPServer(service)
     result = await server.call_tool('list_operations', {'limit': 5})
-    assert result['content'] == []
+    assert result == []
     service.list_operations.assert_awaited_once()

--- a/tests/unit/test_mcp_stdio.py
+++ b/tests/unit/test_mcp_stdio.py
@@ -1,22 +1,26 @@
 from __future__ import annotations
 
 import io
+import json
 from unittest.mock import AsyncMock
 
 import pytest
 
 from atc.mcp.server import MCPServer, MCPStdioServer
+from atc.orchestration.errors import OrchestrationErrorCode, OrchestrationException
 from atc.orchestration.models import OperationAcceptedResponse, OrchestrationRole, OrchestrationStatus, SessionSummary
 
 
 @pytest.mark.asyncio
 async def test_stdio_server_lists_tools() -> None:
     service = AsyncMock()
-    server = MCPStdioServer(MCPServer(service), stdin=io.StringIO('{"method":"tools/list"}\n'), stdout=io.StringIO())
+    output = io.StringIO()
+    server = MCPStdioServer(MCPServer(service), stdin=io.StringIO('{"id":1,"method":"tools/list"}\n'), stdout=output)
     assert await server.run_once() is True
-    output = server._stdout.getvalue()
-    assert 'list_sessions' in output
-    assert 'cancel_session' in output
+    payload = json.loads(output.getvalue())
+    assert payload['jsonrpc'] == '2.0'
+    assert payload['id'] == 1
+    assert 'list_sessions' in [tool['name'] for tool in payload['result']['tools']]
 
 
 @pytest.mark.asyncio
@@ -29,12 +33,33 @@ async def test_stdio_server_calls_tool() -> None:
     service.spawn_leader.return_value = OperationAcceptedResponse(
         request_status='accepted', operation_id='goal-1', session=summary
     )
-    input_data = io.StringIO('{"method":"tools/call","params":{"name":"spawn_leader","arguments":{"project_id":"p1","goal":"Ship it","idempotency_key":"goal-1"}}}\n')
+    input_data = io.StringIO('{"id":"abc","method":"tools/call","params":{"name":"spawn_leader","arguments":{"project_id":"p1","goal":"Ship it","idempotency_key":"goal-1"}}}\n')
     output_data = io.StringIO()
     server = MCPStdioServer(MCPServer(service), stdin=input_data, stdout=output_data)
     assert await server.run_once() is True
-    assert 'goal-1' in output_data.getvalue()
+    payload = json.loads(output_data.getvalue())
+    assert payload['id'] == 'abc'
+    assert payload['result']['content']['operation_id'] == 'goal-1'
     service.spawn_leader.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_stdio_server_returns_error_envelope() -> None:
+    service = AsyncMock()
+    service.get_session.side_effect = OrchestrationException(
+        OrchestrationErrorCode.SESSION_NOT_FOUND,
+        'missing session',
+        retryable=False,
+        details={'session_id': 'missing'},
+    )
+    input_data = io.StringIO('{"id":7,"method":"tools/call","params":{"name":"get_session","arguments":{"session_id":"missing"}}}\n')
+    output_data = io.StringIO()
+    server = MCPStdioServer(MCPServer(service), stdin=input_data, stdout=output_data)
+    assert await server.run_once() is True
+    payload = json.loads(output_data.getvalue())
+    assert payload['id'] == 7
+    assert payload['error']['code'] == -32001
+    assert payload['error']['data']['code'] == 'session_not_found'
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- add JSON-RPC style success and error envelopes to the MCP stdio transport
- preserve the simple orchestration-backed MCP server contract beneath the transport
- normalize MCP error payloads for orchestration failures and bad requests

## Testing
- PYTHONPATH=/tmp/atc-work/src pytest tests/unit/test_mcp_server.py tests/unit/test_mcp_stdio.py tests/unit/test_orchestration_models.py tests/unit/test_orchestration_errors.py tests/unit/test_orchestration_service.py tests/unit/test_orchestration_router.py tests/unit/test_orchestration_idempotency.py tests/unit/test_orchestration_history.py