### PR TITLE
docs: add MCP usage examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,24 @@ python3 -m uvicorn atc.api.app:create_app --factory --reload --port 8420
 cd frontend && npm run dev
 ```
 
+## MCP Entry Point
+
+ATC now includes a thin MCP-oriented stdio entrypoint on top of the orchestration boundary:
+
+```bash
+atc-mcp
+```
+
+It currently supports line-delimited JSON requests for `tools/list` and `tools/call`.
+
+Example:
+
+```bash
+printf '{"id":1,"method":"tools/list"}\n' | atc-mcp
+```
+
+See [docs/mcp.md](docs/mcp.md) for request/response examples and the current tool surface.
+
 ## Configuration
 
 Runtime config lives in `config.yaml`. Override locally with `config.local.yaml` (gitignored).

--- a/docs/API.md
+++ b/docs/API.md
@@ -75,6 +75,34 @@ Notes:
 - `send_instruction` deliberately reuses the existing provider-owned delivery path instead of creating a second prompt-delivery implementation.
 - `wait` is currently a polling contract over session state, which keeps the API stable while backend event plumbing evolves.
 
+## MCP
+
+ATC also exposes a thin MCP-oriented stdio interface through `atc-mcp`.
+
+Current request methods:
+
+```
+tools/list
+tools/call
+```
+
+Current tool names:
+
+```
+list_sessions
+get_session
+list_operations
+get_operation
+list_session_events
+spawn_leader
+spawn_ace
+send_instruction
+wait_for_session
+cancel_session
+```
+
+See `docs/mcp.md` for example request/response envelopes and usage notes.
+
 ## Usage & Budget
 
 ```

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -1,36 +1,81 @@
 # MCP Integration Plan
 
-ATC's MCP layer should sit on top of the orchestration boundary, not call session/tower internals directly.
+ATC's MCP layer sits on top of the orchestration boundary, not directly on session, Tower, or tmux internals.
 
 ## Principles
 
 - MCP tools speak in orchestration models, roles, statuses, and errors.
-- MCP handlers should delegate to `atc.orchestration.service.OrchestrationService`.
+- MCP handlers delegate to `atc.orchestration.service.OrchestrationService`.
 - The orchestration layer remains the normalization boundary between ATC product internals and external control surfaces.
-- Early MCP slices should prefer a stable skeleton over pretending the full protocol/tool catalog is complete.
+- Early MCP slices should prefer a stable thin contract over pretending the full protocol/tool catalog is complete.
 
-## Initial Tool Mapping
+## Current Surface
 
-The first MCP server slice should expose these orchestration-backed operations:
+ATC now ships an `atc-mcp` stdio entrypoint.
+
+```bash
+atc-mcp
+```
+
+The current line-delimited JSON request surface supports:
+
+- `tools/list`
+- `tools/call`
+
+Available orchestration-backed tools:
 
 - `list_sessions`
 - `get_session`
+- `list_operations`
+- `get_operation`
+- `list_session_events`
 - `spawn_leader`
 - `spawn_ace`
 - `send_instruction`
 - `wait_for_session`
 - `cancel_session`
 
-## Response Shape
+## Example Session
 
-The MCP server should return JSON-serializable content based on orchestration models:
+List tools:
 
-- `SessionSummary`
-- `OperationAcceptedResponse`
-- orchestration error envelopes
+```json
+{"id":1,"method":"tools/list"}
+```
 
-## Non-Goals for First Slice
+Response:
 
-- full streaming/session event protocol
-- Tower lifecycle management beyond existing orchestration support
-- bespoke runtime logic outside the orchestration service
+```json
+{"jsonrpc":"2.0","id":1,"result":{"tools":[{"name":"list_sessions","description":"List normalized orchestration sessions","inputSchema":{"type":"object","properties":{"project_id":{"type":"string"},"role":{"type":"string"},"active_only":{"type":"boolean"},"limit":{"type":"integer"}}}}]}}
+```
+
+Call a tool:
+
+```json
+{"id":2,"method":"tools/call","params":{"name":"list_operations","arguments":{"limit":10}}}
+```
+
+Response:
+
+```json
+{"jsonrpc":"2.0","id":2,"result":{"content":[{"operation_id":"goal-123","operation_type":"spawn_leader","session_id":"leader-123","status":"accepted","request_payload":{"project_id":"proj-1","goal":"Ship MCP"},"response_payload":{"request_status":"accepted"},"created_at":"2026-05-26T00:00:00Z","updated_at":"2026-05-26T00:00:00Z"}]}}
+```
+
+Error response shape:
+
+```json
+{"jsonrpc":"2.0","id":3,"error":{"code":-32001,"message":"Session missing not found","data":{"code":"session_not_found","retryable":false,"details":{"session_id":"missing"}}}}
+```
+
+## Current Scope Notes
+
+- `wait_for_session` is still polling-based under the hood.
+- Operation history currently comes from the persisted `orchestration_operations` table.
+- Session event history currently reuses app events filtered by `session_id`.
+- The current stdio layer is JSON-RPC-like and useful for real clients, but it is still a deliberately thin MCP transport rather than a fully exhaustive spec implementation.
+
+## Recommended Next Layers
+
+- stricter MCP spec alignment / handshake polish
+- live subscriptions or streamed session events
+- richer orchestration event sourcing under the history surface


### PR DESCRIPTION
## Summary
- document the  entrypoint in the README
- add MCP request and response examples to 
- add the MCP surface to the main API reference

## Testing
- docs only