### PR TITLE
chore: add tower provider spawn diagnostics

### DIFF
--- a/src/atc/api/routers/tower.py
+++ b/src/atc/api/routers/tower.py
@@ -138,7 +138,14 @@ async def start_tower(body: StartRequest, request: Request) -> dict:
     except Exception as exc:
         raise HTTPException(status_code=500, detail=str(exc)) from exc
 
-    return {"status": "started", "session_id": session_id, "project_id": body.project_id}
+    session = await db.execute("SELECT provider FROM sessions WHERE id = ?", (session_id,))
+    row = await session.fetchone()
+    return {
+        "status": "started",
+        "session_id": session_id,
+        "project_id": body.project_id,
+        "provider": row[0] if row else None,
+    }
 
 
 @router.post("/stop")

--- a/src/atc/tower/controller.py
+++ b/src/atc/tower/controller.py
@@ -180,6 +180,8 @@ class TowerController:
             await self._transition(TowerState.PLANNING)
             await self._transition(TowerState.MANAGING)
 
+        session = await db_ops.get_session(self._db, session_id)
+
         # Broadcast tower session info so the frontend subscribes immediately
         if self._ws_hub is not None:
             await self._ws_hub.broadcast(
@@ -189,6 +191,7 @@ class TowerController:
                     "session_id": session_id,
                     "status": "idle",
                     "project_id": project_id,
+                    "provider": session.provider if session else None,
                 },
             )
 

--- a/src/atc/tower/session.py
+++ b/src/atc/tower/session.py
@@ -194,6 +194,13 @@ async def start_tower_session(
         # --- Runtime debug: verify CLAUDE.md is present at working_dir ---
         _log_working_dir_contents(working_dir, session.id, "start_tower_session")
 
+        logger.warning(
+            "TOWER SPAWN provider=%s launch_command=%s project_id=%s session_id=%s",
+            provider,
+            launch_cmd,
+            project_id,
+            session.id,
+        )
         tmux_session, pane_id = await _spawn_provider_session(
             conn,
             session.id,


### PR DESCRIPTION
## Summary
- log the exact provider and launch command used for Tower spawn
- include Tower session provider in the tower websocket event and start response

## Testing
- ran `python3 -m compileall src/atc/tower/session.py src/atc/tower/controller.py src/atc/api/routers/tower.py`

## Why
The provider-switch restart path is still not behaving honestly. Before making the next structural simplification, we need live proof of whether Tower session rows, websocket metadata, and actual spawn commands agree or diverge.
