### PR TITLE
fix: allow tower start without active project

### DIFF
--- a/frontend/src/components/tower/TowerPanel.tsx
+++ b/frontend/src/components/tower/TowerPanel.tsx
@@ -242,8 +242,8 @@ export default function TowerPanel({ orientation = "bottom" }: TowerPanelProps) 
           {!showTerminal && (
             <button
               className="btn btn-primary btn-sm"
-              onClick={handleStart}
-              disabled={starting || !resolvedProjectId}
+              onClick={() => void handleStart()}
+              disabled={starting}
               data-testid="tower-panel-start"
             >
               {starting ? "Starting..." : "Start"}

--- a/frontend/src/components/tower/__tests__/TowerPanel.test.tsx
+++ b/frontend/src/components/tower/__tests__/TowerPanel.test.tsx
@@ -68,10 +68,38 @@ describe("TowerPanel", () => {
     expect(screen.getByText("Idle")).toBeInTheDocument();
   });
 
-  it("disables Start button when no project is active", () => {
+  it("keeps Start button enabled when no project is active", () => {
     renderWithProviders(<TowerPanel />);
     const startBtn = screen.getByTestId("tower-panel-start");
-    expect(startBtn).toBeDisabled();
+    expect(startBtn).toBeEnabled();
+  });
+
+  it("posts to tower start without a project id when no project is active", async () => {
+    const user = userEvent.setup();
+    const fetchMock = vi.spyOn(globalThis, "fetch");
+    fetchMock.mockImplementation(async (input, init) => {
+      const url = String(input);
+      if (url === "/api/tower/start") {
+        return new Response(JSON.stringify({ status: "started", session_id: "tower-1" }), { status: 200 });
+      }
+      if (url === "/api/projects" || url === "/api/heartbeat") {
+        return new Response(JSON.stringify([]), { status: 200 });
+      }
+      return new Response(JSON.stringify({}), { status: 200 });
+    });
+
+    renderWithProviders(<TowerPanel />);
+    await user.click(screen.getByTestId("tower-panel-start"));
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith(
+        "/api/tower/start",
+        expect.objectContaining({
+          method: "POST",
+          body: JSON.stringify({}),
+        }),
+      );
+    });
   });
 
   it("collapses when toggle is clicked again", async () => {


### PR DESCRIPTION
## Summary
- allow the Tower Start button to work even when no project is active
- keep Tower start global by posting an empty body to /api/tower/start
- add regression coverage for the no-project start path

## Testing
- cd frontend && npm run test -- TowerPanel.test.tsx
