### PR TITLE
fix: remove duplicate codex settings field

### DIFF
--- a/src/atc/api/routers/settings.py
+++ b/src/atc/api/routers/settings.py
@@ -175,7 +175,6 @@ async def get_agent_provider(request: Request) -> AgentProviderResponse:
         tmux_session=cfg.tmux_session,
         claude_command=cfg.claude_command,
         codex_command=cfg.codex_command,
-        codex_command=cfg.codex_command,
     )
 
 


### PR DESCRIPTION
## Summary\n- remove duplicated  keyword from the settings router response\n- restore backend startup after the Codex provider merge\n\n## Validation\n- ........................................................................ [ 87%]
..........                                                               [100%]
82 passed in 2.30s