### PR TITLE
fix: restart tower under switched provider

### DIFF
--- a/docs/provider_runtime_refactor_plan.md
+++ b/docs/provider_runtime_refactor_plan.md
@@ -651,3 +651,5 @@ Settings and project provider validation now list provider names from the runtim
 The runtime registry now also exposes non-empty built-in provider metadata for the live `/settings/providers` surface, so frontend provider lists do not depend on placeholder-zero metadata rows.
 
 File migration replay is now guarded so `015_session_provider_scope.sql` is recorded and skipped when fresh-schema databases already contain the `sessions.provider` column, preventing startup failure from duplicate-column reapplication on new installs.
+
+Tower provider-switch restart now explicitly rehydrates the requested goal and resets controller state before relaunch, so switching from Claude to Codex does not bounce the stopped Tower back into the prior provider-owned session state.

--- a/src/atc/api/routers/settings.py
+++ b/src/atc/api/routers/settings.py
@@ -274,6 +274,8 @@ async def update_agent_provider(
         if tower_was_running:
             try:
                 restart_project_id = handoff["tower"]["project_id"]
+                tower._current_goal = handoff["tower"]["goal"]
+                tower._state = TowerState.IDLE
                 if restart_project_id is not None:
                     await tower.start_session(restart_project_id)
                 else:


### PR DESCRIPTION
## Summary
- reset Tower controller state before restarting after a global provider switch
- preserve the captured Tower goal while preventing the restart path from reviving stale provider-owned state
- document the provider-switch restart behavior in the refactor plan

## Testing
- python3 -m py_compile src/atc/api/routers/settings.py src/atc/tower/controller.py