### PR TITLE
feat: add Codex provider backend

### DIFF
--- a/src/atc/agents/codex_provider.py
+++ b/src/atc/agents/codex_provider.py
@@ -1,0 +1,221 @@
+"""CodexProvider — tmux-backed provider for OpenAI Codex CLI sessions."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import shutil
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncIterator
+
+from atc.agents.base import (
+    OutputChunk,
+    PromptResult,
+    ProviderCapabilities,
+    ProviderError,
+    ProviderSpawnRequest,
+    SessionInfo,
+    SessionStatus,
+)
+from atc.terminal.control import send_instruction_async
+
+logger = logging.getLogger(__name__)
+
+_TMUX_CMD = "tmux"
+
+
+class CodexProvider:
+    """Agent provider using Codex CLI in tmux panes.
+
+    This starts Codex in a tmux window for the same terminal visibility model
+    ATC already uses for Claude Code sessions.
+    """
+
+    def __init__(
+        self,
+        *,
+        tmux_session: str = "atc",
+        codex_command: str = "codex",
+    ) -> None:
+        self._tmux_session = tmux_session
+        self._codex_command = codex_command
+        self._sessions: dict[str, _TrackedSession] = {}
+
+    @property
+    def name(self) -> str:
+        return "codex"
+
+    def get_capabilities(self) -> ProviderCapabilities:
+        return ProviderCapabilities(
+            supports_streaming=True,
+            supports_tool_use=True,
+            context_window=200_000,
+            model="codex",
+        )
+
+    async def spawn_session(
+        self,
+        session_id: str,
+        *,
+        working_dir: str | None = None,
+        env: dict[str, str] | None = None,
+        context_file: Path | None = None,
+        role: str = "ace",
+    ) -> SessionInfo:
+        if session_id in self._sessions:
+            raise ProviderError(self.name, f"Session {session_id} already exists")
+
+        self._check_tmux_available()
+
+        if working_dir:
+            await self.prepare_workspace(session_id, working_dir=working_dir, context_file=context_file)
+
+        tmux_args = [_TMUX_CMD, "new-window", "-t", self._tmux_session, "-d", "-P", "-F", "#{pane_id}"]
+        if working_dir:
+            tmux_args.extend(["-c", working_dir])
+        tmux_args.append(self._codex_command)
+
+        try:
+            proc = await asyncio.create_subprocess_exec(
+                *tmux_args,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+            )
+            stdout, stderr = await proc.communicate()
+        except OSError as exc:
+            raise ProviderError(self.name, f"Failed to spawn tmux pane: {exc}") from exc
+
+        if proc.returncode != 0:
+            err = stderr.decode().strip()
+            raise ProviderError(self.name, f"tmux new-window failed: {err}")
+
+        pane_id = stdout.decode().strip()
+        tracked = _TrackedSession(session_id=session_id, pane_id=pane_id, status=SessionStatus.IDLE)
+        self._sessions[session_id] = tracked
+        logger.info("Spawned Codex session %s in pane %s", session_id, pane_id)
+        return tracked.to_info()
+
+    async def prepare_workspace(
+        self,
+        session_id: str,
+        *,
+        working_dir: str,
+        context_file: Path | None = None,
+    ) -> None:
+        import os as _os
+
+        _os.makedirs(working_dir, exist_ok=True)
+        if context_file is not None:
+            dest = Path(working_dir) / "CLAUDE.md"
+            if not dest.exists():
+                shutil.copy2(str(context_file), str(dest))
+                logger.info("prepare_workspace: copied %s → %s (session %s)", context_file, dest, session_id)
+
+    async def is_ready(self, session_id: str) -> bool:
+        tracked = self._sessions.get(session_id)
+        if tracked is None:
+            return False
+        return await self._pane_is_alive(tracked.pane_id)
+
+    async def handle_startup(self, session_id: str) -> None:
+        self._get_tracked(session_id)
+        return None
+
+    async def spawn_for_session(self, request: ProviderSpawnRequest) -> SessionInfo:
+        info = await self.spawn_session(
+            request.session.id,
+            working_dir=request.working_dir,
+            env=request.env,
+            context_file=request.context_file,
+            role=request.role,
+        )
+        await self.handle_startup(request.session.id)
+        return info
+
+    async def send_prompt(self, session_id: str, prompt: str) -> PromptResult:
+        tracked = self._get_tracked(session_id)
+        try:
+            await send_instruction_async(tracked.pane_id, prompt)
+        except Exception as exc:
+            raise ProviderError(self.name, f"send-keys failed: {exc}") from exc
+        tracked.status = SessionStatus.BUSY
+        return PromptResult(session_id=session_id, accepted=True)
+
+    async def get_status(self, session_id: str) -> SessionInfo:
+        tracked = self._get_tracked(session_id)
+        alive = await self._pane_is_alive(tracked.pane_id)
+        tracked.status = SessionStatus.IDLE if alive else SessionStatus.STOPPED
+        return tracked.to_info()
+
+    async def stream_output(self, session_id: str) -> AsyncIterator[OutputChunk]:
+        tracked = self._get_tracked(session_id)
+        content = await self._capture_pane(tracked.pane_id, lines=200)
+        yield OutputChunk(session_id=session_id, content=content, is_final=True)
+
+    async def stop_session(self, session_id: str) -> None:
+        tracked = self._get_tracked(session_id)
+        try:
+            proc = await asyncio.create_subprocess_exec(
+                _TMUX_CMD, "kill-pane", "-t", tracked.pane_id,
+                stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.PIPE,
+            )
+            await proc.communicate()
+        except OSError as exc:
+            raise ProviderError(self.name, f"kill-pane failed: {exc}") from exc
+        tracked.status = SessionStatus.STOPPED
+        del self._sessions[session_id]
+
+    async def list_sessions(self) -> list[SessionInfo]:
+        return [t.to_info() for t in self._sessions.values()]
+
+    async def _tmux_query(self, *args: str) -> str:
+        try:
+            proc = await asyncio.create_subprocess_exec(
+                _TMUX_CMD, *args,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+            )
+            stdout, stderr = await proc.communicate()
+        except OSError as exc:
+            raise ProviderError(self.name, f"tmux command failed: {exc}") from exc
+        if proc.returncode != 0:
+            raise ProviderError(self.name, stderr.decode().strip() or "tmux query failed")
+        return stdout.decode()
+
+    async def _capture_pane(self, pane_id: str, *, lines: int = 50) -> str:
+        return await self._tmux_query("capture-pane", "-t", pane_id, "-p", "-S", f"-{lines}")
+
+    async def _pane_is_alive(self, pane_id: str) -> bool:
+        try:
+            await self._tmux_query("has-session", "-t", pane_id)
+            return True
+        except ProviderError:
+            return False
+
+    def _get_tracked(self, session_id: str) -> _TrackedSession:
+        tracked = self._sessions.get(session_id)
+        if tracked is None:
+            raise ProviderError(self.name, f"Unknown session {session_id}")
+        return tracked
+
+    def _check_tmux_available(self) -> None:
+        if shutil.which(_TMUX_CMD) is None:
+            raise ProviderError(self.name, "tmux is not installed or not on PATH")
+
+
+@dataclass
+class _TrackedSession:
+    session_id: str
+    pane_id: str
+    status: SessionStatus
+
+    def to_info(self) -> SessionInfo:
+        return SessionInfo(
+            session_id=self.session_id,
+            status=self.status,
+            metadata={"pane_id": self.pane_id},
+        )

--- a/src/atc/agents/factory.py
+++ b/src/atc/agents/factory.py
@@ -28,6 +28,7 @@ _METADATA: dict[str, ProviderMetadata] = {}
 _LAUNCH_COMMANDS: dict[str, str] = {
     "claude_code": "claude --dangerously-skip-permissions",
     "opencode": "opencode",
+    "codex": "codex",
 }
 _SCANNED_DIRS: set[str] = set()
 
@@ -61,6 +62,12 @@ def create_provider(name: str, **kwargs: Any) -> AgentProvider:
         try:
             settings = load_settings()
             kwargs = {"claude_command": settings.agent_provider.claude_command}
+        except Exception:
+            kwargs = {}
+    if not kwargs and name == "codex":
+        try:
+            settings = load_settings()
+            kwargs = {"codex_command": settings.agent_provider.codex_command}
         except Exception:
             kwargs = {}
     provider: AgentProvider = cls(**kwargs)
@@ -162,6 +169,7 @@ def _register_builtins() -> None:
     """Register the built-in providers (claude_code, opencode)."""
     from atc.agents.claude_provider import ClaudeCodeProvider
     from atc.agents.opencode_provider import OpenCodeProvider
+    from atc.agents.codex_provider import CodexProvider
 
     register_provider(
         "claude_code",
@@ -170,6 +178,16 @@ def _register_builtins() -> None:
             name="claude_code",
             version="1.0.0",
             description="Claude Code via tmux panes",
+            author="ATC",
+        ),
+    )
+    register_provider(
+        "codex",
+        CodexProvider,
+        metadata=ProviderMetadata(
+            name="codex",
+            version="1.0.0",
+            description="Codex CLI via tmux panes",
             author="ATC",
         ),
     )

--- a/src/atc/api/routers/settings.py
+++ b/src/atc/api/routers/settings.py
@@ -141,6 +141,7 @@ class AgentProviderResponse(BaseModel):
     opencode_url: str
     tmux_session: str
     claude_command: str
+    codex_command: str
 
 
 class AgentProviderUpdateRequest(BaseModel):
@@ -150,6 +151,7 @@ class AgentProviderUpdateRequest(BaseModel):
     opencode_url: str | None = None
     tmux_session: str | None = None
     claude_command: str | None = None
+    codex_command: str | None = None
 
 
 class ProviderInfo(BaseModel):
@@ -172,6 +174,8 @@ async def get_agent_provider(request: Request) -> AgentProviderResponse:
         opencode_url=cfg.opencode_url,
         tmux_session=cfg.tmux_session,
         claude_command=cfg.claude_command,
+        codex_command=cfg.codex_command,
+        codex_command=cfg.codex_command,
     )
 
 
@@ -200,12 +204,15 @@ async def update_agent_provider(
         cfg.tmux_session = body.tmux_session
     if body.claude_command is not None:
         cfg.claude_command = body.claude_command
+    if body.codex_command is not None:
+        cfg.codex_command = body.codex_command
 
     return AgentProviderResponse(
         default=cfg.default,
         opencode_url=cfg.opencode_url,
         tmux_session=cfg.tmux_session,
         claude_command=cfg.claude_command,
+        codex_command=cfg.codex_command,
     )
 
 

--- a/src/atc/config.py
+++ b/src/atc/config.py
@@ -92,6 +92,7 @@ class AgentProviderConfig(BaseModel):
     opencode_password: str | None = None
     tmux_session: str = "atc"
     claude_command: str = "claude"
+    codex_command: str = "codex"
     plugin_dirs: list[str] = []
 
 

--- a/src/atc/session/ace.py
+++ b/src/atc/session/ace.py
@@ -376,7 +376,9 @@ async def create_ace(
             try:
                 from atc.agents.factory import create_provider
 
-                _provider = create_provider("claude_code")
+                project = await db_ops.get_project(conn, project_id)
+                provider_name = project.agent_provider if project and project.agent_provider else "claude_code"
+                _provider = create_provider(provider_name)
                 await _provider.prepare_workspace(
                     session.id, working_dir=effective_working_dir
                 )

--- a/tests/unit/test_agent_provider.py
+++ b/tests/unit/test_agent_provider.py
@@ -23,6 +23,7 @@ from atc.agents.base import (
     SessionStatus,
 )
 from atc.agents.claude_provider import ClaudeCodeProvider
+from atc.agents.codex_provider import CodexProvider
 from atc.agents.factory import (
     _LAUNCH_COMMANDS,
     _METADATA,
@@ -147,6 +148,9 @@ class TestProtocolCompliance:
     def test_opencode_is_agent_provider(self) -> None:
         assert isinstance(OpenCodeProvider(), AgentProvider)
 
+    def test_codex_is_agent_provider(self) -> None:
+        assert isinstance(CodexProvider(), AgentProvider)
+
 
 # ---------------------------------------------------------------------------
 # Factory
@@ -158,6 +162,7 @@ class TestFactory:
         names = list_providers()
         assert "claude_code" in names
         assert "opencode" in names
+        assert "codex" in names
 
     def test_create_claude_code(self) -> None:
         provider = create_provider("claude_code")
@@ -166,6 +171,10 @@ class TestFactory:
     def test_create_opencode(self) -> None:
         provider = create_provider("opencode", base_url="http://localhost:9999")
         assert provider.name == "opencode"
+
+    def test_create_codex(self) -> None:
+        provider = create_provider("codex")
+        assert provider.name == "codex"
 
     def test_create_unknown_raises(self) -> None:
         with pytest.raises(ProviderError, match="Unknown provider"):
@@ -595,6 +604,7 @@ class TestConfigIntegration:
         cfg = AgentProviderConfig()
         assert cfg.default == "claude_code"
         assert cfg.opencode_url == "http://localhost:4096"
+        assert cfg.codex_command == "codex"
         assert cfg.tmux_session == "atc"
 
     def test_settings_has_agent_provider(self) -> None:
@@ -602,6 +612,7 @@ class TestConfigIntegration:
 
         settings = Settings()
         assert settings.agent_provider.default == "claude_code"
+        assert settings.agent_provider.codex_command == "codex"
 
     def test_create_provider_from_config(self) -> None:
         from atc.config import AgentProviderConfig

--- a/tests/unit/test_codex_provider.py
+++ b/tests/unit/test_codex_provider.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from atc.agents.base import SessionStatus
+from atc.agents.codex_provider import CodexProvider
+
+
+def _make_process(returncode: int = 0, stdout: bytes = b"", stderr: bytes = b"") -> AsyncMock:
+    proc = AsyncMock()
+    proc.returncode = returncode
+    proc.communicate = AsyncMock(return_value=(stdout, stderr))
+    return proc
+
+
+class TestCodexProvider:
+    @pytest.fixture
+    def provider(self) -> CodexProvider:
+        return CodexProvider(tmux_session="test-atc")
+
+    @patch("shutil.which", return_value="/usr/bin/tmux")
+    @patch("asyncio.create_subprocess_exec")
+    async def test_spawn_session(
+        self,
+        mock_exec: AsyncMock,
+        _mock_which: MagicMock,
+        provider: CodexProvider,
+    ) -> None:
+        mock_exec.return_value = _make_process(stdout=b"%42\n")
+        info = await provider.spawn_session("worker-1", working_dir="/tmp/repo")
+        assert info.session_id == "worker-1"
+        assert info.status == SessionStatus.IDLE
+        assert info.metadata["pane_id"] == "%42"
+
+    @patch("shutil.which", return_value=None)
+    async def test_spawn_no_tmux_raises(
+        self,
+        _mock_which: MagicMock,
+        provider: CodexProvider,
+    ) -> None:
+        with pytest.raises(Exception, match="tmux"):
+            await provider.spawn_session("s1")


### PR DESCRIPTION
## Summary
- add a tmux-backed Codex provider implementation
- register Codex in the provider factory and settings config surface
- stop hardcoding Claude-only workspace prep in the ace spawn path
- add backend/provider tests for Codex and provider registry behavior

## Testing
- PYTHONPATH=/tmp/atc-work/src pytest tests/unit/test_agent_provider.py tests/unit/test_codex_provider.py tests/unit/test_provider_abstraction.py tests/unit/test_leader_orchestrator.py tests/unit/test_e2e_wiring.py