### PR TITLE
fix: block tower autostart during provider switch

### DIFF
--- a/frontend/src/components/tower/SettingsPane.tsx
+++ b/frontend/src/components/tower/SettingsPane.tsx
@@ -77,6 +77,9 @@ export default function SettingsPane({ onClose }: Props) {
     setProviderConfig(optimistic);
     setSavingProvider(true);
     setProviderMessage(null);
+    if (providerChanged) {
+      window.dispatchEvent(new CustomEvent("atc:provider-switching"));
+    }
     try {
       const saved = await api.put<AgentProviderConfig>("/settings/agent-provider", next);
       setProviderConfig(saved);
@@ -85,8 +88,14 @@ export default function SettingsPane({ onClose }: Props) {
           ? "Provider updated globally. Existing sessions were restarted or marked for replacement as needed."
           : "Provider settings saved",
       );
+      if (providerChanged) {
+        window.dispatchEvent(new CustomEvent("atc:provider-switched"));
+      }
     } catch (err) {
       setProviderMessage(err instanceof Error ? err.message : "Failed to save provider settings");
+      if (providerChanged) {
+        window.dispatchEvent(new CustomEvent("atc:provider-switched"));
+      }
     } finally {
       setSavingProvider(false);
     }

--- a/frontend/src/components/tower/TowerConsole.tsx
+++ b/frontend/src/components/tower/TowerConsole.tsx
@@ -19,6 +19,7 @@ export default function TowerConsole() {
   const [goal, setGoal] = useState("");
   const [projectId, setProjectId] = useState("");
   const [loading, setLoading] = useState(false);
+  const [providerSwitchPending, setProviderSwitchPending] = useState(false);
   const autoStarted = useRef(false);
   const userStopped = useRef(false);
 
@@ -57,11 +58,29 @@ export default function TowerConsole() {
   }
 
   useEffect(() => {
-    if (isTerminalProvider && isIdle && !loading && !autoStarted.current && !userStopped.current && projectId) {
+    const onProviderSwitching = () => {
+      setProviderSwitchPending(true);
+      autoStarted.current = true;
+    };
+    const onProviderSwitched = () => {
+      setProviderSwitchPending(false);
+      autoStarted.current = false;
+      userStopped.current = false;
+    };
+    window.addEventListener("atc:provider-switching", onProviderSwitching);
+    window.addEventListener("atc:provider-switched", onProviderSwitched);
+    return () => {
+      window.removeEventListener("atc:provider-switching", onProviderSwitching);
+      window.removeEventListener("atc:provider-switched", onProviderSwitched);
+    };
+  }, []);
+
+  useEffect(() => {
+    if (isTerminalProvider && isIdle && !loading && !providerSwitchPending && !autoStarted.current && !userStopped.current && projectId) {
       autoStarted.current = true;
       void handleStart();
     }
-  }, [isTerminalProvider, isIdle, loading, projectId]); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [isTerminalProvider, isIdle, loading, providerSwitchPending, projectId]); // eslint-disable-line react-hooks/exhaustive-deps
 
   async function handleStart() {
     if (!projectId) return;
@@ -113,6 +132,9 @@ export default function TowerConsole() {
           current_goal: null,
         },
       });
+      if (!providerSwitchPending) {
+        autoStarted.current = false;
+      }
     } catch (err) {
       console.error("Failed to stop Tower:", err);
       userStopped.current = false;

--- a/frontend/src/components/tower/TowerPanel.tsx
+++ b/frontend/src/components/tower/TowerPanel.tsx
@@ -27,6 +27,7 @@ export default function TowerPanel() {
   const [expanded, setExpanded] = useState(false);
   const [starting, setStarting] = useState(false);
   const [startError, setStartError] = useState<string | null>(null);
+  const [providerSwitchPending, setProviderSwitchPending] = useState(false);
   const autoStarted = useRef(false);
   const userStopped = useRef(false);
 
@@ -72,16 +73,35 @@ export default function TowerPanel() {
   // Auto-start Tower session when idle (Tower is global — not provider-gated).
   // Respects userStopped ref to prevent re-starting after manual Stop.
   useEffect(() => {
+    const onProviderSwitching = () => {
+      setProviderSwitchPending(true);
+      autoStarted.current = true;
+    };
+    const onProviderSwitched = () => {
+      setProviderSwitchPending(false);
+      autoStarted.current = false;
+      userStopped.current = false;
+    };
+    window.addEventListener("atc:provider-switching", onProviderSwitching);
+    window.addEventListener("atc:provider-switched", onProviderSwitched);
+    return () => {
+      window.removeEventListener("atc:provider-switching", onProviderSwitching);
+      window.removeEventListener("atc:provider-switched", onProviderSwitched);
+    };
+  }, []);
+
+  useEffect(() => {
     if (
       isIdle &&
       !starting &&
+      !providerSwitchPending &&
       !autoStarted.current &&
       !userStopped.current
     ) {
       autoStarted.current = true;
       void handleStart();
     }
-  }, [isIdle, starting]); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [isIdle, starting, providerSwitchPending]); // eslint-disable-line react-hooks/exhaustive-deps
 
   // Re-fit terminal when panel expands; also request a fresh snapshot so the
   // terminal isn't blank when the panel was collapsed during initial load.
@@ -149,6 +169,9 @@ export default function TowerPanel() {
           current_goal: null,
         },
       });
+      if (!providerSwitchPending) {
+        autoStarted.current = false;
+      }
     } catch (err) {
       console.error("Failed to stop tower:", err);
       userStopped.current = false;


### PR DESCRIPTION
## Summary
- block TowerPanel/TowerConsole auto-start while a provider switch is in flight
- prevent idle transition after stop from immediately re-triggering a stale UI start request
- let provider-switch flow own the restart instead of racing the frontend auto-start effects

## Testing
- not run: frontend tests
- not run: manual browser validation

## Why
Live logs showed duplicate `POST /api/tower/start` calls and the diagnostic spawn line proved the restarted Tower was already being asked to spawn as `claude_code` after a codex switch. The most likely cause is a stale auto-start race from the frontend while provider-switch stop/restart is in flight.
