### PR TITLE
feat: default ATC provider to codex

### DIFF
--- a/frontend/src/components/common/CreateProjectModal.tsx
+++ b/frontend/src/components/common/CreateProjectModal.tsx
@@ -20,7 +20,7 @@ export default function CreateProjectModal({
   const [description, setDescription] = useState("");
   const [repoPath, setRepoPath] = useState("");
   const [githubRepo, setGithubRepo] = useState("");
-  const [agentProvider, setAgentProvider] = useState<Project["agent_provider"]>("claude_code");
+  const [agentProvider, setAgentProvider] = useState<Project["agent_provider"]>("codex");
   const [providers, setProviders] = useState<ProviderInfo[]>([]);
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);

--- a/frontend/src/components/tower/SettingsPane.tsx
+++ b/frontend/src/components/tower/SettingsPane.tsx
@@ -13,7 +13,7 @@ interface Props {
 const GITHUB_ORG_KEY = "atc:github_default_org";
 
 const EMPTY_PROVIDER_CONFIG: AgentProviderConfig = {
-  default: "claude_code",
+  default: "codex",
   opencode_url: "http://localhost:4096",
   tmux_session: "atc",
   claude_command: "claude",

--- a/src/atc/api/routers/projects.py
+++ b/src/atc/api/routers/projects.py
@@ -31,7 +31,7 @@ class CreateProjectRequest(BaseModel):
     description: str | None = None
     repo_path: str | None = None
     github_repo: str | None = None
-    agent_provider: str = "claude_code"
+    agent_provider: str = "codex"
 
 
 class ProjectResponse(BaseModel):
@@ -41,7 +41,7 @@ class ProjectResponse(BaseModel):
     description: str | None = None
     repo_path: str | None = None
     github_repo: str | None = None
-    agent_provider: str = "claude_code"
+    agent_provider: str = "codex"
     position: int = 0
     created_at: str
     updated_at: str

--- a/src/atc/config.py
+++ b/src/atc/config.py
@@ -86,7 +86,7 @@ class QALoopConfig(BaseModel):
 class AgentProviderConfig(BaseModel):
     """Configuration for the agent provider abstraction layer."""
 
-    default: str = "claude_code"
+    default: str = "codex"
     opencode_url: str = "http://localhost:4096"
     opencode_username: str | None = None
     opencode_password: str | None = None

--- a/src/atc/state/db.py
+++ b/src/atc/state/db.py
@@ -635,7 +635,7 @@ async def create_project(
     description: str | None = None,
     repo_path: str | None = None,
     github_repo: str | None = None,
-    agent_provider: str = "claude_code",
+    agent_provider: str = "codex",
 ) -> Project:
     """Insert a new project row and return the dataclass."""
     now = _now()
@@ -902,7 +902,7 @@ async def create_session(
     session_type: str,
     name: str,
     *,
-    provider: str = "claude_code",
+    provider: str = "codex",
     scope_type: str = "project",
     scope_id: str | None = None,
     task_id: str | None = None,

--- a/src/atc/state/models.py
+++ b/src/atc/state/models.py
@@ -15,7 +15,7 @@ class Project:
     description: str | None = None
     repo_path: str | None = None
     github_repo: str | None = None
-    agent_provider: str = "claude_code"
+    agent_provider: str = "codex"
     position: int = 0
     created_at: str = ""
     updated_at: str = ""
@@ -49,7 +49,7 @@ class Session:
     session_type: str  # ace|manager|tower
     name: str
     status: str  # idle|connecting|working|paused|waiting|disconnected|error
-    provider: str = "claude_code"
+    provider: str = "codex"
     scope_type: str = "project"  # global|project
     scope_id: str | None = None
     task_id: str | None = None

--- a/tests/unit/test_agent_provider.py
+++ b/tests/unit/test_agent_provider.py
@@ -606,7 +606,7 @@ class TestConfigIntegration:
         from atc.config import AgentProviderConfig
 
         cfg = AgentProviderConfig()
-        assert cfg.default == "claude_code"
+        assert cfg.default == "codex"
         assert cfg.opencode_url == "http://localhost:4096"
         assert cfg.codex_command == "codex"
         assert cfg.tmux_session == "atc"
@@ -615,7 +615,7 @@ class TestConfigIntegration:
         from atc.config import Settings
 
         settings = Settings()
-        assert settings.agent_provider.default == "claude_code"
+        assert settings.agent_provider.default == "codex"
         assert settings.agent_provider.codex_command == "codex"
 
     def test_create_provider_from_config(self) -> None:


### PR DESCRIPTION
## Summary
- switch ATC's default provider configuration from Claude Code to Codex
- make new projects and in-memory model defaults start on Codex by default
- update config/unit expectations to match the new default

## Testing
- PYTHONPATH=src pytest tests/unit/test_agent_provider.py tests/unit/test_reconnect_runtime_semantics.py
- cd frontend && npm run test -- TowerPanel.test.tsx
