### PR TITLE
fix: refresh provider runtimes from live settings

### DIFF
--- a/docs/provider_runtime_refactor_plan.md
+++ b/docs/provider_runtime_refactor_plan.md
@@ -653,3 +653,5 @@ The runtime registry now also exposes non-empty built-in provider metadata for t
 File migration replay is now guarded so `015_session_provider_scope.sql` is recorded and skipped when fresh-schema databases already contain the `sessions.provider` column, preventing startup failure from duplicate-column reapplication on new installs.
 
 Tower provider-switch restart now explicitly rehydrates the requested goal and resets controller state before relaunch, so switching from Claude to Codex does not bounce the stopped Tower back into the prior provider-owned session state.
+
+RuntimeService now refreshes cached provider runtime instances when live app settings change their effective command/tmux configuration, so a global provider switch does not keep relaunching Tower from stale cached runtime command state.

--- a/src/atc/providers/registry.py
+++ b/src/atc/providers/registry.py
@@ -40,6 +40,25 @@ def register_provider_runtime(name: str, factory: ProviderFactory) -> None:
     _REGISTRY[name] = factory
 
 
+def runtime_kwargs_for_provider(name: str, settings: Any | None = None) -> dict[str, Any]:
+    """Resolve live runtime kwargs for a provider from app settings when available."""
+
+    if settings is None:
+        settings = load_settings()
+
+    if name == "claude_code":
+        return {
+            "tmux_session": settings.agent_provider.tmux_session,
+            "claude_command": settings.agent_provider.claude_command,
+        }
+    if name == "codex":
+        return {
+            "tmux_session": settings.agent_provider.tmux_session,
+            "codex_command": settings.agent_provider.codex_command,
+        }
+    return {}
+
+
 def create_provider_runtime(name: str, **kwargs: Any) -> ProviderRuntime:
     """Instantiate a provider runtime by provider name."""
 
@@ -53,17 +72,7 @@ def create_provider_runtime(name: str, **kwargs: Any) -> ProviderRuntime:
 
     if not kwargs:
         try:
-            settings = load_settings()
-            if name == "claude_code":
-                kwargs = {
-                    "tmux_session": settings.agent_provider.tmux_session,
-                    "claude_command": settings.agent_provider.claude_command,
-                }
-            elif name == "codex":
-                kwargs = {
-                    "tmux_session": settings.agent_provider.tmux_session,
-                    "codex_command": settings.agent_provider.codex_command,
-                }
+            kwargs = runtime_kwargs_for_provider(name)
         except Exception:
             kwargs = {}
 

--- a/src/atc/runtime/models.py
+++ b/src/atc/runtime/models.py
@@ -84,6 +84,7 @@ class StartRoleRequest:
     provider_name: str
     role: RoleKind
     project_id: str | None = None
+    connection: Any | None = None
     working_dir: str | None = None
     context_ref: str | None = None
     display_name: str | None = None

--- a/src/atc/runtime/service.py
+++ b/src/atc/runtime/service.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from atc.providers.base import ProviderRuntime
-from atc.providers.registry import create_provider_runtime
+from atc.providers.registry import create_provider_runtime, runtime_kwargs_for_provider
 from atc.runtime.models import (
     InstructionRequest,
     ReadinessResult,
@@ -27,14 +27,23 @@ class RuntimeService:
         self._handles: dict[str, RuntimeSessionHandle] = {}
         self._providers: dict[str, ProviderRuntime] = {}
 
+    def _get_provider_runtime(self, provider_name: str, conn: object | None = None) -> ProviderRuntime:
+        """Resolve a provider runtime, refreshing cached instances when live settings differ."""
+
+        app_state = getattr(getattr(conn, "_connection", None), "app_state", None)
+        settings = getattr(app_state, "settings", None) if app_state is not None else None
+        desired_kwargs = runtime_kwargs_for_provider(provider_name, settings) if settings is not None else runtime_kwargs_for_provider(provider_name)
+
+        provider = self._providers.get(provider_name)
+        if provider is None or any(getattr(provider, key, None) != value for key, value in desired_kwargs.items()):
+            provider = create_provider_runtime(provider_name, **desired_kwargs)
+            self._providers[provider_name] = provider
+        return provider
+
     def get_provider(self, provider_name: str) -> ProviderRuntime:
         """Resolve a provider runtime implementation by name."""
 
-        provider = self._providers.get(provider_name)
-        if provider is None:
-            provider = create_provider_runtime(provider_name)
-            self._providers[provider_name] = provider
-        return provider
+        return self._get_provider_runtime(provider_name)
 
     def remember_handle(self, handle: RuntimeSessionHandle) -> RuntimeSessionHandle:
         """Store a runtime handle for later session-targeted operations."""
@@ -101,7 +110,7 @@ class RuntimeService:
     async def spawn_existing_session(self, request: StartRoleRequest) -> RuntimeSessionHandle:
         """Materialize an already-created DB session row into a live runtime session."""
 
-        provider = self.get_provider(request.provider_name)
+        provider = self._get_provider_runtime(request.provider_name, getattr(request, "connection", None))
         handle = await provider.spawn_existing_session(request)
         return self.remember_handle(handle)
 

--- a/src/atc/session/ace.py
+++ b/src/atc/session/ace.py
@@ -302,6 +302,7 @@ async def _spawn_provider_session(
             provider_name=provider_name,
             role=role,
             project_id=project_id,
+            connection=conn,
             working_dir=working_dir,
             context_ref=str(context_file) if context_file else None,
             metadata={"launch_command": launch_command} if launch_command else {},

--- a/tests/unit/test_runtime_service.py
+++ b/tests/unit/test_runtime_service.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+from types import SimpleNamespace
 
 from atc.providers.registry import register_provider_runtime
 from atc.runtime.models import (
@@ -156,3 +157,18 @@ def test_runtime_service_assign_task_to_ace_uses_provider() -> None:
 
     provider = service.get_provider("dummy_runtime_ace")
     assert provider.assignments[-1].task_id == "task-1"
+
+
+
+def test_service_refreshes_cached_provider_when_live_settings_change() -> None:
+    service = RuntimeService()
+    first_settings = SimpleNamespace(agent_provider=SimpleNamespace(tmux_session="atc", claude_command="claude", codex_command="codex"))
+    second_settings = SimpleNamespace(agent_provider=SimpleNamespace(tmux_session="atc", claude_command="claude", codex_command="codex --profile prod"))
+    first_conn = SimpleNamespace(_connection=SimpleNamespace(app_state=SimpleNamespace(settings=first_settings)))
+    second_conn = SimpleNamespace(_connection=SimpleNamespace(app_state=SimpleNamespace(settings=second_settings)))
+
+    first = service._get_provider_runtime("codex", first_conn)
+    second = service._get_provider_runtime("codex", second_conn)
+
+    assert first is not second
+    assert getattr(second, "codex_command") == "codex --profile prod"


### PR DESCRIPTION
## Summary
- refresh cached provider runtime instances when live app settings change effective provider command config
- pass DB/app connection context into runtime start requests so runtime resolution can honor live provider settings
- add regression coverage for cached runtime refresh behavior

## Testing
- PYTHONPATH=/tmp/atc-work/src pytest -q tests/unit/test_runtime_service.py tests/unit/test_provider_registry.py