### PR TITLE
fix: carry app state on aiosqlite wrapper

### DIFF
--- a/src/atc/api/app.py
+++ b/src/atc/api/app.py
@@ -53,7 +53,7 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
     await db.execute("PRAGMA foreign_keys=ON")
     await db.execute("PRAGMA busy_timeout=30000")
     db.row_factory = aiosqlite.Row
-    setattr(db._connection, "app_state", app.state)
+    db._app_state_carrier.app_state = app.state
     app.state.db = db
 
     # 4. Start WebSocket hub

--- a/src/atc/leader/leader.py
+++ b/src/atc/leader/leader.py
@@ -38,7 +38,7 @@ logger = logging.getLogger(__name__)
 
 
 def _current_provider_config(conn: aiosqlite.Connection) -> AgentProviderConfig:
-    settings = getattr(getattr(conn, "_connection", None), "app_state", None)
+    settings = getattr(getattr(conn, "_app_state_carrier", None), "app_state", None)
     if settings is not None and getattr(settings, "settings", None) is not None:
         return settings.settings.agent_provider
     from atc.config import load_settings

--- a/src/atc/session/ace.py
+++ b/src/atc/session/ace.py
@@ -341,7 +341,7 @@ async def create_ace(
     """
     # Step 1: DB row first — guarantees the UI always sees every entity
     project = await db_ops.get_project(conn, project_id)
-    provider_cfg = getattr(getattr(conn, "_connection", None), "app_state", None)
+    provider_cfg = getattr(getattr(conn, "_app_state_carrier", None), "app_state", None)
     if provider_cfg is not None and getattr(provider_cfg, "settings", None) is not None:
         provider = provider_cfg.settings.agent_provider.default
     else:

--- a/src/atc/state/db.py
+++ b/src/atc/state/db.py
@@ -42,6 +42,16 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+
+class AppStateCarrier:
+    """Attachable holder for live app state alongside sqlite connections."""
+
+    __slots__ = ("app_state",)
+
+    def __init__(self, app_state: Any | None = None) -> None:
+        self.app_state = app_state
+
+
 _memory_counter = itertools.count()
 
 # Default retry settings for SQLITE_BUSY
@@ -199,6 +209,7 @@ async def get_connection(db_path: str) -> AsyncIterator[aiosqlite.Connection]:
         await db.execute("PRAGMA foreign_keys=ON")
         await db.execute("PRAGMA busy_timeout=30000")
         db.row_factory = aiosqlite.Row
+        db._app_state_carrier = AppStateCarrier()
         yield db
     finally:
         await db.close()

--- a/src/atc/tower/session.py
+++ b/src/atc/tower/session.py
@@ -37,7 +37,7 @@ logger = logging.getLogger(__name__)
 
 
 def _current_provider_config(conn: "aiosqlite.Connection") -> AgentProviderConfig:
-    settings = getattr(getattr(conn, "_connection", None), "app_state", None)
+    settings = getattr(getattr(conn, "_app_state_carrier", None), "app_state", None)
     if settings is not None and getattr(settings, "settings", None) is not None:
         return settings.settings.agent_provider
     from atc.config import load_settings


### PR DESCRIPTION
## Summary
- replace the raw sqlite3 app-state monkeypatch with an attachable carrier on the aiosqlite wrapper
- update tower, leader, and ace provider lookups to read live settings from that carrier
- preserve live provider-switch behavior without crashing startup on Python 3.14

## Testing
- PYTHONPATH=/tmp/atc-work/src pytest -q tests/unit/test_runtime_service.py