### PR TITLE
Phase 2: extract shared tmux session runner

### DIFF
--- a/src/atc/providers/claude_code/runtime.py
+++ b/src/atc/providers/claude_code/runtime.py
@@ -112,6 +112,9 @@ class ClaudeCodeRuntime(ProviderRuntime):
         handle: RuntimeSessionHandle,
         request: InstructionRequest,
     ) -> None:
+        # Phase 2 routes Codex through TmuxSessionRunner first. Claude keeps this
+        # compatibility implementation until its provider-specific verification
+        # semantics are migrated in a later phase.
         trace_id = str(request.metadata.get("delivery_trace_id") or "")
         if not handle.tmux_pane:
             self._append_instruction_trace(

--- a/src/atc/providers/codex/runtime.py
+++ b/src/atc/providers/codex/runtime.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import re
 
 from atc.providers.base import ProviderRuntime
-from atc.runtime.errors import RuntimeDeliveryError, RuntimeSessionMissingError
 from atc.runtime.models import (
     InstructionRequest,
     ReadinessResult,
@@ -18,7 +17,7 @@ from atc.runtime.models import (
     StopRoleRequest,
     TaskAssignmentRequest,
 )
-from atc.runtime.tmux.control import send_bracketed_instruction
+from atc.runtime.tmux.runner import RunnerTerminalVerdict, TmuxSessionRunner
 from atc.runtime.tmux.substrate import (
     build_path_env_prefix,
     capture_pane_text,
@@ -32,8 +31,6 @@ from atc.runtime.tracing import (
     DeliveryReasonCode,
     DeliveryStage,
     DeliveryVerdict,
-    append_trace_event,
-    trace_event,
 )
 
 _CODEX_PROMPT_RE = re.compile(r"(^|\n)\s*(❯|>)\s*$", re.MULTILINE)
@@ -108,105 +105,19 @@ class CodexRuntime(ProviderRuntime):
         request: InstructionRequest,
     ) -> None:
         trace_id = str(request.metadata.get("delivery_trace_id") or "")
-        if not handle.tmux_pane:
-            self._append_instruction_trace(
-                request,
-                handle,
-                trace_id,
-                DeliveryStage.FAILED,
-                DeliveryVerdict.FAILED,
-                DeliveryReasonCode.PANE_MISSING,
-            )
-            raise RuntimeSessionMissingError("Codex session has no tmux pane recorded")
-        if not await pane_exists(handle.tmux_pane):
-            self._append_instruction_trace(
-                request,
-                handle,
-                trace_id,
-                DeliveryStage.FAILED,
-                DeliveryVerdict.FAILED,
-                DeliveryReasonCode.PANE_MISSING,
-            )
-            raise RuntimeSessionMissingError("Codex session pane is missing")
-        text = request.message or ""
-        if not text and request.message_file:
-            with open(request.message_file, encoding="utf-8") as f:
-                text = f.read()
-        if not text:
-            self._append_instruction_trace(
-                request,
-                handle,
-                trace_id,
-                DeliveryStage.FAILED,
-                DeliveryVerdict.FAILED,
-                DeliveryReasonCode.EMPTY_PAYLOAD,
-            )
-            raise RuntimeDeliveryError("Instruction payload was empty")
-
-        before = await capture_pane_text(handle.tmux_pane, lines=40)
-        before_state = self._prompt_state_for_excerpt(before)
-        self._append_instruction_trace(
-            request,
-            handle,
-            trace_id,
-            DeliveryStage.WRITE_STARTED,
-            DeliveryVerdict.PENDING,
-            DeliveryReasonCode.PTY_WRITE_STARTED,
-            prompt_state_before=before_state,
-            first_output_excerpt=before,
+        action = self._delivery_action_from_metadata(request.metadata)
+        runner = TmuxSessionRunner(
+            tmux_session=self.tmux_session,
+            provider_name=self.provider_name,
+            prompt_state_for_excerpt=self._prompt_state_for_excerpt,
+            terminal_verdict_for_observation=self._terminal_verdict_for_observation,
         )
-        await send_bracketed_instruction(self.tmux_session, handle.tmux_pane, text)
-        after = await capture_pane_text(handle.tmux_pane, lines=80)
-        after_state = self._prompt_state_for_excerpt(after)
-        self._append_instruction_trace(
-            request,
-            handle,
-            trace_id,
-            DeliveryStage.WRITTEN_TO_PTY,
-            DeliveryVerdict.ACCEPTED,
-            DeliveryReasonCode.PTY_WRITE_ACCEPTED,
-            prompt_state_before=before_state,
-            prompt_state_after=after_state,
-            first_output_excerpt=after,
-        )
-        self._append_instruction_trace(
-            request,
-            handle,
-            trace_id,
-            DeliveryStage.SUBMIT_ATTEMPTED,
-            DeliveryVerdict.ACCEPTED,
-            DeliveryReasonCode.SUBMIT_SENT,
-            prompt_state_before=before_state,
-            prompt_state_after=after_state,
-        )
-        terminal_stage = DeliveryStage.CONFIRMED_RUNNING
-        terminal_reason = DeliveryReasonCode.SESSION_RUNNING
-        terminal_verdict = DeliveryVerdict.CONFIRMED
-        if after_state == "blocked:trust":
-            terminal_stage = DeliveryStage.BLOCKED
-            terminal_reason = DeliveryReasonCode.TRUST_REQUIRED
-            terminal_verdict = DeliveryVerdict.BLOCKED
-        elif after_state == "blocked:auth":
-            terminal_stage = DeliveryStage.BLOCKED
-            terminal_reason = DeliveryReasonCode.AUTH_REQUIRED
-            terminal_verdict = DeliveryVerdict.BLOCKED
-        elif _CODEX_PROMPT_RE.search(after):
-            terminal_stage = DeliveryStage.PROMPT_CLEARED
-            terminal_reason = DeliveryReasonCode.PROMPT_STILL_VISIBLE
-            terminal_verdict = DeliveryVerdict.ACCEPTED
-        elif after.strip():
-            terminal_stage = DeliveryStage.AGENT_OUTPUT_OBSERVED
-            terminal_reason = DeliveryReasonCode.AGENT_OUTPUT
-        self._append_instruction_trace(
-            request,
-            handle,
-            trace_id,
-            terminal_stage,
-            terminal_verdict,
-            terminal_reason,
-            prompt_state_before=before_state,
-            prompt_state_after=after_state,
-            first_output_excerpt=after,
+        await runner.deliver_instruction(
+            handle=handle,
+            metadata=request.metadata,
+            trace_id=trace_id,
+            action=action,
+            payload_loader=lambda: self._instruction_text(request),
         )
 
     async def assign_task(
@@ -383,45 +294,57 @@ class CodexRuntime(ProviderRuntime):
             return f"{readiness.value}:{block_reason.value}"
         return readiness.value
 
-    @staticmethod
-    def _append_instruction_trace(
-        request: InstructionRequest,
-        handle: RuntimeSessionHandle,
-        trace_id: str,
-        stage: DeliveryStage,
-        verdict: DeliveryVerdict,
-        reason_code: DeliveryReasonCode,
-        *,
-        prompt_state_before: str | None = None,
-        prompt_state_after: str | None = None,
-        first_output_excerpt: str | None = None,
-    ) -> None:
-        if not trace_id:
-            return
-        raw_action = request.metadata.get("delivery_action")
-        action = (
-            DeliveryAction.TASK_ASSIGNMENT
-            if raw_action == DeliveryAction.TASK_ASSIGNMENT.value
-            else DeliveryAction.INSTRUCTION
-        )
-        append_trace_event(
-            request.metadata,
-            trace_event(
-                trace_id=trace_id,
-                session_id=handle.session_id,
-                role=handle.role.value,
-                provider=handle.provider_name,
-                pane_id=handle.tmux_pane,
-                action=action,
-                stage=stage,
-                verdict=verdict,
-                reason_code=reason_code,
-                prompt_state_before=prompt_state_before,
-                prompt_state_after=prompt_state_after,
-                first_output_excerpt=first_output_excerpt,
-            ),
-        )
 
+    @staticmethod
+    def _delivery_action_from_metadata(metadata: dict[str, object]) -> DeliveryAction:
+        raw_action = metadata.get("delivery_action")
+        if raw_action == DeliveryAction.TASK_ASSIGNMENT.value:
+            return DeliveryAction.TASK_ASSIGNMENT
+        return DeliveryAction.INSTRUCTION
+
+    @staticmethod
+    async def _instruction_text(request: InstructionRequest) -> str:
+        text = request.message or ""
+        if not text and request.message_file:
+            with open(request.message_file, encoding="utf-8") as f:
+                text = f.read()
+        return text
+
+    @staticmethod
+    def _terminal_verdict_for_observation(
+        _text: str,
+        after_state: str | None,
+        output: str,
+    ) -> RunnerTerminalVerdict:
+        if after_state == "blocked:trust":
+            return RunnerTerminalVerdict(
+                stage=DeliveryStage.BLOCKED,
+                verdict=DeliveryVerdict.BLOCKED,
+                reason_code=DeliveryReasonCode.TRUST_REQUIRED,
+            )
+        if after_state == "blocked:auth":
+            return RunnerTerminalVerdict(
+                stage=DeliveryStage.BLOCKED,
+                verdict=DeliveryVerdict.BLOCKED,
+                reason_code=DeliveryReasonCode.AUTH_REQUIRED,
+            )
+        if _CODEX_PROMPT_RE.search(output):
+            return RunnerTerminalVerdict(
+                stage=DeliveryStage.PROMPT_CLEARED,
+                verdict=DeliveryVerdict.ACCEPTED,
+                reason_code=DeliveryReasonCode.PROMPT_STILL_VISIBLE,
+            )
+        if output.strip():
+            return RunnerTerminalVerdict(
+                stage=DeliveryStage.AGENT_OUTPUT_OBSERVED,
+                verdict=DeliveryVerdict.CONFIRMED,
+                reason_code=DeliveryReasonCode.AGENT_OUTPUT,
+            )
+        return RunnerTerminalVerdict(
+            stage=DeliveryStage.CONFIRMED_RUNNING,
+            verdict=DeliveryVerdict.CONFIRMED,
+            reason_code=DeliveryReasonCode.SESSION_RUNNING,
+        )
     @staticmethod
     def _summary_for_state(
         readiness: ReadinessState,

--- a/src/atc/runtime/tmux/runner.py
+++ b/src/atc/runtime/tmux/runner.py
@@ -1,0 +1,220 @@
+"""Shared hardened tmux session runner for terminal-agent delivery.
+
+Phase 2 introduces this runner as the authoritative place for pane inspection,
+payload validation, atomic PTY writes, Enter submission, verification reads, and
+provider-neutral delivery verdicts. Providers keep prompt classification and
+configuration concerns behind small adapters.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+from atc.runtime.errors import RuntimeDeliveryError, RuntimeSessionMissingError
+from atc.runtime.tmux.control import send_bracketed_instruction
+from atc.runtime.tmux.substrate import capture_pane_text, pane_exists
+from atc.runtime.tracing import (
+    DeliveryAction,
+    DeliveryReasonCode,
+    DeliveryStage,
+    DeliveryVerdict,
+    append_trace_event,
+    trace_event,
+)
+
+PromptClassifier = Callable[[str], str]
+TerminalClassifier = Callable[[str, str | None, str], "RunnerTerminalVerdict"]
+PayloadLoader = Callable[[], Awaitable[str]]
+
+if TYPE_CHECKING:
+    from atc.runtime.models import RuntimeSessionHandle
+
+
+@dataclass(frozen=True, slots=True)
+class RunnerTerminalVerdict:
+    """Provider adapter result for a post-delivery terminal observation."""
+
+    stage: DeliveryStage
+    verdict: DeliveryVerdict
+    reason_code: DeliveryReasonCode
+    raises: bool = False
+    error_message: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class RunnerDeliveryResult:
+    """Final observation emitted by the runner."""
+
+    before: str
+    after: str
+    prompt_state_before: str
+    prompt_state_after: str
+    terminal_verdict: RunnerTerminalVerdict
+
+
+@dataclass(frozen=True, slots=True)
+class TmuxSessionRunner:
+    """Shared runner for tmux-backed instruction delivery."""
+
+    tmux_session: str
+    provider_name: str
+    prompt_state_for_excerpt: PromptClassifier
+    terminal_verdict_for_observation: TerminalClassifier
+    observe_delay_seconds: float = 0.0
+    before_capture_lines: int = 40
+    after_capture_lines: int = 80
+
+    async def deliver_instruction(
+        self,
+        *,
+        handle: RuntimeSessionHandle,
+        metadata: dict[str, Any],
+        trace_id: str,
+        action: DeliveryAction,
+        payload_loader: PayloadLoader,
+    ) -> RunnerDeliveryResult:
+        """Validate, write, submit, verify, and trace one instruction delivery."""
+
+        if not handle.tmux_pane:
+            self._append_trace(
+                handle=handle,
+                metadata=metadata,
+                trace_id=trace_id,
+                action=action,
+                stage=DeliveryStage.FAILED,
+                verdict=DeliveryVerdict.FAILED,
+                reason_code=DeliveryReasonCode.PANE_MISSING,
+            )
+            raise RuntimeSessionMissingError(
+                f"{self.provider_name} session has no tmux pane recorded"
+            )
+        if not await pane_exists(handle.tmux_pane):
+            self._append_trace(
+                handle=handle,
+                metadata=metadata,
+                trace_id=trace_id,
+                action=action,
+                stage=DeliveryStage.FAILED,
+                verdict=DeliveryVerdict.FAILED,
+                reason_code=DeliveryReasonCode.PANE_MISSING,
+            )
+            raise RuntimeSessionMissingError(f"{self.provider_name} session pane is missing")
+
+        text = await payload_loader()
+        if not text:
+            self._append_trace(
+                handle=handle,
+                metadata=metadata,
+                trace_id=trace_id,
+                action=action,
+                stage=DeliveryStage.FAILED,
+                verdict=DeliveryVerdict.FAILED,
+                reason_code=DeliveryReasonCode.EMPTY_PAYLOAD,
+            )
+            raise RuntimeDeliveryError("Instruction payload was empty")
+
+        before = await capture_pane_text(handle.tmux_pane, lines=self.before_capture_lines)
+        before_state = self.prompt_state_for_excerpt(before)
+        self._append_trace(
+            handle=handle,
+            metadata=metadata,
+            trace_id=trace_id,
+            action=action,
+            stage=DeliveryStage.WRITE_STARTED,
+            verdict=DeliveryVerdict.PENDING,
+            reason_code=DeliveryReasonCode.PTY_WRITE_STARTED,
+            prompt_state_before=before_state,
+            first_output_excerpt=before,
+        )
+
+        await send_bracketed_instruction(self.tmux_session, handle.tmux_pane, text)
+        if self.observe_delay_seconds > 0:
+            await asyncio.sleep(self.observe_delay_seconds)
+
+        after = await capture_pane_text(handle.tmux_pane, lines=self.after_capture_lines)
+        after_state = self.prompt_state_for_excerpt(after)
+        self._append_trace(
+            handle=handle,
+            metadata=metadata,
+            trace_id=trace_id,
+            action=action,
+            stage=DeliveryStage.WRITTEN_TO_PTY,
+            verdict=DeliveryVerdict.ACCEPTED,
+            reason_code=DeliveryReasonCode.PTY_WRITE_ACCEPTED,
+            prompt_state_before=before_state,
+            prompt_state_after=after_state,
+            first_output_excerpt=after,
+        )
+        self._append_trace(
+            handle=handle,
+            metadata=metadata,
+            trace_id=trace_id,
+            action=action,
+            stage=DeliveryStage.SUBMIT_ATTEMPTED,
+            verdict=DeliveryVerdict.ACCEPTED,
+            reason_code=DeliveryReasonCode.SUBMIT_SENT,
+            prompt_state_before=before_state,
+            prompt_state_after=after_state,
+        )
+
+        terminal_verdict = self.terminal_verdict_for_observation(text, after_state, after)
+        self._append_trace(
+            handle=handle,
+            metadata=metadata,
+            trace_id=trace_id,
+            action=action,
+            stage=terminal_verdict.stage,
+            verdict=terminal_verdict.verdict,
+            reason_code=terminal_verdict.reason_code,
+            prompt_state_before=before_state,
+            prompt_state_after=after_state,
+            first_output_excerpt=after,
+        )
+        if terminal_verdict.raises:
+            raise RuntimeDeliveryError(
+                terminal_verdict.error_message or "Instruction delivery could not be verified"
+            )
+        return RunnerDeliveryResult(
+            before=before,
+            after=after,
+            prompt_state_before=before_state,
+            prompt_state_after=after_state,
+            terminal_verdict=terminal_verdict,
+        )
+
+    def _append_trace(
+        self,
+        *,
+        handle: RuntimeSessionHandle,
+        metadata: dict[str, Any],
+        trace_id: str,
+        action: DeliveryAction,
+        stage: DeliveryStage,
+        verdict: DeliveryVerdict,
+        reason_code: DeliveryReasonCode,
+        prompt_state_before: str | None = None,
+        prompt_state_after: str | None = None,
+        first_output_excerpt: str | None = None,
+    ) -> None:
+        if not trace_id:
+            return
+        append_trace_event(
+            metadata,
+            trace_event(
+                trace_id=trace_id,
+                session_id=handle.session_id,
+                role=handle.role.value,
+                provider=handle.provider_name,
+                pane_id=handle.tmux_pane,
+                action=action,
+                stage=stage,
+                verdict=verdict,
+                reason_code=reason_code,
+                prompt_state_before=prompt_state_before,
+                prompt_state_after=prompt_state_after,
+                first_output_excerpt=first_output_excerpt,
+            ),
+        )

--- a/tests/unit/test_delivery_tracing.py
+++ b/tests/unit/test_delivery_tracing.py
@@ -25,13 +25,13 @@ def test_codex_instruction_emits_structured_delivery_trace_events() -> None:
     )
 
     with (
-        patch("atc.providers.codex.runtime.pane_exists", AsyncMock(return_value=True)),
+        patch("atc.runtime.tmux.runner.pane_exists", AsyncMock(return_value=True)),
         patch(
-            "atc.providers.codex.runtime.capture_pane_text",
+            "atc.runtime.tmux.runner.capture_pane_text",
             AsyncMock(side_effect=["ready\n>\n", "Thinking about traced work..."]),
         ),
         patch(
-            "atc.providers.codex.runtime.send_bracketed_instruction", AsyncMock()
+            "atc.runtime.tmux.runner.send_bracketed_instruction", AsyncMock()
         ) as send_instruction,
     ):
         asyncio.run(runtime.send_instruction(handle, request))
@@ -71,7 +71,7 @@ def test_codex_instruction_failure_trace_has_stable_reason_code() -> None:
     )
 
     with (
-        patch("atc.providers.codex.runtime.pane_exists", AsyncMock(return_value=False)),
+        patch("atc.runtime.tmux.runner.pane_exists", AsyncMock(return_value=False)),
         suppress(Exception),
     ):
         asyncio.run(runtime.send_instruction(handle, request))

--- a/tests/unit/test_tmux_session_runner.py
+++ b/tests/unit/test_tmux_session_runner.py
@@ -1,0 +1,118 @@
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from atc.runtime.errors import RuntimeDeliveryError, RuntimeSessionMissingError
+from atc.runtime.models import RoleKind, RuntimeSessionHandle, RuntimeTransport
+from atc.runtime.tmux.runner import RunnerTerminalVerdict, TmuxSessionRunner
+from atc.runtime.tracing import (
+    DeliveryAction,
+    DeliveryReasonCode,
+    DeliveryStage,
+    DeliveryVerdict,
+)
+
+
+def _handle(pane: str | None = "%1") -> RuntimeSessionHandle:
+    return RuntimeSessionHandle(
+        session_id="sess-runner-1",
+        provider_name="codex",
+        role=RoleKind.ACE,
+        transport=RuntimeTransport.TMUX,
+        tmux_session="atc",
+        tmux_pane=pane,
+    )
+
+
+def _terminal_verdict(_text: str, state: str | None, _output: str) -> RunnerTerminalVerdict:
+    if state == "blocked:trust":
+        return RunnerTerminalVerdict(
+            stage=DeliveryStage.BLOCKED,
+            verdict=DeliveryVerdict.BLOCKED,
+            reason_code=DeliveryReasonCode.TRUST_REQUIRED,
+        )
+    return RunnerTerminalVerdict(
+        stage=DeliveryStage.AGENT_OUTPUT_OBSERVED,
+        verdict=DeliveryVerdict.CONFIRMED,
+        reason_code=DeliveryReasonCode.AGENT_OUTPUT,
+    )
+
+
+def _runner() -> TmuxSessionRunner:
+    return TmuxSessionRunner(
+        tmux_session="atc",
+        provider_name="codex",
+        prompt_state_for_excerpt=lambda text: "blocked:trust" if "trust" in text else "ready",
+        terminal_verdict_for_observation=_terminal_verdict,
+    )
+
+
+def test_tmux_session_runner_traces_write_submit_and_terminal_verdict() -> None:
+    metadata = {"delivery_trace_id": "trace-1"}
+    with (
+        patch("atc.runtime.tmux.runner.pane_exists", AsyncMock(return_value=True)),
+        patch(
+            "atc.runtime.tmux.runner.capture_pane_text",
+            AsyncMock(side_effect=["❯", "Do you trust the contents?"]),
+        ),
+        patch("atc.runtime.tmux.runner.send_bracketed_instruction", AsyncMock()) as send,
+    ):
+        result = asyncio.run(
+            _runner().deliver_instruction(
+                handle=_handle(),
+                metadata=metadata,
+                trace_id="trace-1",
+                action=DeliveryAction.INSTRUCTION,
+                payload_loader=AsyncMock(return_value="hello"),
+            )
+        )
+
+    send.assert_awaited_once_with("atc", "%1", "hello")
+    assert result.prompt_state_after == "blocked:trust"
+    assert [event["stage"] for event in metadata["delivery_trace_events"]] == [
+        "write_started",
+        "written_to_pty",
+        "submit_attempted",
+        "blocked",
+    ]
+    assert metadata["delivery_trace_events"][-1]["reason_code"] == "trust_required"
+
+
+def test_tmux_session_runner_traces_missing_pane() -> None:
+    metadata = {"delivery_trace_id": "trace-2"}
+    with pytest.raises(RuntimeSessionMissingError):
+        asyncio.run(
+            _runner().deliver_instruction(
+                handle=_handle(pane=None),
+                metadata=metadata,
+                trace_id="trace-2",
+                action=DeliveryAction.INSTRUCTION,
+                payload_loader=AsyncMock(return_value="hello"),
+            )
+        )
+
+    assert metadata["delivery_trace_events"][-1]["stage"] == "failed"
+    assert metadata["delivery_trace_events"][-1]["reason_code"] == "pane_missing"
+
+
+def test_tmux_session_runner_traces_empty_payload() -> None:
+    metadata = {"delivery_trace_id": "trace-3"}
+    with (
+        patch("atc.runtime.tmux.runner.pane_exists", AsyncMock(return_value=True)),
+        pytest.raises(RuntimeDeliveryError),
+    ):
+        asyncio.run(
+            _runner().deliver_instruction(
+                handle=_handle(),
+                metadata=metadata,
+                trace_id="trace-3",
+                action=DeliveryAction.INSTRUCTION,
+                payload_loader=AsyncMock(return_value=""),
+            )
+        )
+
+    assert metadata["delivery_trace_events"][-1]["stage"] == "failed"
+    assert metadata["delivery_trace_events"][-1]["reason_code"] == "empty_payload"


### PR DESCRIPTION
## Summary
- extract a shared `TmuxSessionRunner` for tmux pane inspection, payload validation, atomic write/submit, verification reads, and provider-neutral delivery verdict tracing
- route the Codex instruction path through the shared runner while leaving Claude Code on the compatibility path for later migration
- add focused runner tests for success, missing pane, and empty payload failures
- update delivery trace tests to assert the shared runner path

## Validation
- `ruff check src/atc/runtime/tmux/runner.py src/atc/providers/codex/runtime.py src/atc/providers/claude_code/runtime.py tests/unit/test_tmux_session_runner.py tests/unit/test_delivery_tracing.py`
- `pytest tests/unit/test_tmux_session_runner.py tests/unit/test_codex_runtime.py tests/unit/test_runtime_service.py tests/unit/test_delivery_tracing.py tests/unit/test_tmux_substrate.py tests/e2e/test_smoke.py -q` → 51 passed, 1 warning
- Mac Studio Playwright/API validation passed: spawn and instruction traces observed through the shared runner path

## Evidence
- Report: `/Users/mcole_studio/Repository/atc/test-results/phase2-session-runner-2026-06-07T12-23-26-069Z/report.json`
- Screenshots attached in Slack:
  - `/Users/mcole_studio/Repository/atc/test-results/phase2-session-runner-2026-06-07T12-23-26-069Z/00-dashboard.png`
  - `/Users/mcole_studio/Repository/atc/test-results/phase2-session-runner-2026-06-07T12-23-26-069Z/01-project-runner-validation.png`
  - `/Users/mcole_studio/Repository/atc/test-results/phase2-session-runner-2026-06-07T12-23-26-069Z/02-delivery-trace-events.png`
