### PR TITLE
fix: skip replaying session provider migration

### DIFF
--- a/docs/provider_runtime_refactor_plan.md
+++ b/docs/provider_runtime_refactor_plan.md
@@ -649,3 +649,5 @@ This keeps shared layers normalized while giving downstream generic callers rich
 
 Settings and project provider validation now list provider names from the runtime registry rather than the older agent factory, reducing one more mixed old/new seam on the live API surface.
 The runtime registry now also exposes non-empty built-in provider metadata for the live `/settings/providers` surface, so frontend provider lists do not depend on placeholder-zero metadata rows.
+
+File migration replay is now guarded so `015_session_provider_scope.sql` is recorded and skipped when fresh-schema databases already contain the `sessions.provider` column, preventing startup failure from duplicate-column reapplication on new installs.

--- a/src/atc/state/db.py
+++ b/src/atc/state/db.py
@@ -571,6 +571,16 @@ async def _apply_file_migrations(db: aiosqlite.Connection) -> None:
             )
             await db.commit()
             continue
+        if path.name == "015_session_provider_scope.sql":
+            if await _has_column(db, "sessions", "provider"):
+                logger.info("Migration skip: %s already applied structurally", path.name)
+                await db.execute(
+                    "INSERT INTO schema_migrations (version, applied_at) VALUES (?, ?)",
+                    (path.name, _now()),
+                )
+                await db.commit()
+                continue
+
         sql = path.read_text()
         if sql.strip():
             logger.info("Applying migration file %s", path.name)

--- a/tests/unit/test_db_migrations.py
+++ b/tests/unit/test_db_migrations.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+import pytest
+
+from atc.state.db import _SCHEMA_SQL, _apply_file_migrations, _ensure_schema_migrations_table, _list_applied_migrations, get_connection
+
+
+@pytest.mark.asyncio
+async def test_apply_file_migrations_skips_015_when_provider_column_already_exists() -> None:
+    async with get_connection(":memory:") as db:
+        await db.executescript(_SCHEMA_SQL)
+        await db.commit()
+
+        await _apply_file_migrations(db)
+
+        applied = await _list_applied_migrations(db)
+        assert "015_session_provider_scope.sql" in applied


### PR DESCRIPTION
## Summary
- guard the 015 session-provider migration so it is skipped when the column already exists in fresh-schema databases
- record the migration as applied when schema structure is already present
- add a regression test for fresh-schema migration replay safety

## Testing
- PYTHONPATH=/tmp/atc-work/src pytest -q tests/unit/test_db_migrations.py