### PR TITLE
feat: redesign tower layout for dashboard and project views

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -1,0 +1,77 @@
+.app-shell {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  min-height: 0;
+}
+
+.app-shell__body {
+  flex: 1;
+  min-height: 0;
+}
+
+.app-shell__body--side-tower {
+  --tower-width: 520px;
+  display: flex;
+  overflow: hidden;
+}
+
+.app-shell__body--side-tower > .resize-handle--col {
+  position: relative;
+  z-index: 2;
+}
+
+.app-shell__body--side-tower > .resize-handle--col::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  left: -3px;
+  right: -3px;
+}
+
+.app-shell__body--side-tower > .app-shell__main {
+  min-width: 280px;
+}
+
+.app-shell__body--side-tower > .app-shell__tower {
+  width: var(--tower-width);
+}
+
+.app-shell__body--side-tower > .app-shell__tower .tower-panel--side {
+  min-width: 0;
+}
+
+.app-shell__main {
+  flex: 1;
+  min-width: 0;
+  min-height: 0;
+  overflow: auto;
+}
+
+.app-shell__tower {
+  width: min(46vw, 720px);
+  min-width: 320px;
+  max-width: 50%;
+  min-height: 0;
+  border-left: 1px solid var(--color-border);
+  background: var(--color-bg-surface);
+}
+
+@media (max-width: 1100px) {
+  .app-shell__body--side-tower {
+    flex-direction: column;
+  }
+
+  .app-shell__body--side-tower > .resize-handle--col {
+    display: none;
+  }
+
+  .app-shell__tower {
+    width: 100%;
+    max-width: none;
+    min-width: 0;
+    min-height: 280px;
+    border-left: none;
+    border-top: 1px solid var(--color-border);
+  }
+}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,13 +1,17 @@
-import { BrowserRouter, Routes, Route, Navigate, Outlet } from "react-router-dom";
+import { useCallback, useEffect, useRef, useState } from "react";
+import { BrowserRouter, Routes, Route, Navigate, Outlet, useLocation } from "react-router-dom";
 import { AppProvider, useAppContext } from "./context/AppContext";
+import ResizeHandle from "./components/common/ResizeHandle";
 import TowerBar from "./components/tower/TowerBar";
 import TowerPanel from "./components/tower/TowerPanel";
 import UpdateBanner from "./components/common/UpdateBanner";
 import { useUpdater } from "./hooks/useUpdater";
+import { clampTowerWidth, isSideTowerRoute, readStoredTowerWidth, SIDE_TOWER_WIDTH_KEY } from "./layout/towerSplit";
 import Dashboard from "./pages/Dashboard";
 import ProjectView from "./pages/ProjectView";
 import UsagePage from "./pages/UsagePage";
 import ContextPage from "./pages/ContextPage";
+import "./App.css";
 
 const isTauri =
   typeof window !== "undefined" && "__TAURI_INTERNALS__" in window;
@@ -37,9 +41,55 @@ function StartupGate({ children }: { children: React.ReactNode }) {
 
 function Layout() {
   const updater = useUpdater();
+  const location = useLocation();
+  const showSideTower = isSideTowerRoute(location.pathname);
+  const shellBodyRef = useRef<HTMLDivElement>(null);
+  const [towerWidth, setTowerWidth] = useState(readStoredTowerWidth);
+
+  useEffect(() => {
+    window.localStorage.setItem(SIDE_TOWER_WIDTH_KEY, String(towerWidth));
+  }, [towerWidth]);
+
+  useEffect(() => {
+    if (!showSideTower) {
+      return;
+    }
+
+    const syncWidth = () => {
+      const containerWidth = shellBodyRef.current?.offsetWidth ?? window.innerWidth;
+      setTowerWidth((current) => clampTowerWidth(current, containerWidth));
+    };
+
+    syncWidth();
+    window.addEventListener("resize", syncWidth);
+    return () => window.removeEventListener("resize", syncWidth);
+  }, [showSideTower]);
+
+  const handleTowerResize = useCallback(
+    (e: React.MouseEvent<HTMLDivElement>) => {
+      e.preventDefault();
+      const startX = e.clientX;
+      const startWidth = towerWidth;
+
+      const onMove = (ev: MouseEvent) => {
+        const containerWidth = shellBodyRef.current?.offsetWidth ?? window.innerWidth;
+        const delta = startX - ev.clientX;
+        setTowerWidth(clampTowerWidth(startWidth + delta, containerWidth));
+      };
+
+      const onUp = () => {
+        document.removeEventListener("mousemove", onMove);
+        document.removeEventListener("mouseup", onUp);
+      };
+
+      document.addEventListener("mousemove", onMove);
+      document.addEventListener("mouseup", onUp);
+    },
+    [towerWidth],
+  );
 
   return (
-    <>
+    <div className="app-shell">
       {(updater.status === "available" || updater.status === "downloading") &&
         updater.updateInfo && (
           <UpdateBanner
@@ -51,11 +101,20 @@ function Layout() {
           />
         )}
       <TowerBar />
-      <main style={{ flex: 1, overflow: "auto", minHeight: 0 }}>
-        <Outlet context={updater} />
-      </main>
-      <TowerPanel />
-    </>
+      <div
+        ref={shellBodyRef}
+        className={`app-shell__body${showSideTower ? " app-shell__body--side-tower" : ""}`}
+        style={showSideTower ? { ["--tower-width" as string]: `${towerWidth}px` } : undefined}
+      >
+        <main className="app-shell__main">
+          <Outlet context={updater} />
+        </main>
+        {showSideTower && <ResizeHandle direction="col" onMouseDown={handleTowerResize} />}
+        <div className="app-shell__tower">
+          <TowerPanel orientation={showSideTower ? "side" : "bottom"} />
+        </div>
+      </div>
+    </div>
   );
 }
 

--- a/frontend/src/components/tower/TowerPanel.css
+++ b/frontend/src/components/tower/TowerPanel.css
@@ -3,7 +3,15 @@
   flex-direction: column;
   flex-shrink: 0;
   background: var(--color-bg-surface);
+  min-height: 0;
+}
+
+.tower-panel--bottom {
   border-top: 1px solid var(--color-border);
+}
+
+.tower-panel--side {
+  height: 100%;
 }
 
 /* Minimized: just the bar */
@@ -92,8 +100,12 @@
   border-top: 1px solid var(--color-border-subtle);
 }
 
-.tower-panel--expanded {
+.tower-panel--bottom.tower-panel--expanded {
   height: 280px;
+}
+
+.tower-panel--side.tower-panel--expanded {
+  height: 100%;
 }
 
 /* Terminal area */
@@ -101,6 +113,15 @@
   flex: 1;
   min-height: 0;
   padding: var(--space-1) var(--space-2);
+}
+
+.tower-panel--side .tower-panel__bar {
+  height: 40px;
+  padding: 0 var(--space-3);
+}
+
+.tower-panel--side .tower-panel__content {
+  min-height: 0;
 }
 
 /* Unified input bar at bottom -- terminal-style */

--- a/frontend/src/components/tower/TowerPanel.tsx
+++ b/frontend/src/components/tower/TowerPanel.tsx
@@ -17,7 +17,11 @@ import "./TowerPanel.css";
  * Minimized: single-line ticker showing latest Tower activity.
  * Expanded + running: full PTY terminal + message input bar.
  */
-export default function TowerPanel() {
+interface TowerPanelProps {
+  orientation?: "bottom" | "side";
+}
+
+export default function TowerPanel({ orientation = "bottom" }: TowerPanelProps) {
   const { state, dispatch } = useAppContext();
   const { towerDetail, towerProgress, brainStatus, projects } = state;
 
@@ -92,6 +96,7 @@ export default function TowerPanel() {
 
   useEffect(() => {
     if (
+      resolvedProjectId &&
       isIdle &&
       !starting &&
       !providerSwitchPending &&
@@ -101,7 +106,7 @@ export default function TowerPanel() {
       autoStarted.current = true;
       void handleStart();
     }
-  }, [isIdle, starting, providerSwitchPending]); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [isIdle, starting, providerSwitchPending, resolvedProjectId]); // eslint-disable-line react-hooks/exhaustive-deps
 
   // Re-fit terminal when panel expands; also request a fresh snapshot so the
   // terminal isn't blank when the panel was collapsed during initial load.
@@ -189,7 +194,7 @@ export default function TowerPanel() {
 
   return (
     <div
-      className={`tower-panel ${expanded ? "tower-panel--expanded" : ""}`}
+      className={`tower-panel tower-panel--${orientation} ${expanded ? "tower-panel--expanded" : ""}`}
       data-testid="tower-panel"
     >
       {/* Minimized bar -- always visible */}
@@ -238,7 +243,7 @@ export default function TowerPanel() {
             <button
               className="btn btn-primary btn-sm"
               onClick={handleStart}
-              disabled={starting}
+              disabled={starting || !resolvedProjectId}
               data-testid="tower-panel-start"
             >
               {starting ? "Starting..." : "Start"}

--- a/frontend/src/components/tower/__tests__/TowerPanel.test.tsx
+++ b/frontend/src/components/tower/__tests__/TowerPanel.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { screen } from "@testing-library/react";
+import { screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import TowerPanel from "../TowerPanel";
 import { renderWithProviders } from "../../../test/helpers";
@@ -40,7 +40,9 @@ describe("TowerPanel", () => {
     renderWithProviders(<TowerPanel />);
 
     await user.click(screen.getByTestId("tower-panel-toggle"));
-    expect(screen.getByTestId("tower-panel-content")).toBeVisible();
+    await waitFor(() => {
+      expect(screen.getByTestId("tower-panel-content")).toBeVisible();
+    });
   });
 
   it("shows Start button in the bar when idle", () => {
@@ -78,10 +80,14 @@ describe("TowerPanel", () => {
 
     // Expand
     await user.click(screen.getByTestId("tower-panel-toggle"));
-    expect(screen.getByTestId("tower-panel-content")).toBeVisible();
+    await waitFor(() => {
+      expect(screen.getByTestId("tower-panel-content")).toBeVisible();
+    });
 
     // Collapse — content stays in DOM but is hidden
     await user.click(screen.getByTestId("tower-panel-toggle"));
-    expect(screen.getByTestId("tower-panel-content")).not.toBeVisible();
+    await waitFor(() => {
+      expect(screen.getByTestId("tower-panel-content")).not.toBeVisible();
+    });
   });
 });

--- a/frontend/src/layout/towerSplit.test.ts
+++ b/frontend/src/layout/towerSplit.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+import { clampTowerWidth, isSideTowerRoute, SIDE_TOWER_DEFAULT_WIDTH, SIDE_TOWER_MIN_WIDTH } from "./towerSplit";
+
+describe("towerSplit", () => {
+  it("matches the shell routes that should show the side tower", () => {
+    expect(isSideTowerRoute("/dashboard")).toBe(true);
+    expect(isSideTowerRoute("/projects/abc")).toBe(true);
+    expect(isSideTowerRoute("/usage")).toBe(false);
+  });
+
+  it("clamps the width to the minimum", () => {
+    expect(clampTowerWidth(200, 1400)).toBe(SIDE_TOWER_MIN_WIDTH);
+  });
+
+  it("clamps the width to the computed maximum", () => {
+    expect(clampTowerWidth(900, 1000)).toBe(550);
+    expect(clampTowerWidth(900, 700)).toBeCloseTo(385);
+  });
+
+  it("keeps widths already inside the allowed range", () => {
+    expect(clampTowerWidth(SIDE_TOWER_DEFAULT_WIDTH, 1400)).toBe(SIDE_TOWER_DEFAULT_WIDTH);
+  });
+});

--- a/frontend/src/layout/towerSplit.ts
+++ b/frontend/src/layout/towerSplit.ts
@@ -1,0 +1,26 @@
+export const SIDE_TOWER_WIDTH_KEY = "atc:layout:tower-width";
+export const SIDE_TOWER_MIN_WIDTH = 320;
+export const SIDE_TOWER_MAX_RATIO = 0.55;
+export const SIDE_TOWER_DEFAULT_WIDTH = 520;
+
+export function isSideTowerRoute(pathname: string) {
+  return pathname === "/dashboard" || pathname.startsWith("/projects/");
+}
+
+export function readStoredTowerWidth() {
+  if (typeof window === "undefined") {
+    return SIDE_TOWER_DEFAULT_WIDTH;
+  }
+
+  const stored = Number(window.localStorage.getItem(SIDE_TOWER_WIDTH_KEY));
+  return Number.isFinite(stored) ? stored : SIDE_TOWER_DEFAULT_WIDTH;
+}
+
+export function clampTowerWidth(width: number, containerWidth: number) {
+  const maxWidth = Math.max(
+    SIDE_TOWER_MIN_WIDTH,
+    Math.min(containerWidth * SIDE_TOWER_MAX_RATIO, containerWidth - 280),
+  );
+
+  return Math.min(Math.max(width, SIDE_TOWER_MIN_WIDTH), maxWidth);
+}

--- a/frontend/src/pages/Dashboard.css
+++ b/frontend/src/pages/Dashboard.css
@@ -1,8 +1,7 @@
 .dashboard {
   padding: var(--space-6);
-  max-width: 1200px;
-  margin: 0 auto;
   width: 100%;
+  min-height: 100%;
 }
 
 .dashboard__header {

--- a/frontend/src/pages/ProjectView.css
+++ b/frontend/src/pages/ProjectView.css
@@ -35,29 +35,20 @@
   color: var(--color-text-secondary);
 }
 
-/* Outer layout: column — top row stacked above full-width context */
+/* Left-side project stack, with Tower living in the app shell on the right */
 .project-view__layout {
   display: flex;
-  flex-direction: column;
   flex: 1;
   min-height: 0;
 }
 
-/* Top row: left + right columns side by side */
-.project-view__top {
-  display: flex;
-  flex-direction: row;
-  flex: 1;
-  min-height: 0;
-}
-
-/* Left column: stacked panels separated by row resize handle */
 .project-view__left {
   display: flex;
   flex-direction: column;
   flex-shrink: 0;
   min-height: 0;
   overflow: hidden;
+  gap: 0;
 }
 
 .project-view__tasks {
@@ -86,24 +77,16 @@
   min-height: 0;
 }
 
-/* Right column: leader always full height of top row */
-.project-view__right {
-  flex: 1;
-  display: flex;
-  flex-direction: column;
-  min-height: 0;
-  min-width: 0;
-}
-
 .project-view__leader {
-  flex: 1;
+  flex-shrink: 0;
   display: flex;
   flex-direction: column;
   min-height: 0;
+  margin-bottom: var(--space-3);
 }
 
-/* Context panel: full width, fixed height controlled by JS state */
 .project-view__context {
-  flex-shrink: 0;
+  min-height: 180px;
   overflow-y: auto;
+  margin-top: var(--space-3);
 }

--- a/frontend/src/pages/ProjectView.tsx
+++ b/frontend/src/pages/ProjectView.tsx
@@ -11,10 +11,7 @@ import ResizeHandle from "../components/common/ResizeHandle";
 import "./ProjectView.css";
 
 const MIN_LEFT = 280;
-const MIN_RIGHT = 400;
 const MIN_TASKS = 120;
-const MIN_CTX = 80;
-const MAX_CTX = 400;
 
 function readStorage(key: string, fallback: number): number {
   const v = localStorage.getItem(key);
@@ -47,9 +44,7 @@ export default function ProjectView() {
   const [tasksHeight, setTasksHeight] = useState(() =>
     readStorage("atc:pv:tasks-h", 240)
   );
-  const [ctxHeight, setCtxHeight] = useState(() =>
-    readStorage("atc:pv:ctx-h", 180)
-  );
+  const [leaderHeight] = useState(() => readStorage("atc:pv:leader-h", 240));
 
   const layoutRef = useRef<HTMLDivElement>(null);
 
@@ -60,8 +55,8 @@ export default function ProjectView() {
     localStorage.setItem("atc:pv:tasks-h", String(tasksHeight));
   }, [tasksHeight]);
   useEffect(() => {
-    localStorage.setItem("atc:pv:ctx-h", String(ctxHeight));
-  }, [ctxHeight]);
+    localStorage.setItem("atc:pv:leader-h", String(leaderHeight));
+  }, [leaderHeight]);
 
   const handleSplitDrag = useCallback(
     (e: React.MouseEvent) => {
@@ -76,7 +71,7 @@ export default function ProjectView() {
           MIN_LEFT,
           Math.min(
             startWidth + ev.clientX - startX,
-            containerWidth - MIN_RIGHT - 4
+            containerWidth - 360 - 4
           )
         );
         setLeftWidth(next);
@@ -115,31 +110,6 @@ export default function ProjectView() {
     [tasksHeight]
   );
 
-  const handleCtxDrag = useCallback(
-    (e: React.MouseEvent) => {
-      e.preventDefault();
-      const startY = e.clientY;
-      const startHeight = ctxHeight;
-
-      const onMove = (ev: MouseEvent) => {
-        // Drag up (negative delta) → context grows; drag down → context shrinks
-        const next = Math.max(
-          MIN_CTX,
-          Math.min(MAX_CTX, startHeight - (ev.clientY - startY))
-        );
-        setCtxHeight(next);
-      };
-
-      const onUp = () => {
-        document.removeEventListener("mousemove", onMove);
-        document.removeEventListener("mouseup", onUp);
-      };
-
-      document.addEventListener("mousemove", onMove);
-      document.addEventListener("mouseup", onUp);
-    },
-    [ctxHeight]
-  );
 
   if (!project) {
     return (
@@ -162,79 +132,63 @@ export default function ProjectView() {
         )}
       </div>
 
-      {/* Main layout: top row (left+right) stacked above full-width context */}
       <div className="project-view__layout" ref={layoutRef}>
-        {/* Top row: left column + vertical handle + right column */}
-        <div className="project-view__top">
-          {/* Left column: tasks + aces */}
-          <aside className="project-view__left" style={{ width: leftWidth }}>
-            <div
-              className="panel project-view__tasks"
-              style={{ height: tasksHeight }}
-            >
-              <TaskBoard
+        <aside className="project-view__left" style={{ width: leftWidth }}>
+          <div className="panel project-view__leader" style={{ minHeight: leaderHeight }}>
+            <LeaderConsole
+              projectId={project.id}
+              leader={leader}
+              project={project}
+              onRefresh={fetchAll}
+            />
+          </div>
+
+          <div
+            className="panel project-view__tasks"
+            style={{ height: tasksHeight }}
+          >
+            <TaskBoard
+              projectId={project.id}
+              taskGraphs={projectTaskGraphs}
+              onRefresh={fetchAll}
+            />
+          </div>
+
+          <ResizeHandle direction="row" onMouseDown={handleTasksDrag} />
+
+          <div
+            className={`panel project-view__aces${activeAceId ? " project-view__aces--expanded" : ""}`}
+          >
+            {activeAceId ? (
+              <AceConsole
                 projectId={project.id}
-                taskGraphs={projectTaskGraphs}
+                sessions={projectSessions}
+                activeAceId={activeAceId}
                 onRefresh={fetchAll}
+                onSelectAce={(sid) => setExpandedAceId(sid)}
+                onCollapse={() => setExpandedAceId(null)}
               />
-            </div>
-
-            <ResizeHandle direction="row" onMouseDown={handleTasksDrag} />
-
-            {/* Aces panel: collapses to list or expands to tabbed console IN-PLACE */}
-            <div
-              className={`panel project-view__aces${activeAceId ? " project-view__aces--expanded" : ""}`}
-            >
-              {activeAceId ? (
-                <AceConsole
-                  projectId={project.id}
-                  sessions={projectSessions}
-                  activeAceId={activeAceId}
-                  onRefresh={fetchAll}
-                  onSelectAce={(sid) => setExpandedAceId(sid)}
-                  onCollapse={() => setExpandedAceId(null)}
-                />
-              ) : (
-                <AceList
-                  projectId={project.id}
-                  sessions={projectSessions}
-                  onRefresh={fetchAll}
-                  onExpand={(sid) => setExpandedAceId(sid)}
-                  compact
-                />
-              )}
-            </div>
-          </aside>
-
-          <ResizeHandle direction="col" onMouseDown={handleSplitDrag} />
-
-          {/* Right column — Leader always here, fills full height of top row */}
-          <main className="project-view__right">
-            <div className="panel project-view__leader">
-              <LeaderConsole
+            ) : (
+              <AceList
                 projectId={project.id}
-                leader={leader}
-                project={project}
+                sessions={projectSessions}
                 onRefresh={fetchAll}
+                onExpand={(sid) => setExpandedAceId(sid)}
+                compact
               />
-            </div>
-          </main>
-        </div>
+            )}
+          </div>
 
-        {/* Context resize handle — sits at top edge of context panel */}
-        <ResizeHandle direction="row" onMouseDown={handleCtxDrag} />
+          <div className="panel project-view__context">
+            <ContextHub
+              scope="project"
+              projectId={project.id}
+              showScopeTabs={false}
+            />
+          </div>
+        </aside>
 
-        {/* Context panel — full width, resizable height */}
-        <div
-          className="panel project-view__context"
-          style={{ height: ctxHeight }}
-        >
-          <ContextHub
-            scope="project"
-            projectId={project.id}
-            showScopeTabs={false}
-          />
-        </div>
+        <ResizeHandle direction="col" onMouseDown={handleSplitDrag} />
       </div>
     </div>
   );

--- a/src/atc/api/routers/projects.py
+++ b/src/atc/api/routers/projects.py
@@ -375,12 +375,18 @@ async def start_leader(
                 lines += ["## Repository", f"Local path: {repo_path}", ""]
             lines += [
                 "## Your Instructions",
-                "1. Decompose the goal into well-scoped tasks using the API.",
-                "2. Spawn Aces for each ready task.",
-                "3. Monitor progress and drive to completion.",
-                "4. Report back when done.",
+                "You are the project Leader, not the implementer.",
+                "Do NOT write product files yourself.",
+                "Operate through the ATC orchestration API only.",
                 "",
-                "Begin NOW. Do not ask for clarification — start decomposing.",
+                "1. First decompose the goal into well-scoped tasks via POST /api/projects/{project_id}/leader/decompose.",
+                "2. Then spawn Aces for ready tasks via POST /api/projects/{project_id}/leader/spawn-aces.",
+                "3. Then instruct spawned Aces via POST /api/projects/{project_id}/leader/instruct.",
+                "4. Monitor progress via GET /api/projects/{project_id}/leader/progress.",
+                "5. Drive the project to completion by delegating, not by coding directly.",
+                "",
+                f"Project ID: {project_id}",
+                "Begin NOW by decomposing, not by exploring the workspace.",
             ]
             kickoff_msg = "\n".join(lines)
 


### PR DESCRIPTION
## Summary
- move Tower into a route-aware shell layout so it occupies the full right side on Dashboard and Project pages
- stack the Project page left column as Leader, Tasks, Aces, then Context/detail for a more usable operator workflow
- add a draggable right-side Tower split with persisted width, plus side-orientation support in `TowerPanel`

## Testing
- cd frontend && npm test -- src/components/tower/__tests__/TowerPanel.test.tsx src/pages/__tests__/Dashboard.test.tsx src/pages/__tests__/ProjectView.test.tsx
- cd frontend && npm run build
