### PR TITLE
fix: track app state outside sqlite objects

### DIFF
--- a/src/atc/api/app.py
+++ b/src/atc/api/app.py
@@ -18,7 +18,7 @@ from atc.config import Settings, load_settings
 from atc.core.errors import ATCError
 from atc.core.events import EventBus
 from atc.core.sentry import init_sentry
-from atc.state.db import run_migrations
+from atc.state.db import run_migrations, set_connection_app_state, clear_connection_app_state
 from atc.terminal.pty_stream import PtyStreamPool
 
 if TYPE_CHECKING:
@@ -53,7 +53,7 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
     await db.execute("PRAGMA foreign_keys=ON")
     await db.execute("PRAGMA busy_timeout=30000")
     db.row_factory = aiosqlite.Row
-    db._app_state_carrier.app_state = app.state
+    set_connection_app_state(db, app.state)
     app.state.db = db
 
     # 4. Start WebSocket hub

--- a/src/atc/leader/leader.py
+++ b/src/atc/leader/leader.py
@@ -28,6 +28,7 @@ from atc.session.ace import (
 )
 from atc.session.state_machine import SessionStatus, transition
 from atc.state import db as db_ops
+from atc.state.db import get_connection_app_state
 
 if TYPE_CHECKING:
     import aiosqlite  # type: ignore[import-not-found]
@@ -38,7 +39,7 @@ logger = logging.getLogger(__name__)
 
 
 def _current_provider_config(conn: aiosqlite.Connection) -> AgentProviderConfig:
-    settings = getattr(getattr(conn, "_app_state_carrier", None), "app_state", None)
+    settings = get_connection_app_state(conn)
     if settings is not None and getattr(settings, "settings", None) is not None:
         return settings.settings.agent_provider
     from atc.config import load_settings

--- a/src/atc/session/ace.py
+++ b/src/atc/session/ace.py
@@ -31,6 +31,7 @@ from atc.session.state_machine import (
     transition,
 )
 from atc.state import db as db_ops
+from atc.state.db import get_connection_app_state
 
 if TYPE_CHECKING:
     import aiosqlite  # type: ignore[import-not-found]
@@ -341,7 +342,7 @@ async def create_ace(
     """
     # Step 1: DB row first — guarantees the UI always sees every entity
     project = await db_ops.get_project(conn, project_id)
-    provider_cfg = getattr(getattr(conn, "_app_state_carrier", None), "app_state", None)
+    provider_cfg = get_connection_app_state(conn)
     if provider_cfg is not None and getattr(provider_cfg, "settings", None) is not None:
         provider = provider_cfg.settings.agent_provider.default
     else:

--- a/src/atc/state/db.py
+++ b/src/atc/state/db.py
@@ -42,6 +42,26 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+_CONNECTION_APP_STATE: dict[int, Any] = {}
+
+
+def set_connection_app_state(conn: Any, app_state: Any) -> None:
+    """Bind FastAPI app state to an aiosqlite connection without monkeypatching internals."""
+
+    _CONNECTION_APP_STATE[id(conn)] = app_state
+
+
+def get_connection_app_state(conn: Any) -> Any | None:
+    """Resolve previously bound app state for an aiosqlite connection."""
+
+    return _CONNECTION_APP_STATE.get(id(conn))
+
+
+def clear_connection_app_state(conn: Any) -> None:
+    """Forget app state bound to an aiosqlite connection."""
+
+    _CONNECTION_APP_STATE.pop(id(conn), None)
+
 
 class AppStateCarrier:
     """Attachable holder for live app state alongside sqlite connections."""
@@ -209,9 +229,9 @@ async def get_connection(db_path: str) -> AsyncIterator[aiosqlite.Connection]:
         await db.execute("PRAGMA foreign_keys=ON")
         await db.execute("PRAGMA busy_timeout=30000")
         db.row_factory = aiosqlite.Row
-        db._app_state_carrier = AppStateCarrier()
         yield db
     finally:
+        clear_connection_app_state(db)
         await db.close()
 
 

--- a/src/atc/tower/session.py
+++ b/src/atc/tower/session.py
@@ -27,6 +27,7 @@ from atc.session.ace import (
 )
 from atc.session.state_machine import SessionStatus, transition
 from atc.state import db as db_ops
+from atc.state.db import get_connection_app_state
 
 if TYPE_CHECKING:
     import aiosqlite  # type: ignore[import-not-found]
@@ -37,7 +38,7 @@ logger = logging.getLogger(__name__)
 
 
 def _current_provider_config(conn: "aiosqlite.Connection") -> AgentProviderConfig:
-    settings = getattr(getattr(conn, "_app_state_carrier", None), "app_state", None)
+    settings = get_connection_app_state(conn)
     if settings is not None and getattr(settings, "settings", None) is not None:
         return settings.settings.agent_provider
     from atc.config import load_settings


### PR DESCRIPTION
## Summary
- stop attaching app-state data to sqlite/aiosqlite connection objects directly
- keep a small module-level registry keyed by live connection identity instead
- let tower, leader, and ace provider lookups read live settings without breaking startup on Python 3.14

## Testing
- PYTHONPATH=/tmp/atc-work/src pytest -q tests/unit/test_runtime_service.py