### PR TITLE
fix: sync reused Tower session project context

### DIFF
--- a/frontend/src/context/AppContext.tsx
+++ b/frontend/src/context/AppContext.tsx
@@ -375,6 +375,7 @@ export function AppProvider({ children }: AppProviderProps) {
           type: "SET_TOWER_DETAIL",
           payload: {
             current_session_id: (data.session_id as string) ?? null,
+            current_project_id: (data.project_id as string) ?? null,
           },
         });
       } else if (data.type === "leader_status") {

--- a/src/atc/tower/controller.py
+++ b/src/atc/tower/controller.py
@@ -164,14 +164,19 @@ class TowerController:
         Returns the tower session id.  If a session already exists, returns
         its id without spawning a new one.
         """
-        self._current_project_id = project_id
+        requested_project_id = project_id
+        self._current_project_id = requested_project_id
 
         session_id = await start_tower_session(
             self._db,
-            project_id,
+            requested_project_id,
             event_bus=self._event_bus,
         )
         self._current_session_id = session_id
+
+        session = await db_ops.get_session(self._db, session_id)
+        actual_project_id = session.project_id if session is not None else requested_project_id
+        self._current_project_id = actual_project_id
 
         # Transition to MANAGING so the frontend shows the terminal
         if self._state in (TowerState.IDLE, TowerState.COMPLETE, TowerState.ERROR):
@@ -190,7 +195,8 @@ class TowerController:
                     "type": "tower_session",
                     "session_id": session_id,
                     "status": "idle",
-                    "project_id": project_id,
+                    "project_id": actual_project_id,
+                    "requested_project_id": requested_project_id,
                     "provider": session.provider if session else None,
                 },
             )


### PR DESCRIPTION
## Summary
- sync Tower controller state to the actual reused session project after start/restart
- include reused tower project context in the tower_session websocket payload so the frontend tracks the real active Tower project
- fix the frontend tower session handler to update current_project_id alongside current_session_id

## Testing
- not run: local frontend/unit validation is still environment-blocked in this checkout
- not run: broader app repro still needs validation on a healthy dev environment, ideally the Mac repro path Matthew hit

## Repro context
- reported Slack repro: switching provider to Codex, stopping Tower, then restarting could leave the UI with an empty/idle Tower panel while backend reused an older Tower session anchored to prior context
