### PR TITLE
fix: avoid opencode provider import cycle

### DIFF
--- a/docs/DEVELOPMENT_RULES.md
+++ b/docs/DEVELOPMENT_RULES.md
@@ -44,3 +44,4 @@ Leave behind structure and docs that reduce the need for future deep rediscovery
 - `make cleardb` is a local reset command only. It should stop dev processes and clear DB/state/cache, but it must not pull code, rebuild the venv, or auto-start the app. Use `make setup` and `make dev` explicitly after reset.
 
 - Avoid import-time cycles between legacy providers and session lifecycle modules. If a provider only needs a session helper for spawn-time behavior, prefer a narrow local import at call time instead of a module-level cross-import.
+- The same import-cycle guard applies to OpenCode and other legacy providers too, not just Claude. Provider modules must not import `session.ace` helpers at module import time when a local call-site import will do.

--- a/src/atc/agents/opencode_provider.py
+++ b/src/atc/agents/opencode_provider.py
@@ -28,7 +28,6 @@ from atc.agents.base import (
     SessionStatus,
 )
 
-from atc.session.ace import _ensure_tmux_session
 
 logger = logging.getLogger(__name__)
 
@@ -98,6 +97,8 @@ class OpenCodeProvider:
 
         if shutil.which(_TMUX_CMD) is None:
             raise ProviderError(self.name, "tmux is not installed or not on PATH")
+
+        from atc.session.ace import _ensure_tmux_session
 
         await _ensure_tmux_session(self._tmux_session)
         server_session = f"{self._tmux_session}-opencode-server"


### PR DESCRIPTION
## Summary
- avoid the opencode provider import-time cycle with session.ace
- keep the tmux session helper import local to the server/session startup paths where it is needed
- document the broader provider import-cycle guardrail

## Testing
- python3 -m py_compile src/atc/agents/opencode_provider.py src/atc/agents/claude_provider.py src/atc/session/ace.py src/atc/agents/__init__.py src/atc/agents/factory.py