### PR TITLE
fix: pass live provider commands into runtime spawns

### DIFF
--- a/src/atc/agents/factory.py
+++ b/src/atc/agents/factory.py
@@ -61,17 +61,23 @@ def create_provider(name: str, **kwargs: Any) -> AgentProvider:
     if not kwargs and name == "claude_code":
         try:
             settings = load_settings()
-            kwargs = {"claude_command": settings.agent_provider.claude_command}
+            kwargs = {
+                "claude_command": settings.agent_provider.claude_command,
+                "tmux_session": settings.agent_provider.tmux_session,
+            }
         except Exception:
             kwargs = {}
     if not kwargs and name == "codex":
         try:
             settings = load_settings()
-            kwargs = {"codex_command": settings.agent_provider.codex_command}
+            kwargs = {
+                "codex_command": settings.agent_provider.codex_command,
+                "tmux_session": settings.agent_provider.tmux_session,
+            }
         except Exception:
             kwargs = {}
     provider: AgentProvider = cls(**kwargs)
-    logger.info("Created agent provider: %s (%s)", name, cls.__name__)
+    logger.info("Created agent provider: %s (%s) kwargs=%s", name, cls.__name__, sorted(kwargs.keys()))
     return provider
 
 
@@ -101,6 +107,12 @@ def get_launch_command(provider_name: str) -> str:
         script = Path(__file__).parent.parent.parent.parent / "scripts" / "atc-agent"
         if script.exists():
             return str(script)
+    if provider_name == "codex":
+        try:
+            settings = load_settings()
+            return settings.agent_provider.codex_command
+        except Exception:
+            pass
     return _LAUNCH_COMMANDS.get(provider_name, _LAUNCH_COMMANDS["claude_code"])
 
 

--- a/src/atc/leader/leader.py
+++ b/src/atc/leader/leader.py
@@ -194,7 +194,12 @@ async def start_leader(
         try:
             from atc.agents.factory import create_provider
 
-            _provider = create_provider(provider)
+            provider_kwargs: dict[str, str] = {"tmux_session": provider_cfg.tmux_session}
+            if provider == "claude_code":
+                provider_kwargs["claude_command"] = provider_cfg.claude_command
+            elif provider == "codex":
+                provider_kwargs["codex_command"] = provider_cfg.codex_command
+            _provider = create_provider(provider, **provider_kwargs)
             _cmp = deployed.claude_md_path
             _ctx = _cmp if _cmp.exists() else None
             await _provider.prepare_workspace(

--- a/src/atc/session/ace.py
+++ b/src/atc/session/ace.py
@@ -284,7 +284,16 @@ async def _spawn_provider_session(
     provider_name = session.provider if session and session.provider else (
         project.agent_provider if project and project.agent_provider else "claude_code"
     )
-    provider = create_provider(provider_name)
+    provider_cfg = getattr(getattr(conn, "_connection", None), "app_state", None)
+    provider_kwargs: dict[str, str] = {}
+    if provider_cfg is not None and getattr(provider_cfg, "settings", None) is not None:
+        live_cfg = provider_cfg.settings.agent_provider
+        provider_kwargs["tmux_session"] = live_cfg.tmux_session
+        if provider_name == "claude_code":
+            provider_kwargs["claude_command"] = live_cfg.claude_command
+        elif provider_name == "codex":
+            provider_kwargs["codex_command"] = live_cfg.codex_command
+    provider = create_provider(provider_name, **provider_kwargs)
 
     session = await db_ops.get_session(conn, session_id)
     if session is None:
@@ -450,8 +459,19 @@ async def _send_session_instruction(
         raise ValueError(f"Session {session_id} has no project")
 
     project = await db_ops.get_project(conn, session.project_id)
-    provider_name = project.agent_provider if project and project.agent_provider else "claude_code"
-    provider = create_provider(provider_name)
+    provider_name = session.provider if session.provider else (
+        project.agent_provider if project and project.agent_provider else "claude_code"
+    )
+    provider_cfg = getattr(getattr(conn, "_connection", None), "app_state", None)
+    provider_kwargs: dict[str, str] = {}
+    if provider_cfg is not None and getattr(provider_cfg, "settings", None) is not None:
+        live_cfg = provider_cfg.settings.agent_provider
+        provider_kwargs["tmux_session"] = live_cfg.tmux_session
+        if provider_name == "claude_code":
+            provider_kwargs["claude_command"] = live_cfg.claude_command
+        elif provider_name == "codex":
+            provider_kwargs["codex_command"] = live_cfg.codex_command
+    provider = create_provider(provider_name, **provider_kwargs)
     result = await provider.send_prompt(session_id, instruction)
     return result.accepted
 


### PR DESCRIPTION
## Summary
- pass live runtime provider command settings into provider instances instead of letting them silently reload config from disk
- make codex launch command resolve from the current provider settings rather than static registry defaults
- keep session prompt delivery aligned with the live provider command config

## Testing
- ran `python3 -m compileall src/atc/agents/factory.py src/atc/leader/leader.py src/atc/session/ace.py`
- not run: broader Python test suite
- not run: frontend tests

## Why
Live Mac validation now shows an inversion bug: when Settings says claude_code, Tower behaves like Codex, and when Settings says codex, Tower behaves like Claude. That strongly suggests the runtime provider name and the actual spawned command are crossing wires.
