### PR TITLE
feat: harden provider runtime lifecycle boundary

### DIFF
--- a/docs/CODEBASE_MAP.md
+++ b/docs/CODEBASE_MAP.md
@@ -1,0 +1,105 @@
+# ATC Codebase Map
+
+This is the durable high-level code organization guide for ATC.
+
+It should stay shorter and more stable than deep-dive mapping docs. When the architecture changes materially, update this file.
+
+## Product model
+ATC is an orchestration platform with three main runtime roles:
+- `tower` , top-level orchestration and goal management
+- `leader` , project-scoped decomposition and supervision
+- `ace` , task-scoped execution
+
+## Main layers
+
+### 1. API and app composition
+Primary path:
+- `src/atc/api/`
+
+Important files:
+- `src/atc/api/app.py`
+  - application composition root and runtime startup
+- `src/atc/api/routers/`
+  - HTTP routes for projects, tower, leader, aces, context, settings, etc.
+- `src/atc/api/ws/`
+  - websocket hub/state integration
+
+### 2. State and persistence
+Primary path:
+- `src/atc/state/`
+
+Important files:
+- `src/atc/state/db.py`
+  - current persistence center of gravity, large and high-risk
+- `src/atc/state/models.py`
+  - persistent data models
+
+### 3. Runtime and session control
+Primary paths today:
+- `src/atc/session/`
+- `src/atc/terminal/`
+- `src/atc/tower/`
+- `src/atc/leader/`
+
+Important files today:
+- `src/atc/session/ace.py`
+- `src/atc/session/reconnect.py`
+- `src/atc/terminal/control.py`
+- `src/atc/terminal/pty_stream.py`
+- `src/atc/tower/controller.py`
+- `src/atc/leader/leader.py`
+- `src/atc/leader/orchestrator.py`
+
+### 4. Provider/runtime abstraction work
+Current/future paths:
+- current partial abstraction: `src/atc/agents/`
+- target refactor direction: `src/atc/runtime/` and `src/atc/providers/`
+
+See:
+- `docs/provider_runtime_refactor_plan.md`
+- `docs/provider_cli_wrapper_spec.md`
+- `docs/RUNTIME_PROVIDER_GUARDRAILS.md`
+
+### 5. Frontend and desktop shell
+Primary paths:
+- `frontend/src/`
+- `src-tauri/`
+
+Important files:
+- `frontend/src/context/AppContext.tsx`
+  - current frontend state center of gravity, large and high-risk
+- `frontend/src/pages/ProjectView.tsx`
+- `frontend/src/components/tower/*`
+- `frontend/src/components/leader/*`
+- `frontend/src/components/ace/*`
+- `src-tauri/src/lib.rs`
+  - thin shell/sidecar layer
+
+## High-risk modules
+Be extra careful when touching these:
+- `src/atc/state/db.py`
+- `src/atc/tower/controller.py`
+- `src/atc/api/routers/projects.py`
+- `frontend/src/context/AppContext.tsx`
+
+These files currently carry broad ownership and can create architecture drift quickly.
+
+## Known drift areas
+- `leader` vs `manager` terminology
+- legacy `tasks` vs active `task_graphs`
+- docs/API/runtime drift in some areas
+- partial provider abstraction that is not yet the real runtime boundary
+
+## Rule for changes
+If a change materially alters ownership, flow, folder structure, runtime boundaries, or architectural expectations, update this file.
+
+## Control stack layering
+For current and future refactor work, use this conceptual stack:
+- MCP / external control surface
+- orchestration/application services
+- runtime service
+- provider runtimes
+- provider wrapper + hooks
+- tmux substrate
+
+The runtime/provider refactor is establishing the middle layers so MCP and hooks have a cleaner, more stable foundation.

--- a/docs/DEVELOPMENT_RULES.md
+++ b/docs/DEVELOPMENT_RULES.md
@@ -1,0 +1,41 @@
+# ATC Development Rules
+
+These rules are for keeping the codebase clean as it evolves.
+
+## 1. Prefer clear ownership over convenience
+If you are adding logic and it is not obvious where it belongs, stop and decide the ownership boundary first.
+
+## 2. Do not deepen drift
+Known drift areas already exist:
+- `leader` vs `manager`
+- `tasks` vs `task_graphs`
+- partial provider abstraction vs direct tmux/session control
+
+New code should reduce these problems, not extend them.
+
+## 3. Push logic downward when appropriate
+- workflow/policy belongs in orchestration/application code
+- provider-specific terminal behavior belongs in provider runtime/wrapper code
+- generic tmux behavior belongs in shared runtime/tmux infrastructure
+
+## 4. Avoid monolithic growth
+Be cautious about adding more responsibilities to already-large files such as:
+- `src/atc/state/db.py`
+- `src/atc/tower/controller.py`
+- `src/atc/api/routers/projects.py`
+- `frontend/src/context/AppContext.tsx`
+
+If possible, extract smaller focused modules instead of extending broad ones.
+
+## 5. Refactor toward deletion, not permanent layering
+Temporary compatibility shims are fine.
+Permanent duplicate abstractions are not the goal.
+
+## 6. Update docs as part of development
+Do not treat docs as end-of-project cleanup. Update them in the same workstream.
+
+## 7. Make new boundaries explicit
+When introducing a new architectural boundary, create or update the durable doc that explains it.
+
+## 8. Make changes readable for future agents
+Leave behind structure and docs that reduce the need for future deep rediscovery.

--- a/docs/HARD_RULES.md
+++ b/docs/HARD_RULES.md
@@ -1,0 +1,57 @@
+# ATC Hard Rules
+
+These are non-negotiable rules for future development in this repository.
+
+## 1. Documentation must stay in sync with code
+If you make a code change, you must review the relevant `.md` docs and update them if they are stale.
+
+This is a hard requirement.
+
+Minimum docs to consider on any change:
+- `docs/START_HERE.md`
+- `docs/CODEBASE_MAP.md`
+- `docs/HARD_RULES.md`
+- `docs/DEVELOPMENT_RULES.md`
+- `docs/TESTING_RULES.md`
+- relevant feature/refactor docs
+- relevant architecture/API docs
+
+Do not consider work complete if the code changed but the docs were left stale.
+
+## 2. Shared orchestration code must stay provider-neutral
+Provider-specific behavior must not leak into shared orchestration code.
+
+## 3. One runtime boundary only
+Tower, Leader, and Ace runtime flows must go through the central runtime service once that path exists.
+
+## 4. tmux is shared infrastructure
+Generic tmux operations belong in shared runtime infrastructure, not duplicated provider code.
+
+## 5. Provider behavior lives in provider-owned modules
+Provider command construction, readiness logic, bootstrap behavior, delivery quirks, and recovery rules belong in provider-owned modules or wrapper implementations.
+
+## 6. No new provider-specific hacks in shared code
+Do not add shared-code conditionals for provider-specific sleeps, flags, prompt quirks, or delivery behavior.
+
+## 7. Role vocabulary must stay canonical
+Use:
+- `tower`
+- `leader`
+- `ace`
+
+Do not deepen old terminology drift in new code.
+
+## 8. Machine-readable wrapper/runtime markers are contract surface
+If you change them, update docs and callers intentionally.
+
+## 9. No silent fallback to stale architecture
+Do not hide bypass paths or mixed old/new runtime behavior behind silent fallback.
+
+## 10. Boundary-changing work must update docs in the same workstream
+Architecture changes, API changes, runtime-provider changes, and testing expectations must update the corresponding docs before the work is done.
+
+## 11. Session provider identity is immutable for the life of a session row
+A session row's provider is part of its runtime identity.
+
+Do not mutate an old session row to pretend it was created under a different provider.
+If the desired provider changed, create a replacement session instead of reusing/mutating the old one.

--- a/docs/RUNTIME_PROVIDER_GUARDRAILS.md
+++ b/docs/RUNTIME_PROVIDER_GUARDRAILS.md
@@ -1,0 +1,170 @@
+# Runtime and Provider Development Guardrails
+
+These are hard rules for ATC runtime/provider development.
+
+If future work violates these rules, the codebase will drift back into the mixed abstraction state this refactor is trying to fix.
+
+## 1. One runtime boundary only
+All provider-specific runtime behavior must enter the backend through the central runtime service.
+
+Hard rule:
+- Tower, Leader, and Ace lifecycle/instruction flows must call the runtime service, not provider-specific modules directly.
+
+Do not:
+- launch provider CLIs directly from routers/controllers/orchestrators
+- call provider-specific readiness logic from shared workflow code
+- bypass the runtime service for “just one special case”
+
+## 2. Shared orchestration code must be provider-neutral
+Shared orchestration code is allowed to know:
+- role kind
+- session id
+- project id
+- task id
+- provider name as metadata
+
+Shared orchestration code is not allowed to know:
+- provider-specific sleeps
+- provider-specific prompt formatting
+- provider-specific CLI flags
+- provider-specific trust/login wording
+- provider-specific readiness heuristics
+
+If a provider needs special handling, implement it in the provider module or wrapper.
+
+## 3. tmux is shared infrastructure, not provider logic
+tmux is a core ATC runtime dependency and may be treated as stable shared transport.
+
+Hard rule:
+- generic tmux operations belong in shared runtime infrastructure
+- provider modules may use that infrastructure but must not duplicate it
+
+Generic tmux concerns include:
+- spawn pane/session/window
+- capture output
+- send input
+- resize
+- attach streams
+- check pane/session health
+
+## 4. Provider behavior belongs in provider-owned folders
+All provider-specific behavior must live under provider-owned implementation paths.
+
+Preferred structure:
+```text
+src/atc/providers/<provider>/
+```
+
+This includes:
+- launch command construction
+- workspace/bootstrap setup
+- readiness detection
+- prompt/instruction delivery behavior
+- output interpretation
+- provider-specific recovery behavior
+
+## 5. Wrapper commands are procedural, not orchestration-authoritative
+`atc-provider` is allowed to execute operations.
+It is not allowed to decide workflow policy.
+
+Python decides:
+- which task to assign
+- when to assign it
+- why to retry or stop
+- how state transitions happen
+
+The wrapper decides:
+- how to deliver the operation cleanly to that provider session
+
+## 6. No new provider-specific hacks in shared code
+Forbidden patterns outside provider-owned code include:
+- `if provider == "codex": sleep(...)`
+- `if provider == "claude_code": paste differently`
+- `if provider == "opencode": use these flags here`
+- raw provider CLI command strings in routers/controllers/orchestrators
+
+If you think you need one of these, you are probably putting the logic in the wrong layer.
+
+## 7. New provider support is not complete until the full contract exists
+A provider is not first-class just because ATC can launch it.
+
+A provider is only first-class when it supports the shared runtime contract, including at minimum:
+- start-role
+- send-instruction
+- check-readiness
+- inspect-session
+- restore-session
+
+Prefer also:
+- stop-role
+- assign-task
+
+## 8. Role nouns must stay canonical
+Canonical role names are:
+- `tower`
+- `leader`
+- `ace`
+
+Do not introduce or preserve parallel product/runtime names for the same role in new code.
+
+Migration compatibility is allowed temporarily, but new code should not deepen `manager` drift.
+
+## 9. Session-targeted operations should prefer session identity over role guesses
+After startup, most runtime operations should target a concrete session id.
+
+Hard rule:
+- startup may be role-based
+- post-start operations should usually be session-based
+
+This reduces branching and makes runtime behavior easier to reason about.
+
+## 10. Machine-readable markers are part of the contract
+If a wrapper command changes emitted event names or payload shapes, that is a contract change.
+
+Hard rule:
+- wrapper markers must stay stable and documented
+- event parsing must not depend on ad hoc human-readable terminal text when a documented marker exists
+
+## 11. Docs are part of the implementation
+Any runtime/provider boundary change must update the corresponding docs in the same workstream.
+
+At minimum, review/update:
+- `docs/provider_runtime_refactor_plan.md`
+- `docs/provider_cli_wrapper_spec.md`
+- this file
+- architecture/API docs if public/shared behavior changed
+
+## 12. No silent fallback to old abstractions
+If a new flow is meant to use the runtime service or wrapper contract, do not silently fall back to older direct-launch paths.
+
+Fail clearly instead of preserving hidden bypasses.
+
+Silent mixed-mode behavior is how architecture drift returns.
+
+## 13. Refactor toward deletion, not layering forever
+Temporary compatibility shims are acceptable during migration.
+Permanent duplicate abstraction layers are not.
+
+When a new runtime/provider path is proven, plan the deletion of:
+- old direct provider launch paths
+- stale role terminology
+- duplicate readiness logic
+- duplicate task models where possible
+
+## 14. Tests must defend the boundary
+New runtime/provider work should add tests at the boundary being introduced.
+
+At minimum, prefer tests for:
+- runtime service to provider runtime integration
+- wrapper event/exit code behavior
+- provider readiness interpretation
+- restore/reconnect behavior
+- session lifecycle through the runtime service
+
+## 15. If unsure, push logic downward
+When deciding where code belongs:
+- if it is workflow/policy, keep it in Python orchestration
+- if it is provider-specific terminal behavior, push it into provider runtime/wrapper code
+- if it is generic terminal transport, keep it in shared tmux infrastructure
+
+That is the central organizing rule for keeping ATC clean going forward.

--- a/docs/START_HERE.md
+++ b/docs/START_HERE.md
@@ -1,0 +1,77 @@
+# ATC Start Here
+
+If you are a human or AI agent making changes in this repository, start here.
+
+This file is the entrypoint to ATC's durable developer/agent documentation.
+
+## Read this before making changes
+
+Minimum reading order for any non-trivial change:
+1. `docs/START_HERE.md`
+2. `docs/CODEBASE_MAP.md`
+3. `docs/HARD_RULES.md`
+4. `docs/DEVELOPMENT_RULES.md`
+5. `docs/TESTING_RULES.md`
+6. Any area-specific design/refactor doc relevant to the work
+
+Examples:
+- provider/runtime work:
+  - `docs/provider_runtime_refactor_plan.md`
+  - `docs/provider_cli_wrapper_spec.md`
+  - `docs/RUNTIME_PROVIDER_GUARDRAILS.md`
+- API or architecture work:
+  - `docs/ARCHITECTURE.md`
+  - `docs/API.md`
+- historical design intent:
+  - `docs/design_logs/`
+
+## Hard documentation rule
+If you make a code change, you must review the relevant `.md` docs and update them in the same workstream if they are now stale.
+
+This is a hard rule, not a suggestion.
+
+At minimum, after making a code change, the agent/developer must ask:
+- did the codebase map change?
+- did any hard rules or development rules change?
+- did testing expectations change?
+- did runtime/provider behavior change?
+- did architecture/API/docs become stale because of this change?
+
+If yes, update the docs before considering the work complete.
+
+## Purpose of this doc system
+ATC is large enough that future work should not require every agent to rediscover the architecture from scratch.
+
+These docs exist to:
+- reduce drift between code and mental model
+- reduce repeated deep dives
+- keep architecture rules durable
+- make refactors safer
+- make future agents faster and less likely to damage the codebase
+
+## Document index
+- `docs/CODEBASE_MAP.md`
+  - high-level current-state code organization and ownership map
+- `docs/HARD_RULES.md`
+  - non-negotiable rules for future development
+- `docs/DEVELOPMENT_RULES.md`
+  - coding and refactor guidelines
+- `docs/TESTING_RULES.md`
+  - what test coverage is expected for changes
+- `docs/provider_runtime_refactor_plan.md`
+  - phased runtime/provider refactor plan
+- `docs/provider_cli_wrapper_spec.md`
+  - `atc-provider` wrapper contract
+- `docs/RUNTIME_PROVIDER_GUARDRAILS.md`
+  - runtime/provider boundary rules
+- `docs/ARCHITECTURE.md`
+  - older and broader architecture overview
+- `docs/API.md`
+  - API surface reference, update when API behavior changes
+- `docs/design_logs/`
+  - important historical decisions and accepted design changes
+
+## Completion rule
+A change is not fully complete until both are true:
+1. code/tests are in acceptable shape
+2. relevant docs have been reviewed and updated if needed

--- a/docs/TESTING_RULES.md
+++ b/docs/TESTING_RULES.md
@@ -1,0 +1,42 @@
+# ATC Testing Rules
+
+These rules define the minimum testing expectations for changes.
+
+## 1. Boundary changes require boundary tests
+If you change an architectural boundary, add tests at that boundary.
+
+Examples:
+- runtime service to provider runtime integration
+- wrapper marker parsing and exit code handling
+- restore/reconnect behavior
+- session lifecycle transitions
+
+## 2. New provider support is not complete without runtime contract coverage
+A provider is not first-class just because it launches.
+
+It should have coverage for at least:
+- startup path
+- readiness path
+- instruction delivery path
+- inspection path
+- restore path where applicable
+
+## 3. Do not rely only on unit tests for orchestration changes
+Changes to Tower/Leader/Ace flows should usually include integration coverage as well.
+
+## 4. If docs specify a contract, tests should defend it where practical
+This especially applies to:
+- wrapper markers
+- exit codes
+- role/runtime contract semantics
+- API behavior when changed
+
+## 5. If a high-risk module changes, increase testing scrutiny
+High-risk modules include:
+- `src/atc/state/db.py`
+- `src/atc/tower/controller.py`
+- `src/atc/api/routers/projects.py`
+- `frontend/src/context/AppContext.tsx`
+
+## 6. Completion rule
+A change is not done when it merely compiles. It is done when the relevant level of tests and docs are both in acceptable shape.

--- a/docs/codebase_map_backend.md
+++ b/docs/codebase_map_backend.md
@@ -1,0 +1,370 @@
+# Executive summary
+ATC’s backend is a single-process FastAPI app that keeps durable state in SQLite, coordinates live agent terminals through tmux, and uses an in-process async EventBus plus WebSocket hub to glue the UI, session lifecycle, and background monitors together. The most central paths are `api/app.py` startup, `state/db.py` CRUD and schema, `session/ace.py` for tmux-backed session creation, `tower/controller.py` for top-level goal orchestration, `leader/leader.py` plus `leader/orchestrator.py` for manager/Ace delegation, and `terminal/pty_stream.py` for terminal streaming. The architecture is pragmatic and fairly cohesive, but several seams show strain: DB access is a huge god-module, orchestration logic spans routers/controllers/session helpers, provider abstraction is only partially adopted, and some lifecycle state is split between SQLite and in-memory controller fields.
+
+# ATC backend codebase map
+
+## 1. High-level shape
+- Backend root: `src/atc`
+- Main runtime style: async FastAPI + one shared `aiosqlite` connection + background tasks/monitors.
+- Orchestration substrate:
+  - SQLite persists projects, leaders, sessions, task graphs, assignments, heartbeats, context, usage, QA runs, backup log, etc.
+  - tmux provides the actual long-lived interactive agent terminals.
+  - `PtyStreamPool` pipes tmux pane output into the EventBus and WebSockets.
+  - `EventBus` coordinates internal side effects.
+  - `WsHub` is the frontend pub/sub transport.
+
+## 2. Directory and module map
+
+### `api/`
+- `api/app.py`: app factory and lifespan. Most important composition root.
+- `api/routers/`
+  - `aces.py`: CRUD/start/stop/message/status for Ace sessions.
+  - `tower.py`: Tower session start/stop, goal submission, progress, memory, cost reporting.
+  - `leader.py`: Leader decomposition, Ace spawning, task completion/failure, cleanup.
+  - `context.py`: context hub CRUD and broadcast.
+  - plus support routers for projects, memory, backup, usage, failure logs, heartbeat, settings, QA, system, etc.
+  - `tasks.py` is currently just a stub router.
+- `api/ws/`
+  - `hub.py`: channel-based websocket pub/sub.
+  - `terminal.py`, `browser.py`, `state.py`: ancillary websocket/state support.
+
+### `state/`
+- `db.py`: schema, migrations, connection helpers, and most CRUD. This is the persistence center of gravity.
+- `models.py`: dataclass row models.
+- `migrations/`: migration support, but most active schema creation still lives inline in `db.py`.
+
+### `session/`
+- `ace.py`: tmux spawning, instruction delivery, lifecycle ops, verification/reliability helpers.
+- `reconnect.py`: startup reconnection/respawn logic for existing sessions.
+- `state_machine.py`: allowed session transitions and event emission.
+- `tunnel.py`: remote/session plumbing.
+
+### `tower/`
+- `controller.py`: singleton orchestration controller for top-level goals and Tower/Leader coordination.
+- `session.py`: Tower session start/stop/message helpers.
+- `allocator.py`: capacity logic.
+- `memory.py`: currently stubbed.
+
+### `leader/`
+- `leader.py`: Leader session lifecycle, config deploy, tmux spawn, messaging.
+- `orchestrator.py`: runtime loop for ready-task discovery, Ace spawn/assignment, cleanup, retry.
+- `decomposer.py`: task graph decomposition helpers.
+- `context_package.py`: context assembly for Leader/Ace views.
+
+### `agents/`
+- `base.py`: provider protocol and metadata types.
+- `factory.py`: provider registry, launch command lookup, plugin loading.
+- `claude_provider.py`: tmux-backed provider wrapping current Claude Code flow.
+- `opencode_provider.py`: alternate provider implementation.
+- `deploy.py`: stages CLAUDE.md, hooks, settings for Tower/Leader/Ace.
+- `auth.py`: auth mode and API key resolution.
+
+### `terminal/`
+- `control.py`: lower-level tmux control-mode/send-keys helpers.
+- `pty_stream.py`: tmux `pipe-pane` to FIFO to asyncio streaming.
+- `monitor.py`, `output_parser.py`: terminal/session monitoring utilities.
+
+### Background/support subsystems
+- `core/events.py`: simple in-process async pub/sub.
+- `core/heartbeat.py`: stale-session monitor.
+- `core/cleanup.py`: startup cleanup of orphaned state.
+- `tracking/`: resource monitor, cost tracker, GitHub tracker, budget enforcer.
+- `memory/cron.py`, `memory/consolidation.py`, `memory/ace_stm.py`, `memory/ltm.py`: memory services.
+- `qa/loop.py`: QA feedback loop driven off GitHub PR rows.
+- `backup/`: local/cloud backup services.
+
+## 3. Startup and composition flow
+Central file: `src/atc/api/app.py`.
+
+`lifespan()` does almost all runtime wiring:
+1. Runs DB migrations via `run_migrations()`.
+2. Starts `EventBus`.
+3. Opens one persistent `aiosqlite` app connection and enables WAL/foreign keys.
+4. Creates `WsHub`.
+5. Creates `TowerController(db, event_bus, ws_hub)`.
+6. Starts `PtyStreamPool` and wires:
+   - EventBus `pty_output` -> `WsHub.broadcast("terminal:{session_id}")`
+   - websocket terminal input -> PTY send keys
+   - websocket resize -> tmux resize
+   - terminal subscribe -> capture current pane content
+7. Subscribes session lifecycle events to PTY reader attach/detach and UI state broadcast.
+8. Starts `HeartbeatMonitor` and wires websocket heartbeats.
+9. Runs startup cleanup and smoke test.
+10. Reconnects persisted sessions and restarts PTY readers.
+11. Restores TowerController state from DB if tower/leader sessions survived restart.
+12. Starts resource/cost/github/budget/memory/backup background services.
+13. Optionally auto-starts Tower if there are user projects and no restored tower session.
+
+This file is effectively the service container and operational playbook.
+
+## 4. Main request/control flows
+
+### A. Ace creation and work flow
+Primary files: `api/routers/aces.py`, `session/ace.py`, `session/state_machine.py`, `state/db.py`.
+
+Flow:
+1. `POST /api/projects/{project_id}/aces` in `aces.py` validates project and chooses provider launch command.
+2. `session.ace.create_ace()`:
+   - creates DB session row first with status `connecting`
+   - optionally deploys staged config files using the real session id
+   - publishes `session_created`
+   - prepares workspace via provider hook
+   - ensures tmux session exists, spawns pane, auto-accepts trust dialog
+   - stores `tmux_session`/`tmux_pane`
+   - transitions `connecting -> idle`
+3. `api/app.py` subscriber sees idle session and starts PTY streaming for its pane.
+4. `POST /api/aces/{session_id}/start` calls `start_ace()`:
+   - validates state transition
+   - sets status `working`
+   - sends initial instruction with readiness/delivery verification.
+5. Hooks or APIs later update session status through `PATCH /api/aces/{id}/status`.
+6. `DELETE /api/aces/{id}` kills pane and removes DB row.
+
+Important implementation trait: DB-first entity creation means the UI sees the session even if tmux spawn later fails.
+
+### B. Tower goal orchestration flow
+Primary files: `tower/controller.py`, `tower/session.py`, `leader/leader.py`, `leader/orchestrator.py`, `leader/context_package.py`.
+
+Flow:
+1. `POST /api/tower/start` optionally starts Tower’s own session.
+2. `POST /api/tower/goal` calls `TowerController.submit_goal(project_id, goal)`.
+3. `submit_goal()`:
+   - enforces tower state/budget/capacity guards
+   - moves Tower into `planning -> managing`
+   - builds context package from project metadata + context hub
+   - writes leader context/goal to DB
+   - seeds some project context entries
+   - starts or reuses a Leader session via `leader.start_leader()`
+   - broadcasts leader status to UI
+   - sends kickoff prompt to Leader
+   - starts a background verification/nudge loop
+4. Leader then uses the leader API to decompose tasks and spawn Aces.
+5. `TowerController.get_progress()` derives task status aggregates from `task_graphs`.
+6. When done, `mark_complete()` moves Tower to `complete`; cleanup/reset paths move it back to idle.
+
+### C. Leader decomposition and Ace delegation
+Primary files: `api/routers/leader.py`, `leader/orchestrator.py`, `leader/decomposer.py`.
+
+Flow:
+1. `POST /api/projects/{project_id}/leader/decompose`
+   - reads leader row/context
+   - turns incoming task specs into `task_graphs`
+   - broadcasts task graph updates.
+2. `POST /leader/spawn-aces`
+   - gets/creates in-memory `LeaderOrchestrator` for that project
+   - asks it to spawn Aces for dependency-ready tasks.
+3. `LeaderOrchestrator.spawn_aces_for_ready_tasks()`:
+   - lists task graphs
+   - finds ready tasks
+   - enforces global concurrency/resource governor
+   - spawns Ace sessions
+   - writes idempotent `task_assignments`
+   - advances task status to `assigned` then `in_progress`.
+4. `POST /leader/instruct` sends the actual prompt to the assigned Ace.
+5. `task-done` / `task-failed` update task graph and assignment state, destroy Ace sessions, decrement global counters, and enable retries.
+
+## 5. Session lifecycle ownership
+
+### Ownership layers
+- Persistence truth: `sessions` table in SQLite.
+- Legal transitions: `session/state_machine.py`.
+- tmux process ownership: `session/ace.py` and `leader/leader.py` plus `tower/session.py`.
+- Live stream ownership: `terminal/pty_stream.py`.
+- Cross-restart restoration: `session/reconnect.py` and `api/app.py` startup restore logic.
+- High-level orchestration ownership:
+  - Tower singleton holds current goal/session pointers in memory.
+  - Per-project `LeaderOrchestrator` holds active task-to-Ace assignments in memory.
+
+### Session types
+- `ace`: worker agents.
+- `manager`: Leader session for a project.
+- `tower`: top-level Tower session.
+
+### Notable lifecycle design choices
+- Session rows are created before panes spawn.
+- Status changes publish `session_status_changed` events but DB persistence is done separately by callers.
+- Reconnect logic skips tower/manager sessions for normal reconnection because Tower restore logic handles them specially.
+- PTY readers are attached lazily when session status reaches `idle` and a live pane exists.
+
+## 6. Data and persistence model
+Primary file: `state/db.py`.
+
+### Core relational entities
+- `projects`: repo path, github repo, selected provider, status, ordering.
+- `leaders`: one per project, stores linked session id, goal, serialized context package, status.
+- `sessions`: all tower/leader/ace terminals plus tmux identifiers and runtime flags.
+- `task_graphs`: decomposed tasks and dependency list.
+- `task_assignments`: idempotent Ace-to-task assignment records.
+- `context_entries`: scoped context hub entries (`global`, `project`, `tower`, `leader`, `ace`).
+- `session_heartbeats`: liveness tracking.
+- `usage_events`, `project_budgets`, `github_prs`, `qa_loop_runs`, `tower_memory`, `ace_stm`, `failure_logs`, `app_events`, `backup_log`, etc.
+
+### Persistence patterns
+- Very wide CRUD surface centralized in one module.
+- JSON blobs are stored in TEXT columns for context, dependencies, metadata-like fields.
+- WAL mode and busy timeout are enabled for runtime use.
+- Many tables are created through a monolithic `_SCHEMA_SQL` string, with small additive migration checks afterwards.
+- Some business invariants live in Python, not DB constraints, for example task graph status transitions.
+
+### Context visibility model
+`get_context_for_agent()` encodes inheritance:
+- Ace sees global + project + parent leader + own session entries.
+- Leader sees global + project + own leader entries.
+- Tower sees global + own tower entries.
+
+## 7. Provider/runtime abstractions
+Primary files: `agents/base.py`, `agents/factory.py`, `agents/claude_provider.py`.
+
+### Intended abstraction
+`AgentProvider` protocol abstracts:
+- session spawn
+- workspace prep
+- readiness checks
+- prompt send
+- status lookup
+- output streaming
+- stop/list
+
+### Actual runtime reality today
+- The abstraction exists, but the system is still tmux-first.
+- `factory.get_launch_command()` is widely used to choose the CLI command.
+- `ClaudeCodeProvider` wraps the existing tmux approach and is tested for workspace prep/readiness.
+- Core lifecycle code still directly calls low-level tmux helpers in `session/ace.py` and `leader/leader.py` rather than delegating fully through a provider instance.
+- Provider hooks are used opportunistically for workspace prep, not as the exclusive execution path.
+
+So the provider layer is a partial seam, not yet the dominant architecture.
+
+## 8. Orchestration boundaries
+
+### API boundary
+- FastAPI routers validate input and translate domain errors to HTTP.
+- Routers are mostly thin, but `leader.py` also owns an in-process orchestrator cache, which is a notable leak of orchestration state into the API layer.
+
+### Orchestration boundary
+- `TowerController` owns top-level goal lifecycle and Tower/Leader coordination.
+- `LeaderOrchestrator` owns task readiness, Ace spawning, task completion/failure handling.
+
+### Runtime/process boundary
+- tmux is the process/session boundary for interactive agents.
+- PTY FIFO piping is the streaming boundary.
+- WebSocket channels are the frontend live-state boundary.
+
+### Persistence boundary
+- SQLite is the durable source of truth for nearly everything except some controller-local runtime state.
+
+## 9. Recurring code patterns
+- DB-first creation, then external side effect, then status transition.
+- Event-driven side effects via `EventBus.publish()` after session/tower changes.
+- Best-effort broadcasting to `WsHub` after important state changes.
+- tmux reliability helpers: trust-dialog acceptance, prompt readiness checks, capture-pane verification, pane-alive checks.
+- Startup reconciliation: cleanup, smoke test, reconnect, restore, then background monitors.
+- In-memory caches for orchestration (`TowerController` singleton fields, `_orchestrators` dict, global Ace counter).
+- Repeated state duplication across DB status + in-memory fields + websocket messages.
+
+## 10. Central files and functions
+
+### Most central files
+- `src/atc/api/app.py`
+- `src/atc/state/db.py`
+- `src/atc/session/ace.py`
+- `src/atc/tower/controller.py`
+- `src/atc/leader/leader.py`
+- `src/atc/leader/orchestrator.py`
+- `src/atc/terminal/pty_stream.py`
+- `src/atc/api/ws/hub.py`
+
+### Central functions/methods
+- `api.app.lifespan()`
+- `state.db.run_migrations()`
+- `state.db.create_session()`, `update_session_status()`, `assign_task()`, `get_context_for_agent()`
+- `session.ace.create_ace()`, `start_ace()`, `send_instruction()`, `verify_session()`
+- `session.reconnect.reconnect_session()` / `reconnect_all()`
+- `tower.controller.TowerController.submit_goal()`, `start_session()`, `get_progress()`
+- `leader.leader.start_leader()`, `send_leader_message()`
+- `leader.orchestrator.LeaderOrchestrator.spawn_aces_for_ready_tasks()`, `_spawn_ace_for_task()`, `mark_task_done()`, `mark_task_failed()`
+- `terminal.pty_stream.PtyStreamPool.add_session()`
+- `core.heartbeat.HeartbeatMonitor.handle_heartbeat()` / `_check_heartbeats()`
+
+## 11. Tests and what they cover
+
+### Strongly represented areas
+- `tests/e2e/test_ace_lifecycle.py`: end-to-end REST lifecycle for Ace sessions with tmux mocked.
+- `tests/unit/test_db.py`: connection factory, migrations, project/leader/session CRUD.
+- `tests/unit/test_tower_controller.py`: Tower state transitions, goal submission, monitoring behavior.
+- `tests/unit/test_provider_abstraction.py`: Claude provider workspace prep/readiness.
+- `tests/integration/test_websocket_hub.py`: websocket hub behavior.
+- Several session/tmux reliability tests: `test_terminal_control.py`, `test_pty_stream.py`, `test_state_machine.py`, `test_tower_session_reuse.py`, `test_tower_respawn.py`, `test_creation_reliability.py`.
+
+### Architectural signal from tests
+- The backend is tested more at behavioral boundaries than at pure domain boundaries.
+- tmux flows are heavily mocked, which is practical but means some orchestration complexity is only partially integration-tested.
+
+## 12. Concrete tech debt and refactor seams
+
+### A. `state/db.py` is a god-module
+Symptoms:
+- schema definition, migrations, and almost all CRUD live together
+- spans unrelated domains: projects, sessions, context, budgets, QA, backups, GitHub, heartbeats.
+
+Refactor seam:
+- split by aggregate/domain (`projects_repo.py`, `sessions_repo.py`, `context_repo.py`, etc.) while keeping `models.py` and shared connection helpers.
+
+### B. Provider abstraction is incomplete
+Symptoms:
+- lifecycle code still calls tmux primitives directly
+- provider is used for workspace prep and launch command lookup, not as the canonical runtime path.
+
+Refactor seam:
+- move spawn/send/status/stream responsibilities fully behind provider adapters; make tmux-backed Claude provider the first concrete implementation.
+
+### C. Runtime state is split between DB and process memory
+Symptoms:
+- Tower current goal/session ids live in controller fields
+- Leader orchestrators live in module-global cache
+- global active Ace count is process-local
+- restart recovery needs special-case restore logic.
+
+Risk:
+- stale in-memory state, restart edge cases, hard horizontal scaling.
+
+Refactor seam:
+- persist more orchestration state explicitly, or create a dedicated runtime-state service with clearer ownership.
+
+### D. Orchestration concerns bleed into routers
+Symptoms:
+- `api/routers/leader.py` owns orchestrator cache creation and event subscription.
+
+Refactor seam:
+- introduce an application service/facade layer so routers stay thin transport adapters.
+
+### E. Session state transitions are not transactionally coupled to DB writes
+Symptoms:
+- `transition()` only publishes events; callers separately persist DB changes.
+
+Risk:
+- event says one thing, DB write fails, or vice versa.
+
+Refactor seam:
+- add a transaction-aware session service that validates, persists, and emits in one place.
+
+### F. Startup flow is doing too much in one function
+Symptoms:
+- `lifespan()` owns migrations, bus wiring, PTY wiring, reconnection, tower restore, monitors, smoke tests, auth checks, backup scheduling.
+
+Refactor seam:
+- extract startup coordinators/modules for infra init, session recovery, tower recovery, and background services.
+
+### G. Multiple overlapping terminal control paths
+Symptoms:
+- direct `_tmux_run` helpers, `terminal/control.py`, and `ClaudeCodeProvider` all encapsulate parts of tmux interaction.
+
+Refactor seam:
+- consolidate to one tmux service layer used by session lifecycle and provider implementations.
+
+### H. Stubbed or half-finished areas
+- `api/routers/tasks.py` is empty.
+- `tower/memory.py` is a stub despite tower memory table existing.
+- Some orchestration features appear to exist mainly through side effects and tests rather than cohesive domain modules.
+
+## 13. Overall read on the architecture
+The backend is a practical orchestration server built around a strong core idea: SQLite for durable coordination state, tmux for durable interactive agent processes, and a simple in-process event/websocket layer for liveliness. That core is clear and mostly consistent. The main limitations are not conceptual but organizational: too much logic is concentrated in a few large modules, several abstractions are only half-complete, and runtime ownership is split across DB rows, tmux state, and in-memory controller caches.

--- a/docs/codebase_map_current_state.md
+++ b/docs/codebase_map_current_state.md
@@ -1,0 +1,240 @@
+# ATC current-state architecture brief
+
+## Executive summary
+ATC already has the beginnings of a provider abstraction, but the current runtime is still only partially organized around it. The real execution core remains tmux-centric and strongly shaped by Claude-specific startup, readiness, and terminal assumptions. That means the product surface says providers are selectable, while the backend often still behaves as though it is operating one default provider with alternate launch commands.
+
+The right refactor direction is not to remove tmux. It is to make tmux the stable transport substrate and move all provider-specific CLI behavior behind one central runtime interface. The backend should orchestrate roles and workflows without caring whether the underlying provider implementation is Claude Code, Codex, OpenCode, or another tmux-driven AI CLI.
+
+## What exists today
+
+### Durable strengths
+- ATC already has a clear role model: Tower, Leader, Ace.
+- tmux is already the common runtime transport for interactive CLI sessions.
+- SQLite gives the system durable state for projects, sessions, task graphs, assignments, context, and monitoring.
+- FastAPI, websocket, PTY streaming, and the event bus provide a workable orchestration shell.
+- There is already an `AgentProvider` abstraction in `src/atc/agents/base.py` and a registry in `src/atc/agents/factory.py`.
+
+### What is not actually clean yet
+- Provider selection often changes a launch command, not the lifecycle/control boundary.
+- Shared session code still contains Claude-specific readiness, trust-dialog, workspace, and prompt assumptions.
+- Session creation, restart, and reconnect paths are split across multiple layers instead of going through one runtime boundary.
+- Tower, Leader, and Ace do not all go through one unified provider/runtime contract.
+- Role terminology and task modeling have drifted enough to make refactoring riskier than it should be.
+
+## Current architecture by layer
+
+### 1. Product/orchestration layer
+This is the part of ATC that should remain provider-agnostic.
+
+Primary responsibilities:
+- manage projects
+- manage Tower, Leader, and Ace roles
+- submit goals
+- decompose work
+- assign tasks
+- track progress
+- enforce budgets/concurrency
+- persist state
+- restore operational context
+
+Important files today:
+- `src/atc/tower/controller.py`
+- `src/atc/leader/orchestrator.py`
+- `src/atc/api/routers/projects.py`
+- `src/atc/api/routers/leader.py`
+- `src/atc/api/routers/aces.py`
+- `src/atc/state/db.py`
+
+Reality today: this layer still knows too much about provider-specific runtime behavior.
+
+### 2. Runtime/session-control layer
+This is where tmux-backed terminal lifecycle is actually controlled.
+
+Important files today:
+- `src/atc/session/ace.py`
+- `src/atc/leader/leader.py`
+- `src/atc/tower/session.py`
+- `src/atc/session/reconnect.py`
+- `src/atc/terminal/control.py`
+- `src/atc/terminal/pty_stream.py`
+
+Reality today:
+- this layer is the de facto operational core
+- it is shared across roles, but not cleanly abstracted behind one interface
+- it leaks provider assumptions upward
+
+### 3. Provider layer
+This should be the only place where CLI-specific behavior lives.
+
+Important files today:
+- `src/atc/agents/base.py`
+- `src/atc/agents/factory.py`
+- `src/atc/agents/claude_provider.py`
+- `src/atc/agents/opencode_provider.py`
+
+Reality today:
+- the abstraction exists
+- but much of the runtime bypasses it and uses `get_launch_command()` plus shared tmux helpers directly
+- providers are not the true boundary yet
+
+### 4. UI layer
+The frontend is already mostly expressing the right high-level intent, but it is coupled to backend drift.
+
+Important files today:
+- `frontend/src/context/AppContext.tsx`
+- `frontend/src/pages/ProjectView.tsx`
+- `frontend/src/components/tower/*`
+- `frontend/src/components/leader/*`
+- `frontend/src/components/ace/*`
+
+Reality today:
+- the UI treats providers as selectable
+- but several flows still assume Claude-shaped runtime behavior or incomplete provider semantics
+
+## What the mapping found
+
+### A. The current provider abstraction is partial, not authoritative
+ATC has an interface, but the runtime does not consistently use it as the single owner of provider behavior.
+
+Instead, the real pattern is often:
+1. choose provider
+2. get launch command
+3. spawn pane through shared tmux/session helpers
+4. run shared readiness/delivery logic
+5. special-case provider behavior later
+
+That is why selectable providers feel unstable.
+
+### B. tmux is already the true shared substrate
+That is good news. Matthew's clarified direction matches the architecture that wants to exist here.
+
+The stable shared substrate should be:
+- tmux session/window/pane lifecycle
+- PTY capture/streaming
+- resize/input/output plumbing
+- pane existence/aliveness checks
+- restore/reconnect hooks
+
+Those are cross-provider concerns and can remain shared.
+
+### C. Provider-specific code should only own CLI semantics
+Examples of provider-owned concerns:
+- command construction
+- startup expectations and prompts
+- trust/login/readiness detection
+- instruction framing rules
+- how to determine "idle/ready/working"
+- output parsing hints
+- provider-specific config files or workspace scaffolding
+- provider-specific recoverability rules
+
+### D. Backend orchestration should talk in role operations, not CLI details
+The backend should ask for operations such as:
+- start tower
+- stop tower
+- start leader
+- stop leader
+- start ace
+- stop ace
+- send leader instruction
+- send ace task assignment
+- check readiness/status
+- capture transcript/output
+- reconnect/restore existing session
+
+Those should go through one central runtime interface.
+
+## Biggest current architectural problems
+
+### 1. Shared code still knows Claude-shaped behavior
+Examples surfaced in the mapping:
+- trust-dialog handling in shared paths
+- Claude-specific workspace prep leaking into generic session creation
+- readiness logic tied to expected terminal patterns
+- frontend auto-start logic keyed to `claude_code`
+
+### 2. Runtime ownership is split across too many modules
+The same lifecycle is partly owned by:
+- role-specific session files
+- reconnect logic
+- provider helpers
+- routers/controllers
+- terminal control helpers
+
+That makes provider encapsulation incomplete.
+
+### 3. Terminology drift raises refactor cost
+The repo still mixes:
+- product term: `Leader`
+- runtime/storage/API term: `manager`
+
+This drift is everywhere and should be normalized before or during the refactor.
+
+### 4. Legacy and live work models coexist
+- legacy `tasks`
+- live `task_graphs`
+
+That is a separate but important cleanup seam because it impacts orchestration/UI boundaries.
+
+### 5. Docs/contracts have drifted from runtime truth
+This matters because ATC is being developed with docs/design logs as active artifacts. Those need to be resynced once the new runtime boundary is agreed.
+
+## Recommended target architecture
+
+### Core principle
+The backend should not care which AI CLI provider is being used.
+
+It should care about:
+- role: Tower, Leader, Ace
+- desired operation: start, stop, instruct, assign, inspect, restore
+- persisted session identity/state
+- workflow outcomes
+
+It should not care about:
+- exact CLI startup command details
+- provider-specific prompt quirks
+- provider-specific readiness heuristics
+- provider-specific login/trust sequences
+
+### Stable layering
+
+#### Layer 1: orchestration/application layer
+Provider-agnostic.
+- tower workflows
+- leader workflows
+- ace workflows
+- task assignment/decomposition
+- project state
+- persistence and recovery policy
+
+#### Layer 2: tmux runtime substrate
+Shared, provider-agnostic transport.
+- spawn pane/window/session
+- send raw input
+- capture output
+- stream PTY
+- resize
+- check pane/session aliveness
+- reconnect to existing pane
+
+#### Layer 3: provider runtime interface
+Provider-specific, tmux-backed behavior.
+- construct commands
+- attach provider-specific bootstrap files
+- determine readiness
+- send prompts/instructions correctly
+- interpret output and state transitions
+- detect failures/login/trust conditions
+
+#### Layer 4: provider implementations
+Examples:
+- `providers/claude_code/*`
+- `providers/codex/*`
+- `providers/opencode/*`
+
+Each one implements the same role/runtime contract.
+
+## Recommendation
+The direction Matthew described is the right one.
+
+ATC should keep tmux as the common runtime transport, but the provider refactor should make one runtime interface the only legal entry point for provider-specific behavior. If that is done cleanly, Codex support stops being a special adaptation problem and becomes a normal implementation of the same contract.

--- a/docs/codebase_map_frontend.md
+++ b/docs/codebase_map_frontend.md
@@ -1,0 +1,385 @@
+# Executive summary
+ATC’s frontend is a React + Vite SPA wrapped by a very thin Tauri shell. The main architectural center is `frontend/src/context/AppContext.tsx`, which bootstraps state from REST, keeps it live via a shared WebSocket, and feeds route-level screens for dashboard, project workspace, usage, and context. The desktop side in `src-tauri/src/lib.rs` mostly just starts plugins and spawns the Python `atc-server` sidecar, so almost all product behavior lives in the web app. The strongest refactor seams are around state management and data fetching, repeated imperative fetch-on-render patterns, duplicated session-control logic across Tower/Leader/Ace components, and a settings/test surface that has drifted from the routed app.
+
+# ATC frontend and desktop codebase map
+
+## Scope mapped
+- `atc/frontend/src`
+- `atc/frontend/tests`
+- `atc/src-tauri`
+
+## High-level UI architecture
+- Entry point: `frontend/src/main.tsx`
+  - Initializes Sentry, wraps app in `ErrorBoundary`, and mounts a `QueryClientProvider`.
+  - React Query is configured, but the actual app mostly does not use it yet. Most fetching is manual via `api` and local state.
+- Router and shell: `frontend/src/App.tsx`
+  - Global shell is `TowerBar` on top, route content in the middle, persistent `TowerPanel` on bottom.
+  - Routes:
+    - `/dashboard` → `pages/Dashboard.tsx`
+    - `/projects/:id` → `pages/ProjectView.tsx`
+    - `/usage` → `pages/UsagePage.tsx`
+    - `/context` → `pages/ContextPage.tsx`
+  - `StartupGate` blocks the UI in Tauri until the sidecar backend responds.
+- App-wide state and live updates: `frontend/src/context/AppContext.tsx`
+  - This is the real app hub.
+  - Holds normalized-ish global state for projects, leaders, sessions, task graphs, budgets, usage, GitHub summaries, notifications, tower detail/progress, failure logs, and heartbeats.
+  - Hydrates via `fetchAll()` on backend readiness.
+  - Applies incremental updates from WebSocket channels.
+
+## State and data flow
+### Core pattern
+1. `useBackendReady()` waits for `/api/health` in Tauri.
+2. `AppProvider.fetchAll()` performs a fan-out REST bootstrap.
+3. Components read from context state and call `api` directly for mutations.
+4. WebSocket messages patch the reducer state in near real time.
+5. Some components still call `fetchAll()` after mutations instead of doing targeted cache updates.
+
+### Central files
+- `frontend/src/context/AppContext.tsx`
+- `frontend/src/utils/api.ts`
+- `frontend/src/hooks/useWebSocket.ts`
+- `frontend/src/hooks/useTerminal.ts`
+- `frontend/src/types/index.ts`
+
+### REST bootstrap in `fetchAll()`
+`AppContext` loads:
+- `/projects`
+- per project `/projects/:id/aces`
+- per project `/projects/:id/manager`
+- per project `/projects/:id/task-graphs`
+- `/heartbeat`
+- `/failure-logs?limit=200`
+- `/tower/status`
+
+Notable gap: `initialState` includes `tasks`, `budgets`, `notifications`, and `github`, but `fetchAll()` does not populate all of them here. Some of those surfaces appear partial, legacy, or dependent on websocket payloads / page-local fetches.
+
+### Reducer shape
+`AppContext` reducer is a straightforward switch reducer with:
+- bulk setters (`SET_PROJECTS`, `SET_LEADERS`, etc.)
+- event-like updaters (`ADD_PROJECT`, `UPDATE_SESSION_STATUS`, `UPDATE_HEARTBEAT`)
+- minimal denormalization, mostly storing arrays plus a few maps keyed by project/session id
+
+### API client
+`frontend/src/utils/api.ts`
+- Uses `fetch` with JSON defaults and a 30s timeout.
+- Switches base URL between `/api` in browser dev and `http://127.0.0.1:8420/api` in Tauri.
+- Wraps structured backend errors in `ApiError` with `code` and `extra`.
+
+## WebSocket and realtime integration
+### Shared app stream
+`frontend/src/hooks/useWebSocket.ts`
+- Connects to `/ws`.
+- Subscribes by sending `{ channel: "subscribe", data: [...] }`.
+- Handles reconnect with exponential backoff + jitter.
+- Used centrally by `AppContext` for channels:
+  - `state`
+  - `failure_logs`
+  - `tower`
+  - `heartbeat`
+
+### Message handling in `AppContext`
+- `state` channel:
+  - full/partial state patches
+  - project create/update/delete
+  - session create/status change
+  - task graph refresh for one project
+- `tower` channel:
+  - tower state changes
+  - current tower session id
+  - leader session id
+  - progress counts
+  - leader activity preview
+- `heartbeat` channel:
+  - session liveness state (`alive`, `stale`, `stopped`)
+- `failure_logs` channel:
+  - append and resolve log entries
+
+### PTY / terminal streams
+`frontend/src/hooks/useTerminal.ts`
+- Separate per-terminal WebSocket connection pattern.
+- Builds xterm.js terminal instances and subscribes to `terminal:<session_id>` channels.
+- Sends user input and resize events back over WS.
+- Buffers writes until terminal is attached, and re-requests snapshots for hidden/collapsed panes.
+- Contains output cleanup for overly long box-drawing separators.
+
+This hook is the core integration seam for:
+- Tower terminal
+- Leader terminal
+- Ace terminal
+
+## Main screens and components
+## 1. Dashboard
+Files:
+- `pages/Dashboard.tsx`
+- `components/dashboard/ProjectGridView.tsx`
+- `components/dashboard/ProjectRowView.tsx`
+- `components/dashboard/ProjectBoardView.tsx`
+
+Responsibilities:
+- top summary cards for cost, tokens, sessions, notifications
+- create project entry point
+- three project list modes: grid, row, board
+- localStorage persistence for preferred dashboard view
+- archive/delete project actions
+- optimistic local reorder in all three project presentations
+
+Patterns:
+- Grid and row views reorder via `PATCH /projects/reorder`.
+- Board view additionally changes project status by drag-and-drop across columns.
+- Uses `dnd-kit` heavily for ordering and cross-column moves.
+- Dashboard keeps a local `orderedProjects` array layered over context state for optimistic UX.
+
+Important components:
+- `ProjectGridView`: card-heavy summary, archive/delete actions
+- `ProjectRowView`: denser operational list
+- `ProjectBoardView`: status columns for active/paused/archived
+
+## 2. Project workspace
+Main file: `pages/ProjectView.tsx`
+
+This is the densest operational screen. Layout is custom split-pane UI with persisted sizes.
+
+Structure:
+- Left column
+  - `leader/TaskBoard.tsx` at top
+  - `ace/AceList.tsx` or `ace/AceConsole.tsx` below
+- Right column
+  - `leader/LeaderConsole.tsx`
+- Bottom full-width
+  - `context/ContextHub.tsx`
+
+Key behaviors:
+- panel sizes persisted in localStorage
+- expanded ace console swaps in place with compact ace card list
+- route-driven project lookup from app context
+
+### Leader surface
+`components/leader/LeaderConsole.tsx`
+- Starts/stops project leader via REST.
+- Auto-starts if provider is `claude_code`.
+- Attaches terminal through `useTerminal`.
+- Has a tabbed lower section:
+  - `GitHubPanel`
+  - `BudgetPanel`
+
+### Ace surface
+- `components/ace/AceList.tsx`
+- `components/ace/AceConsole.tsx`
+- `components/ace/AceTerminal.tsx`
+
+Capabilities:
+- create, start, stop, delete ace sessions
+- show session health and status badges
+- map assigned task graph title onto each ace
+- compact list mode embeds mini terminals per ace card
+- expanded console mode gives tabbed ace switching
+
+### Task surface
+`components/leader/TaskBoard.tsx`
+- Local create form for task graphs
+- Toggle between kanban and table modes
+- Currently mostly presentational after creation, with no inline edit/drag/status mutation flow
+
+### Context surface
+`components/context/ContextHub.tsx`
+- Reused in both project page and dedicated context page
+- Supports scopes: `global`, `project`, `tower`, `leader`, `ace`
+- CRUD for context entries
+- Polls every 5 seconds instead of using websocket updates
+- Inline edit/save, restricted toggle, delete confirmation
+
+## 3. Usage page
+Main file: `pages/UsagePage.tsx`
+- Uses Recharts for cost, token, and CPU/RAM charts.
+- Pulls summary numbers from app context, but chart series are fetched locally.
+- Period selector drives cost/token refetch.
+- Budget utilization list reads `budgets` from app context.
+
+Important note:
+- Fetching is triggered imperatively during render using `if (!loaded) void fetch...`, not from `useEffect`. It works, but it is a fragile anti-pattern.
+
+## 4. Context page
+Main file: `pages/ContextPage.tsx`
+- Thin page wrapper around `ContextHub` in global mode with scope tabs enabled.
+
+## Global shell surfaces
+### Tower bar
+`components/tower/TowerBar.tsx`
+- Primary app chrome and nav
+- status dot from tower state
+- cost/token/project metrics
+- notification badge
+- failure log badge
+- opens `LogViewer` and `SettingsPane`
+
+### Tower panel
+`components/tower/TowerPanel.tsx`
+- Persistent bottom terminal panel, conceptually like an IDE integrated terminal
+- Auto-starts Tower when idle unless user explicitly stopped it
+- Resolves context project from route when possible
+- Shows ticker, progress counts, start/stop controls
+- Uses `useTerminal` for live PTY
+
+### Failure log viewer
+`components/tower/LogViewer.tsx`
+- Filterable failure log list
+- Can copy a Claude-friendly incident bundle to clipboard
+- Can send Sentry reports
+- Can mark logs resolved via API
+
+## Settings and provider UX
+### Current settings surface
+There is no routed `/settings` page in `App.tsx`. Settings are exposed as an overlay pane opened from `TowerBar`:
+- `components/tower/SettingsPane.tsx`
+
+### What the pane actually contains
+- Read-only backend URL and simple “Connected” indicator
+- GitHub default org stored in localStorage
+- `BackupPanel`
+- `ResourceLimitsPanel`
+- Tower status summary
+
+### Backup UX
+`components/settings/BackupPanel.tsx`
+- Richest settings subpanel
+- shows backup status and recent backup logs
+- create backup now
+- restore from path
+- connect Dropbox / Google Drive through auth URL + pasted code flows
+
+### Resource limits UX
+`components/settings/ResourceLimitsPanel.tsx`
+- loads and saves `/settings/resource-limits`
+- edits max ace concurrency and CPU/RAM throttle/pause thresholds
+
+### Feature flags / provider-related drift
+- `components/settings/FeatureFlagsPanel.tsx` and `hooks/useFeatureFlags.ts` exist.
+- `FeatureFlagsPanel` does not appear to be wired into the main shell or routed pages.
+- Provider UX at project creation is minimal: `CreateProjectModal` captures name/description/repo path/GitHub repo, but not provider selection despite `Project.agent_provider` existing in types and leader behavior depending on provider.
+
+Implication: provider configuration appears to be backend-driven or incomplete on the frontend.
+
+## Tauri desktop shell integration
+Central files:
+- `src-tauri/src/lib.rs`
+- `src-tauri/src/main.rs`
+- `src-tauri/tauri.conf.json`
+
+### What Tauri does today
+- Registers process and shell plugins in setup.
+- Spawns sidecar binary `atc-server` at startup.
+- Loads built frontend from `../frontend/dist`.
+- Opens one main window at 1280x800.
+
+### Frontend Tauri-awareness
+- Tauri detection pattern is consistent: check `"__TAURI_INTERNALS__" in window`.
+- Used for:
+  - startup gating (`useBackendReady`)
+  - choosing REST base URL
+  - choosing WS host
+  - updater flow (`useUpdater`)
+- Updater UI exists in frontend (`UpdateBanner`, `useUpdater`), but `tauri.conf.json` has `createUpdaterArtifacts: false`, so desktop update support looks only partially enabled.
+
+## Recurring frontend patterns
+### Common good patterns
+- Clear file/domain grouping by feature (`tower`, `leader`, `ace`, `dashboard`, `context`, `settings`)
+- Centralized TS model definitions in `types/index.ts`
+- Confirm actions wrapped in reusable `ConfirmPopover`
+- Strong use of `data-testid` on important surfaces
+- Reusable live terminal abstraction in `useTerminal`
+
+### Common implementation style
+- REST mutations are mostly issued directly from components.
+- Many mutations call `onRefresh` or `fetchAll` instead of updating local state surgically.
+- Local UI state is frequently persisted in localStorage.
+- Several components lazy-fetch their own secondary data rather than using global context.
+
+## Tests and frontend verification surface
+### Unit/integration tests under `frontend/src`
+Examples:
+- `context/__tests__/AppContext.test.tsx`
+- `pages/__tests__/Dashboard.test.tsx`
+- `pages/__tests__/ProjectView.test.tsx`
+- `pages/__tests__/UsagePage.test.tsx`
+- `hooks/useWebSocket.test.ts`
+- `utils/__tests__/api.test.ts`
+
+These mostly exercise rendering and low-level behavior, not deep live workflows.
+
+### E2E tests under `frontend/tests/e2e`
+- `dashboard-views.spec.ts`
+- `atc-qa.spec.ts`
+- `qa-full.spec.ts`
+
+Notable drift:
+- `dashboard-views.spec.ts` tests `/settings`, but the app router currently has no `/settings` route. Settings now live in a shell pane. That is a concrete sign of test/product divergence.
+
+## Tech debt and refactor seams
+### 1. App state management is doing too much in one provider
+`AppContext.tsx` is the central nervous system, but it now owns:
+- initial load orchestration
+- reducer logic
+- websocket event translation
+- backend readiness coupling
+
+Good refactor seam:
+- split into data domains or custom stores/hooks, for example projects/sessions, tower, logs, usage
+- or actually adopt React Query for server state and keep context for only UI/session state
+
+### 2. React Query is present but largely unused
+`main.tsx` installs `QueryClientProvider`, but most of the app still uses hand-written fetch state.
+This creates duplicated loading/error logic and manual invalidation.
+
+### 3. Imperative fetches inside render
+Several components use patterns like `if (!loaded) void fetchPrs()` or `if (!costLoaded) void fetchCost(period)` inside component bodies.
+This is risky under StrictMode and makes render side-effectful.
+Targets include:
+- `UsagePage.tsx`
+- `GitHubPanel.tsx`
+
+### 4. Repeated start/stop session logic
+Tower, Leader, and Ace surfaces each implement similar REST control and optimistic UI logic separately.
+A shared session-control hook/service would reduce duplication and inconsistent behavior.
+
+### 5. Mixed data freshness model
+The app uses:
+- websocket push for state/tower/logs/heartbeats
+- polling for context entries
+- full `fetchAll()` refreshes after many mutations
+- page-local fetches for usage charts and GitHub PRs
+
+This works, but creates uneven responsiveness and more state synchronization burden.
+
+### 6. Settings surface is fragmented and partially orphaned
+- `SettingsPane` is the actual entry point.
+- `FeatureFlagsPanel` exists but appears unmounted.
+- E2E still assumes a `/settings` page.
+- provider configuration is not visible in project creation UX.
+
+### 7. Model/type mismatch or partially implemented state
+`AppState` includes structures that are not fully bootstrapped in `fetchAll()`.
+That suggests either backend websocket dependence, unfinished migration, or stale state fields.
+Worth auditing:
+- `tasks`
+- `budgets`
+- `notifications`
+- `github`
+
+### 8. Terminal integration complexity is concentrated in one hook
+`useTerminal.ts` is effective but fairly intricate, with buffering, reconnects, resize syncing, and hidden-container recovery. It is a valuable abstraction, but also a hotspot where regressions would affect Tower, Leader, and Ace simultaneously.
+
+## Most central files to read first
+If someone is onboarding, the best reading order is:
+1. `frontend/src/App.tsx`
+2. `frontend/src/context/AppContext.tsx`
+3. `frontend/src/utils/api.ts`
+4. `frontend/src/hooks/useWebSocket.ts`
+5. `frontend/src/hooks/useTerminal.ts`
+6. `frontend/src/pages/Dashboard.tsx`
+7. `frontend/src/pages/ProjectView.tsx`
+8. `frontend/src/components/tower/TowerPanel.tsx`
+9. `frontend/src/components/leader/LeaderConsole.tsx`
+10. `src-tauri/src/lib.rs`
+
+## Net assessment
+The frontend already has a coherent operator-console shape: dashboard for project fleet management, deep per-project workspace, persistent tower terminal, and supporting usage/context/settings overlays. Its main challenge is not surface area but consistency: state fetching, live updates, and settings/provider affordances are implemented in several different styles. The cleanest next refactor would be to consolidate server-state access patterns and make the routed/product-tested surface match the actual shell UX.

--- a/docs/codebase_map_provider_runtime.md
+++ b/docs/codebase_map_provider_runtime.md
@@ -1,0 +1,249 @@
+# Executive summary
+
+ATC has a provider abstraction on paper, but the live runtime is still overwhelmingly tmux and Claude-centric. The abstraction lives in `src/atc/agents/base.py` and `src/atc/agents/factory.py`, yet most real lifecycle code for Tower, Leader, and Ace still launches tmux panes directly through `_spawn_pane()` and `get_launch_command()` instead of driving `AgentProvider.spawn_session()` / `send_prompt()`. That split is the main reason provider switching still feels unstable: the UI, settings, and project metadata say providers are selectable, but the operational control plane still assumes a shared tmux-backed terminal model, Claude startup dialogs, Claude-specific working-dir/config deployment, and PTY-based restore/reconnect semantics.
+
+The biggest root causes are: (1) two session-control architectures coexisting, provider protocol vs direct tmux control, (2) inconsistent provider use across roles, especially Ace creation hardcoding Claude workspace prep, (3) multiple overlapping sources of truth for status and restore state, and (4) several semantic mismatches, such as Leader being stored as session type `manager` while some logic looks for `leader`. These issues make selectable-provider behavior look supported in the product surface while remaining only partially real in the runtime.
+
+## 1. Main code map
+
+### Provider abstraction
+- `src/atc/agents/base.py`
+  - Defines `AgentProvider`, `SessionInfo`, `PromptResult`, `OutputChunk`, `ProviderCapabilities`.
+  - Canonical provider API expects provider-owned `spawn_session()`, `send_prompt()`, `get_status()`, `stream_output()`, `stop_session()`, `list_sessions()`.
+- `src/atc/agents/factory.py`
+  - Registry plus builtin providers.
+  - Builtins: `claude_code`, `opencode`.
+  - `get_launch_command()` is especially important because much of the app bypasses provider objects and only asks for a shell command.
+
+### Concrete providers
+- `src/atc/agents/claude_provider.py`
+  - Provider implementation is tmux-native.
+  - Tracks sessions only in an in-memory `_sessions` dict.
+  - Uses tmux `new-window`, `capture-pane`, `kill-pane`, and `send_instruction_async()`.
+- `src/atc/agents/opencode_provider.py`
+  - Talks to an OpenCode HTTP API, but still spawns a tmux pane for visibility.
+  - Tracks sessions only in an in-memory `_pane_ids` dict.
+  - Has no DB integration and does not participate in ATC restore logic.
+
+### Direct session runtime, still dominant
+- `src/atc/session/ace.py`
+  - Shared tmux helpers: `_ensure_tmux_session()`, `_spawn_pane()`, `_accept_trust_dialog()`.
+  - Ace lifecycle: `create_ace()`, `start_ace()`, `stop_ace()`, `destroy_ace()`.
+- `src/atc/leader/leader.py`
+  - Leader lifecycle, but persisted session type is `manager`.
+- `src/atc/tower/session.py`
+  - Tower session lifecycle.
+- `src/atc/session/reconnect.py`
+  - Reconnect/respawn logic after restart.
+- `src/atc/session/state_machine.py`
+  - DB/event-bus session status machine.
+
+### Terminal control and streaming
+- `src/atc/terminal/control.py`
+  - Persistent tmux control-mode connection for reliable send-keys.
+- `src/atc/terminal/pty_stream.py`
+  - `tmux pipe-pane` to FIFO, then event bus `pty_output`.
+- `src/atc/terminal/monitor.py`
+  - Parses PTY output into session status/cost/error events.
+
+### Startup and restore orchestration
+- `src/atc/api/app.py`
+  - Lifespan startup wires TowerController, PTY streaming, websocket forwarding, reconnect, Tower restore, and Tower auto-start.
+
+## 2. What the architecture says vs what the runtime does
+
+### Intended model
+The provider protocol suggests this shape:
+1. choose provider from config/project,
+2. provider spawns and owns sessions,
+3. provider reports status/output,
+4. runtime stays provider-agnostic.
+
+### Actual model
+The live runtime mostly does this instead:
+1. read project `agent_provider`,
+2. convert it to a launch command via `get_launch_command()`,
+3. call shared tmux helpers in `session/ace.py`,
+4. rely on tmux pane IDs in the DB,
+5. stream/capture output via tmux/PTY,
+6. special-case Claude startup dialogs and CLAUDE.md deployment.
+
+That means provider selection is often only changing the command string, not the control plane.
+
+## 3. Provider semantics by role
+
+### Tower
+- Tower is treated as its own session type, `tower`, in `src/atc/tower/session.py`.
+- Startup path:
+  - resolve or create anchor project,
+  - deploy Tower identity files with `deploy_tower_files()`,
+  - choose command with `get_launch_command(project.agent_provider)`,
+  - `_spawn_pane()` in tmux,
+  - `_accept_trust_dialog()`.
+- Tower always uses tmux session state, DB session rows, PTY readers, and websocket terminal channels.
+- Even for non-Claude providers, Tower still depends on a terminal pane and tmux restore behavior.
+
+### Leader
+- Leader is conceptually “Leader”, but persisted as `session_type="manager"` in `src/atc/leader/leader.py` and `src/atc/state/models.py`.
+- Start path is very similar to Tower:
+  - create DB session row,
+  - deploy manager files and copy `CLAUDE.md` / `.claude` into repo path,
+  - choose command from project provider,
+  - spawn tmux pane,
+  - accept Claude trust dialogs.
+- Leader messaging uses `send_instruction()` to the tmux pane, not provider `send_prompt()`.
+
+### Ace
+- Ace creation in `src/atc/session/ace.py:create_ace()` is the most obviously split-brain path.
+- It accepts a provider-specific `launch_command`, but workspace prep is hardcoded to `create_provider("claude_code")` before spawn.
+- After that, it still spawns a tmux pane directly and uses the shared Claude trust-dialog logic.
+- So an Ace in an `opencode` project still inherits Claude-specific prep assumptions in part of the path.
+
+## 4. Runtime startup, restart, and restore flows
+
+### Normal startup path
+In `src/atc/api/app.py` lifespan:
+1. create `TowerController`,
+2. start `PtyStreamPool`,
+3. wire websocket input/resize/subscribe to PTY operations,
+4. run startup smoke test,
+5. call `reconnect_all()` for active sessions,
+6. start PTY readers for active sessions with live panes,
+7. separately restore TowerController state from DB,
+8. optionally auto-start Tower.
+
+### Reconnect flow
+`src/atc/session/reconnect.py`:
+- reconnects active sessions from DB,
+- skips `tower` and `manager` because Tower restore logic owns them,
+- for Ace-like sessions, if pane is alive, status may be pushed back to `idle`,
+- if pane is dead, respawns using `get_launch_command(provider)` and shared tmux helpers.
+
+Important detail: reconnect logic is not provider-owned. It assumes every restorable session can be recreated from a tmux pane plus a launch command.
+
+### Tower restore flow
+`src/atc/api/app.py` has a second, separate restore path for Tower:
+- scans projects and tower sessions,
+- validates pane aliveness,
+- restores TowerController private fields directly (`_current_project_id`, `_current_session_id`, `_leader_session_id`, `_current_goal`, `_state`),
+- starts PTY reader for restored tower pane.
+
+This is a manual controller-state reconstruction, not a provider-level restore.
+
+## 5. Session metadata and sources of truth
+
+### DB session model
+`src/atc/state/models.py:Session` stores:
+- `session_type`,
+- `status`,
+- `tmux_session`,
+- `tmux_pane`,
+- `alternate_on`,
+- no provider-specific runtime metadata blob.
+
+### Provider-side metadata
+Provider protocol supports `SessionInfo.metadata`, but runtime persistence does not meaningfully use it.
+- `ClaudeCodeProvider` keeps pane IDs in memory only.
+- `OpenCodeProvider` keeps pane IDs in memory only.
+- restore/reconnect rely on DB tmux fields, not provider metadata.
+
+### Implication
+The DB schema is tuned for tmux-backed sessions, not generic providers. A provider can expose metadata in theory, but ATC restore and UI lifecycles need tmux pane IDs and session rows.
+
+## 6. tmux and terminal control model
+
+### Control plane
+- `_spawn_pane()` in `src/atc/session/ace.py` is the de facto session launcher.
+- `_accept_trust_dialog()` is Claude-specific and embedded in the shared path.
+- `src/atc/terminal/control.py` maintains persistent tmux control-mode connections for send-keys.
+- `src/atc/terminal/pty_stream.py` uses `tmux pipe-pane` and FIFOs for output.
+- websocket terminal UX subscribes to `terminal:{session_id}` channels in `src/atc/api/app.py`.
+
+### Why that matters
+This control plane assumes every provider can be meaningfully represented as:
+- a tmux pane,
+- interactive terminal input via send-keys,
+- output parsable from PTY text.
+
+That works naturally for Claude Code. It is a poorer fit for OpenCode, whose provider abstraction is HTTP-first and only uses tmux “for human observability”.
+
+## 7. Concrete architectural inconsistencies
+
+### A. Provider abstraction is mostly bypassed
+- Intended provider methods like `spawn_session()` and `send_prompt()` are rarely used in live session flows.
+- Main runtime calls `get_launch_command()` and shared tmux helpers instead.
+- `create_provider()` usage is limited mostly to metadata/capabilities and workspace prep.
+
+### B. Ace path hardcodes Claude provider prep
+- `src/atc/session/ace.py:create_ace()` calls `create_provider("claude_code")` for workspace prep, regardless of project provider.
+- That is a direct bug-shaped inconsistency for selectable providers.
+
+### C. Global/default provider and project provider are separate surfaces
+- Runtime settings expose `settings.agent_provider.default` in `src/atc/config.py` and `src/atc/api/routers/settings.py`.
+- Projects separately store `projects.agent_provider` and update through `PATCH /projects/{id}/agent-provider`.
+- The real lifecycle code usually reads project provider, but not consistently, and not through one central resolution layer.
+- This likely makes “switch provider” feel incomplete because there is no single authoritative resolver for Tower/Leader/Ace creation, restore, and UI assumptions.
+
+### D. Leader vs manager naming mismatch
+- DB/session model uses `manager` as the session type.
+- UI and controller semantics call it Leader.
+- `TowerController._on_session_created()` and `_on_session_status_changed()` look for `session_type in ("leader", "ace")`, not `manager`.
+- That means leader sessions are excluded from active-count accounting and terminal-status bookkeeping in those paths.
+
+### E. Status ownership is split
+There are multiple ways session status changes happen:
+- direct DB writes in session lifecycle code,
+- `transition()` plus event bus publishes in `session/state_machine.py`,
+- PTY-derived status changes in `terminal/monitor.py`,
+- manual websocket broadcasts in `api/app.py`.
+
+Also, `StateLeader` exists in `src/atc/core/state_leader.py` as a queue-backed DB writer, but I could not find it started anywhere in the app. That suggests an unfinished or abandoned alternate status-persistence design.
+
+### F. Restore logic is split across layers
+- generic reconnect in `session/reconnect.py`,
+- special Tower restore in `api/app.py`,
+- provider classes have their own in-memory tracking but are not used to restore,
+- frontend auto-start logic for Claude adds another behavioral layer.
+
+### G. Frontend is provider-aware, but mainly in Claude-specific ways
+- `frontend/src/components/tower/TowerConsole.tsx` and `LeaderConsole.tsx` auto-start when `project.agent_provider === "claude_code"`.
+- For “other providers”, UI often falls back to forms/goals rather than an equivalently first-class terminal experience.
+- This reinforces that Claude is the product’s native runtime, while other providers are partial adapters.
+
+## 8. Likely root causes of provider-switch/selectable-provider instability
+
+1. **Provider selection mostly swaps a launch command, not the lifecycle implementation.**
+   - Core logic remains tmux + pane + trust-dialog + PTY based.
+
+2. **The persistence model is tmux-centric, not provider-centric.**
+   - Sessions persist pane ids and statuses, not provider runtime handles needed for API-native providers.
+
+3. **Provider instances are ephemeral and in-memory.**
+   - `ClaudeCodeProvider` and `OpenCodeProvider` track sessions only in local dicts, which are useless after restart.
+
+4. **Restore/reconnect are written around tmux resurrection, not provider restoration.**
+   - That particularly weakens non-Claude providers.
+
+5. **Tower/Leader/Ace do not share one central provider-driven session launcher.**
+   - They share tmux helpers instead.
+
+6. **Naming drift (`leader` vs `manager`) leaks into control logic.**
+   - This can create missing accounting, special-case bugs, and confusing mental models.
+
+7. **UI semantics and backend semantics do not fully match.**
+   - UI implies provider selection is meaningful now; backend still treats Claude as the default worldview.
+
+## 9. Tech debt to call out explicitly
+
+- Provider protocol exists but is not the true runtime boundary.
+- `get_launch_command()` is effectively more important than `create_provider()` for real session control.
+- Shared helpers in `session/ace.py` have become the hidden session runtime for all roles.
+- Claude-specific deployment and trust-dialog logic is embedded in shared lifecycle code.
+- Tower restore mutates controller internals directly in app startup.
+- `StateLeader` looks orphaned.
+- `manager`/`leader` terminology mismatch is active debt, not just naming style.
+- OpenCode provider is architecturally half-integrated: HTTP-native in class design, tmux-native in surrounding runtime.
+
+## 10. Bottom line
+
+ATC currently has a **tmux/Claude runtime with provider-shaped seams**, not a truly provider-native runtime. Provider selection feels broken because the selectable surface area exceeds the amount of runtime that is actually abstracted. Until session creation, messaging, streaming, persistence, and restore all route through one provider-owned lifecycle, switching providers will continue to hit edge cases, partial behavior, and role-specific inconsistencies.

--- a/docs/codebase_map_tech_debt.md
+++ b/docs/codebase_map_tech_debt.md
@@ -1,0 +1,274 @@
+# Executive summary
+
+ATC has a strong conceptual architecture, but the current codebase is carrying meaningful refactor debt in three cross-cutting areas: terminology/model drift, oversized ownership boundaries, and stale documentation/contracts. The biggest risk is not one broken subsystem, it is that multiple generations of the design now coexist: `Leader` is still `manager` in many runtime contracts, legacy `Task` concepts sit beside newer `task_graphs`, and docs/UI/backend disagree on live interfaces. The code is still test-heavy, but the tests skew toward unit behavior and miss some integration seams where that drift now shows up, including at least one clearly stale method body in `tower/controller.py`. A future refactor should first normalize core nouns and state models, then split monolithic modules around clear service boundaries, then re-establish docs/API/WebSocket truth from code.
+
+# Scope and method
+
+Reviewed current files across:
+- docs: `docs/ARCHITECTURE.md`, `docs/API.md`, `docs/PATTERNS.md`, `docs/ANTI_PATTERNS.md`, `docs/design_logs/*`
+- backend: `src/atc/api/*`, `src/atc/state/*`, `src/atc/tower/*`, `src/atc/leader/*`
+- frontend: `frontend/src/*`
+- tests: `tests/unit/*`, `tests/integration/*`, `tests/e2e/*`
+
+No product code changes were made. This report is grounded in the repository as checked out.
+
+# Priority map
+
+## P0, architecture drift that should be stabilized before a broad refactor
+
+### 1. Terminology drift: `Leader` in product language, `manager` in runtime/storage/API contracts
+
+This is the most pervasive inconsistency in the codebase.
+
+Evidence:
+- design docs present the hierarchy as Tower → Leader → Ace: `docs/ARCHITECTURE.md`, `docs/design_logs/001`, `002`, `012`
+- runtime model still uses `manager` in session types: `src/atc/state/models.py` (`Session.session_type: ace|manager|tower`)
+- project API still exposes `/projects/{id}/manager`: `src/atc/api/routers/projects.py`, `docs/API.md`
+- frontend types and fetch paths still use `manager`: `frontend/src/types/index.ts`, `frontend/src/context/AppContext.tsx`
+- context layer must translate `manager` back to `leader`: `src/atc/api/routers/context.py` scope map
+- cleanup, reconnect, deploy, and tests all still reason about `manager` sessions
+
+Why it matters:
+- every boundary needs translation logic or tribal knowledge
+- it increases onboarding cost and makes bulk refactors riskier
+- it undermines the design-log claim that naming is consistent system-wide
+- it leaks into persistence, API, UI, test names, and agent deployment artifacts
+
+Recommended refactor theme:
+- choose one canonical runtime noun, almost certainly `leader`
+- add a compatibility layer only at the HTTP boundary if needed
+- migrate session type enums, route naming, websocket payloads, test fixtures, and deployment manifests together
+
+### 2. Parallel task models exist, but only one seems live
+
+ATC carries both legacy `Task` and newer `TaskGraph` concepts.
+
+Evidence:
+- `Task` dataclass remains in `src/atc/state/models.py`
+- `tasks` table remains in schema and docs still describe `/api/projects/{id}/tasks`: `src/atc/state/db.py`, `docs/API.md`
+- `tasks` router is a stub: `src/atc/api/routers/tasks.py`
+- active orchestration flows use `task_graphs`, `task_assignments`, and `leader/orchestrator.py`
+- frontend `AppState` still has `tasks: Record<string, Task[]>`, dashboard views still consume `Task[]`, and milestone logic depends on the legacy `Task` shape: `frontend/src/types/index.ts`, `frontend/src/pages/Dashboard.tsx`, `frontend/src/components/dashboard/*`, `frontend/src/utils/milestones.ts`
+- `AppContext.fetchAll()` fetches `task-graphs`, not `tasks`, and never populates `state.tasks`
+
+Why it matters:
+- current ownership of “the task model” is ambiguous
+- UI code is partially coupled to a dead or transitional abstraction
+- any future changes to planning/execution risk duplicating work in both models
+
+Recommended refactor theme:
+- declare `task_graphs` the canonical work model, or intentionally preserve both with separate responsibilities
+- remove or formally deprecate the stubbed `tasks` surface
+- unify dashboard/milestone views on one status vocabulary and data source
+
+### 3. Docs and live contracts have materially diverged
+
+Several docs are stale enough to mislead a refactor.
+
+Evidence:
+- `docs/ARCHITECTURE.md` says the layout is “Option A” with `TowerBar` as an always-visible top bar, but design log 011 explicitly accepted a dockable overlay panel instead
+- the frontend currently renders both `TowerBar` and `TowerPanel`: `frontend/src/App.tsx`
+- `docs/API.md` says `DELETE /api/projects/{id}` archives the project, but the live router hard-deletes and archive is actually `PATCH /{project_id}/archive`: `src/atc/api/routers/projects.py`
+- `docs/API.md` documents `/api/logs*`, while code serves `/api/failure-logs*`: `src/atc/api/routers/failure_logs.py`
+- WebSocket docs still describe `manager:{project_id}`, `logs`, and binary PTY frames; live code/front-end rely on `failure_logs`, `heartbeat`, `tower`, `state`, and channel naming handled by `WsHub`/`AppContext`
+- `docs/ARCHITECTURE.md` still lists `manager:{project_id}` channels
+
+Why it matters:
+- ATC explicitly depends on docs as agent-facing truth
+- stale docs produce wrong generated code, wrong test assumptions, and wrong operator behavior
+- this is not cosmetic drift, it affects destructive operations and realtime protocol expectations
+
+Recommended refactor theme:
+- generate or derive API/WebSocket docs from router/channel definitions where possible
+- define one “runtime contract source of truth” and treat design logs as historical, not current API reference
+
+## P1, structural debt that raises change cost
+
+### 4. Several core modules are doing too many jobs
+
+The strongest examples are:
+- `src/atc/state/db.py` at 2132 lines: schema bootstrap, migrations, CRUD, transition rules, cross-table deletion, feature flags, heartbeat, context, usage, budgets, GitHub, QA
+- `src/atc/tower/controller.py` at 1036 lines: lifecycle state machine, leader kickoff, context seeding, budget gating, session counting, websocket broadcasting, auth detection, progress polling, respawn logic
+- `src/atc/api/routers/projects.py` at 575 lines: project CRUD, leader lifecycle, context seeding, auto-kickoff, budget, GitHub
+- `frontend/src/context/AppContext.tsx` at 453 lines: bootstrap fetch orchestration, reducer, websocket event decoding, normalized cache-ish state, selection state
+
+Why it matters:
+- ownership is hard to reason about
+- module-level tests can still pass while seams between concerns rot
+- refactors become “touch everything” changes
+- domain rules are duplicated because there is no small obvious place for them
+
+Recommended refactor theme:
+- split by domain service, not just by transport
+- examples: `project_service`, `leader_service`, `context_service`, `budget_service`, `ws_event_mapper`, `task_graph_repo`, `session_repo`
+- keep routers thin and move workflow logic out of HTTP handlers
+
+### 5. Transport layers contain domain workflow logic
+
+Examples:
+- project creation auto-creates a leader in the router: `projects.py`
+- leader start route seeds context entries, reads project metadata, schedules retry loops, and builds kickoff prompts: `projects.py`
+- `TowerController.submit_goal()` also seeds project context entries and persists package details
+- context routes auto-seed from leader goal when context is empty: `context.py`
+
+Why it matters:
+- the same business workflow now exists in Tower paths, direct API paths, and fallback read paths
+- it becomes unclear which path is authoritative
+- behavior depends on how an action was initiated, not just what the action was
+
+Recommended refactor theme:
+- pull these behaviors behind explicit application services
+- make “start leader”, “seed project context”, and “kick off goal” idempotent service operations with one owner
+
+### 6. State vocabularies are inconsistent across layers
+
+Examples:
+- tower lifecycle uses `idle|planning|managing|complete|error`
+- leader status uses `idle|planning|managing|paused|error`
+- session status uses `idle|connecting|working|paused|waiting|disconnected|error`
+- task graph status supports `todo|assigned|in_progress|review|done|error` in backend transitions, but frontend `TaskGraph` type only allows `todo|in_progress|done`
+- dashboard milestone UI still uses legacy `Task` statuses like `pending|assigned|blocked|done|cancelled`
+
+Why it matters:
+- mapping code proliferates silently
+- frontend type narrowing can become wrong without compile-time help if payloads are cast loosely
+- analytics and progress summaries become harder to trust
+
+Recommended refactor theme:
+- define explicit shared enums for session, leader, tower, and task graph states
+- if the frontend is intentionally narrower, encode that with mapper functions instead of divergent ad hoc types
+
+## P2, stale abstractions and correctness risks already visible
+
+### 7. There is at least one clearly stale or corrupted implementation in a critical controller
+
+`tower/controller.py` contains both `_notify_tower_goal_started()` and `_on_leader_output()`. The `_on_leader_output()` body appears to be a copied version of the notification logic and references undefined names like `project_id`, `goal`, and `leader_session_id`, rather than using its `data` parameter.
+
+Why it matters:
+- this is a concrete sign of copy-paste drift in one of the highest-risk modules
+- it suggests tests cover nearby behavior but not this exact path
+- it weakens confidence in the surrounding controller logic even where tests exist
+
+Recommended refactor theme:
+- break the controller into small tested helpers before feature work continues there
+- add targeted tests for private event handlers or move them behind public service APIs
+
+### 8. Event and websocket contracts are manually encoded in multiple places
+
+Evidence:
+- channel names live in docs, backend broadcasters, frontend subscriptions, and reducer branches
+- `AppContext.handleWsMessage()` manually interprets many loosely typed payload shapes from `state`, `tower`, `heartbeat`, `failure_logs`
+- `WsHub` is intentionally generic, so semantic correctness depends on many scattered string constants
+
+Why it matters:
+- adding or renaming an event is easy to do incompletely
+- drift is already visible in docs and channel names
+- the frontend is tightly coupled to backend event shape details
+
+Recommended refactor theme:
+- centralize event/channel definitions and payload schemas
+- consider typed server event factories plus frontend decoders per channel
+
+### 9. Design logs are useful, but current-state ownership is blurred
+
+The design logs are recent and thoughtful, but several accepted decisions are not reflected cleanly in live code/docs. That suggests ATC treats logs as intent, but lacks a maintenance mechanism that propagates accepted decisions into runtime contracts and reference docs.
+
+Recommended refactor theme:
+- on each architecture-affecting change, update: design log status, architecture doc, API doc, shared enums/contracts, and tests as one bundle
+- use a lightweight checklist or PR template to keep those artifacts synchronized
+
+# Testing assessment
+
+## What is strong
+
+- backend unit coverage is broad across many modules
+- there are integration tests for context hub, websocket hub, and creation reliability
+- there are frontend component and hook tests, including `AppContext` and `useWebSocket`
+
+## Main blind spots
+
+### 1. End-to-end coverage is shallow relative to architectural complexity
+
+The e2e suite is small: `tests/e2e/test_ace_lifecycle.py`, `test_smoke.py`, `test_task_graph_api.py`. For a system built around Tower → Leader → Ace orchestration, that leaves major workflow seams lightly defended.
+
+Missing or underrepresented flows:
+- full goal submission from Tower through Leader kickoff to task graph progress
+- restart/reconnect behavior across Tower + Leader + Ace together
+- docs/API/WebSocket contract conformance tests
+- project dashboard behavior against real `task_graphs` rather than legacy `tasks`
+
+### 2. Contract drift tests are missing
+
+Given the amount of naming and protocol drift, ATC would benefit from tests that assert:
+- documented routes exist and documented destructive semantics match code
+- documented websocket channels match live broadcasters/subscribers
+- frontend types/decoders accept all backend-emitted statuses
+
+### 3. Monolith modules are hard to test semantically
+
+Some existing unit coverage proves local behavior, but not clean ownership. The stale `_on_leader_output()` body is a good example: nearby behavior can be tested while a dead or broken handler survives.
+
+# Recommended refactor themes
+
+## Theme A, normalize the domain language first
+
+Do first, before major feature work:
+- settle `leader` vs `manager`
+- settle `task` vs `task_graph`
+- publish canonical enum/state vocabularies
+- add thin compatibility shims only where migration cost requires them
+
+## Theme B, introduce explicit service boundaries
+
+Recommended split:
+- repositories: project, session, leader, task graph, context, usage
+- application services: goal submission, leader lifecycle, context seeding, project deletion, budget enforcement
+- transport adapters: REST routers, websocket broadcasters, CLI handlers
+
+This should reduce duplication between Tower, routers, and fallback paths.
+
+## Theme C, treat docs/contracts as generated or at least centrally declared
+
+Prioritize:
+- route inventory from routers
+- websocket channel inventory from broadcaster/subscriber declarations
+- one canonical runtime contract doc that design logs feed into but do not replace
+
+## Theme D, simplify frontend state ownership
+
+- separate initial data loading from realtime event reduction
+- stop carrying both `tasks` and `taskGraphs` unless both are intentional
+- add typed event mappers so reducer logic is not parsing raw protocol dictionaries directly
+
+## Theme E, add a thin architecture regression suite
+
+Useful high-value tests:
+- goal submission happy path across Tower/Leader/task graph state
+- route documentation parity smoke test
+- websocket channel parity smoke test
+- dashboard/task model parity test proving UI reads the live work model
+
+# Suggested execution order
+
+1. Freeze vocabulary and publish a migration map (`manager` → `leader`, `tasks` → `task_graphs` where applicable)
+2. Extract service boundaries from `projects.py`, `tower/controller.py`, and `state/db.py`
+3. Replace duplicated workflow logic with shared application services
+4. Update docs from live contracts
+5. Add architecture regression tests around routes, channels, and state enums
+6. Then do deeper subsystem refactors, especially Tower/Leader orchestration and dashboard state
+
+# File hotspots worth targeting in a future refactor
+
+- `src/atc/state/db.py`
+- `src/atc/tower/controller.py`
+- `src/atc/api/routers/projects.py`
+- `src/atc/api/routers/context.py`
+- `frontend/src/context/AppContext.tsx`
+- `frontend/src/types/index.ts`
+- `frontend/src/pages/Dashboard.tsx` and `frontend/src/components/dashboard/*`
+- `docs/API.md`
+- `docs/ARCHITECTURE.md`
+
+# Bottom line
+
+ATC is not suffering from a lack of architecture. It is suffering from accumulated architecture overlap. The next refactor will go much better if it starts by collapsing duplicate language and state models, then carving transport and workflow concerns apart, rather than trying to optimize individual modules in place.

--- a/docs/provider_cli_wrapper_spec.md
+++ b/docs/provider_cli_wrapper_spec.md
@@ -1,0 +1,340 @@
+# ATC provider CLI wrapper spec
+
+## Status
+Draft design spec for the provider-runtime refactor.
+
+## Purpose
+`atc-provider` is the terminal-facing adapter layer between ATC's Python runtime/orchestration code and provider-specific AI CLIs such as Claude Code, Codex, and OpenCode.
+
+It is not a second orchestration system.
+It is not the source of truth for workflow decisions.
+It is a thin but stable command contract that lets tmux launch and interact with providers in a uniform way while preserving provider-specific behavior where it belongs.
+
+## Architectural position
+
+### Python orchestration/runtime owns
+- which project, goal, or task should run
+- when a role session starts or stops
+- which task is assigned to which Ace
+- persistence, workflow state transitions, retries, and policy
+- provider selection from config/session metadata
+
+### `atc-provider` owns
+- provider-specific terminal launch behavior
+- provider-specific flags/env/bootstrap
+- readiness checks and startup waits
+- provider-specific delivery mechanics into the running session
+- normalized machine-readable terminal markers
+
+## Hard boundary rule
+ATC Python code must not encode provider-specific sleeps, trust/login handling, prompt-shaping rules, or CLI command strings once the wrapper exists for that operation.
+
+If a provider needs special startup/delivery handling, that behavior belongs in:
+- `src/atc/providers/<provider>/...`
+- or the `atc-provider` command implementation for that provider
+
+Never add scattered logic like:
+- `if provider == "codex": sleep(...)`
+- `if provider == "claude_code": use different paste flow`
+- `if provider == "opencode": special-case readiness here`
+
+outside the provider runtime/wrapper boundary.
+
+## Binary shape
+Preferred invocation shape:
+```bash
+atc-provider <provider> <command> [options]
+```
+
+Examples:
+```bash
+atc-provider claude_code start-role --role leader --session-id sess_1 --project-id proj_1 --working-dir /repo
+atc-provider codex assign-task --session-id sess_ace_1 --task-id task_1 --context-ref ctx:task:1 --message-file /tmp/task.txt
+atc-provider codex check-readiness --session-id sess_ace_1
+```
+
+## Command set
+Required command family:
+- `start-role`
+- `stop-role`
+- `send-instruction`
+- `assign-task`
+- `check-readiness`
+- `inspect-session`
+- `restore-session`
+
+### Command design rule
+- startup commands are role-based
+- post-start commands are session-based
+
+That means:
+- `start-role` and `stop-role` accept `--role tower|leader|ace`
+- `send-instruction`, `assign-task`, `check-readiness`, `inspect-session`, and `restore-session` primarily target `--session-id`
+
+## Command specs
+
+## 1. `start-role`
+
+### Required args
+- `--role tower|leader|ace`
+- `--session-id <id>`
+
+### Optional args
+- `--project-id <id>`
+- `--working-dir <path>`
+- `--context-ref <ref>`
+- `--display-name <label>`
+- `--provider-config-ref <ref>`
+- `--bootstrap-file <path>`
+- `--metadata-json <json>`
+- `--metadata-file <path>`
+
+### Responsibilities
+- emit `runtime_starting`
+- apply provider-specific bootstrap/env/flags
+- launch the provider CLI
+- wait for provider-specific readiness condition
+- emit one terminal result marker: `runtime_ready`, `runtime_blocked`, or `runtime_error`
+
+### Exit codes
+- `0` role started and reached a valid ready/running state
+- `10` blocked by trust/login/auth
+- `11` transient startup not ready
+- `12` provider executable/process failure
+- `13` invalid args or unsupported role/provider combination
+- `30` wrapper internal failure
+
+## 2. `stop-role`
+
+### Required args
+- `--role tower|leader|ace`
+- `--session-id <id>`
+
+### Optional args
+- `--reason <text>`
+- `--graceful true|false`
+
+### Responsibilities
+- emit `runtime_stopping`
+- perform provider-appropriate shutdown if required
+- emit `runtime_stopped` or `runtime_error`
+
+## 3. `send-instruction`
+
+### Required args
+- `--session-id <id>`
+- one of:
+  - `--message <text>`
+  - `--message-file <path>`
+
+### Optional args
+- `--context-ref <ref>`
+- `--instruction-id <id>`
+- `--expects-readiness-check true|false`
+- `--metadata-json <json>`
+
+### Responsibilities
+- optionally verify readiness
+- deliver a general instruction using provider-specific paste/submit/timing behavior
+- emit delivery lifecycle markers
+
+### Exit codes
+- `0` delivery confirmed
+- `10` blocked by trust/login/auth
+- `11` session busy/not ready
+- `20` delivery failed
+- `30` wrapper internal failure
+
+## 4. `assign-task`
+
+### Required args
+- `--session-id <id>`
+- `--task-id <id>`
+- one of:
+  - `--message <text>`
+  - `--message-file <path>`
+
+### Optional args
+- `--context-ref <ref>`
+- `--task-title <text>`
+- `--assignment-id <id>`
+- `--metadata-json <json>`
+
+### Responsibilities
+- provider-specialized task delivery path for Ace-like work assignment
+- may differ from generic `send-instruction` in formatting, pacing, and readiness behavior
+- emits task assignment markers
+
+### Exit codes
+- `0` assignment delivery confirmed
+- `10` blocked by trust/login/auth
+- `11` session busy/not ready
+- `20` assignment delivery failed
+- `30` wrapper internal failure
+
+## 5. `check-readiness`
+
+### Required args
+- `--session-id <id>`
+
+### Responsibilities
+- evaluate provider-specific readiness state
+- emit a normalized readiness result marker
+
+### Exit codes
+- `0` ready
+- `10` blocked by auth/trust/login
+- `11` not ready yet / busy
+- `12` session missing or dead
+- `30` wrapper internal failure
+
+## 6. `inspect-session`
+
+### Required args
+- `--session-id <id>`
+
+### Responsibilities
+- return normalized health/inspection result
+- optionally emit short status summary and output excerpt metadata
+
+### Exit codes
+- `0` inspect succeeded
+- `12` session missing or dead
+- `30` wrapper internal failure
+
+## 7. `restore-session`
+
+### Required args
+- `--session-id <id>`
+
+### Optional args
+- `--tmux-session <name>`
+- `--tmux-pane <pane>`
+
+### Responsibilities
+- validate and interpret a prior running provider session after restart
+- emit normalized restore result
+
+### Exit codes
+- `0` restore succeeded / session still viable
+- `12` runtime target missing
+- `21` restore failed / unrecoverable
+- `30` wrapper internal failure
+
+## Marker protocol
+
+### Format
+Every machine-readable line emitted by the wrapper must use:
+```text
+ATC_EVENT <event_name> <json_payload>
+```
+
+### Event name rules
+- lowercase snake_case only
+- stable names, additive evolution preferred
+- no provider-specific event names in shared orchestration handling
+
+### Required event families
+Runtime lifecycle:
+- `runtime_starting`
+- `runtime_ready`
+- `runtime_blocked`
+- `runtime_error`
+- `runtime_stopping`
+- `runtime_stopped`
+
+Delivery lifecycle:
+- `delivery_started`
+- `delivery_confirmed`
+- `delivery_blocked`
+- `delivery_error`
+
+Task lifecycle:
+- `task_assignment_started`
+- `task_assignment_confirmed`
+- `task_assignment_blocked`
+- `task_assignment_error`
+
+Inspection/readiness:
+- `readiness_result`
+- `inspection_result`
+- `restore_result`
+
+### Required payload fields
+All payloads must include:
+- `session_id`
+- `provider`
+- `command`
+
+When applicable, also include:
+- `role`
+- `project_id`
+- `task_id`
+- `instruction_id`
+- `assignment_id`
+- `reason`
+- `message`
+- `details`
+
+### Example markers
+```text
+ATC_EVENT runtime_starting {"session_id":"sess_123","provider":"codex","command":"start-role","role":"ace"}
+ATC_EVENT runtime_ready {"session_id":"sess_123","provider":"codex","command":"start-role"}
+ATC_EVENT runtime_blocked {"session_id":"sess_123","provider":"claude_code","command":"start-role","reason":"login"}
+ATC_EVENT task_assignment_confirmed {"session_id":"sess_123","provider":"codex","command":"assign-task","task_id":"task_789"}
+```
+
+## CLI implementation rules
+- The wrapper must be deterministic for the same inputs.
+- Provider-specific sleeps/waits are allowed here, not in shared orchestration code.
+- All provider command strings and startup flags must live in provider-owned implementation files.
+- Message delivery logic must support both inline text and file-based payloads.
+- Large instructions/task briefs should prefer `--message-file`.
+- The wrapper must never mutate ATC DB state directly.
+- Human-readable output is fine, but machine-readable event lines must remain parseable and stable.
+
+## Python integration rules
+The runtime service should:
+- resolve provider and session metadata
+- build wrapper command invocations
+- consume wrapper markers
+- map exit codes and events into ATC runtime state
+
+The runtime service must not:
+- duplicate provider-specific sleeps or timing hacks
+- hardcode provider CLI flags in orchestration code
+- parse provider-specific terminal quirks outside provider runtime logic unless explicitly documented as shared marker parsing
+
+## Future extensibility rules
+- New provider support must implement the same command family before it is considered first-class.
+- Provider-specific extra flags are allowed, but shared orchestration should not depend on them directly.
+- Shared command semantics must remain stable across providers.
+- If a command cannot be meaningfully supported for a provider, the wrapper must fail clearly rather than silently degrading behavior.
+
+## Relationship to the broader refactor
+This CLI spec is one layer inside the broader ATC runtime/provider refactor. It should be implemented alongside:
+- `docs/codebase_map_current_state.md`
+- `docs/provider_runtime_refactor_plan.md`
+- provider runtime modules under `src/atc/providers/`
+- shared tmux substrate under `src/atc/runtime/tmux/`
+
+## Recommended first implementation slice
+1. implement the shared `atc-provider` binary shell
+2. implement common event emitter utilities
+3. implement `start-role`, `check-readiness`, `inspect-session`
+4. implement Claude Code provider wrapper path
+5. implement Codex provider wrapper path
+6. implement `send-instruction`
+7. implement `assign-task`
+8. implement `restore-session`
+9. add `stop-role` provider nuances only where needed
+
+## Final recommendation
+Yes, ATC should own a provider CLI wrapper layer.
+
+But it must stay:
+- thin
+- procedural
+- provider-specific only in terminal behavior
+- subordinate to Python orchestration
+- aligned with the larger ATC runtime/provider refactor

--- a/docs/provider_runtime_contract_spec.md
+++ b/docs/provider_runtime_contract_spec.md
@@ -1,0 +1,528 @@
+# ATC Provider Runtime Contract Spec
+
+## Status
+Draft contract spec for the ATC runtime/provider refactor.
+
+## Purpose
+This document freezes the exact contract shape between:
+- ATC orchestration/runtime service
+- provider runtime implementations
+- the `atc-provider` CLI wrapper layer
+
+This contract is intended to reduce ambiguity before implementation begins.
+
+## Scope
+This spec covers:
+- canonical shared enums and models
+- Python-side interfaces
+- wrapper event payload schemas
+- exit code mapping expectations
+- integration responsibilities
+
+## Canonical role and transport enums
+
+Suggested module:
+- `src/atc/runtime/models.py`
+
+```python
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import StrEnum
+from typing import Any
+
+
+class RoleKind(StrEnum):
+    TOWER = "tower"
+    LEADER = "leader"
+    ACE = "ace"
+
+
+class RuntimeTransport(StrEnum):
+    TMUX = "tmux"
+
+
+class ReadinessState(StrEnum):
+    STARTING = "starting"
+    READY = "ready"
+    BUSY = "busy"
+    BLOCKED = "blocked"
+    ERROR = "error"
+    STOPPED = "stopped"
+
+
+class RuntimeBlockReason(StrEnum):
+    LOGIN = "login"
+    TRUST = "trust"
+    AUTH = "auth"
+    RATE_LIMIT = "rate_limit"
+    PROVIDER_PROMPT = "provider_prompt"
+    UNKNOWN = "unknown"
+```
+
+## Shared Python models
+
+```python
+@dataclass(slots=True)
+class RuntimeSessionHandle:
+    session_id: str
+    provider_name: str
+    role: RoleKind
+    transport: RuntimeTransport
+    project_id: str | None = None
+    tmux_session: str | None = None
+    tmux_pane: str | None = None
+    working_dir: str | None = None
+    context_ref: str | None = None
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass(slots=True)
+class StartRoleRequest:
+    session_id: str
+    provider_name: str
+    role: RoleKind
+    project_id: str | None = None
+    working_dir: str | None = None
+    context_ref: str | None = None
+    display_name: str | None = None
+    provider_config_ref: str | None = None
+    bootstrap_file: str | None = None
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass(slots=True)
+class StopRoleRequest:
+    reason: str | None = None
+    graceful: bool = True
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass(slots=True)
+class InstructionRequest:
+    session_id: str
+    message: str | None = None
+    message_file: str | None = None
+    context_ref: str | None = None
+    instruction_id: str | None = None
+    expects_readiness_check: bool = True
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass(slots=True)
+class TaskAssignmentRequest:
+    session_id: str
+    task_id: str
+    task_title: str | None = None
+    message: str | None = None
+    message_file: str | None = None
+    context_ref: str | None = None
+    assignment_id: str | None = None
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass(slots=True)
+class ReadinessResult:
+    session_id: str
+    provider_name: str
+    state: ReadinessState
+    block_reason: RuntimeBlockReason | None = None
+    summary: str | None = None
+    details: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass(slots=True)
+class RuntimeInspection:
+    session_id: str
+    provider_name: str
+    alive: bool
+    readiness: ReadinessState
+    block_reason: RuntimeBlockReason | None = None
+    summary: str | None = None
+    last_output_excerpt: str | None = None
+    details: dict[str, Any] = field(default_factory=dict)
+```
+
+## Provider runtime Python interface
+
+Suggested module:
+- `src/atc/providers/base.py`
+
+```python
+from typing import Protocol
+
+
+class ProviderRuntime(Protocol):
+    provider_name: str
+
+    async def prepare_workspace(self, request: StartRoleRequest) -> None: ...
+
+    async def start_role(self, request: StartRoleRequest) -> RuntimeSessionHandle: ...
+
+    async def stop_role(
+        self,
+        handle: RuntimeSessionHandle,
+        request: StopRoleRequest | None = None,
+    ) -> None: ...
+
+    async def send_instruction(
+        self,
+        handle: RuntimeSessionHandle,
+        request: InstructionRequest,
+    ) -> None: ...
+
+    async def assign_task(
+        self,
+        handle: RuntimeSessionHandle,
+        request: TaskAssignmentRequest,
+    ) -> None: ...
+
+    async def check_readiness(
+        self,
+        handle: RuntimeSessionHandle,
+    ) -> ReadinessResult: ...
+
+    async def inspect_session(
+        self,
+        handle: RuntimeSessionHandle,
+    ) -> RuntimeInspection: ...
+
+    async def restore_session(
+        self,
+        handle: RuntimeSessionHandle,
+    ) -> RuntimeInspection: ...
+```
+
+## Runtime service Python interface
+
+Suggested module:
+- `src/atc/runtime/service.py`
+
+```python
+class RuntimeService:
+    async def start_tower(self, request: StartRoleRequest) -> RuntimeSessionHandle: ...
+    async def stop_tower(self, handle: RuntimeSessionHandle, request: StopRoleRequest | None = None) -> None: ...
+
+    async def start_leader(self, request: StartRoleRequest) -> RuntimeSessionHandle: ...
+    async def stop_leader(self, handle: RuntimeSessionHandle, request: StopRoleRequest | None = None) -> None: ...
+
+    async def start_ace(self, request: StartRoleRequest) -> RuntimeSessionHandle: ...
+    async def stop_ace(self, handle: RuntimeSessionHandle, request: StopRoleRequest | None = None) -> None: ...
+
+    async def send_instruction(self, handle: RuntimeSessionHandle, request: InstructionRequest) -> None: ...
+    async def assign_project_to_leader(self, handle: RuntimeSessionHandle, request: InstructionRequest) -> None: ...
+    async def assign_task_to_ace(self, handle: RuntimeSessionHandle, request: TaskAssignmentRequest) -> None: ...
+
+    async def check_readiness(self, handle: RuntimeSessionHandle) -> ReadinessResult: ...
+    async def inspect_session(self, handle: RuntimeSessionHandle) -> RuntimeInspection: ...
+    async def restore_session(self, handle: RuntimeSessionHandle) -> RuntimeInspection: ...
+```
+
+## Wrapper event protocol
+
+Suggested parser home:
+- `src/atc/runtime/wrapper_events.py`
+
+### Line format
+Every machine-readable wrapper line must be:
+```text
+ATC_EVENT <event_name> <json_payload>
+```
+
+### Required common payload fields
+All event payloads must include:
+- `session_id: str`
+- `provider: str`
+- `command: str`
+
+Optional common fields when relevant:
+- `role: "tower" | "leader" | "ace"`
+- `project_id: str`
+- `task_id: str`
+- `instruction_id: str`
+- `assignment_id: str`
+- `reason: str`
+- `message: str`
+- `details: object`
+
+### Event schema definitions
+
+#### `runtime_starting`
+```json
+{
+  "session_id": "sess_123",
+  "provider": "codex",
+  "command": "start-role",
+  "role": "ace",
+  "project_id": "proj_456"
+}
+```
+
+#### `runtime_ready`
+```json
+{
+  "session_id": "sess_123",
+  "provider": "codex",
+  "command": "start-role"
+}
+```
+
+#### `runtime_blocked`
+```json
+{
+  "session_id": "sess_123",
+  "provider": "claude_code",
+  "command": "start-role",
+  "reason": "login",
+  "message": "Provider requires login"
+}
+```
+
+#### `runtime_error`
+```json
+{
+  "session_id": "sess_123",
+  "provider": "codex",
+  "command": "start-role",
+  "message": "Provider exited early",
+  "details": {"exit_code": 1}
+}
+```
+
+#### `delivery_started`
+```json
+{
+  "session_id": "sess_123",
+  "provider": "codex",
+  "command": "send-instruction",
+  "instruction_id": "inst_123"
+}
+```
+
+#### `delivery_confirmed`
+```json
+{
+  "session_id": "sess_123",
+  "provider": "codex",
+  "command": "send-instruction",
+  "instruction_id": "inst_123"
+}
+```
+
+#### `delivery_blocked`
+```json
+{
+  "session_id": "sess_123",
+  "provider": "claude_code",
+  "command": "send-instruction",
+  "instruction_id": "inst_123",
+  "reason": "trust",
+  "message": "Trust prompt is blocking input"
+}
+```
+
+#### `delivery_error`
+```json
+{
+  "session_id": "sess_123",
+  "provider": "codex",
+  "command": "send-instruction",
+  "instruction_id": "inst_123",
+  "message": "Delivery confirmation timed out"
+}
+```
+
+#### `task_assignment_started`
+```json
+{
+  "session_id": "sess_ace_1",
+  "provider": "codex",
+  "command": "assign-task",
+  "task_id": "task_123",
+  "assignment_id": "assign_456"
+}
+```
+
+#### `task_assignment_confirmed`
+```json
+{
+  "session_id": "sess_ace_1",
+  "provider": "codex",
+  "command": "assign-task",
+  "task_id": "task_123",
+  "assignment_id": "assign_456"
+}
+```
+
+#### `task_assignment_blocked`
+```json
+{
+  "session_id": "sess_ace_1",
+  "provider": "codex",
+  "command": "assign-task",
+  "task_id": "task_123",
+  "assignment_id": "assign_456",
+  "reason": "provider_prompt",
+  "message": "Interactive provider prompt blocked assignment"
+}
+```
+
+#### `task_assignment_error`
+```json
+{
+  "session_id": "sess_ace_1",
+  "provider": "codex",
+  "command": "assign-task",
+  "task_id": "task_123",
+  "assignment_id": "assign_456",
+  "message": "Submission failed"
+}
+```
+
+#### `readiness_result`
+```json
+{
+  "session_id": "sess_123",
+  "provider": "codex",
+  "command": "check-readiness",
+  "state": "ready",
+  "reason": null,
+  "message": "Prompt ready"
+}
+```
+
+#### `inspection_result`
+```json
+{
+  "session_id": "sess_123",
+  "provider": "codex",
+  "command": "inspect-session",
+  "alive": true,
+  "state": "busy",
+  "reason": null,
+  "message": "Processing prior instruction",
+  "details": {"last_output_excerpt": "Working..."}
+}
+```
+
+#### `restore_result`
+```json
+{
+  "session_id": "sess_123",
+  "provider": "codex",
+  "command": "restore-session",
+  "alive": true,
+  "state": "ready",
+  "reason": null,
+  "message": "Restored existing tmux-backed provider session"
+}
+```
+
+## Wrapper exit code mapping
+
+```python
+class WrapperExitCode(IntEnum):
+    SUCCESS = 0
+    BLOCKED_AUTH = 10
+    NOT_READY = 11
+    SESSION_MISSING = 12
+    INVALID_ARGS = 13
+    DELIVERY_FAILED = 20
+    RESTORE_FAILED = 21
+    INTERNAL_FAILURE = 30
+```
+
+Runtime-service interpretation expectations:
+- `0`: operation succeeded
+- `10`: session/provider blocked by auth/trust/login class issue
+- `11`: transient not-ready or busy state
+- `12`: target runtime session/pane missing or dead
+- `13`: programming/config error in invocation
+- `20`: delivery/assignment failure
+- `21`: restore failure
+- `30`: unexpected wrapper failure
+
+## Responsibility rules
+
+### Orchestration/runtime service must
+- resolve provider implementation from config/session metadata
+- construct the wrapper invocation
+- persist session/runtime metadata
+- parse wrapper markers and exit codes
+- translate normalized results into ATC session/orchestration state
+
+### Orchestration/runtime service must not
+- hardcode provider command strings
+- implement provider-specific startup sleeps
+- implement provider-specific delivery timing hacks
+- parse provider-specific terminal quirks outside documented wrapper/provider logic
+
+### Provider runtime implementation must
+- own provider command construction
+- own provider readiness interpretation
+- own provider-specific instruction/task delivery mechanics
+- own wrapper invocation behavior for that provider
+
+## Compatibility rules
+- New providers are not first-class until they implement the shared contract.
+- Compatibility shims are allowed temporarily, but must be documented and scheduled for removal.
+- Shared orchestration code should never branch on provider behavior once a provider implements the contract for that operation.
+
+## Recommended next step
+After agreeing on this spec, write the first implementation checklist as Phase 0:
+- create `runtime/models.py`
+- create `providers/base.py`
+- create wrapper event parser models
+- create wrapper exit code enum
+- define `manager -> leader` compatibility notes
+- define initial provider registry shape
+
+## Provider-stamped session rule
+Every ATC session row must be treated as provider-stamped at birth.
+
+Meaning:
+- `sessions.provider` is not just a hint
+- it is the runtime identity of the session row
+- restore/reconnect/spawn-existing flows must respect it
+
+## Provider mismatch rule
+Before any `spawn_existing_session(...)` or restore/reconnect path materializes a session row into a live runtime session, the runtime must compare:
+- the provider stamped on the session row
+- the provider currently desired by the higher-level role/scope/config path
+
+### If the providers match
+- the runtime may restore/reuse/materialize that session row
+
+### If the providers do not match
+- the runtime must not silently reuse the old session
+- the runtime must treat the old row as incompatible with the current desired provider
+- the correct behavior is replacement, not mutation-in-place
+
+Recommended outcomes on mismatch:
+- mark old session as disconnected/superseded/stale
+- create a fresh session row under the new provider when the higher-level workflow wants a new live session
+- do not mutate the old session row's provider field to "convert" it
+
+## Semantic split between startup operations
+This refactor should distinguish between two different operations:
+
+### Role startup
+Examples:
+- `start_tower(...)`
+- `start_leader(...)`
+- `start_ace(...)`
+
+Meaning:
+- start a new role session under the currently desired provider semantics
+- orchestration-facing operation
+
+### Existing-session materialization
+Example:
+- `spawn_existing_session(...)`
+
+Meaning:
+- materialize an already-created DB session row into a live tmux/provider runtime session
+- runtime-facing operation
+- valid only when the stamped provider identity on the row is still compatible with the intended provider path
+
+This is why `spawn_existing_session(...)` should never mean "blindly resurrect whatever old row exists".

--- a/docs/provider_runtime_phase0_checklist.md
+++ b/docs/provider_runtime_phase0_checklist.md
@@ -1,0 +1,92 @@
+# ATC Provider Runtime Refactor: Phase 0 Checklist
+
+## Goal
+Freeze the core contract and prepare the first implementation-safe foundation for the runtime/provider refactor.
+
+Phase 0 is about defining the boundary cleanly before broad code motion starts.
+
+## Required inputs
+Read first:
+- `docs/START_HERE.md`
+- `docs/CODEBASE_MAP.md`
+- `docs/HARD_RULES.md`
+- `docs/DEVELOPMENT_RULES.md`
+- `docs/TESTING_RULES.md`
+- `docs/provider_runtime_refactor_plan.md`
+- `docs/provider_cli_wrapper_spec.md`
+- `docs/provider_runtime_contract_spec.md`
+- `docs/RUNTIME_PROVIDER_GUARDRAILS.md`
+
+## Deliverables
+Phase 0 should produce:
+- canonical runtime/provider models
+- canonical provider runtime interface
+- wrapper event and exit code definitions
+- compatibility note for `manager -> leader`
+- initial provider registry direction
+- tests for the new shared contract objects where practical
+
+## Checklist
+
+### A. Canonical shared models
+- [ ] Create `src/atc/runtime/models.py`
+- [ ] Add `RoleKind`
+- [ ] Add `RuntimeTransport`
+- [ ] Add `ReadinessState`
+- [ ] Add `RuntimeBlockReason`
+- [ ] Add `RuntimeSessionHandle`
+- [ ] Add `StartRoleRequest`
+- [ ] Add `StopRoleRequest`
+- [ ] Add `InstructionRequest`
+- [ ] Add `TaskAssignmentRequest`
+- [ ] Add `ReadinessResult`
+- [ ] Add `RuntimeInspection`
+
+### B. Provider interface
+- [ ] Create `src/atc/providers/base.py`
+- [ ] Define `ProviderRuntime` protocol
+- [ ] Ensure interface matches `docs/provider_runtime_contract_spec.md`
+
+### C. Wrapper event contract
+- [ ] Create parser/schema home, for example `src/atc/runtime/wrapper_events.py`
+- [ ] Define supported event names
+- [ ] Define shared payload expectations
+- [ ] Define parsing/validation helpers
+- [ ] Define wrapper exit code enum
+
+### D. Registry direction
+- [ ] Create or reshape provider registry module, likely `src/atc/providers/registry.py`
+- [ ] Document how provider name resolves to runtime implementation
+- [ ] Record any temporary compatibility with existing `src/atc/agents/` modules
+
+### E. Compatibility and migration notes
+- [ ] Write explicit `manager -> leader` compatibility note in code comments/docs where needed
+- [ ] Record whether old session types remain temporarily supported in persistence
+- [ ] Record temporary rules for old direct launch paths while migration is incomplete
+
+### F. Testing baseline
+- [ ] Add unit tests for shared models if validation/serialization helpers exist
+- [ ] Add unit tests for wrapper event parsing
+- [ ] Add unit tests for wrapper exit code mapping
+- [ ] Add protocol/registry tests if useful
+
+### G. Documentation sync
+- [ ] Re-read all relevant `.md` docs after Phase 0 code changes
+- [ ] Update any docs that became stale from the implementation
+- [ ] Do not close Phase 0 with stale docs
+
+## Out of scope for Phase 0
+Do not yet:
+- migrate all Tower/Leader/Ace flows
+- implement provider-specific startup behavior in full
+- move all tmux helpers
+- rewrite reconnect/restore
+- clean up every old abstraction immediately
+
+Those belong in later phases.
+
+## Phase 0 completion criteria
+Phase 0 is complete only when:
+- the shared contract is represented in code
+- the docs still match the contract
+- the first implementation phase can begin without ambiguity about interfaces, enums, event shapes, or exit codes

--- a/docs/provider_runtime_refactor_plan.md
+++ b/docs/provider_runtime_refactor_plan.md
@@ -1,0 +1,650 @@
+# ATC provider runtime refactor plan
+
+## Executive summary
+ATC should converge on one central tmux-based provider runtime interface. The orchestration/backend layers should express role-based operations such as start Tower, stop Leader, assign task to Ace, send instruction, check readiness, and restore sessions without caring which provider implementation is active. Provider-specific logic should live only in provider-owned modules.
+
+This refactor should not remove tmux. tmux is the common runtime transport and should be treated as a stable substrate. The refactor should move provider-specific CLI semantics behind a single contract, not attempt to abstract away terminal execution itself.
+
+## Design goals
+- Keep tmux as the common transport/runtime substrate.
+- Make the backend provider-neutral, not transport-neutral.
+- Make one runtime service the only legal entry point for provider-specific behavior.
+- Make Tower, Leader, and Ace all use the same runtime contract.
+- Normalize role nouns and session metadata so refactors stop fighting naming drift.
+- Get Codex support by implementing the contract cleanly, not by adding more special cases.
+
+## What should stay shared vs provider-specific
+
+### Shared across all providers
+These are tmux/runtime concerns and should live in shared infrastructure:
+- ensure tmux session exists
+- spawn pane/window/session
+- kill pane/window/session
+- capture pane text
+- send raw keys/paste/input
+- resize pane
+- attach/detach PTY stream
+- check pane/session existence
+- persist tmux identifiers and generic runtime metadata
+
+### Provider-specific
+These should be fully encapsulated in provider modules:
+- launch command construction
+- startup handshake/trust/login handling
+- readiness detection
+- prompt/instruction framing
+- output parsing hints
+- workspace/config/bootstrap file generation
+- recovery heuristics
+- provider-specific health or status signals
+
+## Proposed contract shape
+
+### Shared enums/models
+Create canonical shared models first.
+
+Suggested file:
+- `src/atc/runtime/models.py`
+
+Suggested core enums:
+```python
+class RoleKind(StrEnum):
+    TOWER = "tower"
+    LEADER = "leader"
+    ACE = "ace"
+
+class RuntimeTransport(StrEnum):
+    TMUX = "tmux"
+
+class ReadinessState(StrEnum):
+    STARTING = "starting"
+    READY = "ready"
+    BUSY = "busy"
+    BLOCKED = "blocked"
+    ERROR = "error"
+    STOPPED = "stopped"
+```
+
+Suggested session handle:
+```python
+@dataclass(slots=True)
+class RuntimeSessionHandle:
+    session_id: str
+    project_id: str | None
+    role: RoleKind
+    provider_name: str
+    transport: RuntimeTransport
+    tmux_session: str | None
+    tmux_pane: str | None
+    metadata: dict[str, Any]
+```
+
+Suggested requests/responses:
+```python
+@dataclass(slots=True)
+class StartRoleRequest:
+    session_id: str
+    project_id: str | None
+    role: RoleKind
+    working_dir: str | None
+    display_name: str | None
+    bootstrap_context: dict[str, Any]
+
+@dataclass(slots=True)
+class StopRoleRequest:
+    reason: str | None = None
+
+@dataclass(slots=True)
+class InstructionRequest:
+    text: str
+    expects_prompt_disappearance: bool = True
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+@dataclass(slots=True)
+class TaskAssignmentRequest:
+    task_id: str
+    title: str
+    brief: str
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+@dataclass(slots=True)
+class ReadinessResult:
+    state: ReadinessState
+    summary: str
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+@dataclass(slots=True)
+class RuntimeInspection:
+    alive: bool
+    readiness: ReadinessState
+    last_output_excerpt: str | None
+    metadata: dict[str, Any] = field(default_factory=dict)
+```
+
+### Central provider runtime interface
+Suggested file:
+- `src/atc/providers/base.py`
+
+Suggested interface:
+```python
+class ProviderRuntime(Protocol):
+    provider_name: str
+
+    async def prepare_workspace(self, role: RoleKind, request: StartRoleRequest) -> None: ...
+    async def start_role(self, request: StartRoleRequest) -> RuntimeSessionHandle: ...
+    async def stop_role(self, handle: RuntimeSessionHandle, request: StopRoleRequest | None = None) -> None: ...
+    async def send_instruction(self, handle: RuntimeSessionHandle, request: InstructionRequest) -> None: ...
+    async def assign_task(self, handle: RuntimeSessionHandle, request: TaskAssignmentRequest) -> None: ...
+    async def check_readiness(self, handle: RuntimeSessionHandle) -> ReadinessResult: ...
+    async def inspect_session(self, handle: RuntimeSessionHandle) -> RuntimeInspection: ...
+    async def restore_session(self, handle: RuntimeSessionHandle) -> RuntimeInspection: ...
+```
+
+Notes:
+- `assign_task()` can be a semantic alias over `send_instruction()`, but it is useful to keep as a first-class orchestration call.
+- `start_role()` should be the provider-owned entry point for Tower, Leader, and Ace startup.
+- shared orchestration code should not build provider-specific prompts or startup commands directly.
+
+### Central runtime service
+Suggested file:
+- `src/atc/runtime/service.py`
+
+Responsibilities:
+- resolve configured provider
+- build `StartRoleRequest` / `InstructionRequest` / `TaskAssignmentRequest`
+- load/persist `RuntimeSessionHandle`
+- call the selected provider runtime implementation
+- expose one API to higher layers
+
+Suggested interface:
+```python
+class RuntimeService:
+    async def start_tower(self, ...) -> RuntimeSessionHandle: ...
+    async def stop_tower(self, ...) -> None: ...
+    async def start_leader(self, ...) -> RuntimeSessionHandle: ...
+    async def stop_leader(self, ...) -> None: ...
+    async def start_ace(self, ...) -> RuntimeSessionHandle: ...
+    async def stop_ace(self, ...) -> None: ...
+    async def assign_project_to_leader(self, ...) -> None: ...
+    async def assign_task_to_ace(self, ...) -> None: ...
+    async def send_instruction(self, ...) -> None: ...
+    async def inspect_session(self, session_id: str) -> RuntimeInspection: ...
+    async def restore_session(self, session_id: str) -> RuntimeInspection: ...
+```
+
+This becomes the only legal entry point from routers/controllers/orchestrators.
+
+## Proposed folder structure to adopt first
+
+```text
+src/atc/
+  runtime/
+    __init__.py
+    models.py
+    errors.py
+    service.py
+    tmux/
+      __init__.py
+      substrate.py
+      capture.py
+      control.py
+      streaming.py
+      health.py
+
+  providers/
+    __init__.py
+    base.py
+    registry.py
+    claude_code/
+      __init__.py
+      runtime.py
+      workspace.py
+      readiness.py
+      prompts.py
+      parser.py
+    codex/
+      __init__.py
+      runtime.py
+      workspace.py
+      readiness.py
+      prompts.py
+      parser.py
+    opencode/
+      __init__.py
+      runtime.py
+      workspace.py
+      readiness.py
+      prompts.py
+      parser.py
+```
+
+## Mapping from current files to future ownership
+
+### Keep, but relocate or slim down
+- `src/atc/terminal/control.py`
+  - future home: `src/atc/runtime/tmux/control.py`
+- `src/atc/terminal/pty_stream.py`
+  - future home: `src/atc/runtime/tmux/streaming.py`
+- tmux spawn/capture helpers currently in `src/atc/session/ace.py`
+  - future home: `src/atc/runtime/tmux/substrate.py`
+- provider interface bits from `src/atc/agents/base.py`
+  - evolve into `src/atc/providers/base.py`
+- provider registry bits from `src/atc/agents/factory.py`
+  - evolve into `src/atc/providers/registry.py`
+
+### Shrink or replace
+- `src/atc/session/ace.py`
+  - should stop owning generic spawn/readiness/provider logic
+  - should become thin orchestration helpers or disappear into `runtime/service.py`
+- `src/atc/leader/leader.py`
+  - should stop doing provider-specific startup directly
+  - should call `RuntimeService.start_leader()`
+- `src/atc/tower/session.py`
+  - should stop doing provider-specific startup directly
+  - should call `RuntimeService.start_tower()`
+- `src/atc/session/reconnect.py`
+  - should become runtime-service driven restore logic
+
+### Higher-level callers that should become provider-neutral
+- `src/atc/tower/controller.py`
+- `src/atc/leader/orchestrator.py`
+- `src/atc/api/routers/aces.py`
+- `src/atc/api/routers/leader.py`
+- `src/atc/api/routers/projects.py`
+
+## Explicit implementation phases
+
+## Phase 0, normalize nouns and freeze the contract
+Goal: define the refactor target before moving code.
+
+Target files/modules:
+- new: `src/atc/runtime/models.py`
+- new: `src/atc/providers/base.py`
+- new: `src/atc/providers/registry.py`
+- update: `src/atc/state/models.py`
+- update: `frontend/src/types/index.ts`
+- update: `docs/codebase_map_current_state.md`
+- update: `docs/provider_runtime_refactor_plan.md`
+
+Tasks:
+- define canonical `RoleKind`, `RuntimeSessionHandle`, request/response models
+- decide how `manager -> leader` migration will be represented in code and DB
+- define the runtime service API in code and docs
+- document temporary compatibility shims
+
+Exit criteria:
+- one agreed role vocabulary
+- one agreed provider runtime interface
+- one agreed runtime service surface
+
+## Phase 1, extract shared tmux substrate
+Goal: make tmux support clean and reusable.
+
+Target files/modules:
+- new: `src/atc/runtime/tmux/substrate.py`
+- new: `src/atc/runtime/tmux/control.py`
+- new: `src/atc/runtime/tmux/capture.py`
+- new: `src/atc/runtime/tmux/streaming.py`
+- update/migrate from:
+  - `src/atc/session/ace.py`
+  - `src/atc/terminal/control.py`
+  - `src/atc/terminal/pty_stream.py`
+
+Tasks:
+- move generic tmux helpers into shared substrate
+- keep substrate provider-agnostic
+- expose stable helpers for spawn, kill, capture, send, resize, attach stream, and health checks
+
+Exit criteria:
+- provider/runtime modules no longer need to reach into role-specific code for tmux basics
+
+## Phase 2, create provider runtime implementations over the tmux substrate
+Goal: make provider modules the real owners of provider behavior.
+
+Target files/modules:
+- new: `src/atc/providers/claude_code/runtime.py`
+- new: `src/atc/providers/claude_code/readiness.py`
+- new: `src/atc/providers/claude_code/workspace.py`
+- new: `src/atc/providers/codex/runtime.py`
+- new: `src/atc/providers/codex/readiness.py`
+- new: `src/atc/providers/codex/workspace.py`
+- optional/parallel: `src/atc/providers/opencode/*`
+- update/migrate from:
+  - `src/atc/agents/claude_provider.py`
+  - `src/atc/agents/opencode_provider.py`
+  - `src/atc/agents/deploy.py`
+  - `src/atc/agents/auth.py`
+
+Tasks:
+- make each provider implement `ProviderRuntime`
+- move command construction and readiness logic out of shared session code
+- move provider-specific workspace/config generation into provider packages
+- implement Codex as a first-class provider runtime, not a patched launch-command variant
+
+Exit criteria:
+- provider behavior is encapsulated in provider directories
+- no shared lifecycle code contains provider-specific startup/readiness logic
+
+## Phase 3, introduce RuntimeService and move all role startup to it
+Goal: make one service the lifecycle choke point.
+
+Target files/modules:
+- new: `src/atc/runtime/service.py`
+- update:
+  - `src/atc/tower/session.py`
+  - `src/atc/leader/leader.py`
+  - `src/atc/session/ace.py`
+  - `src/atc/api/app.py`
+
+Tasks:
+- implement `start_tower`, `start_leader`, `start_ace`
+- implement `stop_tower`, `stop_leader`, `stop_ace`
+- persist runtime metadata consistently
+- make callers stop invoking provider logic directly
+
+Exit criteria:
+- all role session startup/stop goes through `RuntimeService`
+
+## Phase 4, move instruction, assignment, readiness, and inspection flows behind the runtime service
+Goal: make execution flows provider-neutral too.
+
+Target files/modules:
+- update:
+  - `src/atc/tower/controller.py`
+  - `src/atc/leader/orchestrator.py`
+  - `src/atc/api/routers/leader.py`
+  - `src/atc/api/routers/aces.py`
+  - `src/atc/session/state_machine.py`
+
+Tasks:
+- route leader kickoff through `assign_project_to_leader()` / `send_instruction()`
+- route ace task assignment through `assign_task_to_ace()`
+- route readiness checks through provider runtime implementations
+- centralize inspection/status snapshot logic
+
+Exit criteria:
+- orchestration code expresses workflow intent only
+- provider/CLI mechanics are hidden behind runtime service calls
+
+## Phase 5, unify restore/reconnect under provider-aware runtime restoration
+Goal: eliminate split restore ownership.
+
+Target files/modules:
+- update:
+  - `src/atc/session/reconnect.py`
+  - `src/atc/api/app.py`
+  - `src/atc/tower/controller.py`
+  - `src/atc/state/db.py`
+
+Tasks:
+- make `restore_session()` provider-aware
+- stop having separate ad hoc Tower restore semantics where possible
+- persist enough runtime metadata for clean restart behavior
+- ensure Tower, Leader, and Ace all restore through the same conceptual path
+
+Exit criteria:
+- restore/reconnect policy is centralized
+- session resurrection no longer depends on scattered role-specific code paths
+
+## Phase 6, clean up model drift, docs, and tests
+Goal: finish the refactor honestly.
+
+Target files/modules:
+- update:
+  - `src/atc/state/models.py`
+  - `src/atc/state/db.py`
+  - `src/atc/api/routers/projects.py`
+  - `src/atc/api/routers/tasks.py`
+  - `frontend/src/context/AppContext.tsx`
+  - `frontend/src/types/index.ts`
+  - `docs/API.md`
+  - `docs/ARCHITECTURE.md`
+  - `docs/PATTERNS.md`
+  - relevant tests in `tests/unit`, `tests/integration`, `tests/e2e`, and `frontend/tests`
+
+Tasks:
+- finish `manager -> leader` cleanup
+- decide and clean up `tasks` vs `task_graphs`
+- resync API/WebSocket/docs to runtime truth
+- remove dead compatibility shims when safe
+- add contract and integration coverage around runtime service/provider implementations
+
+Exit criteria:
+- docs match code
+- tests defend the new boundary
+- stale model drift is materially reduced
+
+## First slice I would implement
+If starting immediately, I would do this exact order:
+1. create `src/atc/runtime/models.py`
+2. create `src/atc/providers/base.py`
+3. create `src/atc/runtime/tmux/substrate.py`
+4. migrate low-level tmux helpers there
+5. create `src/atc/providers/claude_code/runtime.py`
+6. create `src/atc/providers/codex/runtime.py`
+7. create `src/atc/runtime/service.py`
+8. switch Tower startup to call `RuntimeService.start_tower()` first
+9. switch Leader startup next
+10. switch Ace startup last
+
+Why this order:
+- it creates the boundary before broad code motion
+- it proves the contract on one role first
+- it gives Codex a clean home immediately
+- it reduces the temptation to keep patching `get_launch_command()` style flows
+
+## Final recommendation
+The first folder structure to adopt should be `runtime/` plus `providers/`, with tmux substrate code explicitly shared under `runtime/tmux/` and provider-specific logic fully isolated under `providers/<name>/`.
+
+That is the cleanest path to the architecture Matthew wants: tmux-native, provider-neutral in orchestration, and implementation-specific only inside provider modules.
+
+## Live milestone update
+
+### 2026-05-31 Phase 0 progress now partially live
+The refactor is no longer only planned scaffolding.
+
+The following are now real and landed in code:
+- shared runtime contract models under `src/atc/runtime/models.py`
+- provider runtime protocol under `src/atc/providers/base.py`
+- wrapper event parsing under `src/atc/runtime/wrapper_events.py`
+- wrapper/runtime error layer under `src/atc/runtime/errors.py`
+- shared tmux substrate beginnings under `src/atc/runtime/tmux/`
+- built-in new provider runtimes for Claude and Codex under `src/atc/providers/claude_code/` and `src/atc/providers/codex/`
+- built-in runtime registry defaults for `claude_code` and `codex`
+- first real instruction-delivery path routed through `RuntimeService`
+- first real startup spawn path routed through `RuntimeService` via `_spawn_provider_session()`
+
+This means the refactor has crossed from design-only into partial live replacement. Future work should treat the new runtime/provider boundary as active infrastructure, not speculative scaffolding.
+
+## MCP, orchestration, runtime, wrappers, and hooks stack
+
+The intended layering is:
+
+1. **MCP / external control surface**
+   - high-level tool/API surface for ATC control
+   - should call orchestration services, not provider-specific runtime code directly
+
+2. **ATC orchestration/application services**
+   - decides what should run, when, and why
+   - owns project/task/assignment policy and workflow state transitions
+
+3. **ATC runtime service**
+   - provider-neutral runtime boundary
+   - resolves provider implementation and executes lifecycle/delivery operations
+
+4. **Provider runtime implementations**
+   - provider-specific behavior for Claude/Codex/OpenCode
+   - own readiness, startup quirks, delivery mechanics, and restore semantics
+
+5. **ATC provider CLI wrapper + hooks**
+   - terminal-facing provider adapter behavior
+   - wrapper commands, startup timing, trust/login handling, hook entrypoints
+
+6. **Shared tmux substrate**
+   - pane/session spawn, capture, resize, send input, stream output, health checks
+
+### Layering rule
+- MCP belongs above orchestration.
+- Runtime/provider refactor belongs below orchestration.
+- Hooks belong in the provider/runtime execution layer, not in orchestration policy.
+
+### Practical rule
+When MCP-triggered work starts or controls a session, the call path should eventually flow through:
+- orchestration service
+- runtime service
+- provider runtime
+- wrapper/hooks/tmux substrate
+
+It should not bypass directly to provider-specific logic from the MCP layer.
+
+## Provider mismatch and replace-not-mutate rule
+
+Sessions are provider-stamped at birth.
+The `sessions.provider` value is the runtime identity of that session row.
+
+When the currently desired provider changes:
+- old sessions from the previous provider must not be silently reused
+- old session rows must not be mutated in place to pretend they were born under the new provider
+- provider mismatch should lead to replacement behavior, not session identity mutation
+
+This rule applies especially to:
+- restore/reconnect
+- `spawn_existing_session(...)`
+- any session reuse path
+
+Practical rule:
+- match => reuse/materialize may be allowed
+- mismatch => replace, do not mutate in place
+
+
+## Live reconnect seam status
+The reconnect/respawn seam now follows the stamped-provider rule before runtime materialization:
+- `src/atc/session/reconnect.py` compares `session.provider` to the current desired provider
+- mismatch marks the old session disconnected and refuses reuse
+- match allows respawn/materialization to continue through `_spawn_provider_session(...)`
+- `_spawn_provider_session(...)` now routes existing-row materialization through `RuntimeService.spawn_existing_session(...)`
+
+This means reconnect/reuse is no longer just a documented policy. It is now part of the live seam behavior.
+
+
+## Live Tower seam status
+The Tower startup/reuse seam no longer depends on a direct `get_launch_command(...)` call in `src/atc/tower/session.py`.
+Tower startup still performs Tower-specific file deployment and reuse checks, but runtime materialization now continues through `_spawn_provider_session(...)` without that extra direct factory dependency.
+
+
+## Live Leader orchestration seam status
+The Ace spawn path in `src/atc/leader/orchestrator.py` no longer resolves a direct launch command before calling `create_ace(...)`.
+That path now relies on the DB-stamped/session-driven provider flow inside session creation and existing-session materialization rather than passing an extra launch-command decision down from the orchestrator layer.
+
+
+## Live Ace API seam status
+The Ace creation REST path in `src/atc/api/routers/aces.py` no longer resolves a direct `get_launch_command(...)` value before calling `create_ace(...)`.
+The router now stays closer to orchestration intent, while provider/runtime materialization details continue lower in the session/runtime layers.
+
+
+## Live settings/provider discovery seam status
+The provider-listing path in `src/atc/api/routers/settings.py` no longer instantiates old agent-factory providers to read capabilities.
+It now reads provider discovery metadata from the runtime registry boundary instead.
+
+This is a different seam category than session startup/materialization, but it removes another visible old provider-factory dependency from live code.
+
+
+## Live runtime hardening milestone: inspection/readiness/restore
+Claude and Codex runtimes now have a stronger first-pass inspection model:
+- missing pane => `stopped`
+- visible bare prompt => `ready`
+- live pane without visible prompt => `busy`
+- `check_readiness()` now derives from `inspect_session()`
+- `restore_session()` now reflects the richer inspection result instead of treating pane existence alone as sufficient
+
+This is still an early hardening pass, but it is the first real step where the runtime layer carries meaningful restore/readiness behavior instead of only structural placeholders.
+
+
+## Live runtime hardening milestone: blocked-state detection
+The first blocked-state detection pass is now live in provider runtime inspection:
+- Claude runtime can distinguish trust-style prompts from auth-style prompts
+- Codex runtime can distinguish auth-style prompts
+- blocked states now surface as `ReadinessState.BLOCKED` with `RuntimeBlockReason`
+
+This is still intentionally heuristic, but it is a meaningful step toward making runtime restore/readiness semantics represent usability rather than mere process existence.
+
+
+## Live lifecycle regression coverage milestone
+Lifecycle/provider-mismatch behavior now has stronger regression coverage:
+- Tower reuse tests cover same-provider reuse versus provider-mismatch replacement
+- reconnect tests cover provider-mismatch refusal versus same-provider respawn
+
+This helps lock the newer provider-stamped session semantics into test-guarded behavior instead of leaving them as implementation intent only.
+
+
+## Live Tower restore consistency status
+The startup restore path in `src/atc/api/app.py` now enforces the stamped-provider rule for Tower sessions before restoring controller state.
+A live Tower pane with a mismatched provider is now marked disconnected and refused for restore, matching the replace-not-reuse behavior already established in reconnect and Tower startup-reuse paths.
+
+
+## Live Leader reuse consistency status
+The Leader startup path in `src/atc/leader/leader.py` now enforces the stamped-provider rule before reusing an existing linked leader session.
+If the existing leader session was born under a different provider than the current desired provider, reuse is refused, the old session is marked disconnected, and the leader row is cleared so a replacement session can be created.
+
+
+## Live runtime hardening milestone: restore semantics
+Provider `restore_session(...)` now adds first-pass restore-specific meaning on top of inspection results.
+Restore results now explicitly communicate whether a session appears usable after restore, whether it needs attention, and whether the outcome was ready, still active, blocked, or failed due to a missing pane.
+
+## What's left checklist
+
+### A. Remaining mixed old/new architecture seams
+- [ ] audit remaining `atc.agents.factory` usage outside the new runtime boundary
+- [ ] decide whether `atc/orchestration/service.py` launch-command path should move to runtime-owned spawn/materialization semantics
+- [ ] sweep for any lingering provider-specific behavior living in orchestration/session layers instead of provider runtimes
+- [ ] remove or clearly mark transitional compatibility scaffolding that is no longer intended as the primary path
+
+### B. Lifecycle semantic consistency
+- [ ] sweep all remaining reuse/restart/restore/materialization paths for stamped-provider enforcement
+- [ ] confirm every path follows: provider match => may reuse, provider mismatch => replace/do not mutate/reuse
+- [ ] add any missing regression coverage for remaining lifecycle seams after the audit sweep completes
+
+### C. Runtime/provider behavior hardening
+- [ ] deepen `restore_session(...)` beyond first-pass pane/prompt heuristics where provider-specific behavior is known
+- [ ] improve readiness and blocked-state detection beyond current text heuristics where feasible
+- [ ] add clearer provider-specific semantics for auth/login/trust/provider-prompt states
+- [ ] make `spawn_existing_session(...)` and `restore_session(...)` behaviors more intentionally distinct when needed
+
+### D. Wrapper and hook contract hardening
+- [ ] document and harden wrapper event semantics beyond the current first-pass contract
+- [ ] ensure hook ownership stays in provider/runtime layer, not orchestration policy
+- [ ] reduce hidden higher-layer assumptions about provider terminal behavior
+
+### E. Testing and confidence
+- [ ] broaden lifecycle/integration confidence beyond the current targeted slices
+- [ ] add stronger reconnect/restore/provider-switch coverage where still thin
+- [ ] add tests for the remaining runtime/provider hardening behavior once semantics stabilize
+
+### F. Final reconciliation and cleanup
+- [ ] reconcile `provider_runtime_refactor_plan.md` checklist/status against final landed code reality
+- [ ] refresh any docs that still imply older flows are primary
+- [ ] remove dead or redundant old helper paths once the new boundary is clearly dominant
+- [ ] decide the explicit finish line for calling the refactor complete
+
+## Recommended next checklist item
+- [ ] next: inspect `src/atc/orchestration/service.py` and decide whether its remaining `get_launch_command(...)` path should move onto the new runtime boundary or remain intentionally separate for now
+
+
+## Live orchestration Ace-spawn seam status
+The `spawn_ace(...)` path in `src/atc/orchestration/service.py` no longer resolves a direct `get_launch_command(...)` value before calling `create_ace(...)`.
+That orchestration-layer path now stays closer to intent while provider-backed materialization continues lower in the session/runtime boundary, matching the cleanup already done in the REST and leader orchestration Ace spawn seams.
+
+
+## Live runtime hardening milestone: provider-specific restore hints
+Restore results now include first-pass provider-specific restore hints in `details`, including restore stage and suggested action.
+Examples include Claude warm-up/trust/auth distinctions and Codex auth-gate versus active/ready distinctions.
+This is still heuristic, but it makes restore behavior more provider-aware than the earlier generic wrapper around inspection states.
+
+
+## Live runtime hardening milestone: provider-specific inspection hints
+Coverage added for reconnect mismatch without a project anchor and for tower provider-mismatch reuse forcing the old tower row to `disconnected`, so provider-stamped replacement behavior is now asserted more explicitly in the lifecycle tests.
+Provider inspection results now expose first-pass provider-specific runtime hints and suggested actions in `details`, not only at restore time.
+This keeps shared layers normalized while giving downstream generic callers richer provider-owned signals behind the provider runtime boundary.
+
+
+Settings and project provider validation now list provider names from the runtime registry rather than the older agent factory, reducing one more mixed old/new seam on the live API surface.

--- a/src/atc/api/app.py
+++ b/src/atc/api/app.py
@@ -332,6 +332,16 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
             )
             for ts in tower_sessions:
                 if ts.status not in ("error", "disconnected") and ts.tmux_pane:
+                    current_provider = settings.agent_provider.default
+                    if ts.provider != current_provider:
+                        logger.warning(
+                            "Tower session %s provider mismatch on restore (session=%s current=%s) — refusing restore",
+                            ts.id,
+                            ts.provider,
+                            current_provider,
+                        )
+                        await db_ops.update_session_status(db, ts.id, "disconnected")
+                        continue
                     # Verify the tmux pane is actually alive — don't restore
                     # state for dead panes (let frontend auto-start instead).
                     if not await _pane_is_alive(ts.tmux_pane):
@@ -540,7 +550,7 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
     # Resolve the claude binary path at startup to handle nvm / non-standard installs.
     # On macOS with nvm, tmux panes spawn without sourcing shell RC files, so the
     # bare "claude" command is not in PATH.  We resolve it once here and update the
-    # settings so every call to get_launch_command() picks up the absolute path.
+    # settings so provider runtime registry lookups pick up the absolute path.
     _resolve_claude_binary(settings)
 
     logger.info("ATC startup complete")
@@ -614,7 +624,7 @@ def _resolve_claude_binary(settings: "Settings") -> None:
                     "agent_provider",
                     settings.agent_provider.model_copy(update={"claude_command": new_cmd}),
                 )
-            # Also update the factory registry so get_launch_command() uses the full path
+            # Also update the legacy launch-command cache so older fallback paths use the full path
             from atc.agents import factory as _factory
             _factory._LAUNCH_COMMANDS["claude_code"] = new_cmd
             return

--- a/src/atc/api/routers/aces.py
+++ b/src/atc/api/routers/aces.py
@@ -19,7 +19,6 @@ from typing import Any
 from fastapi import APIRouter, HTTPException, Request
 from pydantic import BaseModel
 
-from atc.agents.factory import get_launch_command
 from atc.core.errors import CreationFailedError, SessionNotFoundError, SessionStaleError
 from atc.session import ace as ace_ops
 from atc.session.state_machine import InvalidTransitionError
@@ -124,8 +123,6 @@ async def create_ace(project_id: str, body: CreateAceRequest, request: Request) 
     if project is None:
         raise HTTPException(status_code=404, detail=f"Project {project_id} not found")
 
-    launch_cmd = get_launch_command(project.agent_provider)
-
     try:
         session_id = await ace_ops.create_ace(
             db,
@@ -135,7 +132,6 @@ async def create_ace(project_id: str, body: CreateAceRequest, request: Request) 
             host=body.host,
             event_bus=event_bus,
             working_dir=project.repo_path,
-            launch_command=launch_cmd,
             # Pass deploy info so create_ace can deploy with the real session_id
             deploy_spec_kwargs={
                 "project_name": project.name,

--- a/src/atc/api/routers/projects.py
+++ b/src/atc/api/routers/projects.py
@@ -249,9 +249,9 @@ async def update_project_provider(
     request: Request,
 ) -> ProjectResponse:
     """Update the agent provider for a project."""
-    from atc.agents.factory import list_providers
+    from atc.providers.registry import list_provider_runtimes
 
-    available = list_providers()
+    available = list_provider_runtimes()
     if body.agent_provider not in available:
         raise HTTPException(
             status_code=422,

--- a/src/atc/api/routers/settings.py
+++ b/src/atc/api/routers/settings.py
@@ -187,7 +187,7 @@ async def update_agent_provider(
     request: Request,
 ) -> AgentProviderResponse:
     """Update agent provider configuration for the live app instance."""
-    from atc.agents.factory import list_providers
+    from atc.providers.registry import list_provider_runtimes
     from atc.tower.controller import TowerState
 
     settings = request.app.state.settings
@@ -199,7 +199,7 @@ async def update_agent_provider(
     old_default = cfg.default
 
     if body.default is not None:
-        available = list_providers()
+        available = list_provider_runtimes()
         if body.default not in available:
             raise HTTPException(
                 status_code=422,
@@ -260,35 +260,19 @@ async def update_agent_provider(
 
 @router.get("/providers")
 async def list_available_providers() -> list[ProviderInfo]:
-    """List all registered agent providers with their capabilities."""
-    from atc.agents.factory import create_provider, list_providers
+    """List all registered provider runtimes via the registry boundary."""
+    from atc.providers.registry import list_provider_runtime_infos
 
-    result: list[ProviderInfo] = []
-    for name in list_providers():
-        try:
-            provider = create_provider(name)
-            caps = provider.get_capabilities()
-            result.append(
-                ProviderInfo(
-                    name=name,
-                    supports_streaming=caps.supports_streaming,
-                    supports_tool_use=caps.supports_tool_use,
-                    context_window=caps.context_window,
-                    model=caps.model,
-                )
-            )
-        except Exception:
-            logger.warning("Failed to instantiate provider %s for capabilities", name)
-            result.append(
-                ProviderInfo(
-                    name=name,
-                    supports_streaming=False,
-                    supports_tool_use=False,
-                    context_window=0,
-                    model="",
-                )
-            )
-    return result
+    return [
+        ProviderInfo(
+            name=info.name,
+            supports_streaming=info.supports_streaming,
+            supports_tool_use=info.supports_tool_use,
+            context_window=info.context_window,
+            model=info.model,
+        )
+        for info in list_provider_runtime_infos()
+    ]
 
 
 # ---------------------------------------------------------------------------

--- a/src/atc/leader/leader.py
+++ b/src/atc/leader/leader.py
@@ -17,7 +17,6 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 from atc.agents.deploy import ManagerDeploySpec, deploy_manager_files
-from atc.agents.factory import get_launch_command
 from atc.config import AgentProviderConfig
 from atc.session.ace import (
     _accept_trust_dialog,
@@ -94,21 +93,38 @@ async def start_leader(
     if leader is None:
         leader = await db_ops.create_leader(conn, project_id, goal=goal)
 
-    # If leader already has an active session, just return it
+    project = await db_ops.get_project(conn, project_id)
+    name = f"leader-{project.name}" if project else f"leader-{project_id[:8]}"
+
+    provider_cfg = _current_provider_config(conn)
+    provider = provider_cfg.default
+
+    # If leader already has an active session, only reuse it when the stamped
+    # provider still matches the current desired provider.
     if leader.session_id:
         existing = await db_ops.get_session(conn, leader.session_id)
         if existing and existing.status not in (
             SessionStatus.ERROR.value,
             SessionStatus.DISCONNECTED.value,
         ):
-            return leader.session_id
+            if existing.provider == provider:
+                return leader.session_id
+            logger.warning(
+                "Leader session %s provider mismatch on reuse (session=%s current=%s) — refusing reuse",
+                leader.session_id,
+                existing.provider,
+                provider,
+            )
+            await db_ops.update_session_status(
+                conn, leader.session_id, SessionStatus.DISCONNECTED.value
+            )
+            await conn.execute(
+                "UPDATE leaders SET session_id = NULL, status = 'idle', updated_at = datetime('now') WHERE id = ?",
+                (leader.id,),
+            )
+            await conn.commit()
 
     # Create manager session (DB-first)
-    project = await db_ops.get_project(conn, project_id)
-    name = f"leader-{project.name}" if project else f"leader-{project_id[:8]}"
-
-    provider_cfg = _current_provider_config(conn)
-    provider = provider_cfg.default
 
     session = await db_ops.create_session(
         conn,
@@ -188,26 +204,26 @@ async def start_leader(
             logger.info("Ensured repo_path exists: %s", spec.repo_path)
         working_dir = spec.repo_path or str(deployed.root)
 
-        launch_cmd = get_launch_command(provider)
-
-        # Provider workspace prep (alongside existing tmux logic — fallback safe)
+        # Provider workspace prep via the new runtime service boundary.
         try:
-            from atc.agents.factory import create_provider
+            from atc.runtime.models import RoleKind, StartRoleRequest
+            from atc.runtime.service import RuntimeService
 
-            provider_kwargs: dict[str, str] = {"tmux_session": provider_cfg.tmux_session}
-            if provider == "claude_code":
-                provider_kwargs["claude_command"] = provider_cfg.claude_command
-            elif provider == "codex":
-                provider_kwargs["codex_command"] = provider_cfg.codex_command
-            _provider = create_provider(provider, **provider_kwargs)
             _cmp = deployed.claude_md_path
-            _ctx = _cmp if _cmp.exists() else None
-            await _provider.prepare_workspace(
-                session.id, working_dir=working_dir, context_file=_ctx
+            _ctx = str(_cmp) if _cmp.exists() else None
+            await RuntimeService().prepare_workspace(
+                StartRoleRequest(
+                    session_id=session.id,
+                    provider_name=provider,
+                    role=RoleKind.LEADER,
+                    project_id=project_id,
+                    working_dir=working_dir,
+                    context_ref=_ctx,
+                )
             )
         except Exception as _prep_exc:
             logger.debug(
-                "provider.prepare_workspace skipped for leader %s: %s",
+                "runtime.prepare_workspace skipped for leader %s: %s",
                 session.id,
                 _prep_exc,
             )
@@ -219,7 +235,6 @@ async def start_leader(
             session_type="manager",
             working_dir=working_dir,
             context_file=deployed.claude_md_path if deployed.claude_md_path.exists() else None,
-            launch_command=launch_cmd,
         )
         await db_ops.update_session_tmux(conn, session.id, tmux_session, pane_id)
 

--- a/src/atc/leader/orchestrator.py
+++ b/src/atc/leader/orchestrator.py
@@ -20,7 +20,6 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 from atc.agents.deploy import AceDeploySpec, cleanup_deployed_files, deploy_ace_files
-from atc.agents.factory import get_launch_command
 from atc.leader.context_package import build_context_package
 from atc.leader.decomposer import get_completion_status, get_ready_tasks
 from atc.session.ace import create_ace, destroy_ace, start_ace
@@ -180,7 +179,6 @@ class LeaderOrchestrator:
                 if project and project.agent_provider
                 else self._current_provider_default()
             )
-            launch_cmd = get_launch_command(provider_name)
 
             session_id = await create_ace(
                 self.conn,
@@ -189,7 +187,6 @@ class LeaderOrchestrator:
                 task_id=task_graph_id,
                 event_bus=self.event_bus,
                 working_dir=repo_path,
-                launch_command=launch_cmd,
                 deploy_spec_kwargs={
                     "project_name": project_name,
                     "task_title": title,

--- a/src/atc/orchestration/service.py
+++ b/src/atc/orchestration/service.py
@@ -4,7 +4,6 @@ import asyncio
 import json
 from typing import Any
 
-from atc.agents.factory import get_launch_command
 from atc.leader import leader as leader_ops
 from atc.orchestration.errors import OrchestrationErrorCode, OrchestrationException
 from atc.orchestration.models import (
@@ -225,7 +224,6 @@ class OrchestrationService:
             request.model_dump_json(),
         )
 
-        launch_cmd = get_launch_command(project.agent_provider)
         ace_name = request.context.get("task_title") if request.context else None
         ace_name = ace_name or (f"ace-{request.task_id[:8]}" if request.task_id else "ace-orchestration")
 
@@ -237,7 +235,6 @@ class OrchestrationService:
                 task_id=request.task_id,
                 host=request.host,
                 working_dir=project.repo_path,
-                launch_command=launch_cmd,
                 deploy_spec_kwargs={
                     "project_name": project.name,
                     "task_title": (request.context or {}).get("task_title") or ace_name,

--- a/src/atc/providers/base.py
+++ b/src/atc/providers/base.py
@@ -1,0 +1,73 @@
+"""Provider runtime contract for tmux-backed ATC provider implementations."""
+
+from __future__ import annotations
+
+from typing import Protocol, runtime_checkable
+
+from atc.runtime.models import (
+    InstructionRequest,
+    ReadinessResult,
+    RuntimeInspection,
+    RuntimeSessionHandle,
+    StartRoleRequest,
+    StopRoleRequest,
+    TaskAssignmentRequest,
+)
+
+
+@runtime_checkable
+class ProviderRuntime(Protocol):
+    """Contract that all ATC provider runtime implementations must satisfy."""
+
+    provider_name: str
+
+    async def prepare_workspace(self, request: StartRoleRequest) -> None:
+        """Prepare working directory/bootstrap artifacts before session startup."""
+
+    async def start_role(self, request: StartRoleRequest) -> RuntimeSessionHandle:
+        """Start a provider-backed Tower, Leader, or Ace session."""
+
+    async def stop_role(
+        self,
+        handle: RuntimeSessionHandle,
+        request: StopRoleRequest | None = None,
+    ) -> None:
+        """Stop a provider-backed session."""
+
+    async def send_instruction(
+        self,
+        handle: RuntimeSessionHandle,
+        request: InstructionRequest,
+    ) -> None:
+        """Deliver a general instruction to an existing provider session."""
+
+    async def assign_task(
+        self,
+        handle: RuntimeSessionHandle,
+        request: TaskAssignmentRequest,
+    ) -> None:
+        """Deliver a task assignment to an existing provider session."""
+
+    async def check_readiness(
+        self,
+        handle: RuntimeSessionHandle,
+    ) -> ReadinessResult:
+        """Return normalized readiness state for a provider session."""
+
+    async def inspect_session(
+        self,
+        handle: RuntimeSessionHandle,
+    ) -> RuntimeInspection:
+        """Inspect health/output/readiness for a provider session."""
+
+    async def restore_session(
+        self,
+        handle: RuntimeSessionHandle,
+    ) -> RuntimeInspection:
+        """Attempt to restore/reattach/validate an existing provider session."""
+
+    async def spawn_existing_session(
+        self,
+        request: StartRoleRequest,
+    ) -> RuntimeSessionHandle:
+        """Spawn a runtime pane/process for an already-created ATC session row."""

--- a/src/atc/providers/claude_code/__init__.py
+++ b/src/atc/providers/claude_code/__init__.py
@@ -1,0 +1,1 @@
+"""Claude Code provider runtime implementation package."""

--- a/src/atc/providers/claude_code/runtime.py
+++ b/src/atc/providers/claude_code/runtime.py
@@ -1,0 +1,317 @@
+"""First Claude Code provider runtime implementation on the new contract."""
+
+from __future__ import annotations
+
+import asyncio
+import re
+
+from atc.providers.base import ProviderRuntime
+from atc.runtime.errors import RuntimeDeliveryError, RuntimeSessionMissingError
+from atc.runtime.models import (
+    InstructionRequest,
+    ReadinessResult,
+    ReadinessState,
+    RoleKind,
+    RuntimeBlockReason,
+    RuntimeInspection,
+    RuntimeSessionHandle,
+    RuntimeTransport,
+    StartRoleRequest,
+    StopRoleRequest,
+    TaskAssignmentRequest,
+)
+from atc.runtime.tmux.control import send_bracketed_instruction
+from atc.runtime.tmux.substrate import (
+    build_path_env_prefix,
+    capture_pane_text,
+    ensure_tmux_session,
+    kill_pane,
+    pane_exists,
+    spawn_window_pane,
+)
+
+_BARE_PROMPT_RE = re.compile(r"(^|\n)\s*❯\s*$", re.MULTILINE)
+_WELCOME_TRIGGERS = (
+    "tips for getting started",
+    "welcome to claude code",
+)
+_TRUST_TRIGGERS = (
+    "trust this folder",
+    "do you trust",
+    "bypass permissions",
+)
+_AUTH_TRIGGERS = (
+    "login",
+    "sign in",
+    "authentication",
+    "api key",
+)
+
+
+class ClaudeCodeRuntime(ProviderRuntime):
+    """Minimal first-pass Claude Code runtime on the new contract."""
+
+    provider_name = "claude_code"
+
+    def __init__(
+        self,
+        *,
+        tmux_session: str = "atc",
+        claude_command: str = "claude --dangerously-skip-permissions",
+    ) -> None:
+        self.tmux_session = tmux_session
+        self.claude_command = claude_command
+
+    async def prepare_workspace(self, request: StartRoleRequest) -> None:
+        if request.working_dir:
+            from os import makedirs
+
+            makedirs(request.working_dir, exist_ok=True)
+
+    async def start_role(self, request: StartRoleRequest) -> RuntimeSessionHandle:
+        await ensure_tmux_session(self.tmux_session)
+        command = build_path_env_prefix() + self.claude_command
+        pane_id = await spawn_window_pane(
+            self.tmux_session,
+            command,
+            working_dir=request.working_dir,
+        )
+        return RuntimeSessionHandle(
+            session_id=request.session_id,
+            provider_name=self.provider_name,
+            role=request.role,
+            transport=RuntimeTransport.TMUX,
+            project_id=request.project_id,
+            tmux_session=self.tmux_session,
+            tmux_pane=pane_id,
+            working_dir=request.working_dir,
+            context_ref=request.context_ref,
+            metadata={"display_name": request.display_name} if request.display_name else {},
+        )
+
+    async def spawn_existing_session(self, request: StartRoleRequest) -> RuntimeSessionHandle:
+        return await self.start_role(request)
+
+    async def stop_role(
+        self,
+        handle: RuntimeSessionHandle,
+        request: StopRoleRequest | None = None,
+    ) -> None:
+        if handle.tmux_pane:
+            await kill_pane(handle.tmux_pane)
+
+    async def send_instruction(
+        self,
+        handle: RuntimeSessionHandle,
+        request: InstructionRequest,
+    ) -> None:
+        if not handle.tmux_pane:
+            raise RuntimeSessionMissingError("Claude session has no tmux pane recorded")
+        if not await pane_exists(handle.tmux_pane):
+            raise RuntimeSessionMissingError("Claude session pane is missing")
+
+        text = request.message or ""
+        if not text and request.message_file:
+            text = open(request.message_file, encoding="utf-8").read()
+        if not text:
+            raise RuntimeDeliveryError("Instruction payload was empty")
+
+        await send_bracketed_instruction(self.tmux_session, handle.tmux_pane, text)
+        await asyncio.sleep(0.75)
+        output = await capture_pane_text(handle.tmux_pane, lines=80)
+        lowered = output.lower()
+        fingerprint = text[:80].strip()
+
+        if fingerprint and fingerprint in output:
+            return
+        if any(trigger in lowered for trigger in _WELCOME_TRIGGERS):
+            return
+        if not _BARE_PROMPT_RE.search(output):
+            return
+
+        raise RuntimeDeliveryError("Claude instruction delivery could not be verified")
+
+    async def assign_task(
+        self,
+        handle: RuntimeSessionHandle,
+        request: TaskAssignmentRequest,
+    ) -> None:
+        text = request.message
+        if not text and request.message_file:
+            text = open(request.message_file, encoding="utf-8").read()
+        await self.send_instruction(
+            handle,
+            InstructionRequest(
+                session_id=request.session_id,
+                message=text,
+                context_ref=request.context_ref,
+                instruction_id=request.assignment_id or request.task_id,
+            ),
+        )
+
+    async def check_readiness(
+        self,
+        handle: RuntimeSessionHandle,
+    ) -> ReadinessResult:
+        inspection = await self.inspect_session(handle)
+        return ReadinessResult(
+            session_id=inspection.session_id,
+            provider_name=inspection.provider_name,
+            state=inspection.readiness,
+            block_reason=inspection.block_reason,
+            summary=inspection.summary,
+            details=inspection.details,
+        )
+
+    async def inspect_session(
+        self,
+        handle: RuntimeSessionHandle,
+    ) -> RuntimeInspection:
+        if not handle.tmux_pane or not await pane_exists(handle.tmux_pane):
+            return RuntimeInspection(
+                session_id=handle.session_id,
+                provider_name=self.provider_name,
+                alive=False,
+                readiness=ReadinessState.STOPPED,
+                summary="Pane missing",
+            )
+
+        excerpt = await capture_pane_text(handle.tmux_pane, lines=40)
+        readiness, block_reason = self._classify_readiness(excerpt)
+        inspection = RuntimeInspection(
+            session_id=handle.session_id,
+            provider_name=self.provider_name,
+            alive=True,
+            readiness=readiness,
+            block_reason=block_reason,
+            summary=self._summary_for_state(readiness, block_reason),
+            last_output_excerpt=excerpt,
+        )
+        inspection.details["provider_runtime_hint"] = self._runtime_hint_for_inspection(inspection)
+        inspection.details["provider_runtime_action"] = self._runtime_action_for_inspection(inspection)
+        return inspection
+
+    def _runtime_hint_for_inspection(self, inspection: RuntimeInspection) -> str:
+        if inspection.readiness is ReadinessState.READY:
+            return "prompt_visible"
+        if inspection.readiness is ReadinessState.BUSY and inspection.last_output_excerpt:
+            lowered = inspection.last_output_excerpt.lower()
+            if any(trigger in lowered for trigger in _WELCOME_TRIGGERS):
+                return "startup_banner"
+            return "processing"
+        if inspection.readiness is ReadinessState.BLOCKED and inspection.block_reason is RuntimeBlockReason.TRUST:
+            return "trust_prompt"
+        if inspection.readiness is ReadinessState.BLOCKED and inspection.block_reason is RuntimeBlockReason.AUTH:
+            return "auth_prompt"
+        if inspection.readiness is ReadinessState.STOPPED:
+            return "pane_missing"
+        return inspection.readiness.value
+
+    def _runtime_action_for_inspection(self, inspection: RuntimeInspection) -> str:
+        if inspection.readiness is ReadinessState.READY:
+            return "send_or_resume"
+        if inspection.readiness is ReadinessState.BUSY:
+            return "wait"
+        if inspection.readiness is ReadinessState.BLOCKED and inspection.block_reason is RuntimeBlockReason.TRUST:
+            return "resolve_trust"
+        if inspection.readiness is ReadinessState.BLOCKED and inspection.block_reason is RuntimeBlockReason.AUTH:
+            return "resolve_auth"
+        if inspection.readiness is ReadinessState.STOPPED:
+            return "respawn"
+        return "inspect"
+
+    async def restore_session(
+        self,
+        handle: RuntimeSessionHandle,
+    ) -> RuntimeInspection:
+        inspection = await self.inspect_session(handle)
+        details = dict(inspection.details)
+        details["restore_attempted"] = True
+        details["restore_usable"] = inspection.readiness in {
+            ReadinessState.READY,
+            ReadinessState.BUSY,
+        }
+        details["restore_needs_attention"] = inspection.readiness in {
+            ReadinessState.BLOCKED,
+            ReadinessState.STOPPED,
+            ReadinessState.ERROR,
+        }
+        details["provider_restore_stage"] = self._restore_stage_for_inspection(inspection)
+        details["provider_restore_action"] = self._restore_action_for_inspection(inspection)
+        summary = inspection.summary
+        if inspection.readiness is ReadinessState.READY:
+            summary = "Restored and ready"
+        elif inspection.readiness is ReadinessState.BUSY:
+            summary = "Restored but still active"
+        elif inspection.readiness is ReadinessState.BLOCKED:
+            summary = f"Restore blocked: {inspection.summary}"
+        elif inspection.readiness is ReadinessState.STOPPED:
+            summary = "Restore failed: pane missing"
+        return RuntimeInspection(
+            session_id=inspection.session_id,
+            provider_name=inspection.provider_name,
+            alive=inspection.alive,
+            readiness=inspection.readiness,
+            block_reason=inspection.block_reason,
+            summary=summary,
+            last_output_excerpt=inspection.last_output_excerpt,
+            details=details,
+        )
+
+    def _restore_stage_for_inspection(self, inspection: RuntimeInspection) -> str:
+        if inspection.readiness is ReadinessState.READY:
+            return "ready"
+        if inspection.readiness is ReadinessState.BUSY and inspection.last_output_excerpt:
+            lowered = inspection.last_output_excerpt.lower()
+            if any(trigger in lowered for trigger in _WELCOME_TRIGGERS):
+                return "warming_up"
+            return "active"
+        if inspection.readiness is ReadinessState.BLOCKED and inspection.block_reason is RuntimeBlockReason.TRUST:
+            return "trust_gate"
+        if inspection.readiness is ReadinessState.BLOCKED and inspection.block_reason is RuntimeBlockReason.AUTH:
+            return "auth_gate"
+        if inspection.readiness is ReadinessState.STOPPED:
+            return "missing"
+        return inspection.readiness.value
+
+    def _restore_action_for_inspection(self, inspection: RuntimeInspection) -> str:
+        if inspection.readiness is ReadinessState.READY:
+            return "resume"
+        if inspection.readiness is ReadinessState.BUSY:
+            return "wait"
+        if inspection.readiness is ReadinessState.BLOCKED and inspection.block_reason is RuntimeBlockReason.TRUST:
+            return "resolve_trust"
+        if inspection.readiness is ReadinessState.BLOCKED and inspection.block_reason is RuntimeBlockReason.AUTH:
+            return "resolve_auth"
+        if inspection.readiness is ReadinessState.STOPPED:
+            return "respawn"
+        return "inspect"
+
+    def _classify_readiness(self, excerpt: str) -> tuple[ReadinessState, RuntimeBlockReason | None]:
+        lowered = excerpt.lower()
+        if any(trigger in lowered for trigger in _TRUST_TRIGGERS):
+            return ReadinessState.BLOCKED, RuntimeBlockReason.TRUST
+        if any(trigger in lowered for trigger in _AUTH_TRIGGERS):
+            return ReadinessState.BLOCKED, RuntimeBlockReason.AUTH
+        if any(trigger in lowered for trigger in _WELCOME_TRIGGERS):
+            return ReadinessState.BUSY, None
+        if _BARE_PROMPT_RE.search(excerpt):
+            return ReadinessState.READY, None
+        return ReadinessState.BUSY, None
+
+    @staticmethod
+    def _summary_for_state(
+        readiness: ReadinessState,
+        block_reason: RuntimeBlockReason | None,
+    ) -> str:
+        if readiness is ReadinessState.READY:
+            return "Prompt ready"
+        if readiness is ReadinessState.BLOCKED and block_reason is RuntimeBlockReason.TRUST:
+            return "Blocked on trust prompt"
+        if readiness is ReadinessState.BLOCKED and block_reason is RuntimeBlockReason.AUTH:
+            return "Blocked on authentication"
+        if readiness is ReadinessState.BUSY:
+            return "Session active but not at bare prompt"
+        if readiness is ReadinessState.STOPPED:
+            return "Pane missing"
+        return readiness.value

--- a/src/atc/providers/codex/__init__.py
+++ b/src/atc/providers/codex/__init__.py
@@ -1,0 +1,1 @@
+"""Codex provider runtime implementation package."""

--- a/src/atc/providers/codex/runtime.py
+++ b/src/atc/providers/codex/runtime.py
@@ -1,0 +1,271 @@
+"""First Codex provider runtime implementation on the new contract."""
+
+from __future__ import annotations
+
+import re
+
+from atc.providers.base import ProviderRuntime
+from atc.runtime.errors import RuntimeDeliveryError, RuntimeSessionMissingError
+from atc.runtime.models import (
+    InstructionRequest,
+    ReadinessResult,
+    ReadinessState,
+    RuntimeBlockReason,
+    RuntimeInspection,
+    RuntimeSessionHandle,
+    RuntimeTransport,
+    StartRoleRequest,
+    StopRoleRequest,
+    TaskAssignmentRequest,
+)
+from atc.runtime.tmux.control import send_bracketed_instruction
+from atc.runtime.tmux.substrate import (
+    build_path_env_prefix,
+    capture_pane_text,
+    ensure_tmux_session,
+    kill_pane,
+    pane_exists,
+    spawn_window_pane,
+)
+
+_CODEX_PROMPT_RE = re.compile(r"(^|\n)\s*(❯|>)\s*$", re.MULTILINE)
+_AUTH_TRIGGERS = (
+    "login",
+    "sign in",
+    "authentication",
+    "api key",
+)
+
+
+class CodexRuntime(ProviderRuntime):
+    """Minimal first-pass Codex runtime on the new contract."""
+
+    provider_name = "codex"
+
+    def __init__(
+        self,
+        *,
+        tmux_session: str = "atc",
+        codex_command: str = "codex",
+    ) -> None:
+        self.tmux_session = tmux_session
+        self.codex_command = codex_command
+
+    async def prepare_workspace(self, request: StartRoleRequest) -> None:
+        if request.working_dir:
+            from os import makedirs
+
+            makedirs(request.working_dir, exist_ok=True)
+
+    async def start_role(self, request: StartRoleRequest) -> RuntimeSessionHandle:
+        await ensure_tmux_session(self.tmux_session)
+        command = build_path_env_prefix() + self.codex_command
+        pane_id = await spawn_window_pane(
+            self.tmux_session,
+            command,
+            working_dir=request.working_dir,
+        )
+        return RuntimeSessionHandle(
+            session_id=request.session_id,
+            provider_name=self.provider_name,
+            role=request.role,
+            transport=RuntimeTransport.TMUX,
+            project_id=request.project_id,
+            tmux_session=self.tmux_session,
+            tmux_pane=pane_id,
+            working_dir=request.working_dir,
+            context_ref=request.context_ref,
+            metadata={"display_name": request.display_name} if request.display_name else {},
+        )
+
+    async def spawn_existing_session(self, request: StartRoleRequest) -> RuntimeSessionHandle:
+        return await self.start_role(request)
+
+    async def stop_role(
+        self,
+        handle: RuntimeSessionHandle,
+        request: StopRoleRequest | None = None,
+    ) -> None:
+        if handle.tmux_pane:
+            await kill_pane(handle.tmux_pane)
+
+    async def send_instruction(
+        self,
+        handle: RuntimeSessionHandle,
+        request: InstructionRequest,
+    ) -> None:
+        if not handle.tmux_pane:
+            raise RuntimeSessionMissingError("Codex session has no tmux pane recorded")
+        if not await pane_exists(handle.tmux_pane):
+            raise RuntimeSessionMissingError("Codex session pane is missing")
+        text = request.message or ""
+        if not text and request.message_file:
+            text = open(request.message_file, encoding="utf-8").read()
+        if not text:
+            raise RuntimeDeliveryError("Instruction payload was empty")
+        await send_bracketed_instruction(self.tmux_session, handle.tmux_pane, text)
+
+    async def assign_task(
+        self,
+        handle: RuntimeSessionHandle,
+        request: TaskAssignmentRequest,
+    ) -> None:
+        text = request.message
+        if not text and request.message_file:
+            text = open(request.message_file, encoding="utf-8").read()
+        await self.send_instruction(
+            handle,
+            InstructionRequest(
+                session_id=request.session_id,
+                message=text,
+                context_ref=request.context_ref,
+                instruction_id=request.assignment_id or request.task_id,
+            ),
+        )
+
+    async def check_readiness(
+        self,
+        handle: RuntimeSessionHandle,
+    ) -> ReadinessResult:
+        inspection = await self.inspect_session(handle)
+        return ReadinessResult(
+            session_id=inspection.session_id,
+            provider_name=inspection.provider_name,
+            state=inspection.readiness,
+            block_reason=inspection.block_reason,
+            summary=inspection.summary,
+            details=inspection.details,
+        )
+
+    async def inspect_session(
+        self,
+        handle: RuntimeSessionHandle,
+    ) -> RuntimeInspection:
+        if not handle.tmux_pane or not await pane_exists(handle.tmux_pane):
+            return RuntimeInspection(
+                session_id=handle.session_id,
+                provider_name=self.provider_name,
+                alive=False,
+                readiness=ReadinessState.STOPPED,
+                summary="Pane missing",
+            )
+
+        excerpt = await capture_pane_text(handle.tmux_pane, lines=40)
+        readiness, block_reason = self._classify_readiness(excerpt)
+        inspection = RuntimeInspection(
+            session_id=handle.session_id,
+            provider_name=self.provider_name,
+            alive=True,
+            readiness=readiness,
+            block_reason=block_reason,
+            summary=self._summary_for_state(readiness, block_reason),
+            last_output_excerpt=excerpt,
+        )
+        inspection.details["provider_runtime_hint"] = self._runtime_hint_for_inspection(inspection)
+        inspection.details["provider_runtime_action"] = self._runtime_action_for_inspection(inspection)
+        return inspection
+
+    def _runtime_hint_for_inspection(self, inspection: RuntimeInspection) -> str:
+        if inspection.readiness is ReadinessState.READY:
+            return "prompt_visible"
+        if inspection.readiness is ReadinessState.BUSY:
+            return "processing"
+        if inspection.readiness is ReadinessState.BLOCKED and inspection.block_reason is RuntimeBlockReason.AUTH:
+            return "auth_prompt"
+        if inspection.readiness is ReadinessState.STOPPED:
+            return "pane_missing"
+        return inspection.readiness.value
+
+    def _runtime_action_for_inspection(self, inspection: RuntimeInspection) -> str:
+        if inspection.readiness is ReadinessState.READY:
+            return "send_or_resume"
+        if inspection.readiness is ReadinessState.BUSY:
+            return "wait"
+        if inspection.readiness is ReadinessState.BLOCKED and inspection.block_reason is RuntimeBlockReason.AUTH:
+            return "resolve_auth"
+        if inspection.readiness is ReadinessState.STOPPED:
+            return "respawn"
+        return "inspect"
+
+    async def restore_session(
+        self,
+        handle: RuntimeSessionHandle,
+    ) -> RuntimeInspection:
+        inspection = await self.inspect_session(handle)
+        details = dict(inspection.details)
+        details["restore_attempted"] = True
+        details["restore_usable"] = inspection.readiness in {
+            ReadinessState.READY,
+            ReadinessState.BUSY,
+        }
+        details["restore_needs_attention"] = inspection.readiness in {
+            ReadinessState.BLOCKED,
+            ReadinessState.STOPPED,
+            ReadinessState.ERROR,
+        }
+        details["provider_restore_stage"] = self._restore_stage_for_inspection(inspection)
+        details["provider_restore_action"] = self._restore_action_for_inspection(inspection)
+        summary = inspection.summary
+        if inspection.readiness is ReadinessState.READY:
+            summary = "Restored and ready"
+        elif inspection.readiness is ReadinessState.BUSY:
+            summary = "Restored but still active"
+        elif inspection.readiness is ReadinessState.BLOCKED:
+            summary = f"Restore blocked: {inspection.summary}"
+        elif inspection.readiness is ReadinessState.STOPPED:
+            summary = "Restore failed: pane missing"
+        return RuntimeInspection(
+            session_id=inspection.session_id,
+            provider_name=inspection.provider_name,
+            alive=inspection.alive,
+            readiness=inspection.readiness,
+            block_reason=inspection.block_reason,
+            summary=summary,
+            last_output_excerpt=inspection.last_output_excerpt,
+            details=details,
+        )
+
+    def _restore_stage_for_inspection(self, inspection: RuntimeInspection) -> str:
+        if inspection.readiness is ReadinessState.READY:
+            return "ready"
+        if inspection.readiness is ReadinessState.BUSY:
+            return "active"
+        if inspection.readiness is ReadinessState.BLOCKED and inspection.block_reason is RuntimeBlockReason.AUTH:
+            return "auth_gate"
+        if inspection.readiness is ReadinessState.STOPPED:
+            return "missing"
+        return inspection.readiness.value
+
+    def _restore_action_for_inspection(self, inspection: RuntimeInspection) -> str:
+        if inspection.readiness is ReadinessState.READY:
+            return "resume"
+        if inspection.readiness is ReadinessState.BUSY:
+            return "wait"
+        if inspection.readiness is ReadinessState.BLOCKED and inspection.block_reason is RuntimeBlockReason.AUTH:
+            return "resolve_auth"
+        if inspection.readiness is ReadinessState.STOPPED:
+            return "respawn"
+        return "inspect"
+
+    def _classify_readiness(self, excerpt: str) -> tuple[ReadinessState, RuntimeBlockReason | None]:
+        lowered = excerpt.lower()
+        if any(trigger in lowered for trigger in _AUTH_TRIGGERS):
+            return ReadinessState.BLOCKED, RuntimeBlockReason.AUTH
+        if _CODEX_PROMPT_RE.search(excerpt):
+            return ReadinessState.READY, None
+        return ReadinessState.BUSY, None
+
+    @staticmethod
+    def _summary_for_state(
+        readiness: ReadinessState,
+        block_reason: RuntimeBlockReason | None,
+    ) -> str:
+        if readiness is ReadinessState.READY:
+            return "Prompt ready"
+        if readiness is ReadinessState.BLOCKED and block_reason is RuntimeBlockReason.AUTH:
+            return "Blocked on authentication"
+        if readiness is ReadinessState.BUSY:
+            return "Session active but not at prompt"
+        if readiness is ReadinessState.STOPPED:
+            return "Pane missing"
+        return readiness.value

--- a/src/atc/providers/registry.py
+++ b/src/atc/providers/registry.py
@@ -1,0 +1,103 @@
+"""Provider runtime registry for tmux-backed ATC provider implementations."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from collections.abc import Callable
+from typing import Any
+
+from atc.config import load_settings
+from atc.providers.base import ProviderRuntime
+from atc.providers.claude_code.runtime import ClaudeCodeRuntime
+from atc.providers.codex.runtime import CodexRuntime
+
+ProviderFactory = Callable[..., ProviderRuntime]
+
+
+@dataclass(frozen=True, slots=True)
+class ProviderRuntimeInfo:
+    """Registry-owned provider metadata for listing/config surfaces."""
+
+    name: str
+    model: str = ""
+    supports_streaming: bool = False
+    supports_tool_use: bool = False
+    context_window: int = 0
+
+_REGISTRY: dict[str, ProviderFactory] = {}
+_BUILTINS_REGISTERED = False
+
+
+class ProviderRegistryError(ValueError):
+    """Raised when provider runtime registry operations fail."""
+
+
+def register_provider_runtime(name: str, factory: ProviderFactory) -> None:
+    """Register a provider runtime factory under a stable provider name."""
+
+    if not name:
+        raise ProviderRegistryError("Provider name must be non-empty")
+    _REGISTRY[name] = factory
+
+
+def create_provider_runtime(name: str, **kwargs: Any) -> ProviderRuntime:
+    """Instantiate a provider runtime by provider name."""
+
+    _register_builtin_provider_runtimes()
+    factory = _REGISTRY.get(name)
+    if factory is None:
+        available = ", ".join(sorted(_REGISTRY)) or "(none)"
+        raise ProviderRegistryError(
+            f"Unknown provider runtime {name!r}. Available: {available}"
+        )
+
+    if not kwargs:
+        try:
+            settings = load_settings()
+            if name == "claude_code":
+                kwargs = {
+                    "tmux_session": settings.agent_provider.tmux_session,
+                    "claude_command": settings.agent_provider.claude_command,
+                }
+            elif name == "codex":
+                kwargs = {
+                    "tmux_session": settings.agent_provider.tmux_session,
+                    "codex_command": settings.agent_provider.codex_command,
+                }
+        except Exception:
+            kwargs = {}
+
+    return factory(**kwargs)
+
+
+def get_provider_runtime_factory(name: str) -> ProviderFactory | None:
+    """Return the registered factory for a provider, if any."""
+
+    _register_builtin_provider_runtimes()
+    return _REGISTRY.get(name)
+
+
+def list_provider_runtimes() -> list[str]:
+    """List registered provider runtime names."""
+
+    _register_builtin_provider_runtimes()
+    return sorted(_REGISTRY)
+
+
+
+
+def list_provider_runtime_infos() -> list[ProviderRuntimeInfo]:
+    """List registry-owned provider metadata for settings and discovery surfaces."""
+
+    return [
+        ProviderRuntimeInfo(name=name)
+        for name in list_provider_runtimes()
+    ]
+
+def _register_builtin_provider_runtimes() -> None:
+    global _BUILTINS_REGISTERED
+    if _BUILTINS_REGISTERED:
+        return
+    register_provider_runtime("claude_code", ClaudeCodeRuntime)
+    register_provider_runtime("codex", CodexRuntime)
+    _BUILTINS_REGISTERED = True

--- a/src/atc/runtime/errors.py
+++ b/src/atc/runtime/errors.py
@@ -1,0 +1,86 @@
+"""Shared runtime/provider error types for ATC."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+from atc.runtime.models import RuntimeBlockReason, WrapperExitCode
+
+
+@dataclass(slots=True)
+class RuntimeErrorContext:
+    """Structured context for runtime/provider failures."""
+
+    session_id: str | None = None
+    provider_name: str | None = None
+    command: str | None = None
+    role: str | None = None
+    details: dict[str, Any] = field(default_factory=dict)
+
+
+class ATCRuntimeError(Exception):
+    """Base error for runtime/provider layer failures."""
+
+    def __init__(self, message: str, *, context: RuntimeErrorContext | None = None) -> None:
+        super().__init__(message)
+        self.context = context or RuntimeErrorContext()
+
+
+class RuntimeBlockedError(ATCRuntimeError):
+    """Raised when a runtime action is blocked by auth/trust/prompt conditions."""
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        reason: RuntimeBlockReason = RuntimeBlockReason.UNKNOWN,
+        context: RuntimeErrorContext | None = None,
+    ) -> None:
+        super().__init__(message, context=context)
+        self.reason = reason
+
+
+class RuntimeNotReadyError(ATCRuntimeError):
+    """Raised when a runtime action cannot proceed because the session is not ready."""
+
+
+class RuntimeSessionMissingError(ATCRuntimeError):
+    """Raised when a targeted runtime session or pane cannot be found."""
+
+
+class RuntimeDeliveryError(ATCRuntimeError):
+    """Raised when instruction or task delivery fails."""
+
+
+class RuntimeRestoreError(ATCRuntimeError):
+    """Raised when runtime restoration fails."""
+
+
+class RuntimeInvocationError(ATCRuntimeError):
+    """Raised when ATC invokes the wrapper or provider incorrectly."""
+
+
+def map_wrapper_exit_code(
+    exit_code: int,
+    *,
+    message: str,
+    context: RuntimeErrorContext | None = None,
+) -> ATCRuntimeError | None:
+    """Map a wrapper exit code to a typed runtime error, if any."""
+
+    if exit_code == WrapperExitCode.SUCCESS:
+        return None
+    if exit_code == WrapperExitCode.BLOCKED_AUTH:
+        return RuntimeBlockedError(message, reason=RuntimeBlockReason.AUTH, context=context)
+    if exit_code == WrapperExitCode.NOT_READY:
+        return RuntimeNotReadyError(message, context=context)
+    if exit_code == WrapperExitCode.SESSION_MISSING:
+        return RuntimeSessionMissingError(message, context=context)
+    if exit_code == WrapperExitCode.INVALID_ARGS:
+        return RuntimeInvocationError(message, context=context)
+    if exit_code == WrapperExitCode.DELIVERY_FAILED:
+        return RuntimeDeliveryError(message, context=context)
+    if exit_code == WrapperExitCode.RESTORE_FAILED:
+        return RuntimeRestoreError(message, context=context)
+    return ATCRuntimeError(message, context=context)

--- a/src/atc/runtime/models.py
+++ b/src/atc/runtime/models.py
@@ -1,0 +1,162 @@
+"""Shared runtime/provider contract models for ATC.
+
+These models define the provider-neutral contract between orchestration,
+runtime services, provider implementations, and wrapper integration.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import IntEnum, StrEnum
+from typing import Any
+
+
+class RoleKind(StrEnum):
+    """Canonical runtime role kinds."""
+
+    TOWER = "tower"
+    LEADER = "leader"
+    ACE = "ace"
+
+
+class RuntimeTransport(StrEnum):
+    """Supported runtime transports."""
+
+    TMUX = "tmux"
+
+
+class ReadinessState(StrEnum):
+    """Normalized readiness states across providers."""
+
+    STARTING = "starting"
+    READY = "ready"
+    BUSY = "busy"
+    BLOCKED = "blocked"
+    ERROR = "error"
+    STOPPED = "stopped"
+
+
+class RuntimeBlockReason(StrEnum):
+    """Common reasons a provider session may be blocked."""
+
+    LOGIN = "login"
+    TRUST = "trust"
+    AUTH = "auth"
+    RATE_LIMIT = "rate_limit"
+    PROVIDER_PROMPT = "provider_prompt"
+    UNKNOWN = "unknown"
+
+
+class WrapperExitCode(IntEnum):
+    """Stable exit codes for the provider CLI wrapper."""
+
+    SUCCESS = 0
+    BLOCKED_AUTH = 10
+    NOT_READY = 11
+    SESSION_MISSING = 12
+    INVALID_ARGS = 13
+    DELIVERY_FAILED = 20
+    RESTORE_FAILED = 21
+    INTERNAL_FAILURE = 30
+
+
+@dataclass(slots=True)
+class RuntimeSessionHandle:
+    """Normalized runtime handle for a provider-managed session."""
+
+    session_id: str
+    provider_name: str
+    role: RoleKind
+    transport: RuntimeTransport
+    project_id: str | None = None
+    tmux_session: str | None = None
+    tmux_pane: str | None = None
+    working_dir: str | None = None
+    context_ref: str | None = None
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass(slots=True)
+class StartRoleRequest:
+    """Request to start a runtime role session."""
+
+    session_id: str
+    provider_name: str
+    role: RoleKind
+    project_id: str | None = None
+    working_dir: str | None = None
+    context_ref: str | None = None
+    display_name: str | None = None
+    provider_config_ref: str | None = None
+    bootstrap_file: str | None = None
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass(slots=True)
+class StopRoleRequest:
+    """Request to stop a runtime role session."""
+
+    reason: str | None = None
+    graceful: bool = True
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass(slots=True)
+class InstructionRequest:
+    """Request to deliver a general instruction to a session."""
+
+    session_id: str
+    message: str | None = None
+    message_file: str | None = None
+    context_ref: str | None = None
+    instruction_id: str | None = None
+    expects_readiness_check: bool = True
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        if not self.message and not self.message_file:
+            raise ValueError("InstructionRequest requires message or message_file")
+
+
+@dataclass(slots=True)
+class TaskAssignmentRequest:
+    """Request to assign a task to a session."""
+
+    session_id: str
+    task_id: str
+    task_title: str | None = None
+    message: str | None = None
+    message_file: str | None = None
+    context_ref: str | None = None
+    assignment_id: str | None = None
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        if not self.message and not self.message_file:
+            raise ValueError("TaskAssignmentRequest requires message or message_file")
+
+
+@dataclass(slots=True)
+class ReadinessResult:
+    """Normalized readiness result from a provider."""
+
+    session_id: str
+    provider_name: str
+    state: ReadinessState
+    block_reason: RuntimeBlockReason | None = None
+    summary: str | None = None
+    details: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass(slots=True)
+class RuntimeInspection:
+    """Normalized inspection result for a provider-managed session."""
+
+    session_id: str
+    provider_name: str
+    alive: bool
+    readiness: ReadinessState
+    block_reason: RuntimeBlockReason | None = None
+    summary: str | None = None
+    last_output_excerpt: str | None = None
+    details: dict[str, Any] = field(default_factory=dict)

--- a/src/atc/runtime/service.py
+++ b/src/atc/runtime/service.py
@@ -1,0 +1,159 @@
+"""Central provider-neutral runtime service for Tower, Leader, and Ace flows."""
+
+from __future__ import annotations
+
+from atc.providers.base import ProviderRuntime
+from atc.providers.registry import create_provider_runtime
+from atc.runtime.models import (
+    InstructionRequest,
+    ReadinessResult,
+    RoleKind,
+    RuntimeInspection,
+    RuntimeSessionHandle,
+    StartRoleRequest,
+    StopRoleRequest,
+    TaskAssignmentRequest,
+)
+
+
+class RuntimeService:
+    """Provider-neutral entrypoint for ATC runtime operations.
+
+    This service is the intended choke point for role session lifecycle,
+    instruction delivery, task assignment, readiness checks, and restore.
+    """
+
+    def __init__(self) -> None:
+        self._handles: dict[str, RuntimeSessionHandle] = {}
+        self._providers: dict[str, ProviderRuntime] = {}
+
+    def get_provider(self, provider_name: str) -> ProviderRuntime:
+        """Resolve a provider runtime implementation by name."""
+
+        provider = self._providers.get(provider_name)
+        if provider is None:
+            provider = create_provider_runtime(provider_name)
+            self._providers[provider_name] = provider
+        return provider
+
+    def remember_handle(self, handle: RuntimeSessionHandle) -> RuntimeSessionHandle:
+        """Store a runtime handle for later session-targeted operations."""
+
+        self._handles[handle.session_id] = handle
+        return handle
+
+    def get_handle(self, session_id: str) -> RuntimeSessionHandle:
+        """Look up a previously remembered runtime handle."""
+
+        try:
+            return self._handles[session_id]
+        except KeyError as exc:
+            raise KeyError(f"Unknown runtime session handle: {session_id}") from exc
+
+    async def prepare_workspace(self, request: StartRoleRequest) -> None:
+        """Run provider-owned workspace/bootstrap preparation for a role request."""
+
+        provider = self.get_provider(request.provider_name)
+        await provider.prepare_workspace(request)
+
+    async def start_tower(self, request: StartRoleRequest) -> RuntimeSessionHandle:
+        if request.role is not RoleKind.TOWER:
+            raise ValueError("start_tower requires role=tower")
+        return await self._start_role(request)
+
+    async def stop_tower(
+        self,
+        handle: RuntimeSessionHandle,
+        request: StopRoleRequest | None = None,
+    ) -> None:
+        if handle.role is not RoleKind.TOWER:
+            raise ValueError("stop_tower requires tower handle")
+        await self._stop_role(handle, request)
+
+    async def start_leader(self, request: StartRoleRequest) -> RuntimeSessionHandle:
+        if request.role is not RoleKind.LEADER:
+            raise ValueError("start_leader requires role=leader")
+        return await self._start_role(request)
+
+    async def stop_leader(
+        self,
+        handle: RuntimeSessionHandle,
+        request: StopRoleRequest | None = None,
+    ) -> None:
+        if handle.role is not RoleKind.LEADER:
+            raise ValueError("stop_leader requires leader handle")
+        await self._stop_role(handle, request)
+
+    async def start_ace(self, request: StartRoleRequest) -> RuntimeSessionHandle:
+        if request.role is not RoleKind.ACE:
+            raise ValueError("start_ace requires role=ace")
+        return await self._start_role(request)
+
+    async def stop_ace(
+        self,
+        handle: RuntimeSessionHandle,
+        request: StopRoleRequest | None = None,
+    ) -> None:
+        if handle.role is not RoleKind.ACE:
+            raise ValueError("stop_ace requires ace handle")
+        await self._stop_role(handle, request)
+
+    async def spawn_existing_session(self, request: StartRoleRequest) -> RuntimeSessionHandle:
+        """Materialize an already-created DB session row into a live runtime session."""
+
+        provider = self.get_provider(request.provider_name)
+        handle = await provider.spawn_existing_session(request)
+        return self.remember_handle(handle)
+
+    async def send_instruction(
+        self,
+        handle: RuntimeSessionHandle,
+        request: InstructionRequest,
+    ) -> None:
+        provider = self.get_provider(handle.provider_name)
+        await provider.send_instruction(handle, request)
+
+    async def assign_project_to_leader(
+        self,
+        handle: RuntimeSessionHandle,
+        request: InstructionRequest,
+    ) -> None:
+        if handle.role is not RoleKind.LEADER:
+            raise ValueError("assign_project_to_leader requires leader handle")
+        await self.send_instruction(handle, request)
+
+    async def assign_task_to_ace(
+        self,
+        handle: RuntimeSessionHandle,
+        request: TaskAssignmentRequest,
+    ) -> None:
+        if handle.role is not RoleKind.ACE:
+            raise ValueError("assign_task_to_ace requires ace handle")
+        provider = self.get_provider(handle.provider_name)
+        await provider.assign_task(handle, request)
+
+    async def check_readiness(self, handle: RuntimeSessionHandle) -> ReadinessResult:
+        provider = self.get_provider(handle.provider_name)
+        return await provider.check_readiness(handle)
+
+    async def inspect_session(self, handle: RuntimeSessionHandle) -> RuntimeInspection:
+        provider = self.get_provider(handle.provider_name)
+        return await provider.inspect_session(handle)
+
+    async def restore_session(self, handle: RuntimeSessionHandle) -> RuntimeInspection:
+        provider = self.get_provider(handle.provider_name)
+        return await provider.restore_session(handle)
+
+    async def _start_role(self, request: StartRoleRequest) -> RuntimeSessionHandle:
+        provider = self.get_provider(request.provider_name)
+        await provider.prepare_workspace(request)
+        handle = await provider.start_role(request)
+        return self.remember_handle(handle)
+
+    async def _stop_role(
+        self,
+        handle: RuntimeSessionHandle,
+        request: StopRoleRequest | None = None,
+    ) -> None:
+        provider = self.get_provider(handle.provider_name)
+        await provider.stop_role(handle, request)

--- a/src/atc/runtime/tmux/control.py
+++ b/src/atc/runtime/tmux/control.py
@@ -1,0 +1,15 @@
+"""Thin compatibility bridge to the existing tmux control-mode helpers.
+
+This module provides the first delivery primitive on the new runtime boundary
+without reimplementing the existing low-level control-mode stack all at once.
+"""
+
+from __future__ import annotations
+
+from atc.terminal.control import send_instruction_async as _legacy_send_instruction_async
+
+
+async def send_bracketed_instruction(tmux_session: str, pane_id: str, text: str) -> None:
+    """Send bracketed-paste instruction text followed by Enter to a tmux pane."""
+
+    await _legacy_send_instruction_async(tmux_session, pane_id, text)

--- a/src/atc/runtime/tmux/substrate.py
+++ b/src/atc/runtime/tmux/substrate.py
@@ -1,0 +1,115 @@
+"""Shared tmux substrate helpers for the runtime/provider refactor."""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import shutil
+from pathlib import Path
+
+from atc.runtime.errors import RuntimeInvocationError
+
+
+def resolve_tmux_binary() -> str:
+    """Resolve the tmux binary path consistently across environments."""
+
+    tmux = shutil.which("tmux")
+    if tmux:
+        return tmux
+    for candidate in ("/usr/local/bin/tmux", "/opt/homebrew/bin/tmux", "/usr/bin/tmux"):
+        if shutil.which(candidate):
+            return candidate
+    return "tmux"
+
+
+async def run_tmux(*args: str) -> str:
+    """Run a tmux command and return stdout, raising a typed runtime error on failure."""
+
+    proc = await asyncio.create_subprocess_exec(
+        resolve_tmux_binary(),
+        *args,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+    )
+    stdout, stderr = await proc.communicate()
+    if proc.returncode != 0:
+        raise RuntimeInvocationError(
+            f"tmux {' '.join(args)} failed: {stderr.decode().strip()}"
+        )
+    return stdout.decode().strip()
+
+
+async def ensure_tmux_session(session_name: str) -> None:
+    """Ensure a detached tmux session exists with sane default dimensions."""
+
+    try:
+        await run_tmux("has-session", "-t", session_name)
+    except RuntimeInvocationError:
+        await run_tmux("new-session", "-d", "-s", session_name, "-x", "120", "-y", "40")
+
+
+async def spawn_window_pane(
+    session_name: str,
+    command: str | None = None,
+    *,
+    working_dir: str | None = None,
+) -> str:
+    """Create a new window in a tmux session and return its pane id."""
+
+    args = ["new-window", "-a", "-t", session_name, "-d", "-P", "-F", "#{pane_id}"]
+    if working_dir:
+        if not os.path.isdir(working_dir):
+            os.makedirs(working_dir, exist_ok=True)
+        args.extend(["-c", working_dir])
+    if command:
+        args.append(command)
+    return await run_tmux(*args)
+
+
+async def kill_pane(pane_id: str) -> None:
+    """Kill a tmux pane by pane id."""
+
+    await run_tmux("kill-pane", "-t", pane_id)
+
+
+async def capture_pane_text(pane_id: str, *, lines: int = 50) -> str:
+    """Capture the last visible lines from a tmux pane."""
+
+    return await run_tmux("capture-pane", "-t", pane_id, "-p", "-S", f"-{lines}")
+
+
+async def pane_exists(pane_id: str) -> bool:
+    """Return True if the target tmux pane still exists."""
+
+    try:
+        await run_tmux("has-session", "-t", pane_id)
+        return True
+    except RuntimeInvocationError:
+        return False
+
+
+async def alternate_screen_active(pane_id: str) -> bool:
+    """Return True when the pane is in alternate-screen/TUI mode."""
+
+    result = await run_tmux("display-message", "-t", pane_id, "-p", "#{alternate_on}")
+    return result.strip() == "1"
+
+
+def build_path_env_prefix(*, current_path: str | None = None, home: str | None = None) -> str:
+    """Build a PATH=... shell prefix that enriches PATH for tmux pane commands."""
+
+    current_path = current_path if current_path is not None else os.environ.get("PATH", "")
+    home = home if home is not None else str(Path.home())
+    candidates = [
+        "/usr/local/bin",
+        "/opt/homebrew/bin",
+        f"{home}/.nvm/current/bin",
+        f"{home}/.volta/bin",
+        f"{home}/.asdf/shims",
+        f"{home}/.fnm/current/bin",
+    ]
+    extras = [path for path in candidates if os.path.isdir(path) and path not in current_path]
+    if not extras:
+        return ""
+    enriched = ":".join(extras) + ":" + current_path
+    return f"PATH={enriched!s} "

--- a/src/atc/runtime/wrapper_events.py
+++ b/src/atc/runtime/wrapper_events.py
@@ -1,0 +1,94 @@
+"""Wrapper event parsing and schema helpers for atc-provider output."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from typing import Any
+
+_EVENT_PREFIX = "ATC_EVENT "
+
+
+@dataclass(slots=True)
+class WrapperEvent:
+    """Normalized parsed wrapper event."""
+
+    name: str
+    payload: dict[str, Any] = field(default_factory=dict)
+
+    @property
+    def session_id(self) -> str | None:
+        return self.payload.get("session_id")
+
+    @property
+    def provider(self) -> str | None:
+        return self.payload.get("provider")
+
+    @property
+    def command(self) -> str | None:
+        return self.payload.get("command")
+
+
+class WrapperEventParseError(ValueError):
+    """Raised when a wrapper event line is malformed."""
+
+
+SUPPORTED_EVENT_NAMES = {
+    "runtime_starting",
+    "runtime_ready",
+    "runtime_blocked",
+    "runtime_error",
+    "runtime_stopping",
+    "runtime_stopped",
+    "delivery_started",
+    "delivery_confirmed",
+    "delivery_blocked",
+    "delivery_error",
+    "task_assignment_started",
+    "task_assignment_confirmed",
+    "task_assignment_blocked",
+    "task_assignment_error",
+    "readiness_result",
+    "inspection_result",
+    "restore_result",
+}
+
+REQUIRED_COMMON_FIELDS = {"session_id", "provider", "command"}
+
+
+def parse_wrapper_event(line: str) -> WrapperEvent:
+    """Parse a machine-readable `ATC_EVENT` line.
+
+    Expected format:
+        ATC_EVENT <event_name> <json_payload>
+    """
+
+    if not line.startswith(_EVENT_PREFIX):
+        raise WrapperEventParseError("Missing ATC_EVENT prefix")
+
+    remainder = line[len(_EVENT_PREFIX) :].strip()
+    if not remainder:
+        raise WrapperEventParseError("Missing event body")
+
+    try:
+        name, payload_json = remainder.split(" ", 1)
+    except ValueError as exc:
+        raise WrapperEventParseError("Missing payload JSON") from exc
+
+    if name not in SUPPORTED_EVENT_NAMES:
+        raise WrapperEventParseError(f"Unsupported event name: {name}")
+
+    try:
+        payload = json.loads(payload_json)
+    except json.JSONDecodeError as exc:
+        raise WrapperEventParseError("Invalid event JSON payload") from exc
+
+    if not isinstance(payload, dict):
+        raise WrapperEventParseError("Event payload must be an object")
+
+    missing = REQUIRED_COMMON_FIELDS - payload.keys()
+    if missing:
+        missing_list = ", ".join(sorted(missing))
+        raise WrapperEventParseError(f"Missing required event fields: {missing_list}")
+
+    return WrapperEvent(name=name, payload=payload)

--- a/src/atc/session/__init__.py
+++ b/src/atc/session/__init__.py
@@ -1,16 +1,10 @@
-"""Session subsystem — state machine, ace lifecycle, reconnection."""
+"""Session subsystem exports.
 
-from atc.session.ace import (
-    create_ace,
-    destroy_ace,
-    schedule_verification,
-    start_ace,
-    stop_ace,
-    verify_alive,
-    verify_progressing,
-    verify_session,
-    verify_working,
-)
+Keep this package import-light so callers can import submodules like
+`atc.session.state_machine` or `atc.session.reconnect` without eagerly
+pulling in the full ace lifecycle graph and triggering circular imports.
+"""
+
 from atc.session.state_machine import (
     InvalidTransitionError,
     SessionStatus,
@@ -33,3 +27,42 @@ __all__ = [
     "verify_session",
     "verify_working",
 ]
+
+
+def __getattr__(name: str):
+    if name in {
+        "create_ace",
+        "destroy_ace",
+        "schedule_verification",
+        "start_ace",
+        "stop_ace",
+        "verify_alive",
+        "verify_progressing",
+        "verify_session",
+        "verify_working",
+    }:
+        from atc.session.ace import (
+            create_ace,
+            destroy_ace,
+            schedule_verification,
+            start_ace,
+            stop_ace,
+            verify_alive,
+            verify_progressing,
+            verify_session,
+            verify_working,
+        )
+
+        mapping = {
+            "create_ace": create_ace,
+            "destroy_ace": destroy_ace,
+            "schedule_verification": schedule_verification,
+            "start_ace": start_ace,
+            "stop_ace": stop_ace,
+            "verify_alive": verify_alive,
+            "verify_progressing": verify_progressing,
+            "verify_session": verify_session,
+            "verify_working": verify_working,
+        }
+        return mapping[name]
+    raise AttributeError(name)

--- a/src/atc/session/ace.py
+++ b/src/atc/session/ace.py
@@ -25,7 +25,6 @@ from dataclasses import dataclass
 from pathlib import Path as _Path
 from typing import TYPE_CHECKING, Any
 
-from atc.agents.base import ProviderSpawnRequest
 from atc.agents.claude_runtime import accept_startup_dialogs
 from atc.session.state_machine import (
     SessionStatus,
@@ -277,46 +276,39 @@ async def _spawn_provider_session(
     context_file: _Path | None = None,
     launch_command: str | None = None,
 ) -> tuple[str, str]:
-    from atc.agents.factory import create_provider
+    from atc.runtime.models import RoleKind, StartRoleRequest
+    from atc.runtime.service import RuntimeService
 
     project = await db_ops.get_project(conn, project_id) if project_id else None
     session = await db_ops.get_session(conn, session_id)
     provider_name = session.provider if session and session.provider else (
         project.agent_provider if project and project.agent_provider else "claude_code"
     )
-    provider_cfg = getattr(getattr(conn, "_connection", None), "app_state", None)
-    provider_kwargs: dict[str, str] = {}
-    if provider_cfg is not None and getattr(provider_cfg, "settings", None) is not None:
-        live_cfg = provider_cfg.settings.agent_provider
-        provider_kwargs["tmux_session"] = live_cfg.tmux_session
-        if provider_name == "claude_code":
-            provider_kwargs["claude_command"] = live_cfg.claude_command
-        elif provider_name == "codex":
-            provider_kwargs["codex_command"] = live_cfg.codex_command
-    provider = create_provider(provider_name, **provider_kwargs)
 
     session = await db_ops.get_session(conn, session_id)
     if session is None:
         raise ValueError(f"Session {session_id} not found")
 
     role = {
-        "ace": "ace",
-        "manager": "leader",
-        "tower": "tower",
-    }.get(session_type, "ace")
+        "ace": RoleKind.ACE,
+        "manager": RoleKind.LEADER,
+        "tower": RoleKind.TOWER,
+    }.get(session_type, RoleKind.ACE)
 
-    info = await provider.spawn_for_session(
-        ProviderSpawnRequest(
-            session=session,
-            project=project,
-            working_dir=working_dir,
-            launch_command=launch_command,
-            context_file=context_file,
+    service = RuntimeService()
+    handle = await service.spawn_existing_session(
+        StartRoleRequest(
+            session_id=session.id,
+            provider_name=provider_name,
             role=role,
+            project_id=project_id,
+            working_dir=working_dir,
+            context_ref=str(context_file) if context_file else None,
+            metadata={"launch_command": launch_command} if launch_command else {},
         )
     )
-    pane_id = str(info.metadata.get("pane_id") or "")
-    tmux_session = str(info.metadata.get("tmux_session") or ATC_TMUX_SESSION)
+    pane_id = str(handle.tmux_pane or "")
+    tmux_session = str(handle.tmux_session or ATC_TMUX_SESSION)
     if not pane_id:
         raise RuntimeError(f"Provider {provider_name} did not return a pane_id for {session_id}")
     return tmux_session, pane_id
@@ -395,19 +387,25 @@ async def create_ace(
 
     # Step 3: spawn tmux pane
     try:
-        # Provider workspace prep (alongside existing tmux logic — fallback safe)
+        # Provider workspace prep via the new runtime service boundary.
         if effective_working_dir:
             try:
-                from atc.agents.factory import create_provider
+                from atc.runtime.models import RoleKind, StartRoleRequest
+                from atc.runtime.service import RuntimeService
 
-                provider_name = provider
-                _provider = create_provider(provider_name)
-                await _provider.prepare_workspace(
-                    session.id, working_dir=effective_working_dir
+                await RuntimeService().prepare_workspace(
+                    StartRoleRequest(
+                        session_id=session.id,
+                        provider_name=provider,
+                        role=RoleKind.ACE,
+                        project_id=project_id,
+                        working_dir=effective_working_dir,
+                        context_ref=str(deployed.claude_md_path) if deployed and deployed.claude_md_path.exists() else None,
+                    )
                 )
             except Exception as _prep_exc:
                 logger.debug(
-                    "provider.prepare_workspace skipped for %s: %s",
+                    "runtime.prepare_workspace skipped for %s: %s",
                     session.id,
                     _prep_exc,
                 )
@@ -449,31 +447,37 @@ async def _send_session_instruction(
     session_id: str,
     instruction: str,
 ) -> bool:
-    """Send an instruction through the configured provider for a session."""
-    from atc.agents.factory import create_provider
+    """Send an instruction through the new runtime service/provider contract."""
+    from atc.runtime.models import InstructionRequest, RoleKind, RuntimeSessionHandle, RuntimeTransport
+    from atc.runtime.service import RuntimeService
 
     session = await db_ops.get_session(conn, session_id)
     if session is None:
         raise ValueError(f"Session {session_id} not found")
-    if not session.project_id:
-        raise ValueError(f"Session {session_id} has no project")
 
-    project = await db_ops.get_project(conn, session.project_id)
-    provider_name = session.provider if session.provider else (
-        project.agent_provider if project and project.agent_provider else "claude_code"
+    role = RoleKind.ACE
+    if session.session_type == "tower":
+        role = RoleKind.TOWER
+    elif session.session_type in ("leader", "manager"):
+        role = RoleKind.LEADER
+
+    handle = RuntimeSessionHandle(
+        session_id=session.id,
+        provider_name=session.provider or "claude_code",
+        role=role,
+        transport=RuntimeTransport.TMUX,
+        project_id=session.project_id,
+        tmux_session=session.tmux_session,
+        tmux_pane=session.tmux_pane,
     )
-    provider_cfg = getattr(getattr(conn, "_connection", None), "app_state", None)
-    provider_kwargs: dict[str, str] = {}
-    if provider_cfg is not None and getattr(provider_cfg, "settings", None) is not None:
-        live_cfg = provider_cfg.settings.agent_provider
-        provider_kwargs["tmux_session"] = live_cfg.tmux_session
-        if provider_name == "claude_code":
-            provider_kwargs["claude_command"] = live_cfg.claude_command
-        elif provider_name == "codex":
-            provider_kwargs["codex_command"] = live_cfg.codex_command
-    provider = create_provider(provider_name, **provider_kwargs)
-    result = await provider.send_prompt(session_id, instruction)
-    return result.accepted
+
+    service = RuntimeService()
+    request = InstructionRequest(
+        session_id=session.id,
+        message=instruction,
+    )
+    await service.send_instruction(handle, request)
+    return True
 
 
 async def start_ace(

--- a/src/atc/session/reconnect.py
+++ b/src/atc/session/reconnect.py
@@ -12,7 +12,6 @@ import os
 from typing import TYPE_CHECKING
 
 from atc.agents.deploy import TowerDeploySpec, deploy_tower_files
-from atc.agents.factory import get_launch_command
 from atc.leader.leader import _build_manager_deploy_spec
 from atc.session.ace import _kill_pane, _pane_is_alive, _spawn_provider_session
 from atc.session.state_machine import SessionStatus, transition
@@ -116,8 +115,9 @@ async def reconnect_session(
         await db_ops.update_session_status(conn, session_id, SessionStatus.CONNECTING.value)
 
     try:
-        # Look up the project's agent provider to get the correct launch command
-        launch_cmd: str | None = None
+        # Reconnect must honor the provider stamped on the session row.
+        # If the currently desired provider has changed, do not silently reuse
+        # or mutate the old session in place.
         working_dir: str | None = None
         project = None
         if session.project_id:
@@ -132,14 +132,15 @@ async def reconnect_session(
                     current_provider = load_settings().agent_provider.default
                 if session.provider != current_provider:
                     logger.info(
-                        "Session %s provider mismatch on reconnect (session=%s current=%s), forcing replacement instead of reuse",
+                        "Session %s provider mismatch on reconnect (session=%s current=%s), refusing reuse so a replacement session can be created",
                         session_id,
                         session.provider,
                         current_provider,
                     )
-                    await db_ops.update_session_status(conn, session_id, SessionStatus.DISCONNECTED.value)
+                    await db_ops.update_session_status(
+                        conn, session_id, SessionStatus.DISCONNECTED.value
+                    )
                     return False
-                launch_cmd = get_launch_command(current_provider)
                 working_dir = project.repo_path
 
         # Tower sessions need their identity files (CLAUDE.md, settings)
@@ -196,7 +197,6 @@ async def reconnect_session(
             session_type=getattr(session, "session_type", "ace"),
             working_dir=working_dir,
             context_file=context_file,
-            launch_command=launch_cmd,
         )
         await db_ops.update_session_tmux(conn, session_id, tmux_session, pane_id)
 

--- a/src/atc/tower/session.py
+++ b/src/atc/tower/session.py
@@ -15,7 +15,6 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 from atc.agents.deploy import _DEFAULT_STAGING_ROOT, TowerDeploySpec, deploy_tower_files
-from atc.agents.factory import get_launch_command
 from atc.config import AgentProviderConfig
 from atc.session.ace import (
     _accept_trust_dialog,
@@ -171,7 +170,6 @@ async def start_tower_session(
         )
 
     try:
-        launch_cmd = get_launch_command(provider)
         working_dir = project.repo_path if project and project.repo_path else None
 
         # Deploy config files (CLAUDE.md, hooks, settings.json) before launch
@@ -195,9 +193,8 @@ async def start_tower_session(
         _log_working_dir_contents(working_dir, session.id, "start_tower_session")
 
         logger.warning(
-            "TOWER SPAWN provider=%s launch_command=%s project_id=%s session_id=%s",
+            "TOWER SPAWN provider=%s project_id=%s session_id=%s",
             provider,
-            launch_cmd,
             project_id,
             session.id,
         )
@@ -208,7 +205,6 @@ async def start_tower_session(
             session_type="tower",
             working_dir=working_dir,
             context_file=deployed.claude_md_path if deployed.claude_md_path.exists() else None,
-            launch_command=launch_cmd,
         )
         await db_ops.update_session_tmux(conn, session.id, tmux_session, pane_id)
 

--- a/tests/unit/test_claude_code_runtime.py
+++ b/tests/unit/test_claude_code_runtime.py
@@ -1,0 +1,212 @@
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, patch
+
+from atc.providers.claude_code.runtime import ClaudeCodeRuntime
+from atc.runtime.models import ReadinessState, RoleKind, RuntimeSessionHandle, RuntimeTransport, StartRoleRequest
+
+
+def test_claude_code_runtime_metadata() -> None:
+    runtime = ClaudeCodeRuntime()
+    assert runtime.provider_name == "claude_code"
+    assert runtime.tmux_session == "atc"
+
+
+def test_claude_code_runtime_prepare_workspace_creates_dir(tmp_path) -> None:
+    runtime = ClaudeCodeRuntime()
+    workdir = tmp_path / "repo"
+    request = StartRoleRequest(
+        session_id="sess-1",
+        provider_name="claude_code",
+        role=RoleKind.LEADER,
+        working_dir=str(workdir),
+    )
+
+    asyncio.run(runtime.prepare_workspace(request))
+
+    assert workdir.is_dir()
+
+
+def test_claude_inspect_session_reports_stopped_when_pane_missing() -> None:
+    runtime = ClaudeCodeRuntime()
+    handle = RuntimeSessionHandle(
+        session_id="sess-1",
+        provider_name="claude_code",
+        role=RoleKind.LEADER,
+        transport=RuntimeTransport.TMUX,
+        tmux_pane="%1",
+    )
+
+    with patch("atc.providers.claude_code.runtime.pane_exists", AsyncMock(return_value=False)):
+        inspection = asyncio.run(runtime.inspect_session(handle))
+
+    assert inspection.alive is False
+    assert inspection.readiness is ReadinessState.STOPPED
+
+
+def test_claude_inspect_session_reports_ready_at_prompt() -> None:
+    runtime = ClaudeCodeRuntime()
+    handle = RuntimeSessionHandle(
+        session_id="sess-2",
+        provider_name="claude_code",
+        role=RoleKind.LEADER,
+        transport=RuntimeTransport.TMUX,
+        tmux_pane="%2",
+    )
+
+    with (
+        patch("atc.providers.claude_code.runtime.pane_exists", AsyncMock(return_value=True)),
+        patch("atc.providers.claude_code.runtime.capture_pane_text", AsyncMock(return_value="some output\n❯\n")),
+    ):
+        inspection = asyncio.run(runtime.inspect_session(handle))
+
+    assert inspection.alive is True
+    assert inspection.readiness is ReadinessState.READY
+    assert inspection.summary == "Prompt ready"
+
+
+def test_claude_inspect_session_reports_busy_when_not_at_prompt() -> None:
+    runtime = ClaudeCodeRuntime()
+    handle = RuntimeSessionHandle(
+        session_id="sess-3",
+        provider_name="claude_code",
+        role=RoleKind.LEADER,
+        transport=RuntimeTransport.TMUX,
+        tmux_pane="%3",
+    )
+
+    with (
+        patch("atc.providers.claude_code.runtime.pane_exists", AsyncMock(return_value=True)),
+        patch("atc.providers.claude_code.runtime.capture_pane_text", AsyncMock(return_value="Thinking hard...")),
+    ):
+        inspection = asyncio.run(runtime.inspect_session(handle))
+
+    assert inspection.alive is True
+    assert inspection.readiness is ReadinessState.BUSY
+
+
+
+def test_claude_inspect_session_reports_blocked_on_trust() -> None:
+    runtime = ClaudeCodeRuntime()
+    handle = RuntimeSessionHandle(
+        session_id="sess-4",
+        provider_name="claude_code",
+        role=RoleKind.LEADER,
+        transport=RuntimeTransport.TMUX,
+        tmux_pane="%4",
+    )
+
+    with (
+        patch("atc.providers.claude_code.runtime.pane_exists", AsyncMock(return_value=True)),
+        patch("atc.providers.claude_code.runtime.capture_pane_text", AsyncMock(return_value="Do you trust this folder?")),
+    ):
+        inspection = asyncio.run(runtime.inspect_session(handle))
+
+    assert inspection.readiness is ReadinessState.BLOCKED
+    assert inspection.block_reason is not None
+    assert inspection.summary == "Blocked on trust prompt"
+
+
+def test_claude_inspect_session_reports_blocked_on_auth() -> None:
+    runtime = ClaudeCodeRuntime()
+    handle = RuntimeSessionHandle(
+        session_id="sess-5",
+        provider_name="claude_code",
+        role=RoleKind.LEADER,
+        transport=RuntimeTransport.TMUX,
+        tmux_pane="%5",
+    )
+
+    with (
+        patch("atc.providers.claude_code.runtime.pane_exists", AsyncMock(return_value=True)),
+        patch("atc.providers.claude_code.runtime.capture_pane_text", AsyncMock(return_value="Please login with your API key")),
+    ):
+        inspection = asyncio.run(runtime.inspect_session(handle))
+
+    assert inspection.readiness is ReadinessState.BLOCKED
+    assert inspection.summary == "Blocked on authentication"
+
+
+
+def test_claude_restore_session_marks_ready_restore() -> None:
+    runtime = ClaudeCodeRuntime()
+    handle = RuntimeSessionHandle(
+        session_id="sess-6",
+        provider_name="claude_code",
+        role=RoleKind.LEADER,
+        transport=RuntimeTransport.TMUX,
+        tmux_pane="%6",
+    )
+
+    with (
+        patch("atc.providers.claude_code.runtime.pane_exists", AsyncMock(return_value=True)),
+        patch("atc.providers.claude_code.runtime.capture_pane_text", AsyncMock(return_value="output\n❯\n")),
+    ):
+        inspection = asyncio.run(runtime.restore_session(handle))
+
+    assert inspection.summary == "Restored and ready"
+    assert inspection.details["restore_attempted"] is True
+    assert inspection.details["restore_usable"] is True
+
+
+def test_claude_restore_session_marks_blocked_restore() -> None:
+    runtime = ClaudeCodeRuntime()
+    handle = RuntimeSessionHandle(
+        session_id="sess-7",
+        provider_name="claude_code",
+        role=RoleKind.LEADER,
+        transport=RuntimeTransport.TMUX,
+        tmux_pane="%7",
+    )
+
+    with (
+        patch("atc.providers.claude_code.runtime.pane_exists", AsyncMock(return_value=True)),
+        patch("atc.providers.claude_code.runtime.capture_pane_text", AsyncMock(return_value="Please login with your API key")),
+    ):
+        inspection = asyncio.run(runtime.restore_session(handle))
+
+    assert inspection.summary == "Restore blocked: Blocked on authentication"
+    assert inspection.details["restore_needs_attention"] is True
+
+
+
+def test_claude_restore_session_marks_warming_up_stage() -> None:
+    runtime = ClaudeCodeRuntime()
+    handle = RuntimeSessionHandle(
+        session_id="sess-8",
+        provider_name="claude_code",
+        role=RoleKind.LEADER,
+        transport=RuntimeTransport.TMUX,
+        tmux_pane="%8",
+    )
+
+    with (
+        patch("atc.providers.claude_code.runtime.pane_exists", AsyncMock(return_value=True)),
+        patch("atc.providers.claude_code.runtime.capture_pane_text", AsyncMock(return_value="Welcome to Claude Code")),
+    ):
+        inspection = asyncio.run(runtime.restore_session(handle))
+
+    assert inspection.details["provider_restore_stage"] == "warming_up"
+    assert inspection.details["provider_restore_action"] == "wait"
+
+
+
+def test_claude_inspect_session_exposes_runtime_hint() -> None:
+    runtime = ClaudeCodeRuntime()
+    handle = RuntimeSessionHandle(
+        session_id="sess-9",
+        provider_name="claude_code",
+        role=RoleKind.LEADER,
+        transport=RuntimeTransport.TMUX,
+        tmux_pane="%9",
+    )
+
+    with (
+        patch("atc.providers.claude_code.runtime.pane_exists", AsyncMock(return_value=True)),
+        patch("atc.providers.claude_code.runtime.capture_pane_text", AsyncMock(return_value="Welcome to Claude Code")),
+    ):
+        inspection = asyncio.run(runtime.inspect_session(handle))
+
+    assert inspection.details["provider_runtime_hint"] == "startup_banner"
+    assert inspection.details["provider_runtime_action"] == "wait"

--- a/tests/unit/test_codex_runtime.py
+++ b/tests/unit/test_codex_runtime.py
@@ -1,0 +1,188 @@
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, patch
+
+from atc.providers.codex.runtime import CodexRuntime
+from atc.runtime.models import ReadinessState, RoleKind, RuntimeSessionHandle, RuntimeTransport, StartRoleRequest
+
+
+def test_codex_runtime_metadata() -> None:
+    runtime = CodexRuntime()
+    assert runtime.provider_name == "codex"
+    assert runtime.tmux_session == "atc"
+
+
+def test_codex_runtime_prepare_workspace_creates_dir(tmp_path) -> None:
+    runtime = CodexRuntime()
+    workdir = tmp_path / "repo"
+    request = StartRoleRequest(
+        session_id="sess-1",
+        provider_name="codex",
+        role=RoleKind.ACE,
+        working_dir=str(workdir),
+    )
+
+    asyncio.run(runtime.prepare_workspace(request))
+
+    assert workdir.is_dir()
+
+
+def test_codex_inspect_session_reports_stopped_when_pane_missing() -> None:
+    runtime = CodexRuntime()
+    handle = RuntimeSessionHandle(
+        session_id="sess-1",
+        provider_name="codex",
+        role=RoleKind.ACE,
+        transport=RuntimeTransport.TMUX,
+        tmux_pane="%1",
+    )
+
+    with patch("atc.providers.codex.runtime.pane_exists", AsyncMock(return_value=False)):
+        inspection = asyncio.run(runtime.inspect_session(handle))
+
+    assert inspection.alive is False
+    assert inspection.readiness is ReadinessState.STOPPED
+
+
+def test_codex_inspect_session_reports_ready_at_prompt() -> None:
+    runtime = CodexRuntime()
+    handle = RuntimeSessionHandle(
+        session_id="sess-2",
+        provider_name="codex",
+        role=RoleKind.ACE,
+        transport=RuntimeTransport.TMUX,
+        tmux_pane="%2",
+    )
+
+    with (
+        patch("atc.providers.codex.runtime.pane_exists", AsyncMock(return_value=True)),
+        patch("atc.providers.codex.runtime.capture_pane_text", AsyncMock(return_value="all good\n>\n")),
+    ):
+        inspection = asyncio.run(runtime.inspect_session(handle))
+
+    assert inspection.alive is True
+    assert inspection.readiness is ReadinessState.READY
+    assert inspection.summary == "Prompt ready"
+
+
+def test_codex_inspect_session_reports_busy_when_not_at_prompt() -> None:
+    runtime = CodexRuntime()
+    handle = RuntimeSessionHandle(
+        session_id="sess-3",
+        provider_name="codex",
+        role=RoleKind.ACE,
+        transport=RuntimeTransport.TMUX,
+        tmux_pane="%3",
+    )
+
+    with (
+        patch("atc.providers.codex.runtime.pane_exists", AsyncMock(return_value=True)),
+        patch("atc.providers.codex.runtime.capture_pane_text", AsyncMock(return_value="Processing request...")),
+    ):
+        inspection = asyncio.run(runtime.inspect_session(handle))
+
+    assert inspection.alive is True
+    assert inspection.readiness is ReadinessState.BUSY
+
+
+
+def test_codex_inspect_session_reports_blocked_on_auth() -> None:
+    runtime = CodexRuntime()
+    handle = RuntimeSessionHandle(
+        session_id="sess-4",
+        provider_name="codex",
+        role=RoleKind.ACE,
+        transport=RuntimeTransport.TMUX,
+        tmux_pane="%4",
+    )
+
+    with (
+        patch("atc.providers.codex.runtime.pane_exists", AsyncMock(return_value=True)),
+        patch("atc.providers.codex.runtime.capture_pane_text", AsyncMock(return_value="Sign in to continue")),
+    ):
+        inspection = asyncio.run(runtime.inspect_session(handle))
+
+    assert inspection.readiness is ReadinessState.BLOCKED
+    assert inspection.summary == "Blocked on authentication"
+
+
+
+def test_codex_restore_session_marks_ready_restore() -> None:
+    runtime = CodexRuntime()
+    handle = RuntimeSessionHandle(
+        session_id="sess-5",
+        provider_name="codex",
+        role=RoleKind.ACE,
+        transport=RuntimeTransport.TMUX,
+        tmux_pane="%5",
+    )
+
+    with (
+        patch("atc.providers.codex.runtime.pane_exists", AsyncMock(return_value=True)),
+        patch("atc.providers.codex.runtime.capture_pane_text", AsyncMock(return_value="ok\n>\n")),
+    ):
+        inspection = asyncio.run(runtime.restore_session(handle))
+
+    assert inspection.summary == "Restored and ready"
+    assert inspection.details["restore_attempted"] is True
+    assert inspection.details["restore_usable"] is True
+
+
+def test_codex_restore_session_marks_stopped_restore() -> None:
+    runtime = CodexRuntime()
+    handle = RuntimeSessionHandle(
+        session_id="sess-6",
+        provider_name="codex",
+        role=RoleKind.ACE,
+        transport=RuntimeTransport.TMUX,
+        tmux_pane="%6",
+    )
+
+    with patch("atc.providers.codex.runtime.pane_exists", AsyncMock(return_value=False)):
+        inspection = asyncio.run(runtime.restore_session(handle))
+
+    assert inspection.summary == "Restore failed: pane missing"
+    assert inspection.details["restore_needs_attention"] is True
+
+
+
+def test_codex_restore_session_marks_auth_gate_action() -> None:
+    runtime = CodexRuntime()
+    handle = RuntimeSessionHandle(
+        session_id="sess-7",
+        provider_name="codex",
+        role=RoleKind.ACE,
+        transport=RuntimeTransport.TMUX,
+        tmux_pane="%7",
+    )
+
+    with (
+        patch("atc.providers.codex.runtime.pane_exists", AsyncMock(return_value=True)),
+        patch("atc.providers.codex.runtime.capture_pane_text", AsyncMock(return_value="Sign in to continue")),
+    ):
+        inspection = asyncio.run(runtime.restore_session(handle))
+
+    assert inspection.details["provider_restore_stage"] == "auth_gate"
+    assert inspection.details["provider_restore_action"] == "resolve_auth"
+
+
+
+def test_codex_inspect_session_exposes_runtime_hint() -> None:
+    runtime = CodexRuntime()
+    handle = RuntimeSessionHandle(
+        session_id="sess-8",
+        provider_name="codex",
+        role=RoleKind.ACE,
+        transport=RuntimeTransport.TMUX,
+        tmux_pane="%8",
+    )
+
+    with (
+        patch("atc.providers.codex.runtime.pane_exists", AsyncMock(return_value=True)),
+        patch("atc.providers.codex.runtime.capture_pane_text", AsyncMock(return_value="Sign in to continue")),
+    ):
+        inspection = asyncio.run(runtime.inspect_session(handle))
+
+    assert inspection.details["provider_runtime_hint"] == "auth_prompt"
+    assert inspection.details["provider_runtime_action"] == "resolve_auth"

--- a/tests/unit/test_provider_registry.py
+++ b/tests/unit/test_provider_registry.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+from atc.providers.claude_code.runtime import ClaudeCodeRuntime
+from atc.providers.codex.runtime import CodexRuntime
+from atc.providers.registry import (
+    ProviderRegistryError,
+    create_provider_runtime,
+    get_provider_runtime_factory,
+    list_provider_runtime_infos,
+    list_provider_runtimes,
+    register_provider_runtime,
+)
+
+
+class DummyProvider:
+    provider_name = "dummy"
+
+
+class AnotherProvider:
+    provider_name = "another"
+
+
+def test_register_and_create_provider_runtime() -> None:
+    register_provider_runtime("dummy_test", DummyProvider)
+
+    provider = create_provider_runtime("dummy_test")
+
+    assert isinstance(provider, DummyProvider)
+
+
+def test_list_provider_runtimes_contains_registered_name() -> None:
+    register_provider_runtime("another_test", AnotherProvider)
+
+    assert "another_test" in list_provider_runtimes()
+
+
+def test_create_provider_runtime_raises_for_unknown() -> None:
+    try:
+        create_provider_runtime("missing-provider")
+    except ProviderRegistryError as exc:
+        assert "Unknown provider runtime" in str(exc)
+    else:
+        raise AssertionError("Expected ProviderRegistryError")
+
+
+def test_builtin_claude_runtime_registered() -> None:
+    factory = get_provider_runtime_factory("claude_code")
+    assert factory is ClaudeCodeRuntime
+
+
+def test_builtin_codex_runtime_registered() -> None:
+    factory = get_provider_runtime_factory("codex")
+    assert factory is CodexRuntime
+
+
+
+def test_list_provider_runtime_infos_contains_builtins() -> None:
+    infos = list_provider_runtime_infos()
+    names = {info.name for info in infos}
+    assert "claude_code" in names
+    assert "codex" in names

--- a/tests/unit/test_reconnect_runtime_semantics.py
+++ b/tests/unit/test_reconnect_runtime_semantics.py
@@ -1,0 +1,105 @@
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from atc.session.reconnect import reconnect_session
+from atc.session.state_machine import SessionStatus
+from atc.state.db import _SCHEMA_SQL, create_project, create_session, get_connection, get_session
+
+
+@pytest.fixture
+async def db():
+    async with get_connection(":memory:") as conn:
+        await conn.executescript(_SCHEMA_SQL)
+        await conn.commit()
+        yield conn
+
+
+@pytest.mark.asyncio
+async def test_reconnect_refuses_reuse_on_provider_mismatch(db) -> None:
+    project = await create_project(db, "proj")
+    session = await create_session(
+        db,
+        project_id=project.id,
+        session_type="ace",
+        name="ace-test",
+        provider="codex",
+        status=SessionStatus.IDLE.value,
+    )
+    await db.commit()
+    with (
+        patch("atc.session.reconnect._pane_is_alive", new_callable=AsyncMock, return_value=False),
+        patch("atc.config.load_settings") as mock_load_settings,
+    ):
+        mock_load_settings.return_value.agent_provider.default = "claude_code"
+        ok = await reconnect_session(db, session.id)
+
+    assert ok is False
+    refreshed = await get_session(db, session.id)
+    assert refreshed is not None
+    assert refreshed.status == SessionStatus.DISCONNECTED.value
+
+
+@pytest.mark.asyncio
+async def test_reconnect_respawns_when_provider_matches(db) -> None:
+    project = await create_project(db, "proj")
+    session = await create_session(
+        db,
+        project_id=project.id,
+        session_type="ace",
+        name="ace-test",
+        provider="claude_code",
+        status=SessionStatus.IDLE.value,
+    )
+    await db.commit()
+    with (
+        patch("atc.session.reconnect._pane_is_alive", new_callable=AsyncMock, return_value=False),
+        patch("atc.config.load_settings") as mock_load_settings,
+        patch(
+            "atc.session.reconnect._spawn_provider_session",
+            new_callable=AsyncMock,
+            return_value=("atc", "%atc:0.55"),
+        ),
+        patch("atc.session.reconnect.transition", new_callable=AsyncMock),
+        patch("atc.session.reconnect.db_ops.update_session_tmux", new_callable=AsyncMock),
+    ):
+        mock_load_settings.return_value.agent_provider.default = "claude_code"
+        ok = await reconnect_session(db, session.id)
+
+    assert ok is True
+
+
+
+@pytest.mark.asyncio
+async def test_reconnect_uses_stamped_provider_even_if_current_default_changed(db) -> None:
+    project = await create_project(db, "proj")
+    session = await create_session(
+        db,
+        project_id=project.id,
+        session_type="ace",
+        name="sticky-provider-ace",
+        provider="codex",
+        status=SessionStatus.IDLE.value,
+    )
+    await db.commit()
+    with (
+        patch("atc.session.reconnect._pane_is_alive", new_callable=AsyncMock, return_value=False),
+        patch("atc.config.load_settings") as mock_load_settings,
+        patch(
+            "atc.session.reconnect._spawn_provider_session",
+            new_callable=AsyncMock,
+            return_value=("atc", "%atc:0.77"),
+        ) as mock_spawn,
+        patch("atc.session.reconnect.transition", new_callable=AsyncMock),
+        patch("atc.session.reconnect.db_ops.update_session_tmux", new_callable=AsyncMock),
+    ):
+        mock_load_settings.return_value.agent_provider.default = "codex"
+        ok = await reconnect_session(db, session.id)
+
+    assert ok is True
+    assert mock_spawn.await_count == 1
+    args, kwargs = mock_spawn.await_args
+    assert args[1] == session.id
+    assert kwargs["session_type"] == "ace"

--- a/tests/unit/test_runtime_errors.py
+++ b/tests/unit/test_runtime_errors.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+from atc.runtime.errors import (
+    RuntimeBlockedError,
+    RuntimeDeliveryError,
+    RuntimeInvocationError,
+    RuntimeNotReadyError,
+    RuntimeRestoreError,
+    RuntimeSessionMissingError,
+    map_wrapper_exit_code,
+)
+from atc.runtime.models import WrapperExitCode
+
+
+def test_map_wrapper_exit_code_success_returns_none() -> None:
+    assert map_wrapper_exit_code(WrapperExitCode.SUCCESS, message="ok") is None
+
+
+def test_map_wrapper_exit_code_blocked_auth() -> None:
+    err = map_wrapper_exit_code(WrapperExitCode.BLOCKED_AUTH, message="blocked")
+    assert isinstance(err, RuntimeBlockedError)
+
+
+def test_map_wrapper_exit_code_not_ready() -> None:
+    err = map_wrapper_exit_code(WrapperExitCode.NOT_READY, message="not ready")
+    assert isinstance(err, RuntimeNotReadyError)
+
+
+def test_map_wrapper_exit_code_session_missing() -> None:
+    err = map_wrapper_exit_code(WrapperExitCode.SESSION_MISSING, message="missing")
+    assert isinstance(err, RuntimeSessionMissingError)
+
+
+def test_map_wrapper_exit_code_delivery_failed() -> None:
+    err = map_wrapper_exit_code(WrapperExitCode.DELIVERY_FAILED, message="delivery failed")
+    assert isinstance(err, RuntimeDeliveryError)
+
+
+def test_map_wrapper_exit_code_restore_failed() -> None:
+    err = map_wrapper_exit_code(WrapperExitCode.RESTORE_FAILED, message="restore failed")
+    assert isinstance(err, RuntimeRestoreError)
+
+
+def test_map_wrapper_exit_code_invalid_args() -> None:
+    err = map_wrapper_exit_code(WrapperExitCode.INVALID_ARGS, message="invalid")
+    assert isinstance(err, RuntimeInvocationError)

--- a/tests/unit/test_runtime_models.py
+++ b/tests/unit/test_runtime_models.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+import pytest
+
+from atc.runtime.models import (
+    InstructionRequest,
+    ReadinessState,
+    RoleKind,
+    RuntimeTransport,
+    TaskAssignmentRequest,
+    WrapperExitCode,
+)
+
+
+def test_role_kind_values() -> None:
+    assert RoleKind.TOWER.value == "tower"
+    assert RoleKind.LEADER.value == "leader"
+    assert RoleKind.ACE.value == "ace"
+
+
+def test_runtime_transport_value() -> None:
+    assert RuntimeTransport.TMUX.value == "tmux"
+
+
+def test_readiness_state_ready_value() -> None:
+    assert ReadinessState.READY.value == "ready"
+
+
+def test_wrapper_exit_code_success() -> None:
+    assert int(WrapperExitCode.SUCCESS) == 0
+
+
+def test_instruction_request_requires_message_or_file() -> None:
+    with pytest.raises(ValueError):
+        InstructionRequest(session_id="sess-1")
+
+
+def test_task_assignment_request_requires_message_or_file() -> None:
+    with pytest.raises(ValueError):
+        TaskAssignmentRequest(session_id="sess-1", task_id="task-1")

--- a/tests/unit/test_runtime_service.py
+++ b/tests/unit/test_runtime_service.py
@@ -1,0 +1,158 @@
+from __future__ import annotations
+
+import asyncio
+
+from atc.providers.registry import register_provider_runtime
+from atc.runtime.models import (
+    InstructionRequest,
+    ReadinessResult,
+    ReadinessState,
+    RoleKind,
+    RuntimeInspection,
+    RuntimeSessionHandle,
+    RuntimeTransport,
+    StartRoleRequest,
+    TaskAssignmentRequest,
+)
+from atc.runtime.service import RuntimeService
+
+
+class DummyProviderRuntime:
+    provider_name = "dummy_runtime"
+
+    def __init__(self) -> None:
+        self.prepared: list[StartRoleRequest] = []
+        self.started: list[StartRoleRequest] = []
+        self.spawned_existing: list[StartRoleRequest] = []
+        self.instructions: list[InstructionRequest] = []
+        self.assignments: list[TaskAssignmentRequest] = []
+
+    async def prepare_workspace(self, request: StartRoleRequest) -> None:
+        self.prepared.append(request)
+
+    async def start_role(self, request: StartRoleRequest) -> RuntimeSessionHandle:
+        self.started.append(request)
+        return RuntimeSessionHandle(
+            session_id=request.session_id,
+            provider_name=request.provider_name,
+            role=request.role,
+            transport=RuntimeTransport.TMUX,
+            project_id=request.project_id,
+            working_dir=request.working_dir,
+            context_ref=request.context_ref,
+        )
+
+    async def spawn_existing_session(self, request: StartRoleRequest) -> RuntimeSessionHandle:
+        self.spawned_existing.append(request)
+        return RuntimeSessionHandle(
+            session_id=request.session_id,
+            provider_name=request.provider_name,
+            role=request.role,
+            transport=RuntimeTransport.TMUX,
+            project_id=request.project_id,
+            working_dir=request.working_dir,
+            context_ref=request.context_ref,
+        )
+
+    async def stop_role(self, handle: RuntimeSessionHandle, request=None) -> None:
+        return None
+
+    async def send_instruction(self, handle: RuntimeSessionHandle, request: InstructionRequest) -> None:
+        self.instructions.append(request)
+
+    async def assign_task(self, handle: RuntimeSessionHandle, request: TaskAssignmentRequest) -> None:
+        self.assignments.append(request)
+
+    async def check_readiness(self, handle: RuntimeSessionHandle) -> ReadinessResult:
+        return ReadinessResult(
+            session_id=handle.session_id,
+            provider_name=handle.provider_name,
+            state=ReadinessState.READY,
+        )
+
+    async def inspect_session(self, handle: RuntimeSessionHandle) -> RuntimeInspection:
+        return RuntimeInspection(
+            session_id=handle.session_id,
+            provider_name=handle.provider_name,
+            alive=True,
+            readiness=ReadinessState.READY,
+        )
+
+    async def restore_session(self, handle: RuntimeSessionHandle) -> RuntimeInspection:
+        return RuntimeInspection(
+            session_id=handle.session_id,
+            provider_name=handle.provider_name,
+            alive=True,
+            readiness=ReadinessState.READY,
+        )
+
+
+def test_runtime_service_prepare_workspace_uses_provider() -> None:
+    register_provider_runtime("dummy_runtime_prepare", DummyProviderRuntime)
+    service = RuntimeService()
+    request = StartRoleRequest(
+        session_id="sess-prep-1",
+        provider_name="dummy_runtime_prepare",
+        role=RoleKind.LEADER,
+        working_dir="/tmp/repo",
+    )
+
+    asyncio.run(service.prepare_workspace(request))
+
+    provider = service.get_provider("dummy_runtime_prepare")
+    assert provider.prepared[-1].session_id == "sess-prep-1"
+
+
+def test_runtime_service_start_tower_remembers_handle() -> None:
+    register_provider_runtime("dummy_runtime", DummyProviderRuntime)
+    service = RuntimeService()
+    request = StartRoleRequest(
+        session_id="sess-tower-1",
+        provider_name="dummy_runtime",
+        role=RoleKind.TOWER,
+        project_id="proj-1",
+    )
+
+    handle = asyncio.run(service.start_tower(request))
+
+    assert handle.session_id == "sess-tower-1"
+    assert service.get_handle("sess-tower-1").role is RoleKind.TOWER
+
+
+def test_runtime_service_spawn_existing_session_uses_provider() -> None:
+    register_provider_runtime("dummy_runtime_existing", DummyProviderRuntime)
+    service = RuntimeService()
+    request = StartRoleRequest(
+        session_id="sess-existing-1",
+        provider_name="dummy_runtime_existing",
+        role=RoleKind.LEADER,
+        project_id="proj-2",
+    )
+
+    handle = asyncio.run(service.spawn_existing_session(request))
+
+    provider = service.get_provider("dummy_runtime_existing")
+    assert provider.spawned_existing[-1].session_id == "sess-existing-1"
+    assert service.get_handle("sess-existing-1").role is RoleKind.LEADER
+    assert handle.session_id == "sess-existing-1"
+
+
+def test_runtime_service_assign_task_to_ace_uses_provider() -> None:
+    register_provider_runtime("dummy_runtime_ace", DummyProviderRuntime)
+    service = RuntimeService()
+    request = StartRoleRequest(
+        session_id="sess-ace-1",
+        provider_name="dummy_runtime_ace",
+        role=RoleKind.ACE,
+    )
+
+    handle = asyncio.run(service.start_ace(request))
+    assignment = TaskAssignmentRequest(
+        session_id="sess-ace-1",
+        task_id="task-1",
+        message="Do the work",
+    )
+    asyncio.run(service.assign_task_to_ace(handle, assignment))
+
+    provider = service.get_provider("dummy_runtime_ace")
+    assert provider.assignments[-1].task_id == "task-1"

--- a/tests/unit/test_tmux_substrate.py
+++ b/tests/unit/test_tmux_substrate.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+
+from atc.runtime.tmux.substrate import build_path_env_prefix, resolve_tmux_binary
+
+
+def test_resolve_tmux_binary_returns_string() -> None:
+    result = resolve_tmux_binary()
+    assert isinstance(result, str)
+    assert result
+
+
+def test_build_path_env_prefix_returns_string() -> None:
+    result = build_path_env_prefix(current_path="/usr/bin", home="/tmp/does-not-matter")
+    assert isinstance(result, str)

--- a/tests/unit/test_tower_session_reuse.py
+++ b/tests/unit/test_tower_session_reuse.py
@@ -3,27 +3,17 @@
 from __future__ import annotations
 
 from pathlib import Path
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
 
 from atc.session.state_machine import SessionStatus
-from atc.state.db import (
-    _SCHEMA_SQL,
-    create_project,
-    create_session,
-    get_connection,
-    get_session,
-    run_migrations,
-    update_session_status,
-)
-from atc.tower.session import _DEFAULT_STAGING_ROOT, start_tower_session
+from atc.state.db import _SCHEMA_SQL, create_project, create_session, get_connection
+from atc.tower.session import start_tower_session
 
 
 @pytest.fixture
 async def db():
-    """In-memory database with schema applied."""
-    await run_migrations(":memory:")
     async with get_connection(":memory:") as conn:
         await conn.executescript(_SCHEMA_SQL)
         await conn.commit()
@@ -31,64 +21,84 @@ async def db():
 
 
 @pytest.mark.asyncio
-async def test_reuses_most_recent_disconnected_session_with_valid_staging_dir(
+async def test_reuses_live_same_provider_tower_session_with_valid_staging_dir(
     db, tmp_path: Path
 ) -> None:
-    """After all tower sessions are disconnected, start_tower_session should reuse
-    the most recent one that has a valid CLAUDE.md in its staging dir."""
     project = await create_project(db, "test-proj")
-
-    # Create a disconnected tower session
     sess = await create_session(
         db,
         project_id=project.id,
         session_type="tower",
         name="tower-test",
-        status=SessionStatus.DISCONNECTED.value,
+        provider="claude_code",
+        status=SessionStatus.IDLE.value,
     )
+    await db.execute("UPDATE sessions SET tmux_pane = ? WHERE id = ?", ("%existing-pane", sess.id))
     await db.commit()
 
-    # Place a CLAUDE.md in the staging directory
     staging_dir = Path(tmp_path) / sess.id
     staging_dir.mkdir(parents=True)
     (staging_dir / "CLAUDE.md").write_text("# Tower\n")
 
-    mock_pane_id = "%atc:0.99"
-
     with (
-        patch(
-            "atc.tower.session._DEFAULT_STAGING_ROOT",
-            str(tmp_path),
-        ),
-        patch(
-            "atc.tower.session._spawn_provider_session",
-            new_callable=AsyncMock,
-            return_value=("atc", mock_pane_id),
-        ),
-        patch("atc.tower.session._pane_is_alive", new_callable=AsyncMock, return_value=False),
-        patch("atc.tower.session.get_launch_command", return_value="claude"),
-        patch("atc.tower.session.transition", new_callable=AsyncMock),
-        patch("atc.tower.session.db_ops.update_session_tmux", new_callable=AsyncMock),
+        patch("atc.tower.session._DEFAULT_STAGING_ROOT", str(tmp_path)),
+        patch("atc.tower.session._pane_is_alive", new_callable=AsyncMock, return_value=True),
     ):
         returned_id = await start_tower_session(db, project.id)
 
-    # Must reuse the existing session, not create a new row
     assert returned_id == sess.id
 
-    # Confirm no extra tower sessions were created
-    cursor = await db.execute(
-        "SELECT COUNT(*) FROM sessions WHERE session_type = 'tower'"
+
+@pytest.mark.asyncio
+async def test_does_not_reuse_live_tower_session_when_provider_mismatches(
+    db, tmp_path: Path
+) -> None:
+    project = await create_project(db, "test-proj")
+    sess = await create_session(
+        db,
+        project_id=project.id,
+        session_type="tower",
+        name="tower-test",
+        provider="codex",
+        status=SessionStatus.IDLE.value,
     )
+    await db.commit()
+
+    staging_dir = Path(tmp_path) / sess.id
+    staging_dir.mkdir(parents=True)
+    (staging_dir / "CLAUDE.md").write_text("# Tower\n")
+
+    mock_root = tmp_path / "new-sess"
+    mock_root.mkdir()
+    (mock_root / "CLAUDE.md").write_text("# Tower\n")
+    mock_deployed = Mock()
+    mock_deployed.root = mock_root
+    mock_deployed.claude_md_path = mock_root / "CLAUDE.md"
+
+    with (
+        patch("atc.tower.session._DEFAULT_STAGING_ROOT", str(tmp_path)),
+        patch("atc.tower.session._pane_is_alive", new_callable=AsyncMock, return_value=True),
+        patch("atc.tower.session._kill_pane", new_callable=AsyncMock),
+        patch(
+            "atc.tower.session._spawn_provider_session",
+            new_callable=AsyncMock,
+            return_value=("atc", "%atc:0.99"),
+        ),
+        patch("atc.tower.session.transition", new_callable=AsyncMock),
+        patch("atc.tower.session.db_ops.update_session_tmux", new_callable=AsyncMock),
+        patch("atc.tower.session.deploy_tower_files", return_value=mock_deployed),
+    ):
+        returned_id = await start_tower_session(db, project.id)
+
+    assert returned_id != sess.id
+    cursor = await db.execute("SELECT COUNT(*) FROM sessions WHERE session_type = 'tower'")
     row = await cursor.fetchone()
-    assert row[0] == 1
+    assert row[0] == 2
 
 
 @pytest.mark.asyncio
 async def test_creates_new_session_when_no_valid_staging_dir(db, tmp_path: Path) -> None:
-    """When no disconnected session has a valid CLAUDE.md, a new session is created."""
     project = await create_project(db, "test-proj")
-
-    # Create a disconnected tower session but NO staging dir
     await create_session(
         db,
         project_id=project.id,
@@ -98,39 +108,75 @@ async def test_creates_new_session_when_no_valid_staging_dir(db, tmp_path: Path)
     )
     await db.commit()
 
-    mock_pane_id = "%atc:0.99"
+    mock_root = tmp_path / "new-sess"
+    mock_root.mkdir()
+    (mock_root / "CLAUDE.md").write_text("# Tower\n")
+    mock_deployed = Mock()
+    mock_deployed.root = mock_root
+    mock_deployed.claude_md_path = mock_root / "CLAUDE.md"
 
     with (
-        patch(
-            "atc.tower.session._DEFAULT_STAGING_ROOT",
-            str(tmp_path),
-        ),
+        patch("atc.tower.session._DEFAULT_STAGING_ROOT", str(tmp_path)),
         patch(
             "atc.tower.session._spawn_provider_session",
             new_callable=AsyncMock,
-            return_value=("atc", mock_pane_id),
+            return_value=("atc", "%atc:0.99"),
         ),
         patch("atc.tower.session._pane_is_alive", new_callable=AsyncMock, return_value=False),
-        patch("atc.tower.session.get_launch_command", return_value="claude"),
         patch("atc.tower.session.transition", new_callable=AsyncMock),
         patch("atc.tower.session.db_ops.update_session_tmux", new_callable=AsyncMock),
-        patch("atc.tower.session.deploy_tower_files") as mock_deploy,
+        patch("atc.tower.session.deploy_tower_files", return_value=mock_deployed),
     ):
-        mock_root = tmp_path / "new-sess"
-        mock_root.mkdir()
-        (mock_root / "CLAUDE.md").write_text("# Tower\n")
-        from unittest.mock import Mock
-
-        mock_deployed = Mock()
-        mock_deployed.root = mock_root
-        mock_deployed.claude_md_path = mock_root / "CLAUDE.md"
-        mock_deploy.return_value = mock_deployed
-
         returned_id = await start_tower_session(db, project.id)
 
-    # Should be a NEW session (different from the disconnected one)
-    cursor = await db.execute(
-        "SELECT COUNT(*) FROM sessions WHERE session_type = 'tower'"
-    )
+    cursor = await db.execute("SELECT COUNT(*) FROM sessions WHERE session_type = 'tower'")
     row = await cursor.fetchone()
-    assert row[0] == 2  # original disconnected + new one
+    assert row[0] == 2
+    assert returned_id is not None
+
+
+
+@pytest.mark.asyncio
+async def test_mismatch_reuse_marks_old_tower_disconnected(db, tmp_path: Path) -> None:
+    project = await create_project(db, "test-proj")
+    sess = await create_session(
+        db,
+        project_id=project.id,
+        session_type="tower",
+        name="tower-test",
+        provider="codex",
+        status=SessionStatus.IDLE.value,
+    )
+    await db.execute("UPDATE sessions SET tmux_pane = ? WHERE id = ?", ("%existing-pane", sess.id))
+    await db.commit()
+
+    staging_dir = Path(tmp_path) / sess.id
+    staging_dir.mkdir(parents=True)
+    (staging_dir / "CLAUDE.md").write_text("# Tower\n")
+
+    mock_root = tmp_path / "new-sess"
+    mock_root.mkdir()
+    (mock_root / "CLAUDE.md").write_text("# Tower\n")
+    mock_deployed = Mock()
+    mock_deployed.root = mock_root
+    mock_deployed.claude_md_path = mock_root / "CLAUDE.md"
+
+    with (
+        patch("atc.tower.session._DEFAULT_STAGING_ROOT", str(tmp_path)),
+        patch("atc.tower.session._pane_is_alive", new_callable=AsyncMock, return_value=True),
+        patch("atc.tower.session._kill_pane", new_callable=AsyncMock),
+        patch(
+            "atc.tower.session._spawn_provider_session",
+            new_callable=AsyncMock,
+            return_value=("atc", "%atc:0.99"),
+        ),
+        patch("atc.tower.session.transition", new_callable=AsyncMock),
+        patch("atc.tower.session.db_ops.update_session_tmux", new_callable=AsyncMock),
+        patch("atc.tower.session.deploy_tower_files", return_value=mock_deployed),
+    ):
+        returned_id = await start_tower_session(db, project.id)
+
+    assert returned_id != sess.id
+    cursor = await db.execute("SELECT status FROM sessions WHERE id = ?", (sess.id,))
+    row = await cursor.fetchone()
+    assert row[0] == SessionStatus.DISCONNECTED.value

--- a/tests/unit/test_wrapper_events.py
+++ b/tests/unit/test_wrapper_events.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+import pytest
+
+from atc.runtime.wrapper_events import WrapperEventParseError, parse_wrapper_event
+
+
+def test_parse_wrapper_event_success() -> None:
+    event = parse_wrapper_event(
+        'ATC_EVENT runtime_ready {"session_id":"sess_1","provider":"codex","command":"start-role"}'
+    )
+
+    assert event.name == "runtime_ready"
+    assert event.session_id == "sess_1"
+    assert event.provider == "codex"
+    assert event.command == "start-role"
+
+
+def test_parse_wrapper_event_requires_prefix() -> None:
+    with pytest.raises(WrapperEventParseError):
+        parse_wrapper_event('runtime_ready {"session_id":"sess_1","provider":"codex","command":"start-role"}')
+
+
+def test_parse_wrapper_event_rejects_unknown_name() -> None:
+    with pytest.raises(WrapperEventParseError):
+        parse_wrapper_event(
+            'ATC_EVENT nope {"session_id":"sess_1","provider":"codex","command":"start-role"}'
+        )
+
+
+def test_parse_wrapper_event_requires_common_fields() -> None:
+    with pytest.raises(WrapperEventParseError):
+        parse_wrapper_event('ATC_EVENT runtime_ready {"session_id":"sess_1","provider":"codex"}')


### PR DESCRIPTION
## Summary
- add a provider runtime service boundary with Claude and Codex runtime implementations
- harden provider-stamped lifecycle semantics across reuse, reconnect, restore, and existing-session materialization
- add refactor docs, guardrails, and targeted regression coverage for runtime/provider behavior

## Testing
- PYTHONPATH=/tmp/atc-work/src pytest -q tests/unit/test_provider_registry.py tests/unit/test_runtime_service.py tests/unit/test_reconnect_runtime_semantics.py tests/unit/test_tower_session_reuse.py tests/unit/test_claude_code_runtime.py tests/unit/test_codex_runtime.py
- PYTHONPATH=/tmp/atc-work/src pytest -q tests/unit/test_reconnect_runtime_semantics.py tests/unit/test_tower_session_reuse.py tests/unit/test_claude_code_runtime.py tests/unit/test_codex_runtime.py tests/unit/test_runtime_service.py tests/unit/test_provider_registry.py