### PR TITLE
fix: honor launch command in provider session spawns

### DIFF
--- a/src/atc/agents/claude_provider.py
+++ b/src/atc/agents/claude_provider.py
@@ -154,6 +154,8 @@ class ClaudeCodeProvider:
 
     async def spawn_for_session(self, request: ProviderSpawnRequest) -> SessionInfo:
         """Spawn a Claude runtime pane for an existing ATC session row."""
+        if request.launch_command:
+            self._claude_command = request.launch_command
         info = await self.spawn_session(
             request.session.id,
             working_dir=request.working_dir,

--- a/src/atc/agents/codex_provider.py
+++ b/src/atc/agents/codex_provider.py
@@ -129,6 +129,8 @@ class CodexProvider:
         return None
 
     async def spawn_for_session(self, request: ProviderSpawnRequest) -> SessionInfo:
+        if request.launch_command:
+            self._codex_command = request.launch_command
         info = await self.spawn_session(
             request.session.id,
             working_dir=request.working_dir,


### PR DESCRIPTION
## Summary
- make Claude and Codex provider spawn_for_session paths actually honor the launch_command passed by lifecycle code
- ensure provider-switch restarts use the command selected by the replacement flow instead of silently falling back to provider constructor defaults

## Testing
- ran `python3 -m compileall src/atc/agents/claude_provider.py src/atc/agents/codex_provider.py`
- not run: broader Python test suite
- not run: frontend tests

## Why
Cold startup is now correct, but provider-switch restart still relaunches Claude when switching to Codex. That suggests the restart path is computing the right launch command but the provider implementation is ignoring it during spawn_for_session.
