### PR TITLE
fix: attach app state to sqlite connection

### DIFF
--- a/src/atc/api/app.py
+++ b/src/atc/api/app.py
@@ -53,7 +53,7 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
     await db.execute("PRAGMA foreign_keys=ON")
     await db.execute("PRAGMA busy_timeout=30000")
     db.row_factory = aiosqlite.Row
-    db.app_state = app.state
+    setattr(db._connection, "app_state", app.state)
     app.state.db = db
 
     # 4. Start WebSocket hub

--- a/tests/unit/test_runtime_service.py
+++ b/tests/unit/test_runtime_service.py
@@ -172,3 +172,21 @@ def test_service_refreshes_cached_provider_when_live_settings_change() -> None:
 
     assert first is not second
     assert getattr(second, "codex_command") == "codex --profile prod"
+
+
+
+def test_service_refreshes_cached_provider_when_live_settings_change_via_sqlite_connection() -> None:
+    service = RuntimeService()
+    first_settings = SimpleNamespace(agent_provider=SimpleNamespace(tmux_session="atc", claude_command="claude", codex_command="codex"))
+    second_settings = SimpleNamespace(agent_provider=SimpleNamespace(tmux_session="atc", claude_command="claude", codex_command="codex --profile prod"))
+    sqlite_conn = SimpleNamespace()
+    first_conn = SimpleNamespace(_connection=sqlite_conn)
+    sqlite_conn.app_state = SimpleNamespace(settings=first_settings)
+
+    first = service._get_provider_runtime("codex", first_conn)
+
+    sqlite_conn.app_state = SimpleNamespace(settings=second_settings)
+    second = service._get_provider_runtime("codex", first_conn)
+
+    assert first is not second
+    assert getattr(second, "codex_command") == "codex --profile prod"


### PR DESCRIPTION
## Summary
- attach FastAPI app state to the underlying sqlite connection object used by provider/session code
- let tower/session provider lookups read live settings mutations instead of falling back to load_settings()
- add regression coverage for runtime refresh through a reused sqlite connection

## Testing
- PYTHONPATH=/tmp/atc-work/src pytest -q tests/unit/test_runtime_service.py