### PR TITLE
feat: align Tower console with global provider model

### DIFF
--- a/frontend/src/components/tower/TowerConsole.tsx
+++ b/frontend/src/components/tower/TowerConsole.tsx
@@ -6,11 +6,11 @@ import StatusBadge from "../common/StatusBadge";
 import "./TowerConsole.css";
 
 /**
- * Full interactive terminal panel for the Tower Claude session.
+ * Full interactive terminal panel for the Tower session.
  *
- * For claude_code provider: auto-starts as an open terminal on app load.
- * For other providers: shows goal form with Start button.
- * Running: Full PTY terminal (type directly into the terminal).
+ * Tower is now modeled as a global provider-bound runtime, even though it may
+ * still choose a project context for goals. The UI should not suggest that
+ * switching projects also means switching Tower's provider identity directly.
  */
 export default function TowerConsole() {
   const { state, dispatch } = useAppContext();
@@ -28,23 +28,12 @@ export default function TowerConsole() {
   const terminalBackedProviders = new Set(["claude_code", "codex"]);
 
   const selectedProvider = selectedProject?.agent_provider ?? null;
-  const activeTowerProvider = activeTowerProject?.agent_provider ?? null;
   const isTerminalProvider = selectedProvider !== null && terminalBackedProviders.has(selectedProvider);
-  const towerSessionProvider = towerDetail.current_session_id ? activeTowerProvider : null;
   const towerProjectMismatch = Boolean(
     towerDetail.current_session_id &&
       selectedProject &&
       activeTowerProject &&
       selectedProject.id !== activeTowerProject.id,
-  );
-  const towerProviderMismatch = Boolean(
-    towerSessionProvider &&
-      selectedProvider &&
-      towerProjectMismatch &&
-      selectedProvider !== towerSessionProvider,
-  );
-  const canApplySelectedProvider = Boolean(
-    selectedProject && selectedProvider && isTerminalProvider,
   );
 
   const isRunning =
@@ -132,17 +121,11 @@ export default function TowerConsole() {
     }
   }
 
-  async function handleRestartWithSelectedProvider() {
-    if (!projectId || !selectedProvider || !canApplySelectedProvider) return;
+  async function handleRestartForSelectedProject() {
+    if (!projectId) return;
     userStopped.current = false;
     setLoading(true);
     try {
-      const updatedProject = await api.patch<typeof selectedProject>(`/projects/${projectId}/agent-provider`, {
-        agent_provider: selectedProvider,
-      });
-      if (updatedProject) {
-        dispatch({ type: "UPDATE_PROJECT", payload: updatedProject });
-      }
       if (towerDetail.current_session_id) {
         await api.post("/tower/stop");
       }
@@ -160,7 +143,7 @@ export default function TowerConsole() {
         },
       });
     } catch (err) {
-      console.error("Failed to restart Tower with selected provider:", err);
+      console.error("Failed to restart Tower for selected project:", err);
     } finally {
       setLoading(false);
     }
@@ -223,26 +206,16 @@ export default function TowerConsole() {
 
       {towerProjectMismatch && (
         <div className="tower-console__error" data-testid="tower-console-provider-mismatch">
-          Tower is currently attached to <strong>{activeTowerProject?.name ?? "another project"}</strong>
-          {towerSessionProvider ? (
-            <>
-              {" "}using <strong>{towerSessionProvider}</strong>
-            </>
-          ) : null}
-          , while the selected project is <strong>{selectedProject?.name}</strong>
-          {selectedProvider ? (
-            <>
-              {" "}with <strong>{selectedProvider}</strong>
-            </>
-          ) : null}
-          . Restart Tower to switch live session context.
+          Tower is currently attached to <strong>{activeTowerProject?.name ?? "another project"}</strong>,
+          while the selected project is <strong>{selectedProject?.name}</strong>. Restart Tower if you want the
+          live session to move to the selected project context.
           <button
             className="btn btn-sm"
-            onClick={handleRestartWithSelectedProvider}
-            disabled={loading || !canApplySelectedProvider}
+            onClick={handleRestartForSelectedProject}
+            disabled={loading || !selectedProject}
             data-testid="tower-console-restart-provider"
           >
-            {loading ? "Applying..." : "Apply selected project and restart Tower"}
+            {loading ? "Restarting..." : "Restart Tower for selected project"}
           </button>
         </div>
       )}

--- a/frontend/src/components/tower/__tests__/TowerConsole.test.tsx
+++ b/frontend/src/components/tower/__tests__/TowerConsole.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { screen, fireEvent } from "@testing-library/react";
+import { screen } from "@testing-library/react";
 import TowerConsole from "../TowerConsole";
 import { renderWithProviders } from "../../../test/helpers";
 
@@ -76,7 +76,7 @@ describe("TowerConsole", () => {
     expect(screen.queryByTestId("tower-console-goal")).not.toBeInTheDocument();
   });
 
-  it("shows a mismatch warning when Tower is attached to a different project", () => {
+  it("shows a project-context restart warning when Tower is attached elsewhere", () => {
     renderWithProviders(<TowerConsole />, {
       initialState: {
         projects: [
@@ -115,7 +115,7 @@ describe("TowerConsole", () => {
     });
     expect(screen.getByTestId("tower-console-provider-mismatch")).toBeInTheDocument();
     expect(screen.getByTestId("tower-console-restart-provider")).toHaveTextContent(
-      "Apply selected project and restart Tower",
+      "Restart Tower for selected project",
     );
   });
 });


### PR DESCRIPTION
## Summary
- remove Tower console messaging that implied per-project provider switching
- treat mismatch state as a project-context restart choice, not a provider-apply flow
- update Tower console tests to match the new global-provider model wording

## Testing
- not run: frontend tests are still not reliable in this checkout
- not run: broader app validation

## Notes
- this is a UI semantics cleanup slice on top of the backend provider/global-scope work already landed
