### PR TITLE
feat: honor global provider in session startup

### DIFF
--- a/src/atc/api/app.py
+++ b/src/atc/api/app.py
@@ -53,6 +53,7 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
     await db.execute("PRAGMA foreign_keys=ON")
     await db.execute("PRAGMA busy_timeout=30000")
     db.row_factory = aiosqlite.Row
+    db.app_state = app.state
     app.state.db = db
 
     # 4. Start WebSocket hub

--- a/src/atc/leader/leader.py
+++ b/src/atc/leader/leader.py
@@ -18,6 +18,7 @@ from typing import TYPE_CHECKING, Any
 
 from atc.agents.deploy import ManagerDeploySpec, deploy_manager_files
 from atc.agents.factory import get_launch_command
+from atc.config import AgentProviderConfig
 from atc.session.ace import (
     _accept_trust_dialog,
     _ensure_tmux_session,
@@ -35,6 +36,15 @@ if TYPE_CHECKING:
     from atc.core.events import EventBus
 
 logger = logging.getLogger(__name__)
+
+
+def _current_provider_config(conn: aiosqlite.Connection) -> AgentProviderConfig:
+    settings = getattr(getattr(conn, "_connection", None), "app_state", None)
+    if settings is not None and getattr(settings, "settings", None) is not None:
+        return settings.settings.agent_provider
+    from atc.config import load_settings
+
+    return load_settings().agent_provider
 
 
 def _build_manager_deploy_spec(
@@ -97,7 +107,8 @@ async def start_leader(
     project = await db_ops.get_project(conn, project_id)
     name = f"leader-{project.name}" if project else f"leader-{project_id[:8]}"
 
-    provider = project.agent_provider if project and project.agent_provider else "claude_code"
+    provider_cfg = _current_provider_config(conn)
+    provider = provider_cfg.default
 
     session = await db_ops.create_session(
         conn,

--- a/src/atc/session/ace.py
+++ b/src/atc/session/ace.py
@@ -336,7 +336,13 @@ async def create_ace(
     """
     # Step 1: DB row first — guarantees the UI always sees every entity
     project = await db_ops.get_project(conn, project_id)
-    provider = project.agent_provider if project and project.agent_provider else "claude_code"
+    provider_cfg = getattr(getattr(conn, "_connection", None), "app_state", None)
+    if provider_cfg is not None and getattr(provider_cfg, "settings", None) is not None:
+        provider = provider_cfg.settings.agent_provider.default
+    else:
+        from atc.config import load_settings
+
+        provider = load_settings().agent_provider.default
 
     session = await db_ops.create_session(
         conn,

--- a/src/atc/session/reconnect.py
+++ b/src/atc/session/reconnect.py
@@ -123,8 +123,23 @@ async def reconnect_session(
         if session.project_id:
             project = await db_ops.get_project(conn, session.project_id)
             if project:
-                provider = project.agent_provider or "claude_code"
-                launch_cmd = get_launch_command(provider)
+                app_state = getattr(getattr(conn, "_connection", None), "app_state", None)
+                if app_state is not None and getattr(app_state, "settings", None) is not None:
+                    current_provider = app_state.settings.agent_provider.default
+                else:
+                    from atc.config import load_settings
+
+                    current_provider = load_settings().agent_provider.default
+                if session.provider != current_provider:
+                    logger.info(
+                        "Session %s provider mismatch on reconnect (session=%s current=%s), forcing replacement instead of reuse",
+                        session_id,
+                        session.provider,
+                        current_provider,
+                    )
+                    await db_ops.update_session_status(conn, session_id, SessionStatus.DISCONNECTED.value)
+                    return False
+                launch_cmd = get_launch_command(current_provider)
                 working_dir = project.repo_path
 
         # Tower sessions need their identity files (CLAUDE.md, settings)

--- a/src/atc/tower/session.py
+++ b/src/atc/tower/session.py
@@ -16,6 +16,7 @@ from typing import TYPE_CHECKING
 
 from atc.agents.deploy import _DEFAULT_STAGING_ROOT, TowerDeploySpec, deploy_tower_files
 from atc.agents.factory import get_launch_command
+from atc.config import AgentProviderConfig
 from atc.session.ace import (
     _accept_trust_dialog,
     _ensure_tmux_session,
@@ -34,6 +35,15 @@ if TYPE_CHECKING:
     from atc.core.events import EventBus
 
 logger = logging.getLogger(__name__)
+
+
+def _current_provider_config(conn: "aiosqlite.Connection") -> AgentProviderConfig:
+    settings = getattr(getattr(conn, "_connection", None), "app_state", None)
+    if settings is not None and getattr(settings, "settings", None) is not None:
+        return settings.settings.agent_provider
+    from atc.config import load_settings
+
+    return load_settings().agent_provider
 
 
 async def _resolve_tower_project_id(conn: "aiosqlite.Connection") -> str:
@@ -82,7 +92,9 @@ async def start_tower_session(
         project_id = await _resolve_tower_project_id(conn)
 
     project = await db_ops.get_project(conn, project_id)
-    name = f"tower-{project.name}" if project else f"tower-{project_id[:8]}"
+    provider_cfg = _current_provider_config(conn)
+    current_provider = provider_cfg.default
+    name = f"tower-{current_provider}"
 
     # Check for existing tower session — validate tmux pane is actually alive
     # AND that the Tower identity files are deployed at the working directory.
@@ -103,10 +115,11 @@ async def start_tower_session(
             # Verify CLAUDE.md is deployed — a stale pane from a prior app run
             # may have been launched without Tower identity files.
             staging_dir = Path(_DEFAULT_STAGING_ROOT) / sess.id
-            if (staging_dir / "CLAUDE.md").is_file():
+            if (staging_dir / "CLAUDE.md").is_file() and sess.provider == current_provider:
                 logger.info(
-                    "Reusing existing tower session %s (CLAUDE.md present at %s)",
+                    "Reusing existing tower session %s (provider=%s, CLAUDE.md present at %s)",
                     sess.id,
+                    sess.provider,
                     staging_dir,
                 )
                 return sess.id
@@ -139,10 +152,11 @@ async def start_tower_session(
     # `existing` is ordered by created_at DESC, so the first match is most recent.
     for sess in existing:
         staging_dir = Path(_DEFAULT_STAGING_ROOT) / sess.id
-        if (staging_dir / "CLAUDE.md").is_file():
+        if (staging_dir / "CLAUDE.md").is_file() and sess.provider == current_provider:
             logger.info(
-                "Reusing disconnected tower session %s — CLAUDE.md present at %s",
+                "Reusing disconnected tower session %s — provider=%s, CLAUDE.md present at %s",
                 sess.id,
+                sess.provider,
                 staging_dir,
             )
             await db_ops.update_session_status(conn, sess.id, SessionStatus.CONNECTING.value)
@@ -158,8 +172,7 @@ async def start_tower_session(
             working_dir = str(staging_dir)
             _log_working_dir_contents(working_dir, sess.id, "start_tower_session:reuse")
             try:
-                provider = project.agent_provider if project else "claude_code"
-                launch_cmd = get_launch_command(provider)
+                launch_cmd = get_launch_command(current_provider)
                 tmux_session, pane_id = await _spawn_provider_session(
                     conn,
                     sess.id,
@@ -187,7 +200,7 @@ async def start_tower_session(
                 raise RuntimeError(str(exc)) from exc
             return sess.id
 
-    provider = project.agent_provider if project else "claude_code"
+    provider = current_provider
 
     session = await db_ops.create_session(
         conn,


### PR DESCRIPTION
## Summary
- make new Tower, Leader, and Ace sessions read the current global provider instead of project-local provider state
- only reuse existing Tower sessions when their stamped provider matches the current global provider
- make reconnect reject provider-mismatched sessions so stale sessions are replaced instead of silently restored

## Testing
- ran `python3 -m compileall src/atc/api/app.py src/atc/leader/leader.py src/atc/session/ace.py src/atc/session/reconnect.py src/atc/tower/session.py`
- not run: broader Python test suite
- not run: frontend tests

## Notes
- this still leaves follow-up work for full provider-switch lifecycle behavior, including explicit bulk restart/replacement orchestration and frontend UX cleanup
