### PR TITLE
feat: wire codex provider through frontend settings

### DIFF
--- a/frontend/src/components/common/CreateProjectModal.tsx
+++ b/frontend/src/components/common/CreateProjectModal.tsx
@@ -1,6 +1,6 @@
 import { useState, useRef, useEffect } from "react";
 import { api } from "../../utils/api";
-import type { Project } from "../../types";
+import type { AgentProviderConfig, Project, ProviderInfo } from "../../types";
 import "./CreateProjectModal.css";
 
 const GITHUB_ORG_KEY = "atc:github_default_org";
@@ -20,11 +20,35 @@ export default function CreateProjectModal({
   const [description, setDescription] = useState("");
   const [repoPath, setRepoPath] = useState("");
   const [githubRepo, setGithubRepo] = useState("");
+  const [agentProvider, setAgentProvider] = useState<Project["agent_provider"]>("claude_code");
+  const [providers, setProviders] = useState<ProviderInfo[]>([]);
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const nameRef = useRef<HTMLInputElement>(null);
 
   const defaultOrg = localStorage.getItem(GITHUB_ORG_KEY) ?? "";
+
+  useEffect(() => {
+    let mounted = true;
+    void (async () => {
+      try {
+        const [providerList, providerConfig] = await Promise.all([
+          api.get<ProviderInfo[]>("/settings/providers"),
+          api.get<AgentProviderConfig>("/settings/agent-provider"),
+        ]);
+        if (!mounted) return;
+        setProviders(providerList);
+        if (providerConfig.default === "claude_code" || providerConfig.default === "codex" || providerConfig.default === "opencode") {
+          setAgentProvider(providerConfig.default);
+        }
+      } catch {
+        if (!mounted) return;
+      }
+    })();
+    return () => {
+      mounted = false;
+    };
+  }, []);
 
   useEffect(() => {
     if (open) {
@@ -62,6 +86,7 @@ export default function CreateProjectModal({
         description: description.trim() || null,
         repo_path: repoPath.trim() || null,
         github_repo: githubRepo.trim() || null,
+        agent_provider: agentProvider,
       });
       onCreated(project);
       onClose();
@@ -112,6 +137,21 @@ export default function CreateProjectModal({
                 placeholder="What this project does..."
                 rows={2}
               />
+            </div>
+
+            <div className="form-group">
+              <label htmlFor="project-provider">Agent Provider</label>
+              <select
+                id="project-provider"
+                value={agentProvider}
+                onChange={(e) => setAgentProvider(e.target.value as Project["agent_provider"])}
+              >
+                {providers.map((provider) => (
+                  <option key={provider.name} value={provider.name}>
+                    {provider.name}
+                  </option>
+                ))}
+              </select>
             </div>
 
             <div className="form-group">

--- a/frontend/src/components/leader/LeaderConsole.tsx
+++ b/frontend/src/components/leader/LeaderConsole.tsx
@@ -37,7 +37,7 @@ export default function LeaderConsole({
   const autoStarted = useRef(false);
   const userStopped = useRef(false);
 
-  const isClaudeCode = project?.agent_provider === "claude_code";
+  const isTerminalProvider = project?.agent_provider === "claude_code" || project?.agent_provider === "codex";
 
   const isRunning =
     leader?.status === "planning" || leader?.status === "managing";
@@ -50,7 +50,7 @@ export default function LeaderConsole({
 
   const { attachRef } = useTerminal({
     channel: terminalChannel,
-    enabled: (isRunning || (isClaudeCode && !!terminalChannel)) && !!terminalChannel,
+    enabled: (isRunning || (isTerminalProvider && !!terminalChannel)) && !!terminalChannel,
   });
 
   // Reset auto-start flag when the project changes so Leader
@@ -64,11 +64,11 @@ export default function LeaderConsole({
   // Respects userStopped ref to prevent re-starting after manual Stop.
   // Note: does NOT require `leader` to exist — handleStart() creates one if needed.
   useEffect(() => {
-    if (isClaudeCode && isIdle && !loading && !autoStarted.current && !userStopped.current) {
+    if (isTerminalProvider && isIdle && !loading && !autoStarted.current && !userStopped.current) {
       autoStarted.current = true;
       void handleStart();
     }
-  }, [isClaudeCode, isIdle, loading, projectId]); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [isTerminalProvider, isIdle, loading, projectId]); // eslint-disable-line react-hooks/exhaustive-deps
 
   async function handleStart() {
     userStopped.current = false;
@@ -170,7 +170,7 @@ export default function LeaderConsole({
         </div>
       )}
 
-      {!isRunning && !isClaudeCode && (
+      {!isRunning && !isTerminalProvider && (
         <div className="leader-console__start-form">
           <div className="form-group">
             <label htmlFor="leader-goal">Goal (optional)</label>
@@ -188,12 +188,12 @@ export default function LeaderConsole({
         </div>
       )}
 
-      {!isRunning && isClaudeCode && loading && (
+      {!isRunning && isTerminalProvider && loading && (
         <div className="leader-console__loading">Starting terminal...</div>
       )}
 
       {/* Terminal — always keep alive when running */}
-      {(isRunning || (isClaudeCode && !!terminalChannel)) && (
+      {(isRunning || (isTerminalProvider && !!terminalChannel)) && (
         <div className="leader-console__terminal" ref={attachRef} />
       )}
 

--- a/frontend/src/components/leader/__tests__/LeaderConsole.test.tsx
+++ b/frontend/src/components/leader/__tests__/LeaderConsole.test.tsx
@@ -3,14 +3,12 @@ import { screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import LeaderConsole from "../LeaderConsole";
 import { renderWithProviders } from "../../../test/helpers";
-import type { Leader } from "../../../types";
+import type { Leader, Project } from "../../../types";
 
-// Mock useTerminal to avoid xterm.js dependencies
 vi.mock("../../../hooks/useTerminal", () => ({
   useTerminal: () => ({ attachRef: vi.fn() }),
 }));
 
-// Mock WebSocket
 class MockWebSocket {
   onopen: (() => void) | null = null;
   onmessage: ((e: MessageEvent) => void) | null = null;
@@ -50,6 +48,18 @@ const planningLeader: Leader = {
   ...idleLeader,
   status: "planning",
   session_id: "sess-2",
+};
+
+const codexProject: Project = {
+  id: "proj-1",
+  name: "Codex Project",
+  description: null,
+  repo_path: null,
+  github_repo: null,
+  agent_provider: "codex",
+  status: "active",
+  created_at: "2024-01-01T00:00:00Z",
+  updated_at: "2024-01-01T00:00:00Z",
 };
 
 describe("LeaderConsole", () => {
@@ -153,10 +163,8 @@ describe("LeaderConsole", () => {
       <LeaderConsole projectId="proj-1" leader={managingLeader} onRefresh={onRefresh} />,
     );
 
-    // Click the Stop button (wrapped in ConfirmPopover)
     await user.click(screen.getByText("Stop"));
 
-    // Find and click the confirm button inside the popover
     const confirmButtons = screen.getAllByText("Stop");
     const confirmBtn = confirmButtons.find(
       (el) => el.closest(".confirm-popover__confirm") !== null,
@@ -186,7 +194,14 @@ describe("LeaderConsole", () => {
     await user.click(screen.getByText("Start"));
     expect(screen.getByText("Starting...")).toBeInTheDocument();
 
-    // Resolve to clean up
     resolvePost(new Response(JSON.stringify({ status: "started" }), { status: 200 }));
+  });
+
+  it("treats codex as a terminal-backed provider", () => {
+    renderWithProviders(
+      <LeaderConsole projectId="proj-1" leader={idleLeader} onRefresh={vi.fn()} project={codexProject} />,
+      { initialState: { projects: [codexProject] } },
+    );
+    expect(screen.queryByLabelText("Goal (optional)")).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/components/tower/SettingsPane.tsx
+++ b/frontend/src/components/tower/SettingsPane.tsx
@@ -1,5 +1,7 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { useAppContext } from "../../context/AppContext";
+import { api } from "../../utils/api";
+import type { AgentProviderConfig, ProviderInfo } from "../../types";
 import { BackupPanel } from "../settings/BackupPanel";
 import { ResourceLimitsPanel } from "../settings/ResourceLimitsPanel";
 import "./SettingsPane.css";
@@ -10,11 +12,44 @@ interface Props {
 
 const GITHUB_ORG_KEY = "atc:github_default_org";
 
+const EMPTY_PROVIDER_CONFIG: AgentProviderConfig = {
+  default: "claude_code",
+  opencode_url: "http://localhost:4096",
+  tmux_session: "atc",
+  claude_command: "claude",
+  codex_command: "codex",
+};
+
 export default function SettingsPane({ onClose }: Props) {
   const { state } = useAppContext();
   const [githubOrg, setGithubOrg] = useState(
     () => localStorage.getItem(GITHUB_ORG_KEY) ?? "",
   );
+  const [providerConfig, setProviderConfig] = useState<AgentProviderConfig>(EMPTY_PROVIDER_CONFIG);
+  const [providers, setProviders] = useState<ProviderInfo[]>([]);
+  const [savingProvider, setSavingProvider] = useState(false);
+  const [providerMessage, setProviderMessage] = useState<string | null>(null);
+
+  useEffect(() => {
+    let mounted = true;
+    void (async () => {
+      try {
+        const [cfg, providerList] = await Promise.all([
+          api.get<AgentProviderConfig>("/settings/agent-provider"),
+          api.get<ProviderInfo[]>("/settings/providers"),
+        ]);
+        if (!mounted) return;
+        setProviderConfig(cfg);
+        setProviders(providerList);
+      } catch (err) {
+        if (!mounted) return;
+        setProviderMessage(err instanceof Error ? err.message : "Failed to load provider settings");
+      }
+    })();
+    return () => {
+      mounted = false;
+    };
+  }, []);
 
   function handleGithubOrgChange(value: string) {
     setGithubOrg(value);
@@ -24,6 +59,24 @@ export default function SettingsPane({ onClose }: Props) {
       localStorage.removeItem(GITHUB_ORG_KEY);
     }
   }
+
+  async function saveProviderConfig(next: Partial<AgentProviderConfig>) {
+    const optimistic = { ...providerConfig, ...next };
+    setProviderConfig(optimistic);
+    setSavingProvider(true);
+    setProviderMessage(null);
+    try {
+      const saved = await api.put<AgentProviderConfig>("/settings/agent-provider", next);
+      setProviderConfig(saved);
+      setProviderMessage("Provider settings saved");
+    } catch (err) {
+      setProviderMessage(err instanceof Error ? err.message : "Failed to save provider settings");
+    } finally {
+      setSavingProvider(false);
+    }
+  }
+
+  const terminalBackedProviders = new Set(["claude_code", "codex"]);
 
   return (
     <div className="settings-pane" data-testid="settings-pane">
@@ -54,6 +107,76 @@ export default function SettingsPane({ onClose }: Props) {
             <span className="settings-pane__dot settings-pane__dot--connected" />
             Connected
           </div>
+        </section>
+
+        <section className="panel settings-pane__section">
+          <h3>Agent Provider</h3>
+          <div className="form-group">
+            <label htmlFor="provider-default">Default Provider</label>
+            <select
+              id="provider-default"
+              value={providerConfig.default}
+              onChange={(e) => void saveProviderConfig({ default: e.target.value })}
+              disabled={savingProvider}
+            >
+              {providers.map((provider) => (
+                <option key={provider.name} value={provider.name}>
+                  {provider.name}
+                </option>
+              ))}
+            </select>
+            <span className="form-hint">
+              {terminalBackedProviders.has(providerConfig.default)
+                ? "This provider uses live tmux terminal panes in the app."
+                : "This provider may use a non-terminal control flow even if a visibility pane exists."}
+            </span>
+          </div>
+
+          <div className="form-group">
+            <label htmlFor="provider-claude-command">Claude Code Command</label>
+            <input
+              id="provider-claude-command"
+              type="text"
+              value={providerConfig.claude_command}
+              onChange={(e) => setProviderConfig((prev) => ({ ...prev, claude_command: e.target.value }))}
+              onBlur={() => void saveProviderConfig({ claude_command: providerConfig.claude_command })}
+            />
+          </div>
+
+          <div className="form-group">
+            <label htmlFor="provider-codex-command">Codex Command</label>
+            <input
+              id="provider-codex-command"
+              type="text"
+              value={providerConfig.codex_command}
+              onChange={(e) => setProviderConfig((prev) => ({ ...prev, codex_command: e.target.value }))}
+              onBlur={() => void saveProviderConfig({ codex_command: providerConfig.codex_command })}
+            />
+          </div>
+
+          <div className="form-group">
+            <label htmlFor="provider-opencode-url">OpenCode URL</label>
+            <input
+              id="provider-opencode-url"
+              type="text"
+              value={providerConfig.opencode_url}
+              onChange={(e) => setProviderConfig((prev) => ({ ...prev, opencode_url: e.target.value }))}
+              onBlur={() => void saveProviderConfig({ opencode_url: providerConfig.opencode_url })}
+            />
+          </div>
+
+          <div className="form-group">
+            <label htmlFor="provider-tmux-session">tmux Session</label>
+            <input
+              id="provider-tmux-session"
+              type="text"
+              value={providerConfig.tmux_session}
+              onChange={(e) => setProviderConfig((prev) => ({ ...prev, tmux_session: e.target.value }))}
+              onBlur={() => void saveProviderConfig({ tmux_session: providerConfig.tmux_session })}
+            />
+          </div>
+
+          {providerMessage && <div className="form-hint">{providerMessage}</div>}
         </section>
 
         <section className="panel settings-pane__section">

--- a/frontend/src/components/tower/TowerConsole.tsx
+++ b/frontend/src/components/tower/TowerConsole.tsx
@@ -31,7 +31,7 @@ export default function TowerConsole() {
 
   // Check if the default project uses claude_code provider
   const activeProject = projects.find((p) => p.status === "active");
-  const isClaudeCode = activeProject?.agent_provider === "claude_code";
+  const isTerminalProvider = activeProject?.agent_provider === "claude_code" || activeProject?.agent_provider === "codex";
 
   const terminalChannel = towerDetail.current_session_id
     ? `terminal:${towerDetail.current_session_id}`
@@ -39,7 +39,7 @@ export default function TowerConsole() {
 
   const { attachRef } = useTerminal({
     channel: terminalChannel,
-    enabled: (isRunning || (isClaudeCode && !!terminalChannel)) && !!terminalChannel,
+    enabled: (isRunning || (isTerminalProvider && !!terminalChannel)) && !!terminalChannel,
   });
 
   // Default to first active project
@@ -50,19 +50,19 @@ export default function TowerConsole() {
   // Auto-start for claude_code provider on app load.
   // Respects userStopped ref to prevent re-starting after manual Stop.
   useEffect(() => {
-    if (isClaudeCode && isIdle && !loading && !autoStarted.current && !userStopped.current && projectId) {
+    if (isTerminalProvider && isIdle && !loading && !autoStarted.current && !userStopped.current && projectId) {
       autoStarted.current = true;
       void handleStart();
     }
-  }, [isClaudeCode, isIdle, loading, projectId]); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [isTerminalProvider, isIdle, loading, projectId]); // eslint-disable-line react-hooks/exhaustive-deps
 
   async function handleStart() {
     if (!projectId) return;
     userStopped.current = false;
     setLoading(true);
     try {
-      if (isClaudeCode) {
-        // For claude_code: start Tower's own Claude Code session
+      if (isTerminalProvider) {
+        // For terminal-backed CLI providers: start Tower's own session
         const res = await api.post<{ session_id?: string }>("/tower/start", {
           project_id: projectId,
         });
@@ -174,7 +174,7 @@ export default function TowerConsole() {
       </div>
 
       {/* Idle: goal form (only for non-claude_code providers) */}
-      {isIdle && !isClaudeCode && (
+      {isIdle && !isTerminalProvider && (
         <div className="tower-console__start-form">
           <div className="form-group">
             <label htmlFor="tower-project">Project</label>
@@ -214,7 +214,7 @@ export default function TowerConsole() {
       )}
 
       {/* Claude Code auto-starting indicator */}
-      {isIdle && isClaudeCode && loading && (
+      {isIdle && isTerminalProvider && loading && (
         <div className="tower-console__loading">Starting terminal...</div>
       )}
 
@@ -242,7 +242,7 @@ export default function TowerConsole() {
       )}
 
       {/* Running: terminal (input via xterm.js) */}
-      {(isRunning || (isClaudeCode && !!terminalChannel)) && (
+      {(isRunning || (isTerminalProvider && !!terminalChannel)) && (
         <div
           className="tower-console__terminal"
           ref={attachRef}

--- a/frontend/src/components/tower/__tests__/TowerConsole.test.tsx
+++ b/frontend/src/components/tower/__tests__/TowerConsole.test.tsx
@@ -34,7 +34,7 @@ describe("TowerConsole", () => {
     expect(screen.getByTestId("tower-console-start")).toHaveTextContent("Start");
   });
 
-  it("shows goal input and project select when idle", () => {
+  it("shows goal input and project select when idle for non-terminal providers", () => {
     renderWithProviders(<TowerConsole />);
     expect(screen.getByTestId("tower-console-goal")).toBeInTheDocument();
     expect(screen.getByTestId("tower-console-project")).toBeInTheDocument();
@@ -42,7 +42,6 @@ describe("TowerConsole", () => {
 
   it("shows status badge", () => {
     renderWithProviders(<TowerConsole />);
-    // The status badge should render with the brain status
     expect(screen.getByText("idle")).toBeInTheDocument();
   });
 
@@ -53,7 +52,27 @@ describe("TowerConsole", () => {
 
   it("disables Start when no project is selected", () => {
     renderWithProviders(<TowerConsole />);
-    // No projects available, so no project is selected
     expect(screen.getByTestId("tower-console-start")).toBeDisabled();
+  });
+
+  it("treats codex as a terminal-backed provider", () => {
+    renderWithProviders(<TowerConsole />, {
+      initialState: {
+        projects: [
+          {
+            id: "proj-1",
+            name: "Codex Project",
+            description: null,
+            repo_path: null,
+            github_repo: null,
+            agent_provider: "codex",
+            status: "active",
+            created_at: "2024-01-01T00:00:00Z",
+            updated_at: "2024-01-01T00:00:00Z",
+          },
+        ],
+      },
+    });
+    expect(screen.queryByTestId("tower-console-goal")).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -6,7 +6,7 @@ export interface Project {
   description: string | null;
   repo_path: string | null;
   github_repo: string | null;
-  agent_provider: "claude_code" | "opencode";
+  agent_provider: "claude_code" | "codex" | "opencode";
   status: "active" | "paused" | "archived";
   position?: number;
   created_at: string;
@@ -18,6 +18,7 @@ export interface AgentProviderConfig {
   opencode_url: string;
   tmux_session: string;
   claude_command: string;
+  codex_command: string;
 }
 
 export interface ProviderInfo {


### PR DESCRIPTION
## Summary\n- expose provider config in the Settings pane, including Codex command/default selection\n- allow project creation to choose the provider and default to the configured provider\n- treat Codex as a terminal-backed provider in Tower and Leader consoles\n- extend frontend console tests for Codex terminal-backed behavior\n\n## Validation\n- Backend provider slice already merged in #219\n- Local frontend validation in this checkout is currently env-blocked: frontend devDependencies are incomplete/stale ( and  binaries missing despite partial node_modules), so  / 
[41m                                                                               [0m
[41m[37m                This is not the tsc command you are looking for                [0m
[41m                                                                               [0m

To get access to the TypeScript compiler, [34mtsc[0m, from the command line either:

- Use [1mnpm install typescript[0m to first add TypeScript to your project [1mbefore[0m using npx
- Use [1myarn[0m to avoid accidentally running code from un-installed packages could not be run honestly here\n\n## Notes\n- This preserves PR workflow after a local mistaken commit on ; the commit was moved onto this branch before push