### PR TITLE
feat: make Tower provider apply semantics explicit in settings

### DIFF
--- a/frontend/src/components/tower/SettingsPane.css
+++ b/frontend/src/components/tower/SettingsPane.css
@@ -101,3 +101,24 @@
 .settings-pane__dot--connected {
   background: var(--color-status-green);
 }
+
+.settings-pane__provider-actions {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+  margin-top: var(--space-3);
+  padding-top: var(--space-3);
+  border-top: 1px solid var(--color-border-subtle);
+}
+
+.settings-pane__provider-action-buttons {
+  display: flex;
+  gap: var(--space-2);
+  flex-wrap: wrap;
+}
+
+.settings-pane__provider-status {
+  border: 1px solid var(--color-border-subtle);
+  border-radius: var(--radius-md);
+  overflow: hidden;
+}

--- a/frontend/src/components/tower/SettingsPane.tsx
+++ b/frontend/src/components/tower/SettingsPane.tsx
@@ -1,7 +1,7 @@
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { useAppContext } from "../../context/AppContext";
 import { api } from "../../utils/api";
-import type { AgentProviderConfig, ProviderInfo } from "../../types";
+import type { AgentProviderConfig, Project, ProviderInfo } from "../../types";
 import { BackupPanel } from "../settings/BackupPanel";
 import { ResourceLimitsPanel } from "../settings/ResourceLimitsPanel";
 import "./SettingsPane.css";
@@ -21,7 +21,7 @@ const EMPTY_PROVIDER_CONFIG: AgentProviderConfig = {
 };
 
 export default function SettingsPane({ onClose }: Props) {
-  const { state } = useAppContext();
+  const { state, dispatch } = useAppContext();
   const [githubOrg, setGithubOrg] = useState(
     () => localStorage.getItem(GITHUB_ORG_KEY) ?? "",
   );
@@ -29,6 +29,8 @@ export default function SettingsPane({ onClose }: Props) {
   const [providers, setProviders] = useState<ProviderInfo[]>([]);
   const [savingProvider, setSavingProvider] = useState(false);
   const [providerMessage, setProviderMessage] = useState<string | null>(null);
+  const [providerActionProjectId, setProviderActionProjectId] = useState<string>("");
+  const [applyingProvider, setApplyingProvider] = useState(false);
 
   useEffect(() => {
     let mounted = true;
@@ -50,6 +52,47 @@ export default function SettingsPane({ onClose }: Props) {
       mounted = false;
     };
   }, []);
+
+  const activeProjects = useMemo(
+    () => state.projects.filter((project) => project.status === "active"),
+    [state.projects],
+  );
+
+  const selectedProviderActionProject =
+    activeProjects.find((project) => project.id === providerActionProjectId) ?? null;
+  const activeTowerProject = state.towerDetail.current_project_id
+    ? state.projects.find((project) => project.id === state.towerDetail.current_project_id) ?? null
+    : null;
+  const terminalBackedProviders = new Set(["claude_code", "codex"]);
+  const savedProjectProvider = selectedProviderActionProject?.agent_provider ?? null;
+  const defaultMatchesSelectedProject = Boolean(
+    savedProjectProvider && providerConfig.default === savedProjectProvider,
+  );
+  const towerAlreadyOnSelectedProject = Boolean(
+    state.towerDetail.current_session_id &&
+      activeTowerProject &&
+      selectedProviderActionProject &&
+      activeTowerProject.id === selectedProviderActionProject.id,
+  );
+  const towerNeedsRestartForSelectedProject = Boolean(
+    selectedProviderActionProject &&
+      terminalBackedProviders.has(selectedProviderActionProject.agent_provider) &&
+      (!towerAlreadyOnSelectedProject || activeTowerProject?.agent_provider !== selectedProviderActionProject.agent_provider),
+  );
+  const canRestartTowerWithSelectedProject = Boolean(
+    selectedProviderActionProject && terminalBackedProviders.has(selectedProviderActionProject.agent_provider),
+  );
+
+  useEffect(() => {
+    if (providerActionProjectId) return;
+    if (activeTowerProject) {
+      setProviderActionProjectId(activeTowerProject.id);
+      return;
+    }
+    if (activeProjects.length > 0) {
+      setProviderActionProjectId(activeProjects[0].id);
+    }
+  }, [providerActionProjectId, activeProjects, activeTowerProject]);
 
   function handleGithubOrgChange(value: string) {
     setGithubOrg(value);
@@ -76,7 +119,55 @@ export default function SettingsPane({ onClose }: Props) {
     }
   }
 
-  const terminalBackedProviders = new Set(["claude_code", "codex"]);
+  async function handleApplyProviderSettingToProject() {
+    if (!providerConfig.default || !providerActionProjectId) return;
+    setApplyingProvider(true);
+    setProviderMessage(null);
+    try {
+      const updatedProject = await api.patch<Project>(`/projects/${providerActionProjectId}/agent-provider`, {
+        agent_provider: providerConfig.default,
+      });
+      dispatch({ type: "UPDATE_PROJECT", payload: updatedProject });
+      setProviderMessage(
+        state.towerDetail.current_session_id && activeTowerProject?.id === providerActionProjectId
+          ? "Project provider updated. Restart Tower below to apply it to the live session."
+          : "Project provider updated.",
+      );
+    } catch (err) {
+      setProviderMessage(err instanceof Error ? err.message : "Failed to apply provider to project");
+    } finally {
+      setApplyingProvider(false);
+    }
+  }
+
+  async function handleRestartTowerForSelectedProject() {
+    if (!providerActionProjectId || !canRestartTowerWithSelectedProject) return;
+    setApplyingProvider(true);
+    setProviderMessage(null);
+    try {
+      if (state.towerDetail.current_session_id) {
+        await api.post("/tower/stop");
+      }
+      const res = await api.post<{ session_id?: string }>("/tower/start", {
+        project_id: providerActionProjectId,
+      });
+      setProviderMessage("Tower restarted with the selected project provider.");
+      dispatch({
+        type: "SET_TOWER_DETAIL",
+        payload: {
+          state: "managing",
+          current_session_id: res.session_id ?? null,
+          current_project_id: providerActionProjectId,
+          current_goal: null,
+          leader_session_id: null,
+        },
+      });
+    } catch (err) {
+      setProviderMessage(err instanceof Error ? err.message : "Failed to restart Tower");
+    } finally {
+      setApplyingProvider(false);
+    }
+  }
 
   return (
     <div className="settings-pane" data-testid="settings-pane">
@@ -174,6 +265,77 @@ export default function SettingsPane({ onClose }: Props) {
               onChange={(e) => setProviderConfig((prev) => ({ ...prev, tmux_session: e.target.value }))}
               onBlur={() => void saveProviderConfig({ tmux_session: providerConfig.tmux_session })}
             />
+          </div>
+
+          <div className="settings-pane__provider-actions">
+            <div className="form-group">
+              <label htmlFor="provider-action-project">Apply default provider to project</label>
+              <select
+                id="provider-action-project"
+                value={providerActionProjectId}
+                onChange={(e) => setProviderActionProjectId(e.target.value)}
+                disabled={applyingProvider || activeProjects.length === 0}
+                data-testid="provider-action-project"
+              >
+                <option value="" disabled>
+                  Select active project...
+                </option>
+                {activeProjects.map((project) => (
+                  <option key={project.id} value={project.id}>
+                    {project.name}
+                  </option>
+                ))}
+              </select>
+              <span className="form-hint">
+                Changing the default provider only affects new projects. Use these actions to update an existing project and, if needed, restart the live Tower session with that project context.
+              </span>
+            </div>
+
+            {selectedProviderActionProject && (
+              <div className="settings-pane__provider-status" data-testid="provider-action-status">
+                <div className="settings-pane__info-row">
+                  <span className="settings-pane__label">Default provider</span>
+                  <span className="settings-pane__value">{providerConfig.default}</span>
+                </div>
+                <div className="settings-pane__info-row">
+                  <span className="settings-pane__label">Selected project provider</span>
+                  <span className="settings-pane__value">{savedProjectProvider}</span>
+                </div>
+                <div className="settings-pane__info-row">
+                  <span className="settings-pane__label">Live Tower session</span>
+                  <span className="settings-pane__value">
+                    {state.towerDetail.current_session_id
+                      ? `${activeTowerProject?.name ?? "Unknown"} (${activeTowerProject?.agent_provider ?? "unknown"})`
+                      : "Not running"}
+                  </span>
+                </div>
+              </div>
+            )}
+
+            <div className="settings-pane__provider-action-buttons">
+              <button
+                className="btn btn-sm"
+                onClick={() => void handleApplyProviderSettingToProject()}
+                disabled={applyingProvider || !providerActionProjectId || defaultMatchesSelectedProject}
+                data-testid="provider-apply-project"
+              >
+                {applyingProvider ? "Applying..." : defaultMatchesSelectedProject ? "Project already matches default" : "Apply default to project"}
+              </button>
+              <button
+                className="btn btn-sm"
+                onClick={() => void handleRestartTowerForSelectedProject()}
+                disabled={applyingProvider || !canRestartTowerWithSelectedProject || !towerNeedsRestartForSelectedProject}
+                data-testid="provider-restart-tower"
+              >
+                {applyingProvider ? "Applying..." : towerNeedsRestartForSelectedProject ? "Restart Tower with selected project" : "Tower already matches selected project"}
+              </button>
+            </div>
+
+            <span className="form-hint">
+              {towerNeedsRestartForSelectedProject
+                ? "The saved project provider and the live Tower session are still distinct. Restart Tower after applying if you want the visible session to move over too."
+                : "The selected project and live Tower session already line up, so no restart is needed right now."}
+            </span>
           </div>
 
           {providerMessage && <div className="form-hint">{providerMessage}</div>}

--- a/frontend/src/components/tower/__tests__/SettingsPane.test.tsx
+++ b/frontend/src/components/tower/__tests__/SettingsPane.test.tsx
@@ -1,0 +1,225 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import SettingsPane from "../SettingsPane";
+import { renderWithProviders } from "../../../test/helpers";
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("SettingsPane", () => {
+  it("shows provider action controls for existing projects", async () => {
+    const fetchMock = vi.spyOn(globalThis, "fetch");
+    fetchMock
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            default: "codex",
+            opencode_url: "http://localhost:4096",
+            tmux_session: "atc",
+            claude_command: "claude",
+            codex_command: "codex",
+          }),
+          { status: 200 },
+        ),
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify([
+            {
+              name: "claude_code",
+              supports_streaming: true,
+              supports_tool_use: true,
+              context_window: 200000,
+              model: "claude",
+            },
+            {
+              name: "codex",
+              supports_streaming: true,
+              supports_tool_use: true,
+              context_window: 200000,
+              model: "codex",
+            },
+          ]),
+          { status: 200 },
+        ),
+      );
+
+    renderWithProviders(<SettingsPane onClose={() => undefined} />, {
+      initialState: {
+        projects: [
+          {
+            id: "proj-1",
+            name: "Alpha",
+            description: null,
+            repo_path: null,
+            github_repo: null,
+            agent_provider: "claude_code",
+            status: "active",
+            created_at: "2024-01-01T00:00:00Z",
+            updated_at: "2024-01-01T00:00:00Z",
+          },
+        ],
+      },
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("provider-action-project")).toBeInTheDocument();
+    });
+    expect(screen.getByTestId("provider-apply-project")).toBeInTheDocument();
+    expect(screen.getByTestId("provider-restart-tower")).toBeInTheDocument();
+    expect(screen.getByTestId("provider-action-status")).toBeInTheDocument();
+  });
+
+  it("applies the default provider to the selected project", async () => {
+    const user = userEvent.setup();
+    const fetchMock = vi.spyOn(globalThis, "fetch");
+    fetchMock
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            default: "codex",
+            opencode_url: "http://localhost:4096",
+            tmux_session: "atc",
+            claude_command: "claude",
+            codex_command: "codex",
+          }),
+          { status: 200 },
+        ),
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify([
+            {
+              name: "claude_code",
+              supports_streaming: true,
+              supports_tool_use: true,
+              context_window: 200000,
+              model: "claude",
+            },
+            {
+              name: "codex",
+              supports_streaming: true,
+              supports_tool_use: true,
+              context_window: 200000,
+              model: "codex",
+            },
+          ]),
+          { status: 200 },
+        ),
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            id: "proj-1",
+            name: "Alpha",
+            description: null,
+            repo_path: null,
+            github_repo: null,
+            agent_provider: "codex",
+            status: "active",
+            created_at: "2024-01-01T00:00:00Z",
+            updated_at: "2024-01-01T00:00:01Z",
+          }),
+          { status: 200 },
+        ),
+      );
+
+    renderWithProviders(<SettingsPane onClose={() => undefined} />, {
+      initialState: {
+        projects: [
+          {
+            id: "proj-1",
+            name: "Alpha",
+            description: null,
+            repo_path: null,
+            github_repo: null,
+            agent_provider: "claude_code",
+            status: "active",
+            created_at: "2024-01-01T00:00:00Z",
+            updated_at: "2024-01-01T00:00:00Z",
+          },
+        ],
+      },
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("provider-apply-project")).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByTestId("provider-apply-project"));
+
+    await waitFor(() => {
+      expect(screen.getByText("Project provider updated.")).toBeInTheDocument();
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "http://127.0.0.1:8420/api/projects/proj-1/agent-provider",
+      expect.objectContaining({ method: "PATCH" }),
+    );
+  });
+
+  it("disables apply when the selected project already matches the default provider", async () => {
+    const fetchMock = vi.spyOn(globalThis, "fetch");
+    fetchMock
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            default: "codex",
+            opencode_url: "http://localhost:4096",
+            tmux_session: "atc",
+            claude_command: "claude",
+            codex_command: "codex",
+          }),
+          { status: 200 },
+        ),
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify([
+            {
+              name: "claude_code",
+              supports_streaming: true,
+              supports_tool_use: true,
+              context_window: 200000,
+              model: "claude",
+            },
+            {
+              name: "codex",
+              supports_streaming: true,
+              supports_tool_use: true,
+              context_window: 200000,
+              model: "codex",
+            },
+          ]),
+          { status: 200 },
+        ),
+      );
+
+    renderWithProviders(<SettingsPane onClose={() => undefined} />, {
+      initialState: {
+        projects: [
+          {
+            id: "proj-1",
+            name: "Alpha",
+            description: null,
+            repo_path: null,
+            github_repo: null,
+            agent_provider: "codex",
+            status: "active",
+            created_at: "2024-01-01T00:00:00Z",
+            updated_at: "2024-01-01T00:00:00Z",
+          },
+        ],
+      },
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("provider-apply-project")).toBeDisabled();
+    });
+    expect(screen.getByTestId("provider-apply-project")).toHaveTextContent(
+      "Project already matches default",
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- add explicit provider action controls in Settings for applying the default provider to an existing active project
- show the current default provider, selected project provider, and live Tower session side by side so the distinction is obvious
- disable action buttons when the selected project already matches the default or when the live Tower session already lines up, so the flow explains itself instead of encouraging unnecessary restarts
- add SettingsPane coverage for the new provider action/status UI

## Testing
- not run: `cd frontend && npm test` still fails in this checkout because `vitest` is missing locally (`sh: 1: vitest: not found`)
