### PR TITLE
feat: simplify settings to global provider flow

### DIFF
--- a/frontend/src/components/tower/SettingsPane.tsx
+++ b/frontend/src/components/tower/SettingsPane.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useMemo, useState } from "react";
 import { useAppContext } from "../../context/AppContext";
 import { api } from "../../utils/api";
-import type { AgentProviderConfig, Project, ProviderInfo } from "../../types";
+import type { AgentProviderConfig, ProviderInfo } from "../../types";
 import { BackupPanel } from "../settings/BackupPanel";
 import { ResourceLimitsPanel } from "../settings/ResourceLimitsPanel";
 import "./SettingsPane.css";
@@ -21,7 +21,7 @@ const EMPTY_PROVIDER_CONFIG: AgentProviderConfig = {
 };
 
 export default function SettingsPane({ onClose }: Props) {
-  const { state, dispatch } = useAppContext();
+  const { state } = useAppContext();
   const [githubOrg, setGithubOrg] = useState(
     () => localStorage.getItem(GITHUB_ORG_KEY) ?? "",
   );
@@ -29,8 +29,6 @@ export default function SettingsPane({ onClose }: Props) {
   const [providers, setProviders] = useState<ProviderInfo[]>([]);
   const [savingProvider, setSavingProvider] = useState(false);
   const [providerMessage, setProviderMessage] = useState<string | null>(null);
-  const [providerActionProjectId, setProviderActionProjectId] = useState<string>("");
-  const [applyingProvider, setApplyingProvider] = useState(false);
 
   useEffect(() => {
     let mounted = true;
@@ -58,41 +56,10 @@ export default function SettingsPane({ onClose }: Props) {
     [state.projects],
   );
 
-  const selectedProviderActionProject =
-    activeProjects.find((project) => project.id === providerActionProjectId) ?? null;
   const activeTowerProject = state.towerDetail.current_project_id
     ? state.projects.find((project) => project.id === state.towerDetail.current_project_id) ?? null
     : null;
   const terminalBackedProviders = new Set(["claude_code", "codex"]);
-  const savedProjectProvider = selectedProviderActionProject?.agent_provider ?? null;
-  const defaultMatchesSelectedProject = Boolean(
-    savedProjectProvider && providerConfig.default === savedProjectProvider,
-  );
-  const towerAlreadyOnSelectedProject = Boolean(
-    state.towerDetail.current_session_id &&
-      activeTowerProject &&
-      selectedProviderActionProject &&
-      activeTowerProject.id === selectedProviderActionProject.id,
-  );
-  const towerNeedsRestartForSelectedProject = Boolean(
-    selectedProviderActionProject &&
-      terminalBackedProviders.has(selectedProviderActionProject.agent_provider) &&
-      (!towerAlreadyOnSelectedProject || activeTowerProject?.agent_provider !== selectedProviderActionProject.agent_provider),
-  );
-  const canRestartTowerWithSelectedProject = Boolean(
-    selectedProviderActionProject && terminalBackedProviders.has(selectedProviderActionProject.agent_provider),
-  );
-
-  useEffect(() => {
-    if (providerActionProjectId) return;
-    if (activeTowerProject) {
-      setProviderActionProjectId(activeTowerProject.id);
-      return;
-    }
-    if (activeProjects.length > 0) {
-      setProviderActionProjectId(activeProjects[0].id);
-    }
-  }, [providerActionProjectId, activeProjects, activeTowerProject]);
 
   function handleGithubOrgChange(value: string) {
     setGithubOrg(value);
@@ -105,67 +72,23 @@ export default function SettingsPane({ onClose }: Props) {
 
   async function saveProviderConfig(next: Partial<AgentProviderConfig>) {
     const optimistic = { ...providerConfig, ...next };
+    const providerChanged =
+      next.default !== undefined && next.default !== providerConfig.default;
     setProviderConfig(optimistic);
     setSavingProvider(true);
     setProviderMessage(null);
     try {
       const saved = await api.put<AgentProviderConfig>("/settings/agent-provider", next);
       setProviderConfig(saved);
-      setProviderMessage("Provider settings saved");
+      setProviderMessage(
+        providerChanged
+          ? "Provider updated globally. Existing sessions were restarted or marked for replacement as needed."
+          : "Provider settings saved",
+      );
     } catch (err) {
       setProviderMessage(err instanceof Error ? err.message : "Failed to save provider settings");
     } finally {
       setSavingProvider(false);
-    }
-  }
-
-  async function handleApplyProviderSettingToProject() {
-    if (!providerConfig.default || !providerActionProjectId) return;
-    setApplyingProvider(true);
-    setProviderMessage(null);
-    try {
-      const updatedProject = await api.patch<Project>(`/projects/${providerActionProjectId}/agent-provider`, {
-        agent_provider: providerConfig.default,
-      });
-      dispatch({ type: "UPDATE_PROJECT", payload: updatedProject });
-      setProviderMessage(
-        state.towerDetail.current_session_id && activeTowerProject?.id === providerActionProjectId
-          ? "Project provider updated. Restart Tower below to apply it to the live session."
-          : "Project provider updated.",
-      );
-    } catch (err) {
-      setProviderMessage(err instanceof Error ? err.message : "Failed to apply provider to project");
-    } finally {
-      setApplyingProvider(false);
-    }
-  }
-
-  async function handleRestartTowerForSelectedProject() {
-    if (!providerActionProjectId || !canRestartTowerWithSelectedProject) return;
-    setApplyingProvider(true);
-    setProviderMessage(null);
-    try {
-      if (state.towerDetail.current_session_id) {
-        await api.post("/tower/stop");
-      }
-      const res = await api.post<{ session_id?: string }>("/tower/start", {
-        project_id: providerActionProjectId,
-      });
-      setProviderMessage("Tower restarted with the selected project provider.");
-      dispatch({
-        type: "SET_TOWER_DETAIL",
-        payload: {
-          state: "managing",
-          current_session_id: res.session_id ?? null,
-          current_project_id: providerActionProjectId,
-          current_goal: null,
-          leader_session_id: null,
-        },
-      });
-    } catch (err) {
-      setProviderMessage(err instanceof Error ? err.message : "Failed to restart Tower");
-    } finally {
-      setApplyingProvider(false);
     }
   }
 
@@ -203,7 +126,7 @@ export default function SettingsPane({ onClose }: Props) {
         <section className="panel settings-pane__section">
           <h3>Agent Provider</h3>
           <div className="form-group">
-            <label htmlFor="provider-default">Default Provider</label>
+            <label htmlFor="provider-default">Global Provider</label>
             <select
               id="provider-default"
               value={providerConfig.default}
@@ -219,7 +142,9 @@ export default function SettingsPane({ onClose }: Props) {
             <span className="form-hint">
               {terminalBackedProviders.has(providerConfig.default)
                 ? "This provider uses live tmux terminal panes in the app."
-                : "This provider may use a non-terminal control flow even if a visibility pane exists."} Default provider applies to new projects. Existing projects keep their saved provider until changed per-project, and any already-running Tower session keeps its current provider until restarted.
+                : "This provider may use a non-terminal control flow even if a visibility pane exists."}{" "}
+              Changing the global provider affects all new sessions immediately. Existing live Tower, Leader,
+              and Ace sessions will be restarted or recreated as needed so stale provider-bound sessions do not linger.
             </span>
           </div>
 
@@ -267,75 +192,23 @@ export default function SettingsPane({ onClose }: Props) {
             />
           </div>
 
-          <div className="settings-pane__provider-actions">
-            <div className="form-group">
-              <label htmlFor="provider-action-project">Apply default provider to project</label>
-              <select
-                id="provider-action-project"
-                value={providerActionProjectId}
-                onChange={(e) => setProviderActionProjectId(e.target.value)}
-                disabled={applyingProvider || activeProjects.length === 0}
-                data-testid="provider-action-project"
-              >
-                <option value="" disabled>
-                  Select active project...
-                </option>
-                {activeProjects.map((project) => (
-                  <option key={project.id} value={project.id}>
-                    {project.name}
-                  </option>
-                ))}
-              </select>
-              <span className="form-hint">
-                Changing the default provider only affects new projects. Use these actions to update an existing project and, if needed, restart the live Tower session with that project context.
+          <div className="settings-pane__provider-status" data-testid="provider-global-status">
+            <div className="settings-pane__info-row">
+              <span className="settings-pane__label">Global provider</span>
+              <span className="settings-pane__value">{providerConfig.default}</span>
+            </div>
+            <div className="settings-pane__info-row">
+              <span className="settings-pane__label">Active projects</span>
+              <span className="settings-pane__value">{activeProjects.length}</span>
+            </div>
+            <div className="settings-pane__info-row">
+              <span className="settings-pane__label">Live Tower session</span>
+              <span className="settings-pane__value">
+                {state.towerDetail.current_session_id
+                  ? `${activeTowerProject?.name ?? "Global"} (${providerConfig.default})`
+                  : "Not running"}
               </span>
             </div>
-
-            {selectedProviderActionProject && (
-              <div className="settings-pane__provider-status" data-testid="provider-action-status">
-                <div className="settings-pane__info-row">
-                  <span className="settings-pane__label">Default provider</span>
-                  <span className="settings-pane__value">{providerConfig.default}</span>
-                </div>
-                <div className="settings-pane__info-row">
-                  <span className="settings-pane__label">Selected project provider</span>
-                  <span className="settings-pane__value">{savedProjectProvider}</span>
-                </div>
-                <div className="settings-pane__info-row">
-                  <span className="settings-pane__label">Live Tower session</span>
-                  <span className="settings-pane__value">
-                    {state.towerDetail.current_session_id
-                      ? `${activeTowerProject?.name ?? "Unknown"} (${activeTowerProject?.agent_provider ?? "unknown"})`
-                      : "Not running"}
-                  </span>
-                </div>
-              </div>
-            )}
-
-            <div className="settings-pane__provider-action-buttons">
-              <button
-                className="btn btn-sm"
-                onClick={() => void handleApplyProviderSettingToProject()}
-                disabled={applyingProvider || !providerActionProjectId || defaultMatchesSelectedProject}
-                data-testid="provider-apply-project"
-              >
-                {applyingProvider ? "Applying..." : defaultMatchesSelectedProject ? "Project already matches default" : "Apply default to project"}
-              </button>
-              <button
-                className="btn btn-sm"
-                onClick={() => void handleRestartTowerForSelectedProject()}
-                disabled={applyingProvider || !canRestartTowerWithSelectedProject || !towerNeedsRestartForSelectedProject}
-                data-testid="provider-restart-tower"
-              >
-                {applyingProvider ? "Applying..." : towerNeedsRestartForSelectedProject ? "Restart Tower with selected project" : "Tower already matches selected project"}
-              </button>
-            </div>
-
-            <span className="form-hint">
-              {towerNeedsRestartForSelectedProject
-                ? "The saved project provider and the live Tower session are still distinct. Restart Tower after applying if you want the visible session to move over too."
-                : "The selected project and live Tower session already line up, so no restart is needed right now."}
-            </span>
           </div>
 
           {providerMessage && <div className="form-hint">{providerMessage}</div>}

--- a/frontend/src/components/tower/__tests__/SettingsPane.test.tsx
+++ b/frontend/src/components/tower/__tests__/SettingsPane.test.tsx
@@ -9,7 +9,7 @@ beforeEach(() => {
 });
 
 describe("SettingsPane", () => {
-  it("shows provider action controls for existing projects", async () => {
+  it("shows global provider status instead of project apply controls", async () => {
     const fetchMock = vi.spyOn(globalThis, "fetch");
     fetchMock
       .mockResolvedValueOnce(
@@ -65,21 +65,21 @@ describe("SettingsPane", () => {
     });
 
     await waitFor(() => {
-      expect(screen.getByTestId("provider-action-project")).toBeInTheDocument();
+      expect(screen.getByTestId("provider-global-status")).toBeInTheDocument();
     });
-    expect(screen.getByTestId("provider-apply-project")).toBeInTheDocument();
-    expect(screen.getByTestId("provider-restart-tower")).toBeInTheDocument();
-    expect(screen.getByTestId("provider-action-status")).toBeInTheDocument();
+    expect(screen.queryByTestId("provider-action-project")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("provider-apply-project")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("provider-restart-tower")).not.toBeInTheDocument();
   });
 
-  it("applies the default provider to the selected project", async () => {
+  it("saves the global provider and shows restart/replacement messaging", async () => {
     const user = userEvent.setup();
     const fetchMock = vi.spyOn(globalThis, "fetch");
     fetchMock
       .mockResolvedValueOnce(
         new Response(
           JSON.stringify({
-            default: "codex",
+            default: "claude_code",
             opencode_url: "http://localhost:4096",
             tmux_session: "atc",
             claude_command: "claude",
@@ -112,114 +112,35 @@ describe("SettingsPane", () => {
       .mockResolvedValueOnce(
         new Response(
           JSON.stringify({
-            id: "proj-1",
-            name: "Alpha",
-            description: null,
-            repo_path: null,
-            github_repo: null,
-            agent_provider: "codex",
-            status: "active",
-            created_at: "2024-01-01T00:00:00Z",
-            updated_at: "2024-01-01T00:00:01Z",
+            default: "codex",
+            opencode_url: "http://localhost:4096",
+            tmux_session: "atc",
+            claude_command: "claude",
+            codex_command: "codex",
           }),
           { status: 200 },
         ),
       );
 
-    renderWithProviders(<SettingsPane onClose={() => undefined} />, {
-      initialState: {
-        projects: [
-          {
-            id: "proj-1",
-            name: "Alpha",
-            description: null,
-            repo_path: null,
-            github_repo: null,
-            agent_provider: "claude_code",
-            status: "active",
-            created_at: "2024-01-01T00:00:00Z",
-            updated_at: "2024-01-01T00:00:00Z",
-          },
-        ],
-      },
-    });
+    renderWithProviders(<SettingsPane onClose={() => undefined} />);
 
     await waitFor(() => {
-      expect(screen.getByTestId("provider-apply-project")).toBeInTheDocument();
+      expect(screen.getByLabelText("Global Provider")).toBeInTheDocument();
     });
 
-    await user.click(screen.getByTestId("provider-apply-project"));
+    await user.selectOptions(screen.getByLabelText("Global Provider"), "codex");
 
     await waitFor(() => {
-      expect(screen.getByText("Project provider updated.")).toBeInTheDocument();
+      expect(
+        screen.getByText(
+          "Provider updated globally. Existing sessions were restarted or marked for replacement as needed.",
+        ),
+      ).toBeInTheDocument();
     });
 
     expect(fetchMock).toHaveBeenCalledWith(
-      "http://127.0.0.1:8420/api/projects/proj-1/agent-provider",
-      expect.objectContaining({ method: "PATCH" }),
-    );
-  });
-
-  it("disables apply when the selected project already matches the default provider", async () => {
-    const fetchMock = vi.spyOn(globalThis, "fetch");
-    fetchMock
-      .mockResolvedValueOnce(
-        new Response(
-          JSON.stringify({
-            default: "codex",
-            opencode_url: "http://localhost:4096",
-            tmux_session: "atc",
-            claude_command: "claude",
-            codex_command: "codex",
-          }),
-          { status: 200 },
-        ),
-      )
-      .mockResolvedValueOnce(
-        new Response(
-          JSON.stringify([
-            {
-              name: "claude_code",
-              supports_streaming: true,
-              supports_tool_use: true,
-              context_window: 200000,
-              model: "claude",
-            },
-            {
-              name: "codex",
-              supports_streaming: true,
-              supports_tool_use: true,
-              context_window: 200000,
-              model: "codex",
-            },
-          ]),
-          { status: 200 },
-        ),
-      );
-
-    renderWithProviders(<SettingsPane onClose={() => undefined} />, {
-      initialState: {
-        projects: [
-          {
-            id: "proj-1",
-            name: "Alpha",
-            description: null,
-            repo_path: null,
-            github_repo: null,
-            agent_provider: "codex",
-            status: "active",
-            created_at: "2024-01-01T00:00:00Z",
-            updated_at: "2024-01-01T00:00:00Z",
-          },
-        ],
-      },
-    });
-
-    await waitFor(() => {
-      expect(screen.getByTestId("provider-apply-project")).toBeDisabled();
-    });
-    expect(screen.getByTestId("provider-apply-project")).toHaveTextContent(
-      "Project already matches default",
+      "http://127.0.0.1:8420/api/settings/agent-provider",
+      expect.objectContaining({ method: "PUT" }),
     );
   });
 });


### PR DESCRIPTION
## Summary
- remove selected-project provider apply/restart controls from the settings pane
- present provider selection as a global operation with matching messaging
- update settings tests to assert the new global-provider UX instead of per-project actions

## Testing
- not run: frontend tests are still environment-dependent in this checkout
- not run: broader app validation

## Notes
- backend provider-switch restart behavior is already in place via prior slices; this PR brings the settings UX back in line with the new model
