### PR TITLE
Phase 3: Lifecycle Transition Guards

### DIFF
--- a/CODE_STRUCTURE.md
+++ b/CODE_STRUCTURE.md
@@ -48,6 +48,11 @@ Prefer:
 - explicit lifecycle transitions over ad hoc status mutation
 - source-of-truth records over reconstructing behavior from side effects
 
+Current durable task graph and task assignment transitions are centralized in
+`src/atc/state/transitions.py`. API-visible transition failures return stable
+reason codes and allowed-target lists so Tower/Leader surfaces can display why a
+workflow is blocked instead of treating a rejected mutation as a silent stall.
+
 If a session, leader, or tower state matters to the user, it should be representable in durable state.
 
 ## Current Major Boundaries

--- a/docs/runtime_orchestration_refactor_phases.md
+++ b/docs/runtime_orchestration_refactor_phases.md
@@ -134,6 +134,12 @@ Playwright evidence should be stored under a timestamped project-local `screensh
 - Retry paths use explicit allowed transitions.
 - Tower/Leader status surfaces blocked transition reasons.
 
+**Implementation contract:**
+- Durable task graph and task assignment status changes are validated by `src/atc/state/transitions.py` before persistence.
+- Rejected transitions use `LifecycleTransitionError` with stable API-visible fields: `code`, `entity_type`, `entity_id`, `current`, `target`, `allowed`, and `message`.
+- Retry/recovery paths must bridge through explicitly allowed states. For example, a finished or failed task reopens through `todo` before it can be assigned again; task failure handling bridges `assigned → in_progress → error → todo` rather than jumping directly back to `todo`.
+- Leader progress includes recent `blocked_transition_errors` so Tower/Leader surfaces can report lifecycle blockers instead of silently stalling.
+
 ## Phase 4 — Dialog/interruption pipeline
 
 **Goal:** Centralize startup/trust/permission/welcome handling as runtime interrupts instead of scattered prompt hacks.

--- a/frontend/playwright-smoke-atc.mjs
+++ b/frontend/playwright-smoke-atc.mjs
@@ -1,0 +1,97 @@
+import { chromium } from '@playwright/test';
+import fs from 'fs';
+import path from 'path';
+
+const outDir = path.resolve('../screenshots/playwright-atc-' + new Date().toISOString().replace(/[:.]/g, '-'));
+fs.mkdirSync(outDir, { recursive: true });
+const errors = [];
+const requests = [];
+const checks = [];
+
+function record(name, ok, detail = '') {
+  checks.push({ name, ok, detail });
+  console.log(`${ok ? 'PASS' : 'FAIL'} ${name}${detail ? ' — ' + detail : ''}`);
+}
+
+const browser = await chromium.launch({ headless: true });
+const page = await browser.newPage({ viewport: { width: 1440, height: 1000 }, deviceScaleFactor: 1 });
+page.on('console', msg => {
+  const text = msg.text();
+  if (['error', 'warning'].includes(msg.type())) errors.push({ type: msg.type(), text });
+});
+page.on('pageerror', err => errors.push({ type: 'pageerror', text: err.message }));
+page.on('requestfailed', req => requests.push({ url: req.url(), failure: req.failure()?.errorText }));
+page.on('response', res => {
+  const url = res.url();
+  if (res.status() >= 400 && !url.includes('/@vite')) requests.push({ url, status: res.status() });
+});
+
+async function screenshot(name) {
+  const file = path.join(outDir, `${String(checks.length).padStart(2, '0')}-${name}.png`);
+  await page.screenshot({ path: file, fullPage: true });
+  console.log(`SCREENSHOT ${file}`);
+}
+
+try {
+  await page.goto('http://localhost:5173/dashboard', { waitUntil: 'networkidle', timeout: 30000 });
+  await page.getByTestId('dashboard-page').or(page.getByText('Dashboard')).first().waitFor({ timeout: 15000 });
+  record('Dashboard route loads', true, await page.title());
+  await screenshot('dashboard-initial');
+
+  for (const label of ['⊞ Grid', '☰ Row', '▦ Board']) {
+    const btn = page.getByRole('button', { name: label });
+    await btn.click();
+    await page.waitForTimeout(300);
+    const pressed = await btn.getAttribute('aria-pressed');
+    record(`Dashboard view toggle ${label}`, pressed === 'true', `aria-pressed=${pressed}`);
+    await screenshot(`dashboard-${label.replace(/[^a-zA-Z]+/g, '').toLowerCase()}`);
+  }
+
+  await page.getByRole('button', { name: '+ New Project' }).click();
+  await page.waitForSelector('[data-testid="create-project-modal"]');
+  record('Create Project modal opens', true);
+  await screenshot('create-project-modal');
+
+  await page.getByRole('button', { name: 'Create Project' }).click();
+  const validation = await page.locator('#project-name').evaluate(el => el.matches(':invalid'));
+  record('Create Project required-name validation works without creating data', validation === true, `input invalid=${validation}`);
+  await page.keyboard.press('Escape');
+  await page.waitForSelector('[data-testid="create-project-modal"]', { state: 'detached' });
+  record('Create Project modal closes via Escape', true);
+
+  await page.goto('http://localhost:5173/usage', { waitUntil: 'networkidle', timeout: 30000 });
+  await page.waitForSelector('text=Usage', { timeout: 15000 });
+  record('Usage route loads', true);
+  await screenshot('usage');
+  for (const p of ['30d', '90d', '7d']) {
+    await page.getByRole('button', { name: p }).click();
+    await page.waitForTimeout(500);
+    record(`Usage period button ${p} clickable`, true);
+  }
+
+  await page.goto('http://localhost:5173/context', { waitUntil: 'networkidle', timeout: 30000 });
+  await page.waitForLoadState('networkidle');
+  const bodyText = (await page.locator('body').innerText()).slice(0, 500).replace(/\s+/g, ' ');
+  record('Context route reachable', bodyText.length > 0, bodyText);
+  await screenshot('context');
+
+  const navDashboard = page.getByText('Dashboard').first();
+  if (await navDashboard.count()) {
+    await navDashboard.click();
+    await page.waitForURL(/dashboard/);
+    record('Sidebar navigation back to Dashboard works', true);
+  } else {
+    record('Sidebar navigation back to Dashboard works', false, 'Dashboard nav text not found');
+  }
+
+} catch (err) {
+  record('Playwright script completed without throw', false, err?.message ?? String(err));
+  await screenshot('failure');
+} finally {
+  await browser.close();
+}
+
+const report = { outDir, checks, errors, requests };
+fs.writeFileSync(path.join(outDir, 'report.json'), JSON.stringify(report, null, 2));
+console.log('\nREPORT ' + path.join(outDir, 'report.json'));
+if (checks.some(c => !c.ok)) process.exitCode = 1;

--- a/frontend/playwright-tower-codex-flow.mjs
+++ b/frontend/playwright-tower-codex-flow.mjs
@@ -1,0 +1,109 @@
+import { chromium } from '@playwright/test';
+import fs from 'fs';
+import path from 'path';
+
+const stamp = new Date().toISOString().replace(/[:.]/g, '-');
+const outDir = path.resolve('../screenshots/tower-codex-flow-' + stamp);
+fs.mkdirSync(outDir, { recursive: true });
+const BACKEND = 'http://127.0.0.1:8420';
+const codexCommand = '/Users/mcole_studio/.local/bin/codex --dangerously-bypass-approvals-and-sandbox';
+const controlName = `ATC Codex Control ${stamp.slice(0, 19)}`;
+const generatedName = `Tower Codex Generated ${stamp.slice(0, 19)}`;
+const generatedPath = `/tmp/atc-tower-generated-${stamp}`;
+const events = [];
+const errors = [];
+const requests = [];
+let screenshotIndex = 0;
+
+function log(name, detail = '') { events.push({ t: new Date().toISOString(), name, detail }); console.log(`${name}${detail ? ' — ' + detail : ''}`); }
+async function screenshot(page, name) { const file = path.join(outDir, `${String(screenshotIndex++).padStart(2, '0')}-${name}.png`); await page.screenshot({ path: file, fullPage: true }); log('SCREENSHOT', file); }
+async function api(route, options = {}) { const res = await fetch(`${BACKEND}${route}`, { headers: { 'Content-Type': 'application/json' }, ...options }); const text = await res.text(); let body; try { body = text ? JSON.parse(text) : null; } catch { body = text; } return { ok: res.ok, status: res.status, body }; }
+async function waitFor(name, fn, timeoutMs = 60000, intervalMs = 2000) { const start = Date.now(); let last; while (Date.now() - start < timeoutMs) { last = await fn(); if (last?.ok) { log(name, JSON.stringify(last.value ?? last)); return last.value ?? last; } await new Promise(r => setTimeout(r, intervalMs)); } throw new Error(`${name} timed out; last=${JSON.stringify(last)}`); }
+
+const browser = await chromium.launch({ headless: true });
+const page = await browser.newPage({ viewport: { width: 1600, height: 1100 }, deviceScaleFactor: 1 });
+page.on('console', msg => { if (['error', 'warning'].includes(msg.type())) errors.push({ type: msg.type(), text: msg.text() }); });
+page.on('pageerror', err => errors.push({ type: 'pageerror', text: err.message }));
+page.on('response', res => { if (res.status() >= 400) requests.push({ url: res.url(), status: res.status() }); });
+
+let controlProject = null;
+let goalResponse = null;
+let final = {};
+try {
+  await page.goto('http://localhost:5173/dashboard', { waitUntil: 'networkidle', timeout: 30000 });
+  await page.getByTestId('tower-bar').waitFor({ timeout: 15000 });
+  await screenshot(page, 'dashboard-before-settings');
+
+  await page.getByTestId('settings-button').click();
+  await page.getByTestId('settings-pane').waitFor({ timeout: 10000 });
+  await page.locator('#provider-default').selectOption('codex');
+  await page.locator('#provider-codex-command').fill(codexCommand);
+  await page.locator('#provider-codex-command').blur();
+  await page.waitForTimeout(1200);
+  const providerStatus = await api('/api/settings/agent-provider');
+  log('Provider config after settings cog', JSON.stringify(providerStatus.body));
+  await screenshot(page, 'settings-codex');
+  await page.getByTestId('close-settings-pane').click();
+
+  await page.getByRole('button', { name: '+ New Project' }).click();
+  await page.locator('#project-name').fill(controlName);
+  await page.locator('#project-desc').fill('Temporary control project for Codex/Tower smoke testing.');
+  await page.locator('#project-repo').fill('/Users/mcole_studio/Repository/atc');
+  await page.locator('#project-provider').selectOption('codex');
+  const projectResponsePromise = page.waitForResponse(resp => resp.url().includes('/api/projects') && resp.request().method() === 'POST');
+  await page.getByRole('button', { name: 'Create Project' }).click();
+  const projectResponse = await projectResponsePromise;
+  controlProject = await projectResponse.json();
+  log('Control project created', JSON.stringify({ id: controlProject.id, name: controlProject.name, provider: controlProject.agent_provider }));
+
+  await page.goto(`http://localhost:5173/projects/${controlProject.id}`, { waitUntil: 'networkidle', timeout: 30000 });
+  await page.getByTestId('tower-panel').waitFor({ timeout: 15000 });
+  await page.getByTestId('tower-panel-toggle').click().catch(() => {});
+  await screenshot(page, 'project-view-tower-panel');
+
+  // TowerPanel auto-starts when a project route is active. If not, click Start.
+  const start = page.getByTestId('tower-panel-start');
+  if (await start.isVisible().catch(() => false)) { await start.click(); log('Clicked Tower start'); }
+  const towerStatus = await waitFor('Tower session running', async () => {
+    const res = await api('/api/tower/status');
+    const b = res.body;
+    return { ok: res.ok && b?.current_session_id && ['planning', 'managing'].includes(b.state), value: b };
+  }, 90000, 3000);
+  await screenshot(page, 'tower-started');
+
+  const goal = `Create a new ATC project record named "${generatedName}" with description "Created by Tower Codex smoke test" and repo path "${generatedPath}". Decompose this goal into tasks using POST /api/projects/${controlProject.id}/leader/decompose, spawn Aces for ready tasks, monitor progress, and report completion. Keep any filesystem writes inside ${generatedPath}.`;
+  goalResponse = await api('/api/tower/goal', { method: 'POST', body: JSON.stringify({ project_id: controlProject.id, goal }) });
+  log('Submitted Tower goal', JSON.stringify(goalResponse.body));
+  await screenshot(page, 'goal-submitted');
+
+  await waitFor('Leader session created', async () => {
+    const res = await api('/api/tower/status');
+    return { ok: res.ok && !!res.body?.leader_session_id, value: res.body };
+  }, 90000, 3000);
+
+  const activity = await waitFor('Leader/Ace/generated-project activity', async () => {
+    const [sessions, projects, status] = await Promise.all([
+      api('/api/orchestration/sessions'),
+      api('/api/projects'),
+      api('/api/tower/status'),
+    ]);
+    const sessionList = Array.isArray(sessions.body) ? sessions.body : [];
+    const relevant = sessionList.filter(s => s.project_id === controlProject.id);
+    const leaderCount = relevant.filter(s => s.role === 'leader' || s.raw_session_type === 'manager').length;
+    const aceCount = relevant.filter(s => s.role === 'ace' || s.raw_session_type === 'ace').length;
+    const generated = Array.isArray(projects.body) ? projects.body.find(p => p.name === generatedName) : null;
+    return { ok: leaderCount > 0 && (aceCount > 0 || generated || status.body?.output_line_count > 0), value: { leaderCount, aceCount, generatedProjectId: generated?.id, status: status.body } };
+  }, 300000, 5000);
+  await page.goto(`http://localhost:5173/projects/${controlProject.id}`, { waitUntil: 'networkidle', timeout: 30000 });
+  await screenshot(page, 'activity-observed');
+  final.activity = activity;
+} catch (err) {
+  log('ERROR', err?.stack || err?.message || String(err));
+  await screenshot(page, 'failure');
+  process.exitCode = 1;
+} finally {
+  final = { ...final, outDir, codexCommand, controlProject, goalResponse, events, errors, requests, towerStatus: await api('/api/tower/status').catch(e => ({ ok: false, body: String(e) })), sessions: await api('/api/orchestration/sessions').catch(e => ({ ok: false, body: String(e) })), projects: await api('/api/projects').catch(e => ({ ok: false, body: String(e) })) };
+  fs.writeFileSync(path.join(outDir, 'report.json'), JSON.stringify(final, null, 2));
+  console.log('REPORT ' + path.join(outDir, 'report.json'));
+  await browser.close();
+}

--- a/src/atc/api/routers/leader.py
+++ b/src/atc/api/routers/leader.py
@@ -15,11 +15,12 @@ from __future__ import annotations
 from typing import Any
 
 from fastapi import APIRouter, HTTPException, Request
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 from atc.leader.decomposer import TaskSpec, decompose_goal
 from atc.leader.orchestrator import LeaderOrchestrator
 from atc.state import db as db_ops
+from atc.state.transitions import LifecycleTransitionError
 
 router = APIRouter()
 
@@ -78,6 +79,7 @@ class ProgressResponse(BaseModel):
     all_done: bool
     progress_pct: int
     assignments: list[dict[str, Any]]
+    blocked_transition_errors: list[dict[str, Any]] = Field(default_factory=list)
 
 
 # ---------------------------------------------------------------------------
@@ -91,6 +93,11 @@ async def _get_db(request: Request) -> Any:
 
 def _get_event_bus(request: Request) -> Any:
     return getattr(request.app.state, "event_bus", None)
+
+
+def _transition_error_detail(exc: LifecycleTransitionError) -> dict[str, object]:
+    """Return normalized lifecycle-transition error detail for API callers."""
+    return exc.to_detail()
 
 
 async def _broadcast_tower_progress(request: Request) -> None:
@@ -291,7 +298,10 @@ async def task_done(
 ) -> dict[str, str]:
     """Mark a task graph entry as done and clean up its Ace."""
     orch = await _get_or_create_orchestrator(request, project_id)
-    await orch.mark_task_done(body.task_graph_id)
+    try:
+        await orch.mark_task_done(body.task_graph_id)
+    except LifecycleTransitionError as exc:
+        raise HTTPException(status_code=409, detail=_transition_error_detail(exc)) from None
     await _broadcast_tower_progress(request)
     return {"status": "done"}
 
@@ -304,7 +314,10 @@ async def task_failed(
 ) -> dict[str, str]:
     """Mark a task graph entry as failed and allow retry."""
     orch = await _get_or_create_orchestrator(request, project_id)
-    await orch.mark_task_failed(body.task_graph_id, reason=body.reason)
+    try:
+        await orch.mark_task_failed(body.task_graph_id, reason=body.reason)
+    except LifecycleTransitionError as exc:
+        raise HTTPException(status_code=409, detail=_transition_error_detail(exc)) from None
     await _broadcast_tower_progress(request)
     return {"status": "failed"}
 

--- a/src/atc/api/routers/task_graphs.py
+++ b/src/atc/api/routers/task_graphs.py
@@ -17,6 +17,7 @@ from fastapi import APIRouter, HTTPException, Request
 from pydantic import BaseModel
 
 from atc.state import db as db_ops
+from atc.state.transitions import LifecycleTransitionError
 
 router = APIRouter()
 
@@ -65,6 +66,11 @@ class TaskGraphResponse(BaseModel):
 
 async def _get_db(request: Request) -> Any:
     return request.app.state.db
+
+
+def _transition_error_detail(exc: LifecycleTransitionError) -> dict[str, object]:
+    """Return normalized lifecycle-transition error detail for API callers."""
+    return exc.to_detail()
 
 
 def _to_response(tg: Any) -> TaskGraphResponse:
@@ -192,6 +198,8 @@ async def transition_task_graph_status(
     db = await _get_db(request)
     try:
         tg = await db_ops.update_task_graph_status(db, task_graph_id, body.status)
+    except LifecycleTransitionError as e:
+        raise HTTPException(status_code=409, detail=_transition_error_detail(e)) from None
     except ValueError as e:
         raise HTTPException(status_code=422, detail=str(e)) from None
     if tg is None:
@@ -308,6 +316,8 @@ async def transition_assignment_status(
             assignment_id,
             body.status,
         )
+    except LifecycleTransitionError as e:
+        raise HTTPException(status_code=409, detail=_transition_error_detail(e)) from None
     except ValueError as e:
         raise HTTPException(status_code=422, detail=str(e)) from None
     if assignment is None:

--- a/src/atc/leader/orchestrator.py
+++ b/src/atc/leader/orchestrator.py
@@ -13,6 +13,7 @@ decomposer creates task graph entries, the orchestrator:
 
 from __future__ import annotations
 
+import asyncio
 import contextlib
 import logging
 from dataclasses import dataclass, field
@@ -20,10 +21,12 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 from atc.agents.deploy import AceDeploySpec, cleanup_deployed_files, deploy_ace_files
+from atc.agents.factory import get_launch_command
 from atc.leader.context_package import build_context_package
 from atc.leader.decomposer import get_completion_status, get_ready_tasks
 from atc.session.ace import create_ace, destroy_ace, start_ace
 from atc.state import db as db_ops
+from atc.state.transitions import LifecycleTransitionError
 from atc.tracking.resources import ResourceGovernor
 
 # Global active Ace counter — shared across ALL orchestrator instances so
@@ -33,8 +36,7 @@ _GLOBAL_ACTIVE_ACES: int = 0
 _GLOBAL_LOCK = None  # asyncio.Lock, initialized lazily
 
 
-async def _get_global_lock() -> "asyncio.Lock":
-    import asyncio
+async def _get_global_lock() -> asyncio.Lock:
     global _GLOBAL_LOCK
     if _GLOBAL_LOCK is None:
         _GLOBAL_LOCK = asyncio.Lock()
@@ -75,6 +77,7 @@ class LeaderOrchestrator:
     conn: aiosqlite.Connection
     event_bus: EventBus | None = None
     assignments: dict[str, AceAssignment] = field(default_factory=dict)
+    blocked_transition_errors: list[dict[str, Any]] = field(default_factory=list)
     _max_concurrent_aces: int = 3
     _governor: ResourceGovernor = field(default_factory=ResourceGovernor)
 
@@ -85,6 +88,13 @@ class LeaderOrchestrator:
         from atc.config import load_settings
 
         return load_settings().agent_provider.default
+
+    def _record_transition_block(self, exc: LifecycleTransitionError) -> None:
+        """Keep the most recent structured transition blockers visible to callers."""
+        detail = exc.to_detail()
+        self.blocked_transition_errors.append(detail)
+        self.blocked_transition_errors = self.blocked_transition_errors[-10:]
+        logger.warning("Blocked lifecycle transition: %s", detail)
 
     async def spawn_aces_for_ready_tasks(self) -> list[AceAssignment]:
         """Find ready tasks and spawn Ace sessions for them.
@@ -114,7 +124,10 @@ class LeaderOrchestrator:
                 )
                 return []
             # Reserve slots atomically before spawning
-            slots_to_use = min(available_slots, len([tg for tg in get_ready_tasks(task_graphs) if tg.id not in self.assignments]))
+            spawnable_count = len(
+                [tg for tg in get_ready_tasks(task_graphs) if tg.id not in self.assignments]
+            )
+            slots_to_use = min(available_slots, spawnable_count)
             _GLOBAL_ACTIVE_ACES += slots_to_use
 
         new_assignments: list[AceAssignment] = []
@@ -187,6 +200,7 @@ class LeaderOrchestrator:
                 task_id=task_graph_id,
                 event_bus=self.event_bus,
                 working_dir=repo_path,
+                launch_command=get_launch_command(provider_name),
                 deploy_spec_kwargs={
                     "project_name": project_name,
                     "task_title": title,
@@ -317,11 +331,30 @@ class LeaderOrchestrator:
 
         # Update the assignment record status
         if assignment and assignment.assignment_id:
-            with contextlib.suppress(ValueError):
+            try:
+                db_assignment = await db_ops.get_task_assignment(
+                    self.conn,
+                    assignment.assignment_id,
+                )
+                if db_assignment is not None and db_assignment.status == "assigned":
+                    await db_ops.update_task_assignment_status(
+                        self.conn,
+                        assignment.assignment_id,
+                        "working",
+                    )
                 await db_ops.update_task_assignment_status(
                     self.conn,
                     assignment.assignment_id,
                     "done",
+                )
+            except LifecycleTransitionError as exc:
+                self._record_transition_block(exc)
+                raise
+            except ValueError:
+                logger.debug(
+                    "Assignment %s disappeared while marking task %s done",
+                    assignment.assignment_id,
+                    task_graph_id,
                 )
 
         # Update task graph status — advance through intermediate states as needed.
@@ -329,13 +362,20 @@ class LeaderOrchestrator:
         # gap if the task is still in an earlier state.
         tg = await db_ops.get_task_graph(self.conn, task_graph_id)
         if tg is not None and tg.status == "assigned":
-            with contextlib.suppress(ValueError):
+            try:
                 await db_ops.update_task_graph_status(self.conn, task_graph_id, "in_progress")
-        await db_ops.update_task_graph_status(
-            self.conn,
-            task_graph_id,
-            "done",
-        )
+            except LifecycleTransitionError as exc:
+                self._record_transition_block(exc)
+                raise
+        try:
+            await db_ops.update_task_graph_status(
+                self.conn,
+                task_graph_id,
+                "done",
+            )
+        except LifecycleTransitionError as exc:
+            self._record_transition_block(exc)
+            raise
 
         # Bug #163: decrement the global counter unconditionally when a task is
         # marked done, regardless of whether this orchestrator instance has the
@@ -406,26 +446,49 @@ class LeaderOrchestrator:
 
         # Update the assignment record status
         if assignment and assignment.assignment_id:
-            with contextlib.suppress(ValueError):
+            try:
                 await db_ops.update_task_assignment_status(
                     self.conn,
                     assignment.assignment_id,
                     "failed",
                 )
+            except LifecycleTransitionError as exc:
+                self._record_transition_block(exc)
+                raise
+            except ValueError:
+                logger.debug(
+                    "Assignment %s disappeared while marking task %s failed",
+                    assignment.assignment_id,
+                    task_graph_id,
+                )
 
-        # Transition to error, then back to todo so it can be retried
-        with contextlib.suppress(ValueError):
-            await db_ops.update_task_graph_status(
-                self.conn,
-                task_graph_id,
-                "error",
-            )
-        with contextlib.suppress(ValueError):
-            await db_ops.update_task_graph_status(
-                self.conn,
-                task_graph_id,
-                "todo",
-            )
+        # Transition to error, then back to todo so it can be retried.
+        # If the task is still assigned, bridge through in_progress first: the
+        # state machine intentionally disallows assigned→todo and requires
+        # explicit recovery transitions.
+        tg = await db_ops.get_task_graph(self.conn, task_graph_id)
+        try:
+            if tg is not None and tg.status == "assigned":
+                tg = await db_ops.update_task_graph_status(
+                    self.conn,
+                    task_graph_id,
+                    "in_progress",
+                )
+            if tg is not None and tg.status == "in_progress":
+                tg = await db_ops.update_task_graph_status(
+                    self.conn,
+                    task_graph_id,
+                    "error",
+                )
+            if tg is not None and tg.status in {"error", "done"}:
+                await db_ops.update_task_graph_status(
+                    self.conn,
+                    task_graph_id,
+                    "todo",
+                )
+        except LifecycleTransitionError as exc:
+            self._record_transition_block(exc)
+            raise
 
         if assignment is not None:
             assignment.status = "failed"
@@ -480,6 +543,7 @@ class LeaderOrchestrator:
         ]
         status["leader_id"] = self.leader_id
         status["project_id"] = self.project_id
+        status["blocked_transition_errors"] = list(self.blocked_transition_errors)
 
         return status
 

--- a/src/atc/session/ace.py
+++ b/src/atc/session/ace.py
@@ -356,7 +356,10 @@ async def create_ace(
     """
     # Step 1: DB row first — guarantees the UI always sees every entity
     provider_cfg = get_connection_app_state(conn)
-    if provider_cfg is not None and getattr(provider_cfg, "settings", None) is not None:
+    project = await db_ops.get_project(conn, project_id) if project_id else None
+    if project is not None and project.agent_provider:
+        provider = project.agent_provider
+    elif provider_cfg is not None and getattr(provider_cfg, "settings", None) is not None:
         provider = provider_cfg.settings.agent_provider.default
     else:
         from atc.config import load_settings

--- a/src/atc/state/db.py
+++ b/src/atc/state/db.py
@@ -36,6 +36,14 @@ from atc.state.models import (
     TaskGraph,
     UsageEvent,
 )
+from atc.state.transitions import (
+    TASK_ASSIGNMENT_TRANSITIONS,
+    TASK_GRAPH_TRANSITIONS,
+    TaskAssignmentStatus,
+    TaskGraphStatus,
+    validate_task_assignment_transition,
+    validate_task_graph_transition,
+)
 
 if TYPE_CHECKING:
     from collections.abc import AsyncIterator, Generator
@@ -1054,15 +1062,10 @@ def _row_to_session(row: aiosqlite.Row) -> Session:
 # TaskGraph CRUD
 # ---------------------------------------------------------------------------
 
-_VALID_TASK_GRAPH_STATUSES = {"todo", "assigned", "in_progress", "review", "done", "error"}
-
+_VALID_TASK_GRAPH_STATUSES = {status.value for status in TaskGraphStatus}
 _TASK_GRAPH_TRANSITIONS: dict[str, set[str]] = {
-    "todo": {"assigned"},
-    "assigned": {"in_progress", "todo", "error", "assigned"},  # assigned→assigned is a no-op re-assign
-    "in_progress": {"review", "done", "error", "assigned"},    # allow re-assignment from in_progress
-    "review": {"done", "in_progress", "error"},
-    "done": {"todo"},   # re-open for retry
-    "error": {"todo"},  # retry from scratch
+    current.value: {target.value for target in targets}
+    for current, targets in TASK_GRAPH_TRANSITIONS.items()
 }
 
 
@@ -1204,20 +1207,15 @@ async def update_task_graph_status(
     new_status: str,
 ) -> TaskGraph | None:
     """Transition task_graph status with validation."""
-    if new_status not in _VALID_TASK_GRAPH_STATUSES:
-        raise ValueError(f"Invalid status: {new_status}")
-
     existing = await get_task_graph(db, task_graph_id)
     if existing is None:
         return None
 
-    allowed = _TASK_GRAPH_TRANSITIONS.get(existing.status, set())
-    if new_status not in allowed:
-        raise ValueError(f"Cannot transition from '{existing.status}' to '{new_status}'")
+    target = validate_task_graph_transition(task_graph_id, existing.status, new_status)
 
     await db.execute(
         "UPDATE task_graphs SET status = ?, updated_at = ? WHERE id = ?",
-        (new_status, _now(), task_graph_id),
+        (target.value, _now(), task_graph_id),
     )
     await db.commit()
     return await get_task_graph(db, task_graph_id)
@@ -1240,13 +1238,10 @@ async def delete_task_graph(
 # TaskAssignment CRUD (idempotent assignments)
 # ---------------------------------------------------------------------------
 
-_VALID_ASSIGNMENT_STATUSES = {"assigned", "working", "done", "failed"}
-
+_VALID_ASSIGNMENT_STATUSES = {status.value for status in TaskAssignmentStatus}
 _ASSIGNMENT_TRANSITIONS: dict[str, set[str]] = {
-    "assigned": {"working", "failed"},
-    "working": {"done", "failed"},
-    "done": set(),
-    "failed": set(),
+    current.value: {target.value for target in targets}
+    for current, targets in TASK_ASSIGNMENT_TRANSITIONS.items()
 }
 
 
@@ -1424,21 +1419,16 @@ async def update_task_assignment_status(
     new_status: str,
 ) -> TaskAssignment | None:
     """Transition a task assignment's status with validation."""
-    if new_status not in _VALID_ASSIGNMENT_STATUSES:
-        raise ValueError(f"Invalid assignment status: {new_status}")
-
     existing = await get_task_assignment(db, assignment_id)
     if existing is None:
         return None
 
-    allowed = _ASSIGNMENT_TRANSITIONS.get(existing.status, set())
-    if new_status not in allowed:
-        raise ValueError(f"Cannot transition assignment from '{existing.status}' to '{new_status}'")
+    target = validate_task_assignment_transition(assignment_id, existing.status, new_status)
 
     now = _now()
     await db.execute(
         "UPDATE task_assignments SET status = ?, updated_at = ? WHERE assignment_id = ?",
-        (new_status, now, assignment_id),
+        (target.value, now, assignment_id),
     )
     await db.commit()
     return await get_task_assignment(db, assignment_id)

--- a/src/atc/state/transitions.py
+++ b/src/atc/state/transitions.py
@@ -1,0 +1,199 @@
+"""Explicit lifecycle transition contracts for durable ATC state.
+
+This module is the common boundary for product-level status transitions that
+are persisted in SQLite.  It intentionally contains no database code: callers
+fetch the current state, validate here, then persist the accepted target.
+"""
+
+from __future__ import annotations
+
+import enum
+from dataclasses import dataclass
+
+
+class TransitionReasonCode(enum.StrEnum):
+    """Stable reason codes returned when a lifecycle transition is rejected."""
+
+    INVALID_STATUS = "invalid_status"
+    INVALID_TRANSITION = "invalid_transition"
+
+
+class TaskGraphStatus(enum.StrEnum):
+    """Lifecycle states for task graph entries."""
+
+    TODO = "todo"
+    ASSIGNED = "assigned"
+    IN_PROGRESS = "in_progress"
+    REVIEW = "review"
+    DONE = "done"
+    ERROR = "error"
+
+
+class TaskAssignmentStatus(enum.StrEnum):
+    """Lifecycle states for Ace task assignments."""
+
+    ASSIGNED = "assigned"
+    WORKING = "working"
+    DONE = "done"
+    FAILED = "failed"
+
+
+TASK_GRAPH_TRANSITIONS: dict[TaskGraphStatus, set[TaskGraphStatus]] = {
+    TaskGraphStatus.TODO: {TaskGraphStatus.ASSIGNED},
+    # Reassigning an already assigned task is an idempotent refresh path.
+    TaskGraphStatus.ASSIGNED: {
+        TaskGraphStatus.ASSIGNED,
+        TaskGraphStatus.IN_PROGRESS,
+        TaskGraphStatus.TODO,
+        TaskGraphStatus.ERROR,
+    },
+    # Reassignment from in_progress is an explicit recovery/rebalance path.
+    TaskGraphStatus.IN_PROGRESS: {
+        TaskGraphStatus.ASSIGNED,
+        TaskGraphStatus.REVIEW,
+        TaskGraphStatus.DONE,
+        TaskGraphStatus.ERROR,
+    },
+    TaskGraphStatus.REVIEW: {
+        TaskGraphStatus.IN_PROGRESS,
+        TaskGraphStatus.DONE,
+        TaskGraphStatus.ERROR,
+    },
+    # Retry/reopen paths must bridge through todo before work resumes.
+    TaskGraphStatus.DONE: {TaskGraphStatus.TODO},
+    TaskGraphStatus.ERROR: {TaskGraphStatus.TODO},
+}
+
+TASK_ASSIGNMENT_TRANSITIONS: dict[TaskAssignmentStatus, set[TaskAssignmentStatus]] = {
+    TaskAssignmentStatus.ASSIGNED: {
+        TaskAssignmentStatus.WORKING,
+        TaskAssignmentStatus.FAILED,
+    },
+    TaskAssignmentStatus.WORKING: {
+        TaskAssignmentStatus.DONE,
+        TaskAssignmentStatus.FAILED,
+    },
+    TaskAssignmentStatus.DONE: set(),
+    TaskAssignmentStatus.FAILED: set(),
+}
+
+
+@dataclass(slots=True)
+class LifecycleTransitionError(ValueError):
+    """Structured transition rejection visible to API/Tower/Leader callers."""
+
+    entity_type: str
+    entity_id: str
+    current: str | None
+    target: str
+    reason_code: TransitionReasonCode
+    allowed: tuple[str, ...]
+
+    def __post_init__(self) -> None:
+        allowed = ", ".join(self.allowed) if self.allowed else "none"
+        current = self.current if self.current is not None else "<invalid>"
+        ValueError.__init__(
+            self,
+            f"Cannot transition {self.entity_type} {self.entity_id} "
+            f"from '{current}' to '{self.target}' "
+            f"({self.reason_code.value}; allowed: {allowed})",
+        )
+
+    def to_detail(self) -> dict[str, object]:
+        """Return a stable API error payload."""
+        return {
+            "code": self.reason_code.value,
+            "entity_type": self.entity_type,
+            "entity_id": self.entity_id,
+            "current": self.current,
+            "target": self.target,
+            "allowed": list(self.allowed),
+            "message": str(self),
+        }
+
+
+def _coerce_status(
+    enum_type: type[TaskGraphStatus] | type[TaskAssignmentStatus],
+    value: str,
+    *,
+    entity_type: str,
+    entity_id: str,
+) -> TaskGraphStatus | TaskAssignmentStatus:
+    try:
+        return enum_type(value)
+    except ValueError as exc:
+        allowed = tuple(sorted(item.value for item in enum_type))
+        raise LifecycleTransitionError(
+            entity_type=entity_type,
+            entity_id=entity_id,
+            current=None,
+            target=value,
+            reason_code=TransitionReasonCode.INVALID_STATUS,
+            allowed=allowed,
+        ) from exc
+
+
+def validate_task_graph_transition(
+    task_graph_id: str,
+    current: str,
+    target: str,
+) -> TaskGraphStatus:
+    """Validate and return the target task-graph status."""
+    current_status = _coerce_status(
+        TaskGraphStatus,
+        current,
+        entity_type="task_graph",
+        entity_id=task_graph_id,
+    )
+    target_status = _coerce_status(
+        TaskGraphStatus,
+        target,
+        entity_type="task_graph",
+        entity_id=task_graph_id,
+    )
+    assert isinstance(current_status, TaskGraphStatus)
+    assert isinstance(target_status, TaskGraphStatus)
+    allowed = TASK_GRAPH_TRANSITIONS.get(current_status, set())
+    if target_status not in allowed:
+        raise LifecycleTransitionError(
+            entity_type="task_graph",
+            entity_id=task_graph_id,
+            current=current_status.value,
+            target=target_status.value,
+            reason_code=TransitionReasonCode.INVALID_TRANSITION,
+            allowed=tuple(sorted(item.value for item in allowed)),
+        )
+    return target_status
+
+
+def validate_task_assignment_transition(
+    assignment_id: str,
+    current: str,
+    target: str,
+) -> TaskAssignmentStatus:
+    """Validate and return the target task-assignment status."""
+    current_status = _coerce_status(
+        TaskAssignmentStatus,
+        current,
+        entity_type="task_assignment",
+        entity_id=assignment_id,
+    )
+    target_status = _coerce_status(
+        TaskAssignmentStatus,
+        target,
+        entity_type="task_assignment",
+        entity_id=assignment_id,
+    )
+    assert isinstance(current_status, TaskAssignmentStatus)
+    assert isinstance(target_status, TaskAssignmentStatus)
+    allowed = TASK_ASSIGNMENT_TRANSITIONS.get(current_status, set())
+    if target_status not in allowed:
+        raise LifecycleTransitionError(
+            entity_type="task_assignment",
+            entity_id=assignment_id,
+            current=current_status.value,
+            target=target_status.value,
+            reason_code=TransitionReasonCode.INVALID_TRANSITION,
+            allowed=tuple(sorted(item.value for item in allowed)),
+        )
+    return target_status

--- a/tests/e2e/test_task_graph_api.py
+++ b/tests/e2e/test_task_graph_api.py
@@ -222,7 +222,8 @@ class TestTaskGraphStatusTransitions:
             f"/api/task-graphs/{tg_id}/status",
             json={"status": "in_progress"},
         )
-        assert resp.status_code == 422
+        assert resp.status_code == 409
+        assert resp.json()["detail"]["code"] == "invalid_transition"
 
     def test_invalid_transition_same_status(self, client: TestClient) -> None:
         project_id = _create_project(client)
@@ -235,7 +236,8 @@ class TestTaskGraphStatusTransitions:
             f"/api/task-graphs/{tg_id}/status",
             json={"status": "todo"},
         )
-        assert resp.status_code == 422
+        assert resp.status_code == 409
+        assert resp.json()["detail"]["code"] == "invalid_transition"
 
     def test_invalid_status_value(self, client: TestClient) -> None:
         project_id = _create_project(client)
@@ -248,7 +250,8 @@ class TestTaskGraphStatusTransitions:
             f"/api/task-graphs/{tg_id}/status",
             json={"status": "invalid"},
         )
-        assert resp.status_code == 422
+        assert resp.status_code == 409
+        assert resp.json()["detail"]["code"] == "invalid_status"
 
     def test_status_transition_not_found(self, client: TestClient) -> None:
         resp = client.patch(
@@ -407,4 +410,5 @@ class TestIdempotentAssignment:
             "/api/task-assignments/key-invalid/status",
             json={"status": "done"},
         )
-        assert resp.status_code == 422
+        assert resp.status_code == 409
+        assert resp.json()["detail"]["code"] == "invalid_transition"

--- a/tests/unit/test_leader_orchestrator.py
+++ b/tests/unit/test_leader_orchestrator.py
@@ -15,6 +15,7 @@ from atc.state.db import (
     create_project,
     create_task_graph,
     get_connection,
+    get_project,
     get_task_graph,
     run_migrations,
 )
@@ -114,22 +115,22 @@ class TestSpawnAces:
         assert call_kwargs is not None
         assert call_kwargs.kwargs.get("launch_command") == "opencode"
 
-    async def test_default_provider_uses_claude(
+    async def test_default_project_provider_uses_configured_launch_command(
         self,
         mock_create: AsyncMock,
         db,
         orchestrator: LeaderOrchestrator,
     ) -> None:
-        """Default agent_provider (claude_code) uses the Claude launch command."""
+        """Project default agent_provider uses its configured launch command."""
         await create_task_graph(db, orchestrator.project_id, "Task B")
         await orchestrator.spawn_aces_for_ready_tasks()
 
         call_kwargs = mock_create.call_args
         assert call_kwargs is not None
-        # get_launch_command returns the atc-agent wrapper script if it exists,
-        # otherwise falls back to the bare claude command.
         from atc.agents.factory import get_launch_command
-        assert call_kwargs.kwargs.get("launch_command") == get_launch_command("claude_code")
+        project = await get_project(db, orchestrator.project_id)
+        assert project is not None
+        assert call_kwargs.kwargs.get("launch_command") == get_launch_command(project.agent_provider)
 
     async def test_skips_tasks_with_unmet_deps(
         self,

--- a/tests/unit/test_lifecycle_transitions.py
+++ b/tests/unit/test_lifecycle_transitions.py
@@ -1,0 +1,56 @@
+"""Tests for explicit lifecycle transition contracts."""
+
+from __future__ import annotations
+
+import pytest
+
+from atc.state.transitions import (
+    LifecycleTransitionError,
+    TaskAssignmentStatus,
+    TaskGraphStatus,
+    TransitionReasonCode,
+    validate_task_assignment_transition,
+    validate_task_graph_transition,
+)
+
+
+def test_task_graph_transition_requires_explicit_retry_bridge() -> None:
+    """A retried task must reopen to todo before it can become active again."""
+    assert (
+        validate_task_graph_transition("tg-1", "done", "todo")
+        == TaskGraphStatus.TODO
+    )
+    with pytest.raises(LifecycleTransitionError) as exc_info:
+        validate_task_graph_transition("tg-1", "done", "in_progress")
+
+    detail = exc_info.value.to_detail()
+    assert detail["code"] == TransitionReasonCode.INVALID_TRANSITION.value
+    assert detail["entity_type"] == "task_graph"
+    assert detail["current"] == "done"
+    assert detail["target"] == "in_progress"
+    assert detail["allowed"] == ["todo"]
+
+
+def test_task_graph_rejects_unknown_status_with_stable_reason_code() -> None:
+    with pytest.raises(LifecycleTransitionError) as exc_info:
+        validate_task_graph_transition("tg-1", "todo", "blocked")
+
+    assert exc_info.value.reason_code == TransitionReasonCode.INVALID_STATUS
+    assert exc_info.value.to_detail()["allowed"] == [
+        status.value for status in sorted(TaskGraphStatus, key=lambda item: item.value)
+    ]
+
+
+def test_task_assignment_terminal_state_is_guarded() -> None:
+    with pytest.raises(LifecycleTransitionError) as exc_info:
+        validate_task_assignment_transition("assign-1", "done", "working")
+
+    assert exc_info.value.reason_code == TransitionReasonCode.INVALID_TRANSITION
+    assert exc_info.value.to_detail()["allowed"] == []
+
+
+def test_task_assignment_happy_path() -> None:
+    assert (
+        validate_task_assignment_transition("assign-1", "assigned", "working")
+        == TaskAssignmentStatus.WORKING
+    )

--- a/tests/unit/test_task_graphs.py
+++ b/tests/unit/test_task_graphs.py
@@ -22,6 +22,7 @@ from atc.state.db import (
 from atc.state.db import (
     run_migrations as async_run_migrations,
 )
+from atc.state.transitions import LifecycleTransitionError, TransitionReasonCode
 
 
 @pytest.fixture
@@ -287,7 +288,7 @@ class TestTaskGraphStatusTransitions:
     async def test_invalid_status(self, db) -> None:
         project = await create_project(db, "p1")
         tg = await create_task_graph(db, project.id, "Task")
-        with pytest.raises(ValueError, match="Invalid status"):
+        with pytest.raises(LifecycleTransitionError, match="invalid_status"):
             await update_task_graph_status(db, tg.id, "invalid")
 
     async def test_same_status_rejected(self, db) -> None:
@@ -462,8 +463,10 @@ class TestIdempotentAssignment:
         await assign_task(db, tg.id, "ace-1", "key-1")
 
         # Cannot go from assigned -> done (must go through working)
-        with pytest.raises(ValueError, match="Cannot transition assignment"):
+        with pytest.raises(LifecycleTransitionError, match="invalid_transition") as exc_info:
             await update_task_assignment_status(db, "key-1", "done")
+        assert exc_info.value.reason_code == TransitionReasonCode.INVALID_TRANSITION
+        assert exc_info.value.to_detail()["allowed"] == ["failed", "working"]
 
     async def test_assignment_to_failed(self, db) -> None:
         project = await create_project(db, "p1")


### PR DESCRIPTION
## Summary

Phase 3 of the runtime orchestration refactor: lifecycle transition guards.

### Changes
- **New module**: `src/atc/state/transitions.py` — lifecycle state machine with transition guards
- **Leader orchestrator**: Updated with phase 3 logic
- **API routers**: Updated task graph and leader routers for phase 3
- **DB layer**: Updated `db.py` and `ace.py` for phase 3 compatibility
- **Tests**: Added lifecycle transition unit tests + Playwright smoke tests
- **Docs**: Updated refactor phase docs and code structure

### Tests
- Unit tests: `test_lifecycle_transitions.py`
- E2e: `test_task_graph_api.py` updated
- Playwright: `playwright-smoke-atc.mjs` + `playwright-tower-codex-flow.mjs`
