### PR TITLE
fix: expose builtin provider metadata

### DIFF
--- a/docs/provider_runtime_refactor_plan.md
+++ b/docs/provider_runtime_refactor_plan.md
@@ -648,3 +648,4 @@ This keeps shared layers normalized while giving downstream generic callers rich
 
 
 Settings and project provider validation now list provider names from the runtime registry rather than the older agent factory, reducing one more mixed old/new seam on the live API surface.
+The runtime registry now also exposes non-empty built-in provider metadata for the live `/settings/providers` surface, so frontend provider lists do not depend on placeholder-zero metadata rows.

--- a/src/atc/providers/registry.py
+++ b/src/atc/providers/registry.py
@@ -89,10 +89,33 @@ def list_provider_runtimes() -> list[str]:
 def list_provider_runtime_infos() -> list[ProviderRuntimeInfo]:
     """List registry-owned provider metadata for settings and discovery surfaces."""
 
-    return [
-        ProviderRuntimeInfo(name=name)
-        for name in list_provider_runtimes()
-    ]
+    infos: list[ProviderRuntimeInfo] = []
+    for name in list_provider_runtimes():
+        model = ""
+        supports_streaming = False
+        supports_tool_use = False
+        context_window = 0
+        factory = get_provider_runtime_factory(name)
+        if factory is ClaudeCodeRuntime:
+            model = "claude"
+            supports_streaming = True
+            supports_tool_use = True
+            context_window = 200_000
+        elif factory is CodexRuntime:
+            model = "codex"
+            supports_streaming = True
+            supports_tool_use = True
+            context_window = 200_000
+        infos.append(
+            ProviderRuntimeInfo(
+                name=name,
+                model=model,
+                supports_streaming=supports_streaming,
+                supports_tool_use=supports_tool_use,
+                context_window=context_window,
+            )
+        )
+    return infos
 
 def _register_builtin_provider_runtimes() -> None:
     global _BUILTINS_REGISTERED

--- a/tests/unit/test_provider_registry.py
+++ b/tests/unit/test_provider_registry.py
@@ -59,3 +59,16 @@ def test_list_provider_runtime_infos_contains_builtins() -> None:
     names = {info.name for info in infos}
     assert "claude_code" in names
     assert "codex" in names
+
+
+
+def test_list_provider_runtime_infos_exposes_builtin_metadata() -> None:
+    infos = {info.name: info for info in list_provider_runtime_infos()}
+    assert infos["claude_code"].supports_streaming is True
+    assert infos["claude_code"].supports_tool_use is True
+    assert infos["claude_code"].context_window == 200_000
+    assert infos["claude_code"].model == "claude"
+    assert infos["codex"].supports_streaming is True
+    assert infos["codex"].supports_tool_use is True
+    assert infos["codex"].context_window == 200_000
+    assert infos["codex"].model == "codex"


### PR DESCRIPTION
## Summary
- expose non-empty built-in metadata from the provider runtime registry
- make  return meaningful built-in provider info for the frontend
- cover the builtin metadata contract in provider registry tests

## Testing
- PYTHONPATH=/tmp/atc-work/src pytest -q tests/unit/test_provider_registry.py