### PR TITLE
feat: add MCP initialize handshake

### DIFF
--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -17,8 +17,10 @@ ATC now ships an `atc-mcp` stdio entrypoint.
 atc-mcp
 ```
 
-The current line-delimited JSON request surface supports:
+The current transport now includes a basic MCP-style initialization sequence:
 
+- `initialize`
+- `notifications/initialized`
 - `tools/list`
 - `tools/call`
 
@@ -37,34 +39,46 @@ Available orchestration-backed tools:
 
 ## Example Session
 
-List tools:
+Initialize:
 
 ```json
-{"id":1,"method":"tools/list"}
+{"id":1,"method":"initialize"}
 ```
 
 Response:
 
 ```json
-{"jsonrpc":"2.0","id":1,"result":{"tools":[{"name":"list_sessions","description":"List normalized orchestration sessions","inputSchema":{"type":"object","properties":{"project_id":{"type":"string"},"role":{"type":"string"},"active_only":{"type":"boolean"},"limit":{"type":"integer"}}}}]}}
+{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2024-11-05","capabilities":{"tools":{"listChanged":false}},"serverInfo":{"name":"atc-mcp","version":"0.1.0"}}}
+```
+
+Initialized notification:
+
+```json
+{"method":"notifications/initialized"}
+```
+
+List tools:
+
+```json
+{"id":2,"method":"tools/list"}
 ```
 
 Call a tool:
 
 ```json
-{"id":2,"method":"tools/call","params":{"name":"list_operations","arguments":{"limit":10}}}
+{"id":3,"method":"tools/call","params":{"name":"list_operations","arguments":{"limit":10}}}
 ```
 
 Response:
 
 ```json
-{"jsonrpc":"2.0","id":2,"result":{"content":[{"operation_id":"goal-123","operation_type":"spawn_leader","session_id":"leader-123","status":"accepted","request_payload":{"project_id":"proj-1","goal":"Ship MCP"},"response_payload":{"request_status":"accepted"},"created_at":"2026-05-26T00:00:00Z","updated_at":"2026-05-26T00:00:00Z"}]}}
+{"jsonrpc":"2.0","id":3,"result":{"content":[{"operation_id":"goal-123","operation_type":"spawn_leader","session_id":"leader-123","status":"accepted","request_payload":{"project_id":"proj-1","goal":"Ship MCP"},"response_payload":{"request_status":"accepted"},"created_at":"2026-05-26T00:00:00Z","updated_at":"2026-05-26T00:00:00Z"}]}}
 ```
 
 Error response shape:
 
 ```json
-{"jsonrpc":"2.0","id":3,"error":{"code":-32001,"message":"Session missing not found","data":{"code":"session_not_found","retryable":false,"details":{"session_id":"missing"}}}}
+{"jsonrpc":"2.0","id":4,"error":{"code":-32001,"message":"Session missing not found","data":{"code":"session_not_found","retryable":false,"details":{"session_id":"missing"}}}}
 ```
 
 ## Current Scope Notes
@@ -72,10 +86,10 @@ Error response shape:
 - `wait_for_session` is still polling-based under the hood.
 - Operation history currently comes from the persisted `orchestration_operations` table.
 - Session event history currently reuses app events filtered by `session_id`.
-- The current stdio layer is JSON-RPC-like and useful for real clients, but it is still a deliberately thin MCP transport rather than a fully exhaustive spec implementation.
+- The current stdio layer is now closer to a real MCP handshake, but it is still deliberately thin rather than a fully exhaustive spec implementation.
 
 ## Recommended Next Layers
 
-- stricter MCP spec alignment / handshake polish
 - live subscriptions or streamed session events
 - richer orchestration event sourcing under the history surface
+- any additional MCP compatibility gaps discovered through real client integration

--- a/src/atc/mcp/server.py
+++ b/src/atc/mcp/server.py
@@ -23,6 +23,17 @@ class MCPServer:
     def __init__(self, service: OrchestrationService) -> None:
         self._service = service
 
+    def server_info(self) -> dict[str, Any]:
+        return {
+            "name": "atc-mcp",
+            "version": "0.1.0",
+        }
+
+    def capabilities(self) -> dict[str, Any]:
+        return {
+            "tools": {"listChanged": False},
+        }
+
     def list_tools(self) -> list[dict[str, Any]]:
         return [
             {"name": "list_sessions", "description": "List normalized orchestration sessions", "inputSchema": {"type": "object", "properties": {"project_id": {"type": "string"}, "role": {"type": "string"}, "active_only": {"type": "boolean"}, "limit": {"type": "integer"}}}},
@@ -76,6 +87,7 @@ class MCPStdioServer:
         self._server = server
         self._stdin = stdin or sys.stdin
         self._stdout = stdout or sys.stdout
+        self._initialized = False
 
     def _success_response(self, request_id: Any, result: Any) -> dict[str, Any]:
         return {"jsonrpc": "2.0", "id": request_id, "result": result}
@@ -86,10 +98,25 @@ class MCPStdioServer:
             payload["error"]["data"] = data
         return payload
 
-    async def handle_message(self, message: dict[str, Any]) -> dict[str, Any]:
+    async def handle_message(self, message: dict[str, Any]) -> dict[str, Any] | None:
         request_id = message.get("id")
         method = message.get("method")
         try:
+            if method == "initialize":
+                self._initialized = True
+                return self._success_response(
+                    request_id,
+                    {
+                        "protocolVersion": "2024-11-05",
+                        "capabilities": self._server.capabilities(),
+                        "serverInfo": self._server.server_info(),
+                    },
+                )
+            if method == "notifications/initialized":
+                self._initialized = True
+                return None
+            if not self._initialized:
+                return self._error_response(request_id, -32002, "Server not initialized")
             if method == "tools/list":
                 return self._success_response(request_id, {"tools": self._server.list_tools()})
             if method == "tools/call":
@@ -121,6 +148,7 @@ class MCPStdioServer:
         if not line:
             return True
         response = await self.handle_message(json.loads(line))
-        self._stdout.write(json.dumps(response) + "\n")
-        self._stdout.flush()
+        if response is not None:
+            self._stdout.write(json.dumps(response) + "\n")
+            self._stdout.flush()
         return True

--- a/tests/unit/test_mcp_stdio.py
+++ b/tests/unit/test_mcp_stdio.py
@@ -12,15 +12,38 @@ from atc.orchestration.models import OperationAcceptedResponse, OrchestrationRol
 
 
 @pytest.mark.asyncio
-async def test_stdio_server_lists_tools() -> None:
+async def test_stdio_server_requires_initialize_before_tools() -> None:
     service = AsyncMock()
     output = io.StringIO()
     server = MCPStdioServer(MCPServer(service), stdin=io.StringIO('{"id":1,"method":"tools/list"}\n'), stdout=output)
     assert await server.run_once() is True
     payload = json.loads(output.getvalue())
+    assert payload['error']['code'] == -32002
+
+
+@pytest.mark.asyncio
+async def test_stdio_server_initialize_returns_server_info() -> None:
+    service = AsyncMock()
+    output = io.StringIO()
+    server = MCPStdioServer(MCPServer(service), stdin=io.StringIO('{"id":1,"method":"initialize"}\n'), stdout=output)
+    assert await server.run_once() is True
+    payload = json.loads(output.getvalue())
     assert payload['jsonrpc'] == '2.0'
     assert payload['id'] == 1
-    assert 'list_sessions' in [tool['name'] for tool in payload['result']['tools']]
+    assert payload['result']['serverInfo']['name'] == 'atc-mcp'
+    assert payload['result']['capabilities']['tools']['listChanged'] is False
+
+
+@pytest.mark.asyncio
+async def test_stdio_server_lists_tools_after_initialize() -> None:
+    service = AsyncMock()
+    output = io.StringIO()
+    server = MCPStdioServer(MCPServer(service), stdin=io.StringIO('{"id":1,"method":"initialize"}\n{"id":2,"method":"tools/list"}\n'), stdout=output)
+    assert await server.run_once() is True
+    assert await server.run_once() is True
+    lines = [json.loads(line) for line in output.getvalue().splitlines() if line.strip()]
+    assert lines[1]['id'] == 2
+    assert 'list_sessions' in [tool['name'] for tool in lines[1]['result']['tools']]
 
 
 @pytest.mark.asyncio
@@ -33,14 +56,25 @@ async def test_stdio_server_calls_tool() -> None:
     service.spawn_leader.return_value = OperationAcceptedResponse(
         request_status='accepted', operation_id='goal-1', session=summary
     )
-    input_data = io.StringIO('{"id":"abc","method":"tools/call","params":{"name":"spawn_leader","arguments":{"project_id":"p1","goal":"Ship it","idempotency_key":"goal-1"}}}\n')
+    input_data = io.StringIO('{"id":1,"method":"initialize"}\n{"id":"abc","method":"tools/call","params":{"name":"spawn_leader","arguments":{"project_id":"p1","goal":"Ship it","idempotency_key":"goal-1"}}}\n')
     output_data = io.StringIO()
     server = MCPStdioServer(MCPServer(service), stdin=input_data, stdout=output_data)
     assert await server.run_once() is True
-    payload = json.loads(output_data.getvalue())
+    assert await server.run_once() is True
+    lines = [json.loads(line) for line in output_data.getvalue().splitlines() if line.strip()]
+    payload = lines[1]
     assert payload['id'] == 'abc'
     assert payload['result']['content']['operation_id'] == 'goal-1'
     service.spawn_leader.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_stdio_server_initialized_notification_is_silent() -> None:
+    service = AsyncMock()
+    output = io.StringIO()
+    server = MCPStdioServer(MCPServer(service), stdin=io.StringIO('{"method":"notifications/initialized"}\n'), stdout=output)
+    assert await server.run_once() is True
+    assert output.getvalue() == ''
 
 
 @pytest.mark.asyncio
@@ -52,11 +86,13 @@ async def test_stdio_server_returns_error_envelope() -> None:
         retryable=False,
         details={'session_id': 'missing'},
     )
-    input_data = io.StringIO('{"id":7,"method":"tools/call","params":{"name":"get_session","arguments":{"session_id":"missing"}}}\n')
+    input_data = io.StringIO('{"id":1,"method":"initialize"}\n{"id":7,"method":"tools/call","params":{"name":"get_session","arguments":{"session_id":"missing"}}}\n')
     output_data = io.StringIO()
     server = MCPStdioServer(MCPServer(service), stdin=input_data, stdout=output_data)
     assert await server.run_once() is True
-    payload = json.loads(output_data.getvalue())
+    assert await server.run_once() is True
+    lines = [json.loads(line) for line in output_data.getvalue().splitlines() if line.strip()]
+    payload = lines[1]
     assert payload['id'] == 7
     assert payload['error']['code'] == -32001
     assert payload['error']['data']['code'] == 'session_not_found'


### PR DESCRIPTION
## Summary
- add a basic MCP-style initialize handshake and initialized notification handling
- advertise server info and tool capabilities from the stdio transport
- document the initialize flow in the MCP docs

## Testing
- PYTHONPATH=/tmp/atc-work/src pytest tests/unit/test_mcp_server.py tests/unit/test_mcp_stdio.py tests/unit/test_orchestration_models.py tests/unit/test_orchestration_errors.py tests/unit/test_orchestration_service.py tests/unit/test_orchestration_router.py tests/unit/test_orchestration_idempotency.py tests/unit/test_orchestration_history.py