### PR TITLE
fix: avoid claude provider import cycle

### DIFF
--- a/docs/DEVELOPMENT_RULES.md
+++ b/docs/DEVELOPMENT_RULES.md
@@ -42,3 +42,5 @@ Leave behind structure and docs that reduce the need for future deep rediscovery
 
 
 - `make cleardb` is a local reset command only. It should stop dev processes and clear DB/state/cache, but it must not pull code, rebuild the venv, or auto-start the app. Use `make setup` and `make dev` explicitly after reset.
+
+- Avoid import-time cycles between legacy providers and session lifecycle modules. If a provider only needs a session helper for spawn-time behavior, prefer a narrow local import at call time instead of a module-level cross-import.

--- a/src/atc/agents/claude_provider.py
+++ b/src/atc/agents/claude_provider.py
@@ -31,7 +31,6 @@ from atc.agents.claude_runtime import (
     wait_for_prompt as claude_wait_for_prompt,
 )
 from atc.terminal.control import send_instruction_async
-from atc.session.ace import _ensure_tmux_session
 
 logger = logging.getLogger(__name__)
 
@@ -110,6 +109,8 @@ class ClaudeCodeProvider:
 
         shell_cmd = f"{env_prefix}{' '.join(cmd_parts)}"
         logger.debug("spawn_session role=%s session=%s", role, session_id)
+
+        from atc.session.ace import _ensure_tmux_session
 
         await _ensure_tmux_session(self._tmux_session)
 


### PR DESCRIPTION
## Summary
- avoid the claude provider import-time cycle with session.ace
- keep the tmux session helper import local to the spawn path where it is actually needed
- document the import-cycle guardrail in development rules

## Testing
- python3 -m py_compile src/atc/agents/claude_provider.py src/atc/session/ace.py src/atc/agents/__init__.py src/atc/agents/factory.py