### PR TITLE
feat: add session provider and scope metadata

### DIFF
--- a/src/atc/leader/leader.py
+++ b/src/atc/leader/leader.py
@@ -97,11 +97,16 @@ async def start_leader(
     project = await db_ops.get_project(conn, project_id)
     name = f"leader-{project.name}" if project else f"leader-{project_id[:8]}"
 
+    provider = project.agent_provider if project and project.agent_provider else "claude_code"
+
     session = await db_ops.create_session(
         conn,
         project_id=project_id,
         session_type="manager",
         name=name,
+        provider=provider,
+        scope_type="project",
+        scope_id=project_id,
         status=SessionStatus.CONNECTING.value,
     )
 

--- a/src/atc/session/ace.py
+++ b/src/atc/session/ace.py
@@ -335,11 +335,17 @@ async def create_ace(
             hooks, settings.json) using the real session_id after DB creation.
     """
     # Step 1: DB row first — guarantees the UI always sees every entity
+    project = await db_ops.get_project(conn, project_id)
+    provider = project.agent_provider if project and project.agent_provider else "claude_code"
+
     session = await db_ops.create_session(
         conn,
         project_id=project_id,
         session_type="ace",
         name=name,
+        provider=provider,
+        scope_type="project",
+        scope_id=project_id,
         task_id=task_id,
         host=host,
         status=SessionStatus.CONNECTING.value,
@@ -376,8 +382,7 @@ async def create_ace(
             try:
                 from atc.agents.factory import create_provider
 
-                project = await db_ops.get_project(conn, project_id)
-                provider_name = project.agent_provider if project and project.agent_provider else "claude_code"
+                provider_name = provider
                 _provider = create_provider(provider_name)
                 await _provider.prepare_workspace(
                     session.id, working_dir=effective_working_dir

--- a/src/atc/state/db.py
+++ b/src/atc/state/db.py
@@ -240,6 +240,9 @@ CREATE TABLE IF NOT EXISTS sessions (
     task_id         TEXT,
     name            TEXT NOT NULL,
     status          TEXT NOT NULL DEFAULT 'idle',
+    provider        TEXT NOT NULL DEFAULT 'claude_code',
+    scope_type      TEXT NOT NULL DEFAULT 'project',
+    scope_id        TEXT,
     host            TEXT,
     tmux_session    TEXT,
     tmux_pane       TEXT,
@@ -845,6 +848,9 @@ async def create_session(
     session_type: str,
     name: str,
     *,
+    provider: str = "claude_code",
+    scope_type: str = "project",
+    scope_id: str | None = None,
     task_id: str | None = None,
     host: str | None = None,
     status: str = "connecting",
@@ -857,6 +863,9 @@ async def create_session(
         session_type=session_type,
         name=name,
         status=status,
+        provider=provider,
+        scope_type=scope_type,
+        scope_id=scope_id if scope_id is not None else project_id,
         task_id=task_id,
         host=host,
         created_at=now,
@@ -864,9 +873,9 @@ async def create_session(
     )
     await db.execute(
         """INSERT INTO sessions
-           (id, project_id, session_type, task_id, name, status, host,
+           (id, project_id, session_type, task_id, name, status, provider, scope_type, scope_id, host,
             tmux_session, tmux_pane, alternate_on, auto_accept, created_at, updated_at)
-           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
         (
             session.id,
             session.project_id,
@@ -874,6 +883,9 @@ async def create_session(
             session.task_id,
             session.name,
             session.status,
+            session.provider,
+            session.scope_type,
+            session.scope_id,
             session.host,
             session.tmux_session,
             session.tmux_pane,

--- a/src/atc/state/migrations/versions/015_session_provider_scope.sql
+++ b/src/atc/state/migrations/versions/015_session_provider_scope.sql
@@ -1,0 +1,15 @@
+-- Add provider and explicit scope metadata to sessions.
+-- This is the first staged slice of the provider/session-scope refactor.
+
+ALTER TABLE sessions ADD COLUMN provider TEXT NOT NULL DEFAULT 'claude_code';
+ALTER TABLE sessions ADD COLUMN scope_type TEXT NOT NULL DEFAULT 'project';
+ALTER TABLE sessions ADD COLUMN scope_id TEXT;
+
+-- Backfill existing rows so old project-scoped sessions remain coherent.
+UPDATE sessions
+SET scope_type = 'project',
+    scope_id = project_id
+WHERE scope_id IS NULL;
+
+CREATE INDEX IF NOT EXISTS idx_sessions_scope ON sessions(scope_type, scope_id);
+CREATE INDEX IF NOT EXISTS idx_sessions_provider ON sessions(provider);

--- a/src/atc/state/models.py
+++ b/src/atc/state/models.py
@@ -49,6 +49,9 @@ class Session:
     session_type: str  # ace|manager|tower
     name: str
     status: str  # idle|connecting|working|paused|waiting|disconnected|error
+    provider: str = "claude_code"
+    scope_type: str = "project"  # global|project
+    scope_id: str | None = None
     task_id: str | None = None
     host: str | None = None
     tmux_session: str | None = None

--- a/src/atc/tower/session.py
+++ b/src/atc/tower/session.py
@@ -187,11 +187,16 @@ async def start_tower_session(
                 raise RuntimeError(str(exc)) from exc
             return sess.id
 
+    provider = project.agent_provider if project else "claude_code"
+
     session = await db_ops.create_session(
         conn,
         project_id=project_id,
         session_type="tower",
         name=name,
+        provider=provider,
+        scope_type="global",
+        scope_id=None,
         status=SessionStatus.CONNECTING.value,
     )
 
@@ -202,7 +207,6 @@ async def start_tower_session(
         )
 
     try:
-        provider = project.agent_provider if project else "claude_code"
         launch_cmd = get_launch_command(provider)
         working_dir = project.repo_path if project and project.repo_path else None
 


### PR DESCRIPTION
## Summary
- add session-level provider and scope metadata as the first backend slice of the provider/scope refactor
- stamp new Tower, Leader, and Ace sessions with provider plus explicit global/project scope
- add migration 015 for , , and 

## Testing
- ran 
- not run: broader Python test suite
- not run: frontend tests

## Notes
- this is the first staged backend slice only; create/restart/reconnect logic still needs follow-up work to actively compare current provider against existing sessions and replace mismatches
