### PR TITLE
fix: auto-create tmux session for provider startup

### DIFF
--- a/frontend/src/components/tower/SettingsPane.tsx
+++ b/frontend/src/components/tower/SettingsPane.tsx
@@ -128,7 +128,7 @@ export default function SettingsPane({ onClose }: Props) {
             <span className="form-hint">
               {terminalBackedProviders.has(providerConfig.default)
                 ? "This provider uses live tmux terminal panes in the app."
-                : "This provider may use a non-terminal control flow even if a visibility pane exists."}
+                : "This provider may use a non-terminal control flow even if a visibility pane exists."} Default provider applies to new projects. Existing projects keep their saved provider until changed per-project.
             </span>
           </div>
 

--- a/src/atc/agents/claude_provider.py
+++ b/src/atc/agents/claude_provider.py
@@ -31,6 +31,7 @@ from atc.agents.claude_runtime import (
     wait_for_prompt as claude_wait_for_prompt,
 )
 from atc.terminal.control import send_instruction_async
+from atc.session.ace import _ensure_tmux_session
 
 logger = logging.getLogger(__name__)
 
@@ -109,6 +110,8 @@ class ClaudeCodeProvider:
 
         shell_cmd = f"{env_prefix}{' '.join(cmd_parts)}"
         logger.debug("spawn_session role=%s session=%s", role, session_id)
+
+        await _ensure_tmux_session(self._tmux_session)
 
         tmux_args = [
             _TMUX_CMD,

--- a/src/atc/agents/codex_provider.py
+++ b/src/atc/agents/codex_provider.py
@@ -22,6 +22,7 @@ from atc.agents.base import (
     SessionStatus,
 )
 from atc.terminal.control import send_instruction_async
+from atc.session.ace import _ensure_tmux_session
 
 logger = logging.getLogger(__name__)
 
@@ -73,6 +74,8 @@ class CodexProvider:
 
         if working_dir:
             await self.prepare_workspace(session_id, working_dir=working_dir, context_file=context_file)
+
+        await _ensure_tmux_session(self._tmux_session)
 
         tmux_args = [_TMUX_CMD, "new-window", "-t", self._tmux_session, "-d", "-P", "-F", "#{pane_id}"]
         if working_dir:

--- a/src/atc/agents/opencode_provider.py
+++ b/src/atc/agents/opencode_provider.py
@@ -28,6 +28,8 @@ from atc.agents.base import (
     SessionStatus,
 )
 
+from atc.session.ace import _ensure_tmux_session
+
 logger = logging.getLogger(__name__)
 
 _TMUX_CMD = "tmux"
@@ -97,6 +99,7 @@ class OpenCodeProvider:
         if shutil.which(_TMUX_CMD) is None:
             raise ProviderError(self.name, "tmux is not installed or not on PATH")
 
+        await _ensure_tmux_session(self._tmux_session)
         server_session = f"{self._tmux_session}-opencode-server"
 
         # Check if the tmux session already exists

--- a/src/atc/core/health.py
+++ b/src/atc/core/health.py
@@ -10,6 +10,7 @@ from dataclasses import dataclass
 from atc.session.ace import (
     ATC_TMUX_SESSION,
     _capture_pane,
+    _ensure_tmux_session,
     _kill_pane,
     _spawn_pane,
     _tmux_run,
@@ -37,6 +38,7 @@ async def run_startup_smoke_test() -> HealthResult:
     pane_id: str | None = None
 
     try:
+        await _ensure_tmux_session(ATC_TMUX_SESSION)
         pane_id = await _spawn_pane(ATC_TMUX_SESSION, "bash")
 
         # Give bash a moment to start

--- a/tests/unit/test_agent_provider.py
+++ b/tests/unit/test_agent_provider.py
@@ -581,15 +581,19 @@ class TestOpenCodeProvider:
         mock_exec.side_effect = [
             # First: API check fails (server not running)
             _make_process(returncode=1, stderr=b"Connection refused"),
-            # Second: has-session check (session doesn't exist)
+            # Second: shared atc tmux session check (session doesn't exist)
             _make_process(returncode=1, stderr=b"no session"),
-            # Third: new-session to start opencode serve
+            # Third: create shared atc tmux session
             _make_process(returncode=0),
-            # Fourth: retry API check succeeds
+            # Fourth: opencode server session check (session doesn't exist)
+            _make_process(returncode=1, stderr=b"no session"),
+            # Fifth: new-session to start opencode serve
+            _make_process(returncode=0),
+            # Sixth: retry API check succeeds
             _make_process(stdout=b'{"sessions": []}'),
         ]
         await provider.ensure_server_running()
-        assert mock_exec.call_count == 4
+        assert mock_exec.call_count == 6
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- auto-create the shared tmux session before startup smoke tests and terminal-backed provider spawns
- cover the extra tmux bootstrap behavior in provider tests
- clarify in Settings that the default provider only applies to new projects, while existing projects keep their saved provider

## Why
- `make dev` was failing on fresh/dev setups with `can't find window: atc`
- switching the default provider was confusing because existing projects still used their saved provider

## Validation
- `PYTHONPATH=src python3 -m pytest -q tests/unit/test_provider_abstraction.py tests/unit/test_agent_provider.py`
