### PR TITLE
fix: avoid codex provider import cycle

### DIFF
--- a/docs/DEVELOPMENT_RULES.md
+++ b/docs/DEVELOPMENT_RULES.md
@@ -45,3 +45,4 @@ Leave behind structure and docs that reduce the need for future deep rediscovery
 
 - Avoid import-time cycles between legacy providers and session lifecycle modules. If a provider only needs a session helper for spawn-time behavior, prefer a narrow local import at call time instead of a module-level cross-import.
 - The same import-cycle guard applies to OpenCode and other legacy providers too, not just Claude. Provider modules must not import `session.ace` helpers at module import time when a local call-site import will do.
+- Codex legacy provider imports follow the same rule: no module-level import from `session.ace` when a local spawn-path import avoids the cycle.

--- a/src/atc/agents/codex_provider.py
+++ b/src/atc/agents/codex_provider.py
@@ -22,7 +22,6 @@ from atc.agents.base import (
     SessionStatus,
 )
 from atc.terminal.control import send_instruction_async
-from atc.session.ace import _ensure_tmux_session
 
 logger = logging.getLogger(__name__)
 
@@ -74,6 +73,8 @@ class CodexProvider:
 
         if working_dir:
             await self.prepare_workspace(session_id, working_dir=working_dir, context_file=context_file)
+
+        from atc.session.ace import _ensure_tmux_session
 
         await _ensure_tmux_session(self._tmux_session)
 


### PR DESCRIPTION
## Summary
- avoid the codex provider import-time cycle with session.ace
- keep the tmux session helper import local to the Codex spawn path where it is needed
- document the same cycle-prevention rule for Codex legacy provider code

## Testing
- python3 -m py_compile src/atc/agents/codex_provider.py src/atc/agents/opencode_provider.py src/atc/agents/claude_provider.py src/atc/session/ace.py src/atc/agents/__init__.py src/atc/agents/factory.py