### PR TITLE
fix: use session provider during runtime handoff

### DIFF
--- a/src/atc/api/routers/settings.py
+++ b/src/atc/api/routers/settings.py
@@ -186,7 +186,7 @@ async def update_agent_provider(
     body: AgentProviderUpdateRequest,
     request: Request,
 ) -> AgentProviderResponse:
-    """Update agent provider configuration (runtime only, not persisted to file)."""
+    """Update agent provider configuration for the live app instance."""
     from atc.agents.factory import list_providers
     from atc.tower.controller import TowerState
 

--- a/src/atc/leader/leader.py
+++ b/src/atc/leader/leader.py
@@ -188,17 +188,13 @@ async def start_leader(
             logger.info("Ensured repo_path exists: %s", spec.repo_path)
         working_dir = spec.repo_path or str(deployed.root)
 
-        launch_cmd = get_launch_command(
-            project.agent_provider if project else "claude_code",
-        )
+        launch_cmd = get_launch_command(provider)
 
         # Provider workspace prep (alongside existing tmux logic — fallback safe)
         try:
             from atc.agents.factory import create_provider
 
-            _provider = create_provider(
-                project.agent_provider if project else "claude_code",
-            )
+            _provider = create_provider(provider)
             _cmp = deployed.claude_md_path
             _ctx = _cmp if _cmp.exists() else None
             await _provider.prepare_workspace(

--- a/src/atc/leader/orchestrator.py
+++ b/src/atc/leader/orchestrator.py
@@ -79,6 +79,14 @@ class LeaderOrchestrator:
     _max_concurrent_aces: int = 3
     _governor: ResourceGovernor = field(default_factory=ResourceGovernor)
 
+    def _current_provider_default(self) -> str:
+        app_state = getattr(getattr(self.conn, "_connection", None), "app_state", None)
+        if app_state is not None and getattr(app_state, "settings", None) is not None:
+            return app_state.settings.agent_provider.default
+        from atc.config import load_settings
+
+        return load_settings().agent_provider.default
+
     async def spawn_aces_for_ready_tasks(self) -> list[AceAssignment]:
         """Find ready tasks and spawn Ace sessions for them.
 
@@ -167,9 +175,12 @@ class LeaderOrchestrator:
                 )
                 context_entries = ctx.get("context_entries", [])
 
-            launch_cmd = get_launch_command(
-                project.agent_provider if project else "claude_code",
+            provider_name = (
+                project.agent_provider
+                if project and project.agent_provider
+                else self._current_provider_default()
             )
+            launch_cmd = get_launch_command(provider_name)
 
             session_id = await create_ace(
                 self.conn,

--- a/src/atc/session/ace.py
+++ b/src/atc/session/ace.py
@@ -280,7 +280,10 @@ async def _spawn_provider_session(
     from atc.agents.factory import create_provider
 
     project = await db_ops.get_project(conn, project_id) if project_id else None
-    provider_name = project.agent_provider if project and project.agent_provider else "claude_code"
+    session = await db_ops.get_session(conn, session_id)
+    provider_name = session.provider if session and session.provider else (
+        project.agent_provider if project and project.agent_provider else "claude_code"
+    )
     provider = create_provider(provider_name)
 
     session = await db_ops.get_session(conn, session_id)


### PR DESCRIPTION
## Summary
- make leader launch use the live provider default captured for the new session instead of falling back to project.agent_provider
- make ace prompt delivery use the session's provider stamp instead of the project row when a runtime provider switch has occurred
- tighten orchestrator launch-command selection to prefer the live runtime default

## Testing
- ran `python3 -m compileall src/atc/api/routers/settings.py src/atc/leader/leader.py src/atc/leader/orchestrator.py src/atc/session/ace.py`
- not run: broader Python test suite
- not run: frontend tests

## Why
Live Mac validation showed split-brain behavior after provider switching: Settings UI state, Tower runtime, and Leader/Ace behavior were no longer aligned. The most obvious runtime symptom was Leader staying on Claude Code after the provider was switched.
