### PR TITLE
feat: apply selected provider by restarting live Tower

### DIFF
--- a/frontend/src/components/tower/TowerConsole.tsx
+++ b/frontend/src/components/tower/TowerConsole.tsx
@@ -31,14 +31,20 @@ export default function TowerConsole() {
   const activeTowerProvider = activeTowerProject?.agent_provider ?? null;
   const isTerminalProvider = selectedProvider !== null && terminalBackedProviders.has(selectedProvider);
   const towerSessionProvider = towerDetail.current_session_id ? activeTowerProvider : null;
-  const towerProviderMismatch = Boolean(
+  const towerProjectMismatch = Boolean(
     towerDetail.current_session_id &&
       selectedProject &&
       activeTowerProject &&
+      selectedProject.id !== activeTowerProject.id,
+  );
+  const towerProviderMismatch = Boolean(
+    towerSessionProvider &&
       selectedProvider &&
-      towerSessionProvider &&
-      selectedProject.id !== activeTowerProject.id &&
+      towerProjectMismatch &&
       selectedProvider !== towerSessionProvider,
+  );
+  const canApplySelectedProvider = Boolean(
+    selectedProject && selectedProvider && isTerminalProvider,
   );
 
   const isRunning =
@@ -127,13 +133,16 @@ export default function TowerConsole() {
   }
 
   async function handleRestartWithSelectedProvider() {
-    if (!projectId || !selectedProvider) return;
+    if (!projectId || !selectedProvider || !canApplySelectedProvider) return;
     userStopped.current = false;
     setLoading(true);
     try {
-      await api.patch(`/projects/${projectId}/agent-provider`, {
+      const updatedProject = await api.patch<typeof selectedProject>(`/projects/${projectId}/agent-provider`, {
         agent_provider: selectedProvider,
       });
+      if (updatedProject) {
+        dispatch({ type: "UPDATE_PROJECT", payload: updatedProject });
+      }
       if (towerDetail.current_session_id) {
         await api.post("/tower/stop");
       }
@@ -143,6 +152,7 @@ export default function TowerConsole() {
       dispatch({
         type: "SET_TOWER_DETAIL",
         payload: {
+          state: "managing",
           current_session_id: res.session_id ?? null,
           current_project_id: projectId,
           current_goal: null,
@@ -211,16 +221,28 @@ export default function TowerConsole() {
         </div>
       </div>
 
-      {towerProviderMismatch && (
+      {towerProjectMismatch && (
         <div className="tower-console__error" data-testid="tower-console-provider-mismatch">
-          Tower is currently running with <strong>{towerSessionProvider}</strong>, but the selected project is set to <strong>{selectedProvider}</strong>.
+          Tower is currently attached to <strong>{activeTowerProject?.name ?? "another project"}</strong>
+          {towerSessionProvider ? (
+            <>
+              {" "}using <strong>{towerSessionProvider}</strong>
+            </>
+          ) : null}
+          , while the selected project is <strong>{selectedProject?.name}</strong>
+          {selectedProvider ? (
+            <>
+              {" "}with <strong>{selectedProvider}</strong>
+            </>
+          ) : null}
+          . Restart Tower to switch live session context.
           <button
             className="btn btn-sm"
             onClick={handleRestartWithSelectedProvider}
-            disabled={loading}
+            disabled={loading || !canApplySelectedProvider}
             data-testid="tower-console-restart-provider"
           >
-            {loading ? "Applying..." : "Apply to Tower and restart"}
+            {loading ? "Applying..." : "Apply selected project and restart Tower"}
           </button>
         </div>
       )}

--- a/frontend/src/components/tower/__tests__/TowerConsole.test.tsx
+++ b/frontend/src/components/tower/__tests__/TowerConsole.test.tsx
@@ -76,7 +76,7 @@ describe("TowerConsole", () => {
     expect(screen.queryByTestId("tower-console-goal")).not.toBeInTheDocument();
   });
 
-  it("does not show a mismatch warning just because a different project is selected", () => {
+  it("shows a mismatch warning when Tower is attached to a different project", () => {
     renderWithProviders(<TowerConsole />, {
       initialState: {
         projects: [
@@ -113,6 +113,9 @@ describe("TowerConsole", () => {
         },
       },
     });
-    expect(screen.queryByTestId("tower-console-provider-mismatch")).not.toBeInTheDocument();
+    expect(screen.getByTestId("tower-console-provider-mismatch")).toBeInTheDocument();
+    expect(screen.getByTestId("tower-console-restart-provider")).toHaveTextContent(
+      "Apply selected project and restart Tower",
+    );
   });
 });


### PR DESCRIPTION
## Summary
- surface the live Tower project/provider mismatch even when the session is attached to a different project
- make the apply action update the selected project provider, stop the existing Tower session, and restart Tower into the selected project context
- tighten Tower console coverage around the new mismatch and restart affordance

## Testing
- not run: `cd frontend && npm test` still fails in this checkout because `vitest` is missing locally (`sh: 1: vitest: not found`)
- not run: local Python unit tests are also environment-blocked in this checkout because the repo virtualenv is incomplete and plain `pytest` cannot import `atc`
