### PR TITLE
fix: include user local bin in tmux PATH

### DIFF
--- a/src/atc/runtime/tmux/substrate.py
+++ b/src/atc/runtime/tmux/substrate.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import os
+import shlex
 import shutil
 from pathlib import Path
 
@@ -103,6 +104,7 @@ def build_path_env_prefix(*, current_path: str | None = None, home: str | None =
     candidates = [
         "/usr/local/bin",
         "/opt/homebrew/bin",
+        f"{home}/.local/bin",
         f"{home}/.nvm/current/bin",
         f"{home}/.volta/bin",
         f"{home}/.asdf/shims",
@@ -112,4 +114,4 @@ def build_path_env_prefix(*, current_path: str | None = None, home: str | None =
     if not extras:
         return ""
     enriched = ":".join(extras) + ":" + current_path
-    return f"PATH={enriched!s} "
+    return f"PATH={shlex.quote(enriched)} "

--- a/tests/unit/test_tmux_substrate.py
+++ b/tests/unit/test_tmux_substrate.py
@@ -12,3 +12,27 @@ def test_resolve_tmux_binary_returns_string() -> None:
 def test_build_path_env_prefix_returns_string() -> None:
     result = build_path_env_prefix(current_path="/usr/bin", home="/tmp/does-not-matter")
     assert isinstance(result, str)
+
+
+def test_build_path_env_prefix_includes_user_local_bin(tmp_path) -> None:
+    home = tmp_path / "home"
+    local_bin = home / ".local" / "bin"
+    local_bin.mkdir(parents=True)
+
+    result = build_path_env_prefix(current_path="/usr/bin", home=str(home))
+
+    assert result.startswith("PATH=")
+    assert str(local_bin) in result
+    assert result.endswith(" ")
+
+
+def test_build_path_env_prefix_quotes_paths_with_spaces(tmp_path) -> None:
+    home = tmp_path / "home with spaces"
+    local_bin = home / ".local" / "bin"
+    local_bin.mkdir(parents=True)
+
+    result = build_path_env_prefix(current_path="/usr/bin", home=str(home))
+
+    assert result.startswith("PATH=")
+    assert "'" in result
+    assert str(local_bin) in result


### PR DESCRIPTION
## Summary
- add `~/.local/bin` to tmux PATH enrichment so default `codex` resolves on Mac Studio/user-local installs
- shell-quote the enriched PATH before passing it into tmux shell commands
- add unit coverage for `~/.local/bin` inclusion and paths containing spaces

## Verification
- `pytest tests/unit/test_tmux_substrate.py tests/unit/test_codex_runtime.py tests/unit/test_runtime_service.py tests/e2e/test_smoke.py -q` — 42 passed
- `ruff check src/atc/runtime/tmux/substrate.py tests/unit/test_tmux_substrate.py` — passed
- Playwright focused Mac Studio verification with `codex_command=codex`: Tower Codex session stayed alive and Tower terminal rendered the Codex trust prompt.

## Evidence
- Report: `/private/tmp/atc-work/test-results/codex-default-path-2026-06-07T05-24-37-886Z/report.json`
- Screenshot: `/private/tmp/atc-work/test-results/codex-default-path-2026-06-07T05-24-37-886Z/00-project-before-tower-ready.png`
- Screenshot: `/private/tmp/atc-work/test-results/codex-default-path-2026-06-07T05-24-37-886Z/01-tower-terminal-codex-prompt-visible.png`

## Notes
- Broad frontend `npm test -- --run` is currently failing on pre-existing/unrelated test harness and stale expectation issues (e.g. Playwright specs loaded by Vitest, missing localStorage in jsdom, text expectation drift). No frontend files were changed by this PR.
