### PR TITLE
Phase 1: add runtime delivery trace events

### DIFF
--- a/src/atc/api/app.py
+++ b/src/atc/api/app.py
@@ -567,6 +567,7 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
     await heartbeat_monitor.stop()
     await pty_pool.stop()
     await event_bus.stop()
+    clear_connection_app_state(db)
     await db.close()
 
 
@@ -666,6 +667,7 @@ def create_app(settings: Settings | None = None) -> FastAPI:
     # Register routers
     from atc.api.routers import (
         aces,
+        app_events,
         backup,
         context,
         failure_logs,
@@ -690,6 +692,7 @@ def create_app(settings: Settings | None = None) -> FastAPI:
     app.include_router(task_graphs.router, prefix="/api", tags=["task_graphs"])
     app.include_router(leader.router, prefix="/api", tags=["leader"])
     app.include_router(aces.router, prefix="/api", tags=["aces"])
+    app.include_router(app_events.router, prefix="/api", tags=["app_events"])
     app.include_router(usage.router, prefix="/api/usage", tags=["usage"])
     app.include_router(settings_router.router, prefix="/api/settings", tags=["settings"])
     app.include_router(failure_logs.router, prefix="/api", tags=["failure_logs"])

--- a/src/atc/api/routers/app_events.py
+++ b/src/atc/api/routers/app_events.py
@@ -48,9 +48,12 @@ async def get_event_count(
     level: str | None = Query(None),
     category: str | None = Query(None),
     project_id: str | None = Query(None),
+    session_id: str | None = Query(None),
 ) -> EventCountResponse:
     db = await _get_db(request)
-    total = await count_events(db, level=level, category=category, project_id=project_id)
+    total = await count_events(
+        db, level=level, category=category, project_id=project_id, session_id=session_id
+    )
     return EventCountResponse(count=total)
 
 
@@ -60,6 +63,7 @@ async def get_app_events(
     level: str | None = Query(None),
     category: str | None = Query(None),
     project_id: str | None = Query(None),
+    session_id: str | None = Query(None),
     limit: int = Query(200, ge=1, le=1000),
     offset: int = Query(0, ge=0),
 ) -> list[AppEventResponse]:
@@ -69,6 +73,7 @@ async def get_app_events(
         level=level,
         category=category,
         project_id=project_id,
+        session_id=session_id,
         limit=limit,
         offset=offset,
     )
@@ -81,9 +86,12 @@ async def export_app_events(
     level: str | None = Query(None),
     category: str | None = Query(None),
     project_id: str | None = Query(None),
+    session_id: str | None = Query(None),
 ) -> StreamingResponse:
     db = await _get_db(request)
-    events = await export_events_json(db, level=level, category=category, project_id=project_id)
+    events = await export_events_json(
+        db, level=level, category=category, project_id=project_id, session_id=session_id
+    )
     buf = io.BytesIO()
     with zipfile.ZipFile(buf, "w", zipfile.ZIP_DEFLATED) as zf:
         payload = json.dumps(events, indent=2, default=str)

--- a/src/atc/core/app_events.py
+++ b/src/atc/core/app_events.py
@@ -92,6 +92,7 @@ async def list_events(
     level: str | None = None,
     category: str | None = None,
     project_id: str | None = None,
+    session_id: str | None = None,
     limit: int = 200,
     offset: int = 0,
 ) -> list[dict[str, Any]]:
@@ -108,6 +109,9 @@ async def list_events(
     if project_id:
         clauses.append("project_id = ?")
         params.append(project_id)
+    if session_id:
+        clauses.append("session_id = ?")
+        params.append(session_id)
 
     where = " WHERE " + " AND ".join(clauses) if clauses else ""
     params.extend([limit, offset])
@@ -133,6 +137,7 @@ async def count_events(
     level: str | None = None,
     category: str | None = None,
     project_id: str | None = None,
+    session_id: str | None = None,
 ) -> int:
     """Return count of matching events."""
     clauses: list[str] = []
@@ -147,6 +152,9 @@ async def count_events(
     if project_id:
         clauses.append("project_id = ?")
         params.append(project_id)
+    if session_id:
+        clauses.append("session_id = ?")
+        params.append(session_id)
 
     where = " WHERE " + " AND ".join(clauses) if clauses else ""
 
@@ -164,7 +172,15 @@ async def export_events_json(
     level: str | None = None,
     category: str | None = None,
     project_id: str | None = None,
+    session_id: str | None = None,
     limit: int = 10000,
 ) -> list[dict[str, Any]]:
     """Export events as a list of dicts (for zip packaging)."""
-    return await list_events(db, level=level, category=category, project_id=project_id, limit=limit)
+    return await list_events(
+        db,
+        level=level,
+        category=category,
+        project_id=project_id,
+        session_id=session_id,
+        limit=limit,
+    )

--- a/src/atc/providers/claude_code/runtime.py
+++ b/src/atc/providers/claude_code/runtime.py
@@ -11,7 +11,6 @@ from atc.runtime.models import (
     InstructionRequest,
     ReadinessResult,
     ReadinessState,
-    RoleKind,
     RuntimeBlockReason,
     RuntimeInspection,
     RuntimeSessionHandle,
@@ -28,6 +27,14 @@ from atc.runtime.tmux.substrate import (
     kill_pane,
     pane_exists,
     spawn_window_pane,
+)
+from atc.runtime.tracing import (
+    DeliveryAction,
+    DeliveryReasonCode,
+    DeliveryStage,
+    DeliveryVerdict,
+    append_trace_event,
+    trace_event,
 )
 
 _BARE_PROMPT_RE = re.compile(r"(^|\n)\s*❯\s*$", re.MULTILINE)
@@ -105,30 +112,159 @@ class ClaudeCodeRuntime(ProviderRuntime):
         handle: RuntimeSessionHandle,
         request: InstructionRequest,
     ) -> None:
+        trace_id = str(request.metadata.get("delivery_trace_id") or "")
         if not handle.tmux_pane:
+            self._append_instruction_trace(
+                request,
+                handle,
+                trace_id,
+                DeliveryStage.FAILED,
+                DeliveryVerdict.FAILED,
+                DeliveryReasonCode.PANE_MISSING,
+            )
             raise RuntimeSessionMissingError("Claude session has no tmux pane recorded")
         if not await pane_exists(handle.tmux_pane):
+            self._append_instruction_trace(
+                request,
+                handle,
+                trace_id,
+                DeliveryStage.FAILED,
+                DeliveryVerdict.FAILED,
+                DeliveryReasonCode.PANE_MISSING,
+            )
             raise RuntimeSessionMissingError("Claude session pane is missing")
 
         text = request.message or ""
         if not text and request.message_file:
-            text = open(request.message_file, encoding="utf-8").read()
+            with open(request.message_file, encoding="utf-8") as f:
+                text = f.read()
         if not text:
+            self._append_instruction_trace(
+                request,
+                handle,
+                trace_id,
+                DeliveryStage.FAILED,
+                DeliveryVerdict.FAILED,
+                DeliveryReasonCode.EMPTY_PAYLOAD,
+            )
             raise RuntimeDeliveryError("Instruction payload was empty")
 
+        before = await capture_pane_text(handle.tmux_pane, lines=40)
+        before_state = self._prompt_state_for_excerpt(before)
+        self._append_instruction_trace(
+            request,
+            handle,
+            trace_id,
+            DeliveryStage.WRITE_STARTED,
+            DeliveryVerdict.PENDING,
+            DeliveryReasonCode.PTY_WRITE_STARTED,
+            prompt_state_before=before_state,
+            first_output_excerpt=before,
+        )
         await send_bracketed_instruction(self.tmux_session, handle.tmux_pane, text)
+        self._append_instruction_trace(
+            request,
+            handle,
+            trace_id,
+            DeliveryStage.SUBMIT_ATTEMPTED,
+            DeliveryVerdict.ACCEPTED,
+            DeliveryReasonCode.SUBMIT_SENT,
+            prompt_state_before=before_state,
+        )
         await asyncio.sleep(0.75)
         output = await capture_pane_text(handle.tmux_pane, lines=80)
+        after_state = self._prompt_state_for_excerpt(output)
         lowered = output.lower()
         fingerprint = text[:80].strip()
 
+        self._append_instruction_trace(
+            request,
+            handle,
+            trace_id,
+            DeliveryStage.WRITTEN_TO_PTY,
+            DeliveryVerdict.ACCEPTED,
+            DeliveryReasonCode.PTY_WRITE_ACCEPTED,
+            prompt_state_before=before_state,
+            prompt_state_after=after_state,
+            first_output_excerpt=output,
+        )
+        if after_state == "blocked:trust":
+            self._append_instruction_trace(
+                request,
+                handle,
+                trace_id,
+                DeliveryStage.BLOCKED,
+                DeliveryVerdict.BLOCKED,
+                DeliveryReasonCode.TRUST_REQUIRED,
+                prompt_state_before=before_state,
+                prompt_state_after=after_state,
+                first_output_excerpt=output,
+            )
+            return
+        if after_state == "blocked:auth":
+            self._append_instruction_trace(
+                request,
+                handle,
+                trace_id,
+                DeliveryStage.BLOCKED,
+                DeliveryVerdict.BLOCKED,
+                DeliveryReasonCode.AUTH_REQUIRED,
+                prompt_state_before=before_state,
+                prompt_state_after=after_state,
+                first_output_excerpt=output,
+            )
+            return
         if fingerprint and fingerprint in output:
+            self._append_instruction_trace(
+                request,
+                handle,
+                trace_id,
+                DeliveryStage.AGENT_OUTPUT_OBSERVED,
+                DeliveryVerdict.CONFIRMED,
+                DeliveryReasonCode.AGENT_OUTPUT,
+                prompt_state_before=before_state,
+                prompt_state_after=after_state,
+                first_output_excerpt=output,
+            )
             return
         if any(trigger in lowered for trigger in _WELCOME_TRIGGERS):
+            self._append_instruction_trace(
+                request,
+                handle,
+                trace_id,
+                DeliveryStage.AGENT_OUTPUT_OBSERVED,
+                DeliveryVerdict.ACCEPTED,
+                DeliveryReasonCode.AGENT_OUTPUT,
+                prompt_state_before=before_state,
+                prompt_state_after=after_state,
+                first_output_excerpt=output,
+            )
             return
         if not _BARE_PROMPT_RE.search(output):
+            self._append_instruction_trace(
+                request,
+                handle,
+                trace_id,
+                DeliveryStage.CONFIRMED_RUNNING,
+                DeliveryVerdict.CONFIRMED,
+                DeliveryReasonCode.SESSION_RUNNING,
+                prompt_state_before=before_state,
+                prompt_state_after=after_state,
+                first_output_excerpt=output,
+            )
             return
 
+        self._append_instruction_trace(
+            request,
+            handle,
+            trace_id,
+            DeliveryStage.FAILED,
+            DeliveryVerdict.FAILED,
+            DeliveryReasonCode.DELIVERY_UNVERIFIED,
+            prompt_state_before=before_state,
+            prompt_state_after=after_state,
+            first_output_excerpt=output,
+        )
         raise RuntimeDeliveryError("Claude instruction delivery could not be verified")
 
     async def assign_task(
@@ -138,7 +274,8 @@ class ClaudeCodeRuntime(ProviderRuntime):
     ) -> None:
         text = request.message
         if not text and request.message_file:
-            text = open(request.message_file, encoding="utf-8").read()
+            with open(request.message_file, encoding="utf-8") as f:
+                text = f.read()
         await self.send_instruction(
             handle,
             InstructionRequest(
@@ -146,6 +283,7 @@ class ClaudeCodeRuntime(ProviderRuntime):
                 message=text,
                 context_ref=request.context_ref,
                 instruction_id=request.assignment_id or request.task_id,
+                metadata=request.metadata,
             ),
         )
 
@@ -188,7 +326,9 @@ class ClaudeCodeRuntime(ProviderRuntime):
             last_output_excerpt=excerpt,
         )
         inspection.details["provider_runtime_hint"] = self._runtime_hint_for_inspection(inspection)
-        inspection.details["provider_runtime_action"] = self._runtime_action_for_inspection(inspection)
+        inspection.details["provider_runtime_action"] = self._runtime_action_for_inspection(
+            inspection
+        )
         return inspection
 
     def _runtime_hint_for_inspection(self, inspection: RuntimeInspection) -> str:
@@ -199,9 +339,15 @@ class ClaudeCodeRuntime(ProviderRuntime):
             if any(trigger in lowered for trigger in _WELCOME_TRIGGERS):
                 return "startup_banner"
             return "processing"
-        if inspection.readiness is ReadinessState.BLOCKED and inspection.block_reason is RuntimeBlockReason.TRUST:
+        if (
+            inspection.readiness is ReadinessState.BLOCKED
+            and inspection.block_reason is RuntimeBlockReason.TRUST
+        ):
             return "trust_prompt"
-        if inspection.readiness is ReadinessState.BLOCKED and inspection.block_reason is RuntimeBlockReason.AUTH:
+        if (
+            inspection.readiness is ReadinessState.BLOCKED
+            and inspection.block_reason is RuntimeBlockReason.AUTH
+        ):
             return "auth_prompt"
         if inspection.readiness is ReadinessState.STOPPED:
             return "pane_missing"
@@ -212,9 +358,15 @@ class ClaudeCodeRuntime(ProviderRuntime):
             return "send_or_resume"
         if inspection.readiness is ReadinessState.BUSY:
             return "wait"
-        if inspection.readiness is ReadinessState.BLOCKED and inspection.block_reason is RuntimeBlockReason.TRUST:
+        if (
+            inspection.readiness is ReadinessState.BLOCKED
+            and inspection.block_reason is RuntimeBlockReason.TRUST
+        ):
             return "resolve_trust"
-        if inspection.readiness is ReadinessState.BLOCKED and inspection.block_reason is RuntimeBlockReason.AUTH:
+        if (
+            inspection.readiness is ReadinessState.BLOCKED
+            and inspection.block_reason is RuntimeBlockReason.AUTH
+        ):
             return "resolve_auth"
         if inspection.readiness is ReadinessState.STOPPED:
             return "respawn"
@@ -266,9 +418,15 @@ class ClaudeCodeRuntime(ProviderRuntime):
             if any(trigger in lowered for trigger in _WELCOME_TRIGGERS):
                 return "warming_up"
             return "active"
-        if inspection.readiness is ReadinessState.BLOCKED and inspection.block_reason is RuntimeBlockReason.TRUST:
+        if (
+            inspection.readiness is ReadinessState.BLOCKED
+            and inspection.block_reason is RuntimeBlockReason.TRUST
+        ):
             return "trust_gate"
-        if inspection.readiness is ReadinessState.BLOCKED and inspection.block_reason is RuntimeBlockReason.AUTH:
+        if (
+            inspection.readiness is ReadinessState.BLOCKED
+            and inspection.block_reason is RuntimeBlockReason.AUTH
+        ):
             return "auth_gate"
         if inspection.readiness is ReadinessState.STOPPED:
             return "missing"
@@ -279,9 +437,15 @@ class ClaudeCodeRuntime(ProviderRuntime):
             return "resume"
         if inspection.readiness is ReadinessState.BUSY:
             return "wait"
-        if inspection.readiness is ReadinessState.BLOCKED and inspection.block_reason is RuntimeBlockReason.TRUST:
+        if (
+            inspection.readiness is ReadinessState.BLOCKED
+            and inspection.block_reason is RuntimeBlockReason.TRUST
+        ):
             return "resolve_trust"
-        if inspection.readiness is ReadinessState.BLOCKED and inspection.block_reason is RuntimeBlockReason.AUTH:
+        if (
+            inspection.readiness is ReadinessState.BLOCKED
+            and inspection.block_reason is RuntimeBlockReason.AUTH
+        ):
             return "resolve_auth"
         if inspection.readiness is ReadinessState.STOPPED:
             return "respawn"
@@ -298,6 +462,51 @@ class ClaudeCodeRuntime(ProviderRuntime):
         if _BARE_PROMPT_RE.search(excerpt):
             return ReadinessState.READY, None
         return ReadinessState.BUSY, None
+
+    def _prompt_state_for_excerpt(self, excerpt: str) -> str:
+        readiness, block_reason = self._classify_readiness(excerpt)
+        if block_reason is not None:
+            return f"{readiness.value}:{block_reason.value}"
+        return readiness.value
+
+    @staticmethod
+    def _append_instruction_trace(
+        request: InstructionRequest,
+        handle: RuntimeSessionHandle,
+        trace_id: str,
+        stage: DeliveryStage,
+        verdict: DeliveryVerdict,
+        reason_code: DeliveryReasonCode,
+        *,
+        prompt_state_before: str | None = None,
+        prompt_state_after: str | None = None,
+        first_output_excerpt: str | None = None,
+    ) -> None:
+        if not trace_id:
+            return
+        raw_action = request.metadata.get("delivery_action")
+        action = (
+            DeliveryAction.TASK_ASSIGNMENT
+            if raw_action == DeliveryAction.TASK_ASSIGNMENT.value
+            else DeliveryAction.INSTRUCTION
+        )
+        append_trace_event(
+            request.metadata,
+            trace_event(
+                trace_id=trace_id,
+                session_id=handle.session_id,
+                role=handle.role.value,
+                provider=handle.provider_name,
+                pane_id=handle.tmux_pane,
+                action=action,
+                stage=stage,
+                verdict=verdict,
+                reason_code=reason_code,
+                prompt_state_before=prompt_state_before,
+                prompt_state_after=prompt_state_after,
+                first_output_excerpt=first_output_excerpt,
+            ),
+        )
 
     @staticmethod
     def _summary_for_state(

--- a/src/atc/providers/codex/runtime.py
+++ b/src/atc/providers/codex/runtime.py
@@ -27,6 +27,14 @@ from atc.runtime.tmux.substrate import (
     pane_exists,
     spawn_window_pane,
 )
+from atc.runtime.tracing import (
+    DeliveryAction,
+    DeliveryReasonCode,
+    DeliveryStage,
+    DeliveryVerdict,
+    append_trace_event,
+    trace_event,
+)
 
 _CODEX_PROMPT_RE = re.compile(r"(^|\n)\s*(❯|>)\s*$", re.MULTILINE)
 _AUTH_TRIGGERS = (
@@ -34,6 +42,11 @@ _AUTH_TRIGGERS = (
     "sign in",
     "authentication",
     "api key",
+)
+_TRUST_TRIGGERS = (
+    "trust this folder",
+    "do you trust",
+    "trust the contents",
 )
 
 
@@ -94,16 +107,107 @@ class CodexRuntime(ProviderRuntime):
         handle: RuntimeSessionHandle,
         request: InstructionRequest,
     ) -> None:
+        trace_id = str(request.metadata.get("delivery_trace_id") or "")
         if not handle.tmux_pane:
+            self._append_instruction_trace(
+                request,
+                handle,
+                trace_id,
+                DeliveryStage.FAILED,
+                DeliveryVerdict.FAILED,
+                DeliveryReasonCode.PANE_MISSING,
+            )
             raise RuntimeSessionMissingError("Codex session has no tmux pane recorded")
         if not await pane_exists(handle.tmux_pane):
+            self._append_instruction_trace(
+                request,
+                handle,
+                trace_id,
+                DeliveryStage.FAILED,
+                DeliveryVerdict.FAILED,
+                DeliveryReasonCode.PANE_MISSING,
+            )
             raise RuntimeSessionMissingError("Codex session pane is missing")
         text = request.message or ""
         if not text and request.message_file:
-            text = open(request.message_file, encoding="utf-8").read()
+            with open(request.message_file, encoding="utf-8") as f:
+                text = f.read()
         if not text:
+            self._append_instruction_trace(
+                request,
+                handle,
+                trace_id,
+                DeliveryStage.FAILED,
+                DeliveryVerdict.FAILED,
+                DeliveryReasonCode.EMPTY_PAYLOAD,
+            )
             raise RuntimeDeliveryError("Instruction payload was empty")
+
+        before = await capture_pane_text(handle.tmux_pane, lines=40)
+        before_state = self._prompt_state_for_excerpt(before)
+        self._append_instruction_trace(
+            request,
+            handle,
+            trace_id,
+            DeliveryStage.WRITE_STARTED,
+            DeliveryVerdict.PENDING,
+            DeliveryReasonCode.PTY_WRITE_STARTED,
+            prompt_state_before=before_state,
+            first_output_excerpt=before,
+        )
         await send_bracketed_instruction(self.tmux_session, handle.tmux_pane, text)
+        after = await capture_pane_text(handle.tmux_pane, lines=80)
+        after_state = self._prompt_state_for_excerpt(after)
+        self._append_instruction_trace(
+            request,
+            handle,
+            trace_id,
+            DeliveryStage.WRITTEN_TO_PTY,
+            DeliveryVerdict.ACCEPTED,
+            DeliveryReasonCode.PTY_WRITE_ACCEPTED,
+            prompt_state_before=before_state,
+            prompt_state_after=after_state,
+            first_output_excerpt=after,
+        )
+        self._append_instruction_trace(
+            request,
+            handle,
+            trace_id,
+            DeliveryStage.SUBMIT_ATTEMPTED,
+            DeliveryVerdict.ACCEPTED,
+            DeliveryReasonCode.SUBMIT_SENT,
+            prompt_state_before=before_state,
+            prompt_state_after=after_state,
+        )
+        terminal_stage = DeliveryStage.CONFIRMED_RUNNING
+        terminal_reason = DeliveryReasonCode.SESSION_RUNNING
+        terminal_verdict = DeliveryVerdict.CONFIRMED
+        if after_state == "blocked:trust":
+            terminal_stage = DeliveryStage.BLOCKED
+            terminal_reason = DeliveryReasonCode.TRUST_REQUIRED
+            terminal_verdict = DeliveryVerdict.BLOCKED
+        elif after_state == "blocked:auth":
+            terminal_stage = DeliveryStage.BLOCKED
+            terminal_reason = DeliveryReasonCode.AUTH_REQUIRED
+            terminal_verdict = DeliveryVerdict.BLOCKED
+        elif _CODEX_PROMPT_RE.search(after):
+            terminal_stage = DeliveryStage.PROMPT_CLEARED
+            terminal_reason = DeliveryReasonCode.PROMPT_STILL_VISIBLE
+            terminal_verdict = DeliveryVerdict.ACCEPTED
+        elif after.strip():
+            terminal_stage = DeliveryStage.AGENT_OUTPUT_OBSERVED
+            terminal_reason = DeliveryReasonCode.AGENT_OUTPUT
+        self._append_instruction_trace(
+            request,
+            handle,
+            trace_id,
+            terminal_stage,
+            terminal_verdict,
+            terminal_reason,
+            prompt_state_before=before_state,
+            prompt_state_after=after_state,
+            first_output_excerpt=after,
+        )
 
     async def assign_task(
         self,
@@ -112,7 +216,8 @@ class CodexRuntime(ProviderRuntime):
     ) -> None:
         text = request.message
         if not text and request.message_file:
-            text = open(request.message_file, encoding="utf-8").read()
+            with open(request.message_file, encoding="utf-8") as f:
+                text = f.read()
         await self.send_instruction(
             handle,
             InstructionRequest(
@@ -120,6 +225,7 @@ class CodexRuntime(ProviderRuntime):
                 message=text,
                 context_ref=request.context_ref,
                 instruction_id=request.assignment_id or request.task_id,
+                metadata=request.metadata,
             ),
         )
 
@@ -162,7 +268,9 @@ class CodexRuntime(ProviderRuntime):
             last_output_excerpt=excerpt,
         )
         inspection.details["provider_runtime_hint"] = self._runtime_hint_for_inspection(inspection)
-        inspection.details["provider_runtime_action"] = self._runtime_action_for_inspection(inspection)
+        inspection.details["provider_runtime_action"] = self._runtime_action_for_inspection(
+            inspection
+        )
         return inspection
 
     def _runtime_hint_for_inspection(self, inspection: RuntimeInspection) -> str:
@@ -170,7 +278,10 @@ class CodexRuntime(ProviderRuntime):
             return "prompt_visible"
         if inspection.readiness is ReadinessState.BUSY:
             return "processing"
-        if inspection.readiness is ReadinessState.BLOCKED and inspection.block_reason is RuntimeBlockReason.AUTH:
+        if (
+            inspection.readiness is ReadinessState.BLOCKED
+            and inspection.block_reason is RuntimeBlockReason.AUTH
+        ):
             return "auth_prompt"
         if inspection.readiness is ReadinessState.STOPPED:
             return "pane_missing"
@@ -181,7 +292,10 @@ class CodexRuntime(ProviderRuntime):
             return "send_or_resume"
         if inspection.readiness is ReadinessState.BUSY:
             return "wait"
-        if inspection.readiness is ReadinessState.BLOCKED and inspection.block_reason is RuntimeBlockReason.AUTH:
+        if (
+            inspection.readiness is ReadinessState.BLOCKED
+            and inspection.block_reason is RuntimeBlockReason.AUTH
+        ):
             return "resolve_auth"
         if inspection.readiness is ReadinessState.STOPPED:
             return "respawn"
@@ -230,7 +344,10 @@ class CodexRuntime(ProviderRuntime):
             return "ready"
         if inspection.readiness is ReadinessState.BUSY:
             return "active"
-        if inspection.readiness is ReadinessState.BLOCKED and inspection.block_reason is RuntimeBlockReason.AUTH:
+        if (
+            inspection.readiness is ReadinessState.BLOCKED
+            and inspection.block_reason is RuntimeBlockReason.AUTH
+        ):
             return "auth_gate"
         if inspection.readiness is ReadinessState.STOPPED:
             return "missing"
@@ -241,7 +358,10 @@ class CodexRuntime(ProviderRuntime):
             return "resume"
         if inspection.readiness is ReadinessState.BUSY:
             return "wait"
-        if inspection.readiness is ReadinessState.BLOCKED and inspection.block_reason is RuntimeBlockReason.AUTH:
+        if (
+            inspection.readiness is ReadinessState.BLOCKED
+            and inspection.block_reason is RuntimeBlockReason.AUTH
+        ):
             return "resolve_auth"
         if inspection.readiness is ReadinessState.STOPPED:
             return "respawn"
@@ -249,11 +369,58 @@ class CodexRuntime(ProviderRuntime):
 
     def _classify_readiness(self, excerpt: str) -> tuple[ReadinessState, RuntimeBlockReason | None]:
         lowered = excerpt.lower()
+        if any(trigger in lowered for trigger in _TRUST_TRIGGERS):
+            return ReadinessState.BLOCKED, RuntimeBlockReason.TRUST
         if any(trigger in lowered for trigger in _AUTH_TRIGGERS):
             return ReadinessState.BLOCKED, RuntimeBlockReason.AUTH
         if _CODEX_PROMPT_RE.search(excerpt):
             return ReadinessState.READY, None
         return ReadinessState.BUSY, None
+
+    def _prompt_state_for_excerpt(self, excerpt: str) -> str:
+        readiness, block_reason = self._classify_readiness(excerpt)
+        if block_reason is not None:
+            return f"{readiness.value}:{block_reason.value}"
+        return readiness.value
+
+    @staticmethod
+    def _append_instruction_trace(
+        request: InstructionRequest,
+        handle: RuntimeSessionHandle,
+        trace_id: str,
+        stage: DeliveryStage,
+        verdict: DeliveryVerdict,
+        reason_code: DeliveryReasonCode,
+        *,
+        prompt_state_before: str | None = None,
+        prompt_state_after: str | None = None,
+        first_output_excerpt: str | None = None,
+    ) -> None:
+        if not trace_id:
+            return
+        raw_action = request.metadata.get("delivery_action")
+        action = (
+            DeliveryAction.TASK_ASSIGNMENT
+            if raw_action == DeliveryAction.TASK_ASSIGNMENT.value
+            else DeliveryAction.INSTRUCTION
+        )
+        append_trace_event(
+            request.metadata,
+            trace_event(
+                trace_id=trace_id,
+                session_id=handle.session_id,
+                role=handle.role.value,
+                provider=handle.provider_name,
+                pane_id=handle.tmux_pane,
+                action=action,
+                stage=stage,
+                verdict=verdict,
+                reason_code=reason_code,
+                prompt_state_before=prompt_state_before,
+                prompt_state_after=prompt_state_after,
+                first_output_excerpt=first_output_excerpt,
+            ),
+        )
 
     @staticmethod
     def _summary_for_state(

--- a/src/atc/runtime/service.py
+++ b/src/atc/runtime/service.py
@@ -2,7 +2,8 @@
 
 from __future__ import annotations
 
-from atc.providers.base import ProviderRuntime
+from typing import TYPE_CHECKING
+
 from atc.providers.registry import create_provider_runtime, runtime_kwargs_for_provider
 from atc.runtime.models import (
     InstructionRequest,
@@ -14,6 +15,19 @@ from atc.runtime.models import (
     StopRoleRequest,
     TaskAssignmentRequest,
 )
+from atc.runtime.tracing import (
+    DeliveryAction,
+    DeliveryReasonCode,
+    DeliveryStage,
+    DeliveryVerdict,
+    append_trace_event,
+    new_trace_id,
+    trace_event,
+)
+from atc.state.db import get_connection_app_state
+
+if TYPE_CHECKING:
+    from atc.providers.base import ProviderRuntime
 
 
 class RuntimeService:
@@ -27,15 +41,25 @@ class RuntimeService:
         self._handles: dict[str, RuntimeSessionHandle] = {}
         self._providers: dict[str, ProviderRuntime] = {}
 
-    def _get_provider_runtime(self, provider_name: str, conn: object | None = None) -> ProviderRuntime:
+    def _get_provider_runtime(
+        self, provider_name: str, conn: object | None = None
+    ) -> ProviderRuntime:
         """Resolve a provider runtime, refreshing cached instances when live settings differ."""
 
-        app_state = getattr(getattr(conn, "_connection", None), "app_state", None)
+        app_state = get_connection_app_state(conn) if conn is not None else None
+        if app_state is None:
+            app_state = getattr(getattr(conn, "_connection", None), "app_state", None)
         settings = getattr(app_state, "settings", None) if app_state is not None else None
-        desired_kwargs = runtime_kwargs_for_provider(provider_name, settings) if settings is not None else runtime_kwargs_for_provider(provider_name)
+        desired_kwargs = (
+            runtime_kwargs_for_provider(provider_name, settings)
+            if settings is not None
+            else runtime_kwargs_for_provider(provider_name)
+        )
 
         provider = self._providers.get(provider_name)
-        if provider is None or any(getattr(provider, key, None) != value for key, value in desired_kwargs.items()):
+        if provider is None or any(
+            getattr(provider, key, None) != value for key, value in desired_kwargs.items()
+        ):
             provider = create_provider_runtime(provider_name, **desired_kwargs)
             self._providers[provider_name] = provider
         return provider
@@ -110,8 +134,37 @@ class RuntimeService:
     async def spawn_existing_session(self, request: StartRoleRequest) -> RuntimeSessionHandle:
         """Materialize an already-created DB session row into a live runtime session."""
 
-        provider = self._get_provider_runtime(request.provider_name, getattr(request, "connection", None))
-        handle = await provider.spawn_existing_session(request)
+        trace_id = self._ensure_trace_id(request.metadata)
+        self._append_start_event(
+            request,
+            trace_id,
+            DeliveryStage.QUEUED,
+            DeliveryVerdict.PENDING,
+            DeliveryReasonCode.QUEUED,
+        )
+        self._append_start_event(
+            request,
+            trace_id,
+            DeliveryStage.SPAWN_STARTED,
+            DeliveryVerdict.PENDING,
+            DeliveryReasonCode.SPAWN_REQUESTED,
+        )
+        provider = self._get_provider_runtime(
+            request.provider_name, getattr(request, "connection", None)
+        )
+        try:
+            handle = await provider.spawn_existing_session(request)
+        except Exception as exc:
+            self._append_start_event(
+                request,
+                trace_id,
+                DeliveryStage.FAILED,
+                DeliveryVerdict.FAILED,
+                DeliveryReasonCode.PROVIDER_ERROR,
+                details={"error_type": type(exc).__name__, "error": str(exc)},
+            )
+            raise
+        self._append_spawned_event(request, handle, trace_id)
         return self.remember_handle(handle)
 
     async def send_instruction(
@@ -119,8 +172,42 @@ class RuntimeService:
         handle: RuntimeSessionHandle,
         request: InstructionRequest,
     ) -> None:
+        trace_id = self._ensure_trace_id(request.metadata)
+        append_trace_event(
+            request.metadata,
+            trace_event(
+                trace_id=trace_id,
+                session_id=handle.session_id,
+                role=handle.role.value,
+                provider=handle.provider_name,
+                pane_id=handle.tmux_pane,
+                action=DeliveryAction.INSTRUCTION,
+                stage=DeliveryStage.QUEUED,
+                verdict=DeliveryVerdict.PENDING,
+                reason_code=DeliveryReasonCode.QUEUED,
+                details={"instruction_id": request.instruction_id},
+            ),
+        )
         provider = self.get_provider(handle.provider_name)
-        await provider.send_instruction(handle, request)
+        try:
+            await provider.send_instruction(handle, request)
+        except Exception as exc:
+            append_trace_event(
+                request.metadata,
+                trace_event(
+                    trace_id=trace_id,
+                    session_id=handle.session_id,
+                    role=handle.role.value,
+                    provider=handle.provider_name,
+                    pane_id=handle.tmux_pane,
+                    action=DeliveryAction.INSTRUCTION,
+                    stage=DeliveryStage.FAILED,
+                    verdict=DeliveryVerdict.FAILED,
+                    reason_code=self._reason_code_for_delivery_exception(exc),
+                    details={"error_type": type(exc).__name__, "error": str(exc)},
+                ),
+            )
+            raise
 
     async def assign_project_to_leader(
         self,
@@ -138,8 +225,48 @@ class RuntimeService:
     ) -> None:
         if handle.role is not RoleKind.ACE:
             raise ValueError("assign_task_to_ace requires ace handle")
+        trace_id = self._ensure_trace_id(request.metadata)
+        request.metadata["delivery_action"] = DeliveryAction.TASK_ASSIGNMENT.value
+        append_trace_event(
+            request.metadata,
+            trace_event(
+                trace_id=trace_id,
+                session_id=handle.session_id,
+                role=handle.role.value,
+                provider=handle.provider_name,
+                pane_id=handle.tmux_pane,
+                action=DeliveryAction.TASK_ASSIGNMENT,
+                stage=DeliveryStage.QUEUED,
+                verdict=DeliveryVerdict.PENDING,
+                reason_code=DeliveryReasonCode.QUEUED,
+                details={
+                    "task_id": request.task_id,
+                    "assignment_id": request.assignment_id,
+                },
+            ),
+        )
         provider = self.get_provider(handle.provider_name)
-        await provider.assign_task(handle, request)
+        try:
+            await provider.assign_task(handle, request)
+        except Exception as exc:
+            append_trace_event(
+                request.metadata,
+                trace_event(
+                    trace_id=trace_id,
+                    session_id=handle.session_id,
+                    role=handle.role.value,
+                    provider=handle.provider_name,
+                    pane_id=handle.tmux_pane,
+                    action=DeliveryAction.TASK_ASSIGNMENT,
+                    stage=DeliveryStage.FAILED,
+                    verdict=DeliveryVerdict.FAILED,
+                    reason_code=self._reason_code_for_delivery_exception(exc),
+                    details={"error_type": type(exc).__name__, "error": str(exc)},
+                ),
+            )
+            raise
+        finally:
+            request.metadata.pop("delivery_action", None)
 
     async def check_readiness(self, handle: RuntimeSessionHandle) -> ReadinessResult:
         provider = self.get_provider(handle.provider_name)
@@ -156,7 +283,34 @@ class RuntimeService:
     async def _start_role(self, request: StartRoleRequest) -> RuntimeSessionHandle:
         provider = self.get_provider(request.provider_name)
         await provider.prepare_workspace(request)
-        handle = await provider.start_role(request)
+        trace_id = self._ensure_trace_id(request.metadata)
+        self._append_start_event(
+            request,
+            trace_id,
+            DeliveryStage.QUEUED,
+            DeliveryVerdict.PENDING,
+            DeliveryReasonCode.QUEUED,
+        )
+        self._append_start_event(
+            request,
+            trace_id,
+            DeliveryStage.SPAWN_STARTED,
+            DeliveryVerdict.PENDING,
+            DeliveryReasonCode.SPAWN_REQUESTED,
+        )
+        try:
+            handle = await provider.start_role(request)
+        except Exception as exc:
+            self._append_start_event(
+                request,
+                trace_id,
+                DeliveryStage.FAILED,
+                DeliveryVerdict.FAILED,
+                DeliveryReasonCode.PROVIDER_ERROR,
+                details={"error_type": type(exc).__name__, "error": str(exc)},
+            )
+            raise
+        self._append_spawned_event(request, handle, trace_id)
         return self.remember_handle(handle)
 
     async def _stop_role(
@@ -166,3 +320,73 @@ class RuntimeService:
     ) -> None:
         provider = self.get_provider(handle.provider_name)
         await provider.stop_role(handle, request)
+
+    @staticmethod
+    def _ensure_trace_id(metadata: dict[str, object]) -> str:
+        existing = metadata.get("delivery_trace_id")
+        if isinstance(existing, str) and existing:
+            return existing
+        trace_id = new_trace_id()
+        metadata["delivery_trace_id"] = trace_id
+        return trace_id
+
+    @staticmethod
+    def _append_start_event(
+        request: StartRoleRequest,
+        trace_id: str,
+        stage: DeliveryStage,
+        verdict: DeliveryVerdict,
+        reason_code: DeliveryReasonCode,
+        *,
+        details: dict[str, object] | None = None,
+    ) -> None:
+        append_trace_event(
+            request.metadata,
+            trace_event(
+                trace_id=trace_id,
+                session_id=request.session_id,
+                role=request.role.value,
+                provider=request.provider_name,
+                pane_id=None,
+                action=DeliveryAction.SPAWN,
+                stage=stage,
+                verdict=verdict,
+                reason_code=reason_code,
+                details=details,
+            ),
+        )
+
+    @staticmethod
+    def _append_spawned_event(
+        request: StartRoleRequest, handle: RuntimeSessionHandle, trace_id: str
+    ) -> None:
+        append_trace_event(
+            request.metadata,
+            trace_event(
+                trace_id=trace_id,
+                session_id=request.session_id,
+                role=request.role.value,
+                provider=request.provider_name,
+                pane_id=handle.tmux_pane,
+                action=DeliveryAction.SPAWN,
+                stage=DeliveryStage.SPAWNED,
+                verdict=DeliveryVerdict.ACCEPTED,
+                reason_code=DeliveryReasonCode.PANE_SPAWNED,
+                details={"tmux_session": handle.tmux_session},
+            ),
+        )
+
+    @staticmethod
+    def _reason_code_for_delivery_exception(exc: Exception) -> DeliveryReasonCode:
+        message = str(exc).lower()
+        if "pane" in message and ("missing" in message or "no tmux" in message):
+            return DeliveryReasonCode.PANE_MISSING
+        if "empty" in message:
+            return DeliveryReasonCode.EMPTY_PAYLOAD
+        if "auth" in message or "login" in message or "sign in" in message:
+            return DeliveryReasonCode.AUTH_REQUIRED
+        if "trust" in message:
+            return DeliveryReasonCode.TRUST_REQUIRED
+        if "verif" in message:
+            return DeliveryReasonCode.DELIVERY_UNVERIFIED
+        return DeliveryReasonCode.UNKNOWN_ERROR

--- a/src/atc/runtime/tracing.py
+++ b/src/atc/runtime/tracing.py
@@ -1,0 +1,146 @@
+"""Structured delivery trace event helpers for runtime instruction delivery.
+
+Phase 1 keeps these traces additive and in-process/metadata-backed so existing
+UI/API callers remain compatible while delivery attempts become observable.
+"""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, field
+from datetime import UTC, datetime
+from enum import StrEnum
+from typing import Any
+from uuid import uuid4
+
+
+class DeliveryAction(StrEnum):
+    """High-level delivery actions that can be traced."""
+
+    SPAWN = "spawn"
+    INSTRUCTION = "instruction"
+    TASK_ASSIGNMENT = "task_assignment"
+
+
+class DeliveryStage(StrEnum):
+    """Stable stages for tmux-backed delivery attempts."""
+
+    QUEUED = "queued"
+    SPAWN_STARTED = "spawn_started"
+    SPAWNED = "spawned"
+    WRITE_STARTED = "write_started"
+    WRITTEN_TO_PTY = "written_to_pty"
+    SUBMIT_ATTEMPTED = "submit_attempted"
+    PROMPT_CLEARED = "prompt_cleared"
+    AGENT_OUTPUT_OBSERVED = "agent_output_observed"
+    CONFIRMED_RUNNING = "confirmed_running"
+    BLOCKED = "blocked"
+    FAILED = "failed"
+
+
+class DeliveryVerdict(StrEnum):
+    """Stable verdict vocabulary for delivery trace events."""
+
+    PENDING = "pending"
+    ACCEPTED = "accepted"
+    CONFIRMED = "confirmed"
+    BLOCKED = "blocked"
+    FAILED = "failed"
+
+
+class DeliveryReasonCode(StrEnum):
+    """Stable reason codes attached to trace verdicts."""
+
+    QUEUED = "queued"
+    SPAWN_REQUESTED = "spawn_requested"
+    PANE_SPAWNED = "pane_spawned"
+    PANE_MISSING = "pane_missing"
+    EMPTY_PAYLOAD = "empty_payload"
+    PTY_WRITE_STARTED = "pty_write_started"
+    PTY_WRITE_ACCEPTED = "pty_write_accepted"
+    SUBMIT_SENT = "submit_sent"
+    PROMPT_STILL_VISIBLE = "prompt_still_visible"
+    PROMPT_NOT_READY = "prompt_not_ready"
+    AGENT_OUTPUT = "agent_output"
+    SESSION_RUNNING = "session_running"
+    AUTH_REQUIRED = "auth_required"
+    TRUST_REQUIRED = "trust_required"
+    DELIVERY_UNVERIFIED = "delivery_unverified"
+    PROVIDER_ERROR = "provider_error"
+    UNKNOWN_ERROR = "unknown_error"
+
+
+@dataclass(slots=True)
+class DeliveryTraceEvent:
+    """A structured event emitted while spawning or instructing a runtime session."""
+
+    trace_id: str
+    session_id: str
+    role: str
+    provider: str
+    pane_id: str | None
+    action: str
+    stage: str
+    verdict: str
+    reason_code: str
+    timestamp: str = field(default_factory=lambda: datetime.now(UTC).isoformat())
+    prompt_state_before: str | None = None
+    prompt_state_after: str | None = None
+    first_output_excerpt: str | None = None
+    details: dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+def new_trace_id() -> str:
+    return f"dtr_{uuid4().hex}"
+
+
+def trace_event(
+    *,
+    trace_id: str,
+    session_id: str,
+    role: str,
+    provider: str,
+    pane_id: str | None,
+    action: DeliveryAction | str,
+    stage: DeliveryStage | str,
+    verdict: DeliveryVerdict | str,
+    reason_code: DeliveryReasonCode | str,
+    prompt_state_before: str | None = None,
+    prompt_state_after: str | None = None,
+    first_output_excerpt: str | None = None,
+    details: dict[str, Any] | None = None,
+) -> DeliveryTraceEvent:
+    return DeliveryTraceEvent(
+        trace_id=trace_id,
+        session_id=session_id,
+        role=str(role),
+        provider=provider,
+        pane_id=pane_id,
+        action=action.value if isinstance(action, DeliveryAction) else str(action),
+        stage=stage.value if isinstance(stage, DeliveryStage) else str(stage),
+        verdict=verdict.value if isinstance(verdict, DeliveryVerdict) else str(verdict),
+        reason_code=reason_code.value
+        if isinstance(reason_code, DeliveryReasonCode)
+        else str(reason_code),
+        prompt_state_before=prompt_state_before,
+        prompt_state_after=prompt_state_after,
+        first_output_excerpt=_trim_excerpt(first_output_excerpt),
+        details=details or {},
+    )
+
+
+def append_trace_event(metadata: dict[str, Any], event: DeliveryTraceEvent) -> DeliveryTraceEvent:
+    metadata.setdefault("delivery_trace_id", event.trace_id)
+    metadata.setdefault("delivery_trace_events", []).append(event.to_dict())
+    return event
+
+
+def _trim_excerpt(excerpt: str | None, *, limit: int = 500) -> str | None:
+    if excerpt is None:
+        return None
+    text = excerpt.strip()
+    if len(text) <= limit:
+        return text
+    return text[: limit - 1] + "…"

--- a/src/atc/session/ace.py
+++ b/src/atc/session/ace.py
@@ -26,6 +26,7 @@ from pathlib import Path as _Path
 from typing import TYPE_CHECKING, Any
 
 from atc.agents.claude_runtime import accept_startup_dialogs
+from atc.core.app_events import log_event
 from atc.session.state_machine import (
     SessionStatus,
     transition,
@@ -90,6 +91,7 @@ def _build_env_prefix() -> str:
     launched.
     """
     import os as _os
+
     extra_paths: list[str] = []
     home = _os.path.expanduser("~")
     candidates = [
@@ -100,9 +102,11 @@ def _build_env_prefix() -> str:
         # nvm current symlink
         f"{home}/.nvm/current/bin",
         # nvm active version (resolve symlink)
-        *([str(_Path(f"{home}/.nvm/current/bin").resolve())]
-          if _Path(f"{home}/.nvm/current/bin").is_symlink()
-          else []),
+        *(
+            [str(_Path(f"{home}/.nvm/current/bin").resolve())]
+            if _Path(f"{home}/.nvm/current/bin").is_symlink()
+            else []
+        ),
         # nvm versioned installs.
         # IMPORTANT: newer Node versions may require a newer macOS (e.g. Node 24
         # needs Monterey 13.5+, Big Sur only has 11). We check each bin dir's
@@ -182,6 +186,7 @@ async def _spawn_pane(
         # Ensure the directory exists — tmux silently falls back to $HOME if the
         # working_dir does not exist, which causes Claude Code to start in the wrong place.
         import os as _os
+
         if not _os.path.isdir(working_dir):
             _os.makedirs(working_dir, exist_ok=True)
             logger.info("_spawn_pane: created missing working_dir %s", working_dir)
@@ -282,8 +287,10 @@ async def _spawn_provider_session(
 
     project = await db_ops.get_project(conn, project_id) if project_id else None
     session = await db_ops.get_session(conn, session_id)
-    provider_name = session.provider if session and session.provider else (
-        project.agent_provider if project and project.agent_provider else "claude_code"
+    provider_name = (
+        session.provider
+        if session and session.provider
+        else (project.agent_provider if project and project.agent_provider else "claude_code")
     )
 
     session = await db_ops.get_session(conn, session_id)
@@ -297,18 +304,25 @@ async def _spawn_provider_session(
     }.get(session_type, RoleKind.ACE)
 
     service = RuntimeService()
-    handle = await service.spawn_existing_session(
-        StartRoleRequest(
-            session_id=session.id,
-            provider_name=provider_name,
-            role=role,
-            project_id=project_id,
-            connection=conn,
-            working_dir=working_dir,
-            context_ref=str(context_file) if context_file else None,
-            metadata={"launch_command": launch_command} if launch_command else {},
-        )
+    request = StartRoleRequest(
+        session_id=session.id,
+        provider_name=provider_name,
+        role=role,
+        project_id=project_id,
+        connection=conn,
+        working_dir=working_dir,
+        context_ref=str(context_file) if context_file else None,
+        metadata={"launch_command": launch_command} if launch_command else {},
     )
+    try:
+        handle = await service.spawn_existing_session(request)
+    finally:
+        await _persist_delivery_trace_events(
+            conn,
+            session_id=session.id,
+            project_id=project_id,
+            trace_events=request.metadata.get("delivery_trace_events", []),
+        )
     pane_id = str(handle.tmux_pane or "")
     tmux_session = str(handle.tmux_session or ATC_TMUX_SESSION)
     if not pane_id:
@@ -341,7 +355,6 @@ async def create_ace(
             hooks, settings.json) using the real session_id after DB creation.
     """
     # Step 1: DB row first — guarantees the UI always sees every entity
-    project = await db_ops.get_project(conn, project_id)
     provider_cfg = get_connection_app_state(conn)
     if provider_cfg is not None and getattr(provider_cfg, "settings", None) is not None:
         provider = provider_cfg.settings.agent_provider.default
@@ -402,7 +415,9 @@ async def create_ace(
                         role=RoleKind.ACE,
                         project_id=project_id,
                         working_dir=effective_working_dir,
-                        context_ref=str(deployed.claude_md_path) if deployed and deployed.claude_md_path.exists() else None,
+                        context_ref=str(deployed.claude_md_path)
+                        if deployed and deployed.claude_md_path.exists()
+                        else None,
                     )
                 )
             except Exception as _prep_exc:
@@ -418,7 +433,9 @@ async def create_ace(
             project_id=project_id,
             session_type="ace",
             working_dir=effective_working_dir,
-            context_file=deployed.claude_md_path if deployed and deployed.claude_md_path.exists() else None,
+            context_file=deployed.claude_md_path
+            if deployed and deployed.claude_md_path.exists()
+            else None,
             launch_command=launch_command,
         )
         await db_ops.update_session_tmux(conn, session.id, tmux_session, pane_id)
@@ -450,7 +467,12 @@ async def _send_session_instruction(
     instruction: str,
 ) -> bool:
     """Send an instruction through the new runtime service/provider contract."""
-    from atc.runtime.models import InstructionRequest, RoleKind, RuntimeSessionHandle, RuntimeTransport
+    from atc.runtime.models import (
+        InstructionRequest,
+        RoleKind,
+        RuntimeSessionHandle,
+        RuntimeTransport,
+    )
     from atc.runtime.service import RuntimeService
 
     session = await db_ops.get_session(conn, session_id)
@@ -478,8 +500,41 @@ async def _send_session_instruction(
         session_id=session.id,
         message=instruction,
     )
-    await service.send_instruction(handle, request)
+    try:
+        await service.send_instruction(handle, request)
+    finally:
+        await _persist_delivery_trace_events(
+            conn,
+            session_id=session.id,
+            project_id=session.project_id,
+            trace_events=request.metadata.get("delivery_trace_events", []),
+        )
     return True
+
+
+async def _persist_delivery_trace_events(
+    conn: aiosqlite.Connection,
+    *,
+    session_id: str,
+    project_id: str | None,
+    trace_events: object,
+) -> None:
+    """Persist delivery trace events into the existing app_events stream."""
+
+    if not isinstance(trace_events, list):
+        return
+    for event in trace_events:
+        if not isinstance(event, dict):
+            continue
+        await log_event(
+            conn,
+            level="info" if event.get("verdict") != "failed" else "error",
+            category="delivery_trace",
+            message=f"Delivery trace {event.get('stage', 'unknown')}",
+            detail=event,
+            project_id=project_id,
+            session_id=session_id,
+        )
 
 
 async def start_ace(
@@ -758,7 +813,9 @@ async def schedule_verification(
         await asyncio.sleep(60)  # 120s total
         result = await verify_progressing(conn, session_id, previous_output=mid_output)
         if not result.ok:
-            logger.warning("Session %s: output-progress check failed (%s)", session_id, result.detail)
+            logger.warning(
+                "Session %s: output-progress check failed (%s)", session_id, result.detail
+            )
             await _handle_stalled(conn, session_id, event_bus)
 
     asyncio.create_task(_run_checks())

--- a/src/atc/state/db.py
+++ b/src/atc/state/db.py
@@ -1806,6 +1806,47 @@ async def list_app_events(
     return [AppEvent(**dict(r)) for r in rows]
 
 
+async def create_app_event(
+    db: aiosqlite.Connection,
+    *,
+    level: str,
+    category: str,
+    message: str,
+    detail: dict[str, Any] | None = None,
+    project_id: str | None = None,
+    session_id: str | None = None,
+) -> AppEvent:
+    """Insert a structured app event and return it."""
+
+    event = AppEvent(
+        id=_uuid(),
+        level=level,
+        category=category,
+        message=message,
+        detail=json.dumps(detail or {}, sort_keys=True),
+        project_id=project_id,
+        session_id=session_id,
+        created_at=_now(),
+    )
+    await db.execute(
+        """INSERT INTO app_events
+           (id, level, category, message, detail, project_id, session_id, created_at)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?)""",
+        (
+            event.id,
+            event.level,
+            event.category,
+            event.message,
+            event.detail,
+            event.project_id,
+            event.session_id,
+            event.created_at,
+        ),
+    )
+    await db.commit()
+    return event
+
+
 async def is_feature_enabled(db: aiosqlite.Connection, key: str) -> bool:
     """Check if a feature flag is enabled. Returns False if flag doesn't exist."""
     flag = await get_feature_flag(db, key)

--- a/tests/unit/test_delivery_tracing.py
+++ b/tests/unit/test_delivery_tracing.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+import asyncio
+from contextlib import suppress
+from unittest.mock import AsyncMock, patch
+
+from atc.providers.codex.runtime import CodexRuntime
+from atc.runtime.models import InstructionRequest, RoleKind, RuntimeSessionHandle, RuntimeTransport
+from atc.runtime.tracing import DeliveryReasonCode, DeliveryStage, DeliveryVerdict
+
+
+def test_codex_instruction_emits_structured_delivery_trace_events() -> None:
+    runtime = CodexRuntime()
+    handle = RuntimeSessionHandle(
+        session_id="sess-trace-1",
+        provider_name="codex",
+        role=RoleKind.ACE,
+        transport=RuntimeTransport.TMUX,
+        tmux_pane="%42",
+    )
+    request = InstructionRequest(
+        session_id="sess-trace-1",
+        message="Do the traced work",
+        metadata={"delivery_trace_id": "trace-1"},
+    )
+
+    with (
+        patch("atc.providers.codex.runtime.pane_exists", AsyncMock(return_value=True)),
+        patch(
+            "atc.providers.codex.runtime.capture_pane_text",
+            AsyncMock(side_effect=["ready\n>\n", "Thinking about traced work..."]),
+        ),
+        patch(
+            "atc.providers.codex.runtime.send_bracketed_instruction", AsyncMock()
+        ) as send_instruction,
+    ):
+        asyncio.run(runtime.send_instruction(handle, request))
+
+    send_instruction.assert_awaited_once_with("atc", "%42", "Do the traced work")
+    events = request.metadata["delivery_trace_events"]
+    assert [event["stage"] for event in events] == [
+        DeliveryStage.WRITE_STARTED.value,
+        DeliveryStage.WRITTEN_TO_PTY.value,
+        DeliveryStage.SUBMIT_ATTEMPTED.value,
+        DeliveryStage.AGENT_OUTPUT_OBSERVED.value,
+    ]
+    assert events[-1]["verdict"] == DeliveryVerdict.CONFIRMED.value
+    assert events[-1]["reason_code"] == DeliveryReasonCode.AGENT_OUTPUT.value
+    assert events[-1]["trace_id"] == "trace-1"
+    assert events[-1]["session_id"] == "sess-trace-1"
+    assert events[-1]["role"] == "ace"
+    assert events[-1]["provider"] == "codex"
+    assert events[-1]["pane_id"] == "%42"
+    assert events[-1]["prompt_state_before"] == "ready"
+    assert events[-1]["prompt_state_after"] == "busy"
+
+
+def test_codex_instruction_failure_trace_has_stable_reason_code() -> None:
+    runtime = CodexRuntime()
+    handle = RuntimeSessionHandle(
+        session_id="sess-trace-missing",
+        provider_name="codex",
+        role=RoleKind.LEADER,
+        transport=RuntimeTransport.TMUX,
+        tmux_pane="%99",
+    )
+    request = InstructionRequest(
+        session_id="sess-trace-missing",
+        message="hello",
+        metadata={"delivery_trace_id": "trace-missing"},
+    )
+
+    with (
+        patch("atc.providers.codex.runtime.pane_exists", AsyncMock(return_value=False)),
+        suppress(Exception),
+    ):
+        asyncio.run(runtime.send_instruction(handle, request))
+
+    events = request.metadata["delivery_trace_events"]
+    assert events[-1]["stage"] == DeliveryStage.FAILED.value
+    assert events[-1]["verdict"] == DeliveryVerdict.FAILED.value
+    assert events[-1]["reason_code"] == DeliveryReasonCode.PANE_MISSING.value

--- a/tests/unit/test_runtime_service.py
+++ b/tests/unit/test_runtime_service.py
@@ -16,6 +16,7 @@ from atc.runtime.models import (
     TaskAssignmentRequest,
 )
 from atc.runtime.service import RuntimeService
+from atc.state.db import clear_connection_app_state, set_connection_app_state
 
 
 class DummyProviderRuntime:
@@ -58,10 +59,14 @@ class DummyProviderRuntime:
     async def stop_role(self, handle: RuntimeSessionHandle, request=None) -> None:
         return None
 
-    async def send_instruction(self, handle: RuntimeSessionHandle, request: InstructionRequest) -> None:
+    async def send_instruction(
+        self, handle: RuntimeSessionHandle, request: InstructionRequest
+    ) -> None:
         self.instructions.append(request)
 
-    async def assign_task(self, handle: RuntimeSessionHandle, request: TaskAssignmentRequest) -> None:
+    async def assign_task(
+        self, handle: RuntimeSessionHandle, request: TaskAssignmentRequest
+    ) -> None:
         self.assignments.append(request)
 
     async def check_readiness(self, handle: RuntimeSessionHandle) -> ReadinessResult:
@@ -159,26 +164,46 @@ def test_runtime_service_assign_task_to_ace_uses_provider() -> None:
     assert provider.assignments[-1].task_id == "task-1"
 
 
-
 def test_service_refreshes_cached_provider_when_live_settings_change() -> None:
     service = RuntimeService()
-    first_settings = SimpleNamespace(agent_provider=SimpleNamespace(tmux_session="atc", claude_command="claude", codex_command="codex"))
-    second_settings = SimpleNamespace(agent_provider=SimpleNamespace(tmux_session="atc", claude_command="claude", codex_command="codex --profile prod"))
-    first_conn = SimpleNamespace(_connection=SimpleNamespace(app_state=SimpleNamespace(settings=first_settings)))
-    second_conn = SimpleNamespace(_connection=SimpleNamespace(app_state=SimpleNamespace(settings=second_settings)))
+    first_settings = SimpleNamespace(
+        agent_provider=SimpleNamespace(
+            tmux_session="atc", claude_command="claude", codex_command="codex"
+        )
+    )
+    second_settings = SimpleNamespace(
+        agent_provider=SimpleNamespace(
+            tmux_session="atc", claude_command="claude", codex_command="codex --profile prod"
+        )
+    )
+    first_conn = SimpleNamespace(
+        _connection=SimpleNamespace(app_state=SimpleNamespace(settings=first_settings))
+    )
+    second_conn = SimpleNamespace(
+        _connection=SimpleNamespace(app_state=SimpleNamespace(settings=second_settings))
+    )
 
     first = service._get_provider_runtime("codex", first_conn)
     second = service._get_provider_runtime("codex", second_conn)
 
     assert first is not second
-    assert getattr(second, "codex_command") == "codex --profile prod"
+    assert second.codex_command == "codex --profile prod"
 
 
-
-def test_service_refreshes_cached_provider_when_live_settings_change_via_sqlite_connection() -> None:
+def test_service_refreshes_cached_provider_when_live_settings_change_via_sqlite_connection() -> (
+    None
+):
     service = RuntimeService()
-    first_settings = SimpleNamespace(agent_provider=SimpleNamespace(tmux_session="atc", claude_command="claude", codex_command="codex"))
-    second_settings = SimpleNamespace(agent_provider=SimpleNamespace(tmux_session="atc", claude_command="claude", codex_command="codex --profile prod"))
+    first_settings = SimpleNamespace(
+        agent_provider=SimpleNamespace(
+            tmux_session="atc", claude_command="claude", codex_command="codex"
+        )
+    )
+    second_settings = SimpleNamespace(
+        agent_provider=SimpleNamespace(
+            tmux_session="atc", claude_command="claude", codex_command="codex --profile prod"
+        )
+    )
     sqlite_conn = SimpleNamespace()
     first_conn = SimpleNamespace(_connection=sqlite_conn)
     sqlite_conn.app_state = SimpleNamespace(settings=first_settings)
@@ -189,4 +214,105 @@ def test_service_refreshes_cached_provider_when_live_settings_change_via_sqlite_
     second = service._get_provider_runtime("codex", first_conn)
 
     assert first is not second
-    assert getattr(second, "codex_command") == "codex --profile prod"
+    assert second.codex_command == "codex --profile prod"
+
+
+def test_runtime_service_spawn_existing_session_adds_trace_events() -> None:
+    register_provider_runtime("dummy_runtime_trace_spawn", DummyProviderRuntime)
+    service = RuntimeService()
+    request = StartRoleRequest(
+        session_id="sess-trace-spawn-1",
+        provider_name="dummy_runtime_trace_spawn",
+        role=RoleKind.LEADER,
+        project_id="proj-trace",
+    )
+
+    asyncio.run(service.spawn_existing_session(request))
+
+    events = request.metadata["delivery_trace_events"]
+    assert [event["stage"] for event in events] == ["queued", "spawn_started", "spawned"]
+    assert events[-1]["action"] == "spawn"
+    assert events[-1]["verdict"] == "accepted"
+    assert events[-1]["reason_code"] == "pane_spawned"
+
+
+def test_runtime_service_send_instruction_adds_queued_trace_event() -> None:
+    register_provider_runtime("dummy_runtime_trace_instruction", DummyProviderRuntime)
+    service = RuntimeService()
+    handle = asyncio.run(
+        service.start_ace(
+            StartRoleRequest(
+                session_id="sess-trace-instruction-1",
+                provider_name="dummy_runtime_trace_instruction",
+                role=RoleKind.ACE,
+            )
+        )
+    )
+    request = InstructionRequest(
+        session_id="sess-trace-instruction-1",
+        message="trace this",
+        instruction_id="instruction-1",
+    )
+
+    asyncio.run(service.send_instruction(handle, request))
+
+    events = request.metadata["delivery_trace_events"]
+    assert events[0]["stage"] == "queued"
+    assert events[0]["action"] == "instruction"
+    assert events[0]["details"] == {"instruction_id": "instruction-1"}
+
+
+def test_runtime_service_assign_task_to_ace_preserves_task_assignment_trace() -> None:
+    register_provider_runtime("dummy_runtime_trace_assignment", DummyProviderRuntime)
+    service = RuntimeService()
+    handle = asyncio.run(
+        service.start_ace(
+            StartRoleRequest(
+                session_id="sess-trace-assignment-1",
+                provider_name="dummy_runtime_trace_assignment",
+                role=RoleKind.ACE,
+            )
+        )
+    )
+    request = TaskAssignmentRequest(
+        session_id="sess-trace-assignment-1",
+        task_id="task-1",
+        assignment_id="assignment-1",
+        message="do the task",
+    )
+
+    asyncio.run(service.assign_task_to_ace(handle, request))
+
+    events = request.metadata["delivery_trace_events"]
+    assert events[0]["action"] == "task_assignment"
+    assert events[0]["stage"] == "queued"
+    assert events[0]["details"] == {
+        "task_id": "task-1",
+        "assignment_id": "assignment-1",
+    }
+    provider = service.get_provider("dummy_runtime_trace_assignment")
+    assert provider.assignments[-1].metadata is request.metadata
+
+
+def test_runtime_service_provider_settings_use_connection_app_state_side_map() -> None:
+    service = RuntimeService()
+    conn = SimpleNamespace()
+    settings = SimpleNamespace(
+        agent_provider=SimpleNamespace(
+            codex_command="codex-custom",
+            claude_command="claude",
+            tmux_session="atc-side-map",
+        )
+    )
+    app_state = SimpleNamespace(settings=settings)
+    set_connection_app_state(conn, app_state)
+    try:
+        first = service._get_provider_runtime("codex", conn)
+        settings.agent_provider.codex_command = "codex-updated"
+        second = service._get_provider_runtime("codex", conn)
+    finally:
+        clear_connection_app_state(conn)
+
+    assert first is not second
+    assert first.codex_command == "codex-custom"
+    assert second.codex_command == "codex-updated"


### PR DESCRIPTION
## Summary
- add provider-neutral delivery trace events for spawn and instruction delivery
- persist trace events in session metadata and app events for API/UI evidence
- classify Codex/Claude trust/auth blocks with structured reason codes
- wire app-events router so delivery traces can be queried through /api/app-events

## Validation
- ruff check src/atc/runtime/tracing.py src/atc/runtime/service.py src/atc/providers/codex/runtime.py src/atc/providers/claude_code/runtime.py tests/unit/test_delivery_tracing.py tests/unit/test_runtime_service.py
- pytest tests/unit/test_runtime_models.py tests/unit/test_runtime_service.py tests/unit/test_delivery_tracing.py tests/unit/test_codex_runtime.py tests/unit/test_claude_code_runtime.py tests/unit/test_tmux_substrate.py tests/e2e/test_smoke.py -q — 63 passed
- Mac Studio Playwright/API validation: spawn/instruction traces observed and trust prompt classified as blocked/trust_required

## Playwright evidence
Report: /tmp/atc-work/test-results/phase1-delivery-trace-2026-06-07T06-18-40-629Z/report.json
Screenshots:
- /tmp/atc-work/test-results/phase1-delivery-trace-2026-06-07T06-18-40-629Z/00-dashboard.png
- /tmp/atc-work/test-results/phase1-delivery-trace-2026-06-07T06-18-40-629Z/01-project-trace-validation.png
- /tmp/atc-work/test-results/phase1-delivery-trace-2026-06-07T06-18-40-629Z/02-delivery-trace-events.png