### PR TITLE
Implement Phase 5 runtime boundary migration

### DIFF
--- a/scripts/playwright/phase5-runtime-boundary.mjs
+++ b/scripts/playwright/phase5-runtime-boundary.mjs
@@ -1,0 +1,181 @@
+import { chromium } from '../../frontend/node_modules/@playwright/test/index.mjs';
+import fs from 'node:fs';
+import path from 'node:path';
+
+const stamp = new Date().toISOString().replace(/[:.]/g, '-');
+const root = path.resolve(new URL('../..', import.meta.url).pathname);
+const outDir = path.join(root, 'test-results', `phase5-runtime-boundary-${stamp}`);
+const baseUrl = process.env.ATC_UI_URL || 'http://localhost:5173';
+const apiUrl = process.env.ATC_API_URL || 'http://127.0.0.1:8420';
+const codexCommand = process.env.ATC_CODEX_COMMAND || '/Users/mcole_studio/.local/bin/codex';
+
+fs.mkdirSync(outDir, { recursive: true });
+
+const checks = [];
+const events = [];
+const consoleMessages = [];
+const failedRequests = [];
+let screenshotIndex = 0;
+let project = null;
+let leaderSessionId = null;
+
+function check(name, ok, detail = '') {
+  checks.push({ name, ok, detail });
+  console.log(`${ok ? 'PASS' : 'FAIL'} ${name}${detail ? ` — ${detail}` : ''}`);
+  if (!ok) throw new Error(`${name}: ${detail}`);
+}
+
+function note(name, detail = '') {
+  events.push({ t: new Date().toISOString(), name, detail });
+  console.log(`${name}${detail ? ` — ${detail}` : ''}`);
+}
+
+async function screenshot(page, name) {
+  const file = path.join(outDir, `${String(screenshotIndex++).padStart(2, '0')}-${name}.png`);
+  await page.screenshot({ path: file, fullPage: true });
+  note('SCREENSHOT', file);
+  return file;
+}
+
+async function api(route, options = {}) {
+  const res = await fetch(`${apiUrl}${route}`, {
+    headers: { 'Content-Type': 'application/json', ...(options.headers || {}) },
+    ...options,
+  });
+  const text = await res.text();
+  let body;
+  try {
+    body = text ? JSON.parse(text) : null;
+  } catch {
+    body = text;
+  }
+  return { ok: res.ok, status: res.status, body };
+}
+
+const browser = await chromium.launch({ headless: true });
+const page = await browser.newPage({ viewport: { width: 1365, height: 768 }, deviceScaleFactor: 1 });
+page.on('console', (msg) => {
+  if (['error', 'warning'].includes(msg.type())) {
+    consoleMessages.push({ type: msg.type(), text: msg.text() });
+  }
+});
+page.on('pageerror', (err) => consoleMessages.push({ type: 'pageerror', text: err.message }));
+page.on('requestfailed', (req) => failedRequests.push({ url: req.url(), failure: req.failure()?.errorText }));
+page.on('response', (res) => {
+  if (res.status() >= 400 && !res.url().includes('/@vite')) {
+    failedRequests.push({ url: res.url(), status: res.status() });
+  }
+});
+
+try {
+  const health = await api('/api/health');
+  check('Backend health responds', health.ok, JSON.stringify(health.body));
+
+  const provider = await api('/api/settings/agent-provider', {
+    method: 'PUT',
+    body: JSON.stringify({ default: 'codex', codex_command: codexCommand }),
+  });
+  check('Default provider configured for codex', provider.ok, JSON.stringify(provider.body));
+
+  const projectResp = await api('/api/projects', {
+    method: 'POST',
+    body: JSON.stringify({
+      name: `Phase 5 Runtime Boundary ${stamp.slice(0, 19)}`,
+      description: 'Temporary Phase 5 validation project.',
+      agent_provider: 'codex',
+      auto_kickoff: false,
+    }),
+  });
+  check('Temporary project created', projectResp.ok, JSON.stringify(projectResp.body));
+  project = projectResp.body;
+
+  const leaderStart = await api(`/api/projects/${project.id}/leader/start`, {
+    method: 'POST',
+    body: JSON.stringify({ goal: 'Phase 5 validation: runtime delivery boundary.' }),
+  });
+  check('Leader start endpoint succeeds', leaderStart.ok, JSON.stringify(leaderStart.body));
+  leaderSessionId = leaderStart.body?.session_id;
+  check('Leader start returns session id', Boolean(leaderSessionId), JSON.stringify(leaderStart.body));
+
+  const manager = await api(`/api/projects/${project.id}/manager`);
+  check('Leader manager endpoint returns active leader', manager.ok && Boolean(manager.body?.id), JSON.stringify(manager.body));
+
+  const message = await api(`/api/projects/${project.id}/leader/message`, {
+    method: 'POST',
+    body: JSON.stringify({ message: 'Phase 5 validation ping: report your runtime delivery state.' }),
+  });
+  check('Leader message endpoint succeeds', message.ok, JSON.stringify(message.body));
+  check(
+    'Leader message no longer reports generic sent status',
+    message.body?.status !== 'sent',
+    JSON.stringify(message.body),
+  );
+  check(
+    'Leader message exposes runtime delivery object',
+    Boolean(message.body?.delivery?.status && message.body?.delivery?.stage && message.body?.delivery?.verdict),
+    JSON.stringify(message.body),
+  );
+  check(
+    'Runtime delivery status is operator-truthful',
+    ['queued', 'delivered', 'confirmed', 'blocked', 'failed'].includes(message.body?.delivery?.status),
+    JSON.stringify(message.body),
+  );
+  check(
+    'Runtime delivery reason code is surfaced',
+    Boolean(message.body?.delivery?.reason_code),
+    JSON.stringify(message.body),
+  );
+
+  const managerAfterMessage = await api(`/api/projects/${project.id}/manager`);
+  check(
+    'Leader manager endpoint remains available after delivery',
+    managerAfterMessage.ok && managerAfterMessage.body?.session_id === leaderSessionId,
+    JSON.stringify(managerAfterMessage.body),
+  );
+
+  await page.goto(`${baseUrl}/projects/${project.id}`, { waitUntil: 'networkidle', timeout: 30000 });
+  await page.getByText(project.name).first().waitFor({ timeout: 15000 });
+  await screenshot(page, 'project-runtime-boundary-loaded');
+
+  await page.goto(`${baseUrl}/`, { waitUntil: 'networkidle', timeout: 30000 });
+  await page.getByText(project.name).first().waitFor({ timeout: 15000 });
+  await screenshot(page, 'dashboard-runtime-boundary-project-visible');
+
+  check('No failed browser requests', failedRequests.length === 0, JSON.stringify(failedRequests));
+  const pageErrors = consoleMessages.filter((entry) => entry.type === 'pageerror');
+  check('No page errors', pageErrors.length === 0, JSON.stringify(pageErrors));
+
+  const report = {
+    outDir,
+    baseUrl,
+    apiUrl,
+    codexCommand,
+    project,
+    leaderSessionId,
+    messageDelivery: message.body,
+    checks,
+    events,
+    consoleMessages,
+    failedRequests,
+  };
+  fs.writeFileSync(path.join(outDir, 'report.json'), JSON.stringify(report, null, 2));
+  console.log(`REPORT ${path.join(outDir, 'report.json')}`);
+} catch (err) {
+  checks.push({
+    name: 'Phase 5 Playwright validation completed without throw',
+    ok: false,
+    detail: err?.stack || err?.message || String(err),
+  });
+  await screenshot(page, 'failure');
+  fs.writeFileSync(
+    path.join(outDir, 'report.json'),
+    JSON.stringify({ outDir, checks, events, consoleMessages, failedRequests, project, leaderSessionId }, null, 2),
+  );
+  process.exitCode = 1;
+} finally {
+  await browser.close();
+}
+
+if (checks.some((entry) => !entry.ok)) {
+  process.exitCode = 1;
+}

--- a/src/atc/api/routers/projects.py
+++ b/src/atc/api/routers/projects.py
@@ -19,6 +19,7 @@ from pydantic import BaseModel
 
 from atc.core.errors import CreationFailedError
 from atc.leader import leader as leader_ops
+from atc.runtime.models import RuntimeDeliveryResult
 from atc.state import db as db_ops
 
 logger = logging.getLogger(__name__)
@@ -115,10 +116,13 @@ async def create_project(body: CreateProjectRequest, request: Request) -> Projec
     ws_hub = await _get_ws_hub(request)
     if ws_hub is not None:
         try:
-            await ws_hub.broadcast("state", {
-                "project_created": True,
-                "project": resp.model_dump(),
-            })
+            await ws_hub.broadcast(
+                "state",
+                {
+                    "project_created": True,
+                    "project": resp.model_dump(),
+                },
+            )
         except Exception:
             logger.debug("Failed to broadcast project_created via WebSocket")
 
@@ -138,10 +142,13 @@ async def delete_project(project_id: str, request: Request) -> None:
     ws_hub = await _get_ws_hub(request)
     if ws_hub is not None:
         try:
-            await ws_hub.broadcast("state", {
-                "project_deleted": True,
-                "project_id": project_id,
-            })
+            await ws_hub.broadcast(
+                "state",
+                {
+                    "project_deleted": True,
+                    "project_id": project_id,
+                },
+            )
         except Exception:
             logger.debug("Failed to broadcast project_deleted via WebSocket")
 
@@ -161,10 +168,13 @@ async def archive_project(project_id: str, request: Request) -> ProjectResponse:
     ws_hub = await _get_ws_hub(request)
     if ws_hub is not None:
         try:
-            await ws_hub.broadcast("state", {
-                "project_updated": True,
-                "project": resp.model_dump(),
-            })
+            await ws_hub.broadcast(
+                "state",
+                {
+                    "project_updated": True,
+                    "project": resp.model_dump(),
+                },
+            )
         except Exception:
             logger.debug("Failed to broadcast project_updated via WebSocket")
 
@@ -219,10 +229,13 @@ async def update_project_status(
     ws_hub = await _get_ws_hub(request)
     if ws_hub is not None:
         try:
-            await ws_hub.broadcast("state", {
-                "project_updated": True,
-                "project": resp.model_dump(),
-            })
+            await ws_hub.broadcast(
+                "state",
+                {
+                    "project_updated": True,
+                    "project": resp.model_dump(),
+                },
+            )
         except Exception:
             logger.debug("Failed to broadcast project_updated via WebSocket")
 
@@ -271,10 +284,13 @@ async def update_project_provider(
     ws_hub = await _get_ws_hub(request)
     if ws_hub is not None:
         try:
-            await ws_hub.broadcast("state", {
-                "project_updated": True,
-                "project": resp.model_dump(),
-            })
+            await ws_hub.broadcast(
+                "state",
+                {
+                    "project_updated": True,
+                    "project": resp.model_dump(),
+                },
+            )
         except Exception:
             logger.debug("Failed to broadcast project_updated via WebSocket")
 
@@ -306,7 +322,10 @@ async def start_leader(
     event_bus = await _get_event_bus(request)
     try:
         session_id = await leader_ops.start_leader(
-            db, project_id, goal=body.goal, event_bus=event_bus,
+            db,
+            project_id,
+            goal=body.goal,
+            event_bus=event_bus,
         )
     except RuntimeError as exc:
         raise CreationFailedError(str(exc)) from None
@@ -315,6 +334,7 @@ async def start_leader(
     # populates regardless of whether Tower or CLI started the Leader.
     if body.goal:
         from atc.state import db as db_ops
+
         seed = [("goal", "text", body.goal)]
         cursor = await db.execute(
             "SELECT name, description, repo_path, github_repo FROM projects WHERE id = ?",
@@ -322,14 +342,22 @@ async def start_leader(
         )
         row = await cursor.fetchone()
         if row:
-            if row[1]: seed.append(("project_description", "text", row[1]))
-            if row[2]: seed.append(("repo_path", "text", row[2]))
-            if row[3]: seed.append(("github_repo", "text", row[3]))
+            if row[1]:
+                seed.append(("project_description", "text", row[1]))
+            if row[2]:
+                seed.append(("repo_path", "text", row[2]))
+            if row[3]:
+                seed.append(("github_repo", "text", row[3]))
         for key, etype, val in seed:
             try:
                 await db_ops.create_context_entry(
-                    db, scope="project", key=key, entry_type=etype,
-                    value=val, project_id=project_id, updated_by="leader-start",
+                    db,
+                    scope="project",
+                    key=key,
+                    entry_type=etype,
+                    value=val,
+                    project_id=project_id,
+                    updated_by="leader-start",
                 )
                 await db.commit()
             except Exception:
@@ -348,10 +376,12 @@ async def start_leader(
     # directly from the API for standalone (non-Tower) usage.
     if body.goal and body.auto_kickoff:
         import asyncio as _asyncio
+
         from atc.leader.leader import send_leader_message as _send_leader_msg
 
         async def _kickoff() -> None:
             import logging as _logging
+
             _log = _logging.getLogger(__name__)
             # Build kickoff message
             cursor = await db.execute(
@@ -379,9 +409,12 @@ async def start_leader(
                 "Do NOT write product files yourself.",
                 "Operate through the ATC orchestration API only.",
                 "",
-                "1. First decompose the goal into well-scoped tasks via POST /api/projects/{project_id}/leader/decompose.",
-                "2. Then spawn Aces for ready tasks via POST /api/projects/{project_id}/leader/spawn-aces.",
-                "3. Then instruct spawned Aces via POST /api/projects/{project_id}/leader/instruct.",
+                "1. First decompose the goal into well-scoped tasks via POST "
+                "/api/projects/{project_id}/leader/decompose.",
+                "2. Then spawn Aces for ready tasks via POST "
+                "/api/projects/{project_id}/leader/spawn-aces.",
+                "3. Then instruct spawned Aces via POST "
+                "/api/projects/{project_id}/leader/instruct.",
                 "4. Monitor progress via GET /api/projects/{project_id}/leader/progress.",
                 "5. Drive the project to completion by delegating, not by coding directly.",
                 "",
@@ -401,15 +434,25 @@ async def start_leader(
                 await _asyncio.sleep(5)  # wait for pane to initialise
                 try:
                     await _send_leader_msg(db, project_id, kickoff_msg, event_bus=event_bus)
-                    _log.info("Auto-kickoff sent to leader for project %s (attempt %d)", project_id, attempt)
+                    _log.info(
+                        "Auto-kickoff sent to leader for project %s (attempt %d)",
+                        project_id,
+                        attempt,
+                    )
                     return
                 except ValueError as exc:
-                    _log.debug("Auto-kickoff attempt %d for project %s: %s", attempt, project_id, exc)
+                    _log.debug(
+                        "Auto-kickoff attempt %d for project %s: %s", attempt, project_id, exc
+                    )
                     # Pane not ready yet — retry
                 except Exception:
-                    _log.exception("Auto-kickoff failed for project %s on attempt %d", project_id, attempt)
+                    _log.exception(
+                        "Auto-kickoff failed for project %s on attempt %d", project_id, attempt
+                    )
                     return  # non-retryable error
-            _log.warning("Auto-kickoff timed out for project %s after %d attempts", project_id, attempt)
+            _log.warning(
+                "Auto-kickoff timed out for project %s after %d attempts", project_id, attempt
+            )
 
         _asyncio.ensure_future(_kickoff())
 
@@ -427,18 +470,20 @@ async def stop_leader(project_id: str, request: Request) -> dict[str, str]:
 @router.post("/{project_id}/leader/message")
 async def send_leader_message(
     project_id: str, body: LeaderMessageRequest, request: Request
-) -> dict[str, str]:
+) -> dict[str, object]:
     db = await _get_db(request)
     event_bus = await _get_event_bus(request)
     try:
-        await leader_ops.send_leader_message(db, project_id, body.message, event_bus=event_bus)
+        result = await leader_ops.send_leader_message(
+            db, project_id, body.message, event_bus=event_bus
+        )
     except ValueError as e:
         raise HTTPException(status_code=409, detail=str(e)) from None
     except RuntimeError as e:
-        raise HTTPException(
-            status_code=409, detail=f"Leader pane unavailable: {e}"
-        ) from None
-    return {"status": "sent"}
+        raise HTTPException(status_code=409, detail=f"Leader pane unavailable: {e}") from None
+    if isinstance(result, RuntimeDeliveryResult):
+        return {"status": result.status, "delivery": result.as_dict()}
+    return {"status": "delivered"}
 
 
 # ---------------------------------------------------------------------------

--- a/src/atc/leader/leader.py
+++ b/src/atc/leader/leader.py
@@ -17,15 +17,10 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 from atc.agents.deploy import ManagerDeploySpec, deploy_manager_files
-from atc.config import AgentProviderConfig
-from atc.session.ace import (
-    _accept_trust_dialog,
-    _ensure_tmux_session,
-    _kill_pane,
-    _send_session_instruction,
-    _spawn_pane,
-    _spawn_provider_session,
-)
+from atc.runtime.models import InstructionRequest, StopRoleRequest
+from atc.runtime.service import RuntimeService
+from atc.session.ace import _accept_trust_dialog as _accept_trust_dialog  # noqa: F401
+from atc.session.ace import _spawn_provider_session
 from atc.session.state_machine import SessionStatus, transition
 from atc.state import db as db_ops
 from atc.state.db import get_connection_app_state
@@ -33,6 +28,7 @@ from atc.state.db import get_connection_app_state
 if TYPE_CHECKING:
     import aiosqlite  # type: ignore[import-not-found]
 
+    from atc.config import AgentProviderConfig
     from atc.core.events import EventBus
 
 logger = logging.getLogger(__name__)
@@ -111,7 +107,8 @@ async def start_leader(
             if existing.provider == provider:
                 return leader.session_id
             logger.warning(
-                "Leader session %s provider mismatch on reuse (session=%s current=%s) — refusing reuse",
+                "Leader session %s provider mismatch on reuse "
+                "(session=%s current=%s) — refusing reuse",
                 leader.session_id,
                 existing.provider,
                 provider,
@@ -120,7 +117,8 @@ async def start_leader(
                 conn, leader.session_id, SessionStatus.DISCONNECTED.value
             )
             await conn.execute(
-                "UPDATE leaders SET session_id = NULL, status = 'idle', updated_at = datetime('now') WHERE id = ?",
+                "UPDATE leaders SET session_id = NULL, status = 'idle',"
+                " updated_at = datetime('now') WHERE id = ?",
                 (leader.id,),
             )
             await conn.commit()
@@ -151,10 +149,12 @@ async def start_leader(
         # not a hardcoded default.  Falls back to ATC_API_URL env var / load_settings()
         # via _resolve_api_base_url if settings are unavailable here.
         import os as _os
+
         _api_url = _os.environ.get("ATC_API_URL", "")
         if not _api_url:
             try:
                 from atc.config import load_settings as _ls
+
                 _s = _ls()
                 _api_url = f"http://{_s.server.host}:{_s.server.port}"
             except Exception:
@@ -183,6 +183,7 @@ async def start_leader(
         # Claude Code picks up the leader instructions when starting in the repo.
         if spec.repo_path and Path(spec.repo_path) != deployed.root:
             import shutil as _shutil
+
             dest = Path(spec.repo_path)
             dest.mkdir(parents=True, exist_ok=True)
             claude_md_src = deployed.root / "CLAUDE.md"
@@ -201,6 +202,7 @@ async def start_leader(
         # working_dir does not exist, causing Claude Code to start in the wrong place.
         if spec.repo_path:
             import os as _os
+
             _os.makedirs(spec.repo_path, exist_ok=True)
             logger.info("Ensured repo_path exists: %s", spec.repo_path)
         working_dir = spec.repo_path or str(deployed.root)
@@ -281,11 +283,11 @@ async def stop_leader(
     if session is None:
         return
 
-    # Kill tmux pane
-    if session.tmux_pane:
-        await _kill_pane(session.tmux_pane)
+    await RuntimeService().stop_session_record(
+        session, StopRoleRequest(reason="leader_stop", graceful=True)
+    )
 
-    # Transition session to idle (or just set directly since we killed the pane)
+    # Transition session to idle after provider-neutral stop.
     await db_ops.update_session_status(conn, session.id, SessionStatus.IDLE.value)
 
     if event_bus:
@@ -313,8 +315,8 @@ async def send_leader_message(
     message: str,
     *,
     event_bus: EventBus | None = None,
-) -> None:
-    """Send a message to the Leader's tmux pane."""
+):
+    """Send a message to the Leader through the runtime boundary."""
     leader = await db_ops.get_leader_by_project(conn, project_id)
     if leader is None or leader.session_id is None:
         raise ValueError(f"No active leader for project {project_id}")
@@ -322,12 +324,9 @@ async def send_leader_message(
     session = await db_ops.get_session(conn, leader.session_id)
     if session is None:
         raise ValueError("Leader session not found")
-    if session.tmux_pane is None:
-        raise ValueError("Leader session has no tmux pane")
-
     current = SessionStatus(session.status)
 
-    # Reject sends to sessions that are clearly not running
+    # Reject sends to sessions that are clearly not running.
     if current in (SessionStatus.ERROR, SessionStatus.DISCONNECTED):
         raise ValueError(f"Leader session is {current.value} — stop and restart the leader")
 
@@ -335,12 +334,14 @@ async def send_leader_message(
         await transition(session.id, current, SessionStatus.WORKING, event_bus)
         await db_ops.update_session_status(conn, session.id, SessionStatus.WORKING.value)
 
-    # Verify the pane is alive before sending keys
-    from atc.session.ace import _pane_is_alive
-
-    if not await _pane_is_alive(session.tmux_pane):
-        raise ValueError("Leader tmux pane is dead — stop and restart the leader")
-
-    delivered = await _send_session_instruction(conn, session.id, message)
-    if not delivered:
-        raise ValueError("Leader instruction delivery failed")
+    runtime = RuntimeService()
+    handle = runtime.handle_from_session_record(session)
+    result = await runtime.assign_project_to_leader(
+        handle,
+        InstructionRequest(
+            session_id=session.id,
+            message=message,
+            metadata={"source": "leader_message"},
+        ),
+    )
+    return result

--- a/src/atc/runtime/models.py
+++ b/src/atc/runtime/models.py
@@ -162,3 +162,37 @@ class RuntimeInspection:
     summary: str | None = None
     last_output_excerpt: str | None = None
     details: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass(slots=True)
+class RuntimeDeliveryResult:
+    """Provider-neutral result for a runtime delivery attempt."""
+
+    session_id: str
+    provider_name: str
+    role: RoleKind
+    status: str
+    stage: str | None = None
+    verdict: str | None = None
+    reason_code: str | None = None
+    trace_id: str | None = None
+    message: str | None = None
+    details: dict[str, Any] = field(default_factory=dict)
+
+    @property
+    def ok(self) -> bool:
+        return self.status in {"delivered", "confirmed", "accepted"}
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "session_id": self.session_id,
+            "provider": self.provider_name,
+            "role": self.role.value,
+            "status": self.status,
+            "stage": self.stage,
+            "verdict": self.verdict,
+            "reason_code": self.reason_code,
+            "trace_id": self.trace_id,
+            "message": self.message,
+            "details": self.details,
+        }

--- a/src/atc/runtime/service.py
+++ b/src/atc/runtime/service.py
@@ -5,12 +5,15 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from atc.providers.registry import create_provider_runtime, runtime_kwargs_for_provider
+from atc.runtime.errors import RuntimeInvocationError
 from atc.runtime.models import (
     InstructionRequest,
     ReadinessResult,
     RoleKind,
+    RuntimeDeliveryResult,
     RuntimeInspection,
     RuntimeSessionHandle,
+    RuntimeTransport,
     StartRoleRequest,
     StopRoleRequest,
     TaskAssignmentRequest,
@@ -82,6 +85,27 @@ class RuntimeService:
             return self._handles[session_id]
         except KeyError as exc:
             raise KeyError(f"Unknown runtime session handle: {session_id}") from exc
+
+    def handle_from_session_record(self, session: object) -> RuntimeSessionHandle:
+        """Build and remember a provider-neutral handle from a DB session row/model."""
+
+        session_type = str(getattr(session, "session_type", "ace") or "ace")
+        if session_type == "tower":
+            role = RoleKind.TOWER
+        elif session_type in {"leader", "manager"}:
+            role = RoleKind.LEADER
+        else:
+            role = RoleKind.ACE
+        handle = RuntimeSessionHandle(
+            session_id=str(session.id),
+            provider_name=str(getattr(session, "provider", None) or "claude_code"),
+            role=role,
+            transport=RuntimeTransport.TMUX,
+            project_id=getattr(session, "project_id", None),
+            tmux_session=getattr(session, "tmux_session", None),
+            tmux_pane=getattr(session, "tmux_pane", None),
+        )
+        return self.remember_handle(handle)
 
     async def prepare_workspace(self, request: StartRoleRequest) -> None:
         """Run provider-owned workspace/bootstrap preparation for a role request."""
@@ -171,7 +195,7 @@ class RuntimeService:
         self,
         handle: RuntimeSessionHandle,
         request: InstructionRequest,
-    ) -> None:
+    ) -> RuntimeDeliveryResult:
         trace_id = self._ensure_trace_id(request.metadata)
         append_trace_event(
             request.metadata,
@@ -207,22 +231,31 @@ class RuntimeService:
                     details={"error_type": type(exc).__name__, "error": str(exc)},
                 ),
             )
-            raise
+            return self._result_from_metadata(
+                handle, request.metadata, status="failed", message=str(exc)
+            )
+        self._append_provider_returned_event_if_needed(
+            handle,
+            request.metadata,
+            trace_id,
+            DeliveryAction.INSTRUCTION,
+        )
+        return self._result_from_metadata(handle, request.metadata)
 
     async def assign_project_to_leader(
         self,
         handle: RuntimeSessionHandle,
         request: InstructionRequest,
-    ) -> None:
+    ) -> RuntimeDeliveryResult:
         if handle.role is not RoleKind.LEADER:
             raise ValueError("assign_project_to_leader requires leader handle")
-        await self.send_instruction(handle, request)
+        return await self.send_instruction(handle, request)
 
     async def assign_task_to_ace(
         self,
         handle: RuntimeSessionHandle,
         request: TaskAssignmentRequest,
-    ) -> None:
+    ) -> RuntimeDeliveryResult:
         if handle.role is not RoleKind.ACE:
             raise ValueError("assign_task_to_ace requires ace handle")
         trace_id = self._ensure_trace_id(request.metadata)
@@ -264,7 +297,17 @@ class RuntimeService:
                     details={"error_type": type(exc).__name__, "error": str(exc)},
                 ),
             )
-            raise
+            return self._result_from_metadata(
+                handle, request.metadata, status="failed", message=str(exc)
+            )
+        else:
+            self._append_provider_returned_event_if_needed(
+                handle,
+                request.metadata,
+                trace_id,
+                DeliveryAction.TASK_ASSIGNMENT,
+            )
+            return self._result_from_metadata(handle, request.metadata)
         finally:
             request.metadata.pop("delivery_action", None)
 
@@ -279,6 +322,18 @@ class RuntimeService:
     async def restore_session(self, handle: RuntimeSessionHandle) -> RuntimeInspection:
         provider = self.get_provider(handle.provider_name)
         return await provider.restore_session(handle)
+
+    async def stop_session_record(
+        self, session: object, request: StopRoleRequest | None = None
+    ) -> None:
+        """Stop a DB-backed session via the provider-neutral runtime boundary."""
+
+        await self._stop_role(self.handle_from_session_record(session), request)
+
+    async def inspect_session_record(self, session: object) -> RuntimeInspection:
+        """Inspect a DB-backed session via the provider-neutral runtime boundary."""
+
+        return await self.inspect_session(self.handle_from_session_record(session))
 
     async def _start_role(self, request: StartRoleRequest) -> RuntimeSessionHandle:
         provider = self.get_provider(request.provider_name)
@@ -319,7 +374,13 @@ class RuntimeService:
         request: StopRoleRequest | None = None,
     ) -> None:
         provider = self.get_provider(handle.provider_name)
-        await provider.stop_role(handle, request)
+        try:
+            await provider.stop_role(handle, request)
+        except RuntimeInvocationError as exc:
+            message = str(exc).lower()
+            if "can't find pane" in message or "no such pane" in message:
+                return
+            raise
 
     @staticmethod
     def _ensure_trace_id(metadata: dict[str, object]) -> str:
@@ -374,6 +435,75 @@ class RuntimeService:
                 reason_code=DeliveryReasonCode.PANE_SPAWNED,
                 details={"tmux_session": handle.tmux_session},
             ),
+        )
+
+    @staticmethod
+    def _append_provider_returned_event_if_needed(
+        handle: RuntimeSessionHandle,
+        metadata: dict[str, object],
+        trace_id: str,
+        action: DeliveryAction,
+    ) -> None:
+        events = metadata.get("delivery_trace_events")
+        if isinstance(events, list) and events:
+            latest = events[-1]
+            if isinstance(latest, dict) and latest.get("stage") != DeliveryStage.QUEUED.value:
+                return
+        append_trace_event(
+            metadata,
+            trace_event(
+                trace_id=trace_id,
+                session_id=handle.session_id,
+                role=handle.role.value,
+                provider=handle.provider_name,
+                pane_id=handle.tmux_pane,
+                action=action,
+                stage=DeliveryStage.CONFIRMED_RUNNING,
+                verdict=DeliveryVerdict.ACCEPTED,
+                reason_code=DeliveryReasonCode.DELIVERY_UNVERIFIED,
+                details={"source": "provider_returned_without_detailed_trace"},
+            ),
+        )
+
+    @staticmethod
+    def _result_from_metadata(
+        handle: RuntimeSessionHandle,
+        metadata: dict[str, object],
+        *,
+        status: str | None = None,
+        message: str | None = None,
+    ) -> RuntimeDeliveryResult:
+        events = metadata.get("delivery_trace_events")
+        latest = events[-1] if isinstance(events, list) and events else {}
+        verdict = str(latest.get("verdict", "")) if isinstance(latest, dict) else ""
+        stage = str(latest.get("stage", "")) if isinstance(latest, dict) else ""
+        if status is None:
+            if verdict == DeliveryVerdict.BLOCKED.value:
+                status = "blocked"
+            elif verdict == DeliveryVerdict.FAILED.value:
+                status = "failed"
+            elif verdict == DeliveryVerdict.CONFIRMED.value:
+                status = "confirmed"
+            elif verdict == DeliveryVerdict.ACCEPTED.value:
+                status = "delivered"
+            else:
+                status = "queued"
+        details = latest.get("details", {}) if isinstance(latest, dict) else {}
+        return RuntimeDeliveryResult(
+            session_id=handle.session_id,
+            provider_name=handle.provider_name,
+            role=handle.role,
+            status=status,
+            stage=stage or None,
+            verdict=verdict or None,
+            reason_code=str(latest.get("reason_code"))
+            if isinstance(latest, dict) and latest.get("reason_code")
+            else None,
+            trace_id=str(metadata.get("delivery_trace_id"))
+            if metadata.get("delivery_trace_id")
+            else None,
+            message=message,
+            details=details if isinstance(details, dict) else {},
         )
 
     @staticmethod

--- a/src/atc/session/ace.py
+++ b/src/atc/session/ace.py
@@ -27,6 +27,8 @@ from typing import TYPE_CHECKING, Any
 
 from atc.agents.claude_runtime import accept_startup_dialogs
 from atc.core.app_events import log_event
+from atc.runtime.models import StopRoleRequest
+from atc.runtime.service import RuntimeService
 from atc.session.state_machine import (
     SessionStatus,
     transition,
@@ -601,9 +603,9 @@ async def destroy_ace(
     if session is None:
         raise ValueError(f"Session {session_id} not found")
 
-    # Kill tmux pane if present
-    if session.tmux_pane:
-        await _kill_pane(session.tmux_pane)
+    await RuntimeService().stop_session_record(
+        session, StopRoleRequest(reason="ace_destroy", graceful=True)
+    )
 
     # Delete from DB
     await db_ops.delete_session(conn, session_id)
@@ -655,15 +657,15 @@ async def verify_alive(
     if session.status == SessionStatus.ERROR.value:
         return VerificationResult(ok=False, phase="alive", detail="session status is error")
 
-    if not session.tmux_pane:
-        return VerificationResult(ok=False, phase="alive", detail="no tmux pane assigned")
-
-    if not await _pane_is_alive(session.tmux_pane):
+    inspection = await RuntimeService().inspect_session_record(session)
+    if not inspection.alive:
         return VerificationResult(
-            ok=False, phase="alive", detail=f"tmux pane {session.tmux_pane} is dead"
+            ok=False,
+            phase="alive",
+            detail=inspection.summary or "runtime session is not alive",
         )
 
-    return VerificationResult(ok=True, phase="alive")
+    return VerificationResult(ok=True, phase="alive", detail=inspection.readiness.value)
 
 
 async def verify_working(

--- a/tests/e2e/test_smoke.py
+++ b/tests/e2e/test_smoke.py
@@ -14,6 +14,7 @@ from fastapi.testclient import TestClient
 
 from atc.api.app import create_app
 from atc.config import Settings
+from atc.runtime.models import RoleKind, RuntimeDeliveryResult
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -107,7 +108,7 @@ class TestProjectCRUD:
 @patch(
     "atc.leader.leader._spawn_provider_session", new_callable=AsyncMock, return_value=("atc", "%1")
 )
-@patch("atc.leader.leader._send_session_instruction", new_callable=AsyncMock, return_value=True)
+@patch("atc.runtime.service.RuntimeService.send_instruction", new_callable=AsyncMock)
 class TestLeaderLifecycle:
     def test_start_leader(
         self,
@@ -164,8 +165,41 @@ class TestLeaderLifecycle:
             json={"message": "Hello leader"},
         )
         assert resp.status_code == 200
-        assert resp.json()["status"] == "sent"
+        assert resp.json()["status"] == "delivered"
         mock_send.assert_called()
+
+    def test_send_leader_message_surfaces_blocked_delivery(
+        self,
+        mock_send: AsyncMock,
+        mock_spawn_provider: AsyncMock,
+        mock_tmux: AsyncMock,
+        client: TestClient,
+    ) -> None:
+        mock_send.return_value = RuntimeDeliveryResult(
+            session_id="session-test",
+            provider_name="codex",
+            role=RoleKind.LEADER,
+            status="blocked",
+            stage="interrupted",
+            verdict="blocked",
+            reason_code="trust_required",
+            message="Leader instruction blocked: trust_required",
+            trace_id="trace-test",
+        )
+        resp = client.post("/api/projects", json={"name": "blocked-msg-proj"})
+        project_id = resp.json()["id"]
+
+        client.post(f"/api/projects/{project_id}/leader/start", json={"goal": "Accept messages"})
+        resp = client.post(
+            f"/api/projects/{project_id}/leader/message",
+            json={"message": "Hello leader"},
+        )
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["status"] == "blocked"
+        assert data["delivery"]["status"] == "blocked"
+        assert data["delivery"]["reason_code"] == "trust_required"
 
     def test_message_without_active_leader(
         self,
@@ -235,7 +269,7 @@ class TestTowerStatus:
         data = resp.json()
         assert data["total_sessions"] >= 1
 
-    @patch("atc.leader.leader._send_session_instruction", new_callable=AsyncMock, return_value=True)
+    @patch("atc.runtime.service.RuntimeService.send_instruction", new_callable=AsyncMock)
     @patch(
         "atc.leader.leader._spawn_provider_session",
         new_callable=AsyncMock,
@@ -263,7 +297,7 @@ class TestTowerStatus:
         resp = client.post("/api/tower/goal", json={"project_id": "nonexistent", "goal": "Ship v1"})
         assert resp.status_code == 404
 
-    @patch("atc.leader.leader._send_session_instruction", new_callable=AsyncMock, return_value=True)
+    @patch("atc.runtime.service.RuntimeService.send_instruction", new_callable=AsyncMock)
     @patch(
         "atc.leader.leader._spawn_provider_session",
         new_callable=AsyncMock,
@@ -287,8 +321,8 @@ class TestTowerStatus:
         assert resp.status_code == 200
 
     @patch("atc.tower.session.stop_tower_session", new_callable=AsyncMock)
-    @patch("atc.leader.leader._kill_pane", new_callable=AsyncMock)
-    @patch("atc.leader.leader._send_session_instruction", new_callable=AsyncMock, return_value=True)
+    @patch("atc.runtime.service.RuntimeService.stop_session_record", new_callable=AsyncMock)
+    @patch("atc.runtime.service.RuntimeService.send_instruction", new_callable=AsyncMock)
     @patch(
         "atc.leader.leader._spawn_provider_session",
         new_callable=AsyncMock,

--- a/tests/unit/test_creation_reliability.py
+++ b/tests/unit/test_creation_reliability.py
@@ -12,7 +12,14 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 
-from atc.session.ace import VerificationResult, _get_alternate_on, verify_alive, verify_progressing, verify_working
+from atc.runtime.models import ReadinessState, RuntimeInspection
+from atc.session.ace import (
+    VerificationResult,
+    _get_alternate_on,
+    verify_alive,
+    verify_progressing,
+    verify_working,
+)
 from atc.state.models import Session
 
 
@@ -52,14 +59,20 @@ class TestGetAlternateOn:
 
 class TestVerifyAlive:
     @pytest.mark.asyncio
-    @patch("atc.session.ace._pane_is_alive", new_callable=AsyncMock)
+    @patch("atc.session.ace.RuntimeService.inspect_session_record", new_callable=AsyncMock)
     @patch("atc.session.ace.db_ops.get_session", new_callable=AsyncMock)
-    async def test_healthy(self, mock_get: AsyncMock, mock_alive: AsyncMock) -> None:
+    async def test_healthy(self, mock_get: AsyncMock, mock_inspect: AsyncMock) -> None:
         mock_get.return_value = _make_session()
-        mock_alive.return_value = True
+        mock_inspect.return_value = RuntimeInspection(
+            session_id="test-session-1",
+            provider_name="codex",
+            alive=True,
+            readiness=ReadinessState.READY,
+        )
         result = await verify_alive(AsyncMock(), "test-session-1")
         assert result.ok is True
         assert result.phase == "alive"
+        assert result.detail == "ready"
 
     @pytest.mark.asyncio
     @patch("atc.session.ace.db_ops.get_session", new_callable=AsyncMock)
@@ -77,19 +90,33 @@ class TestVerifyAlive:
         assert result.ok is False
 
     @pytest.mark.asyncio
+    @patch("atc.session.ace.RuntimeService.inspect_session_record", new_callable=AsyncMock)
     @patch("atc.session.ace.db_ops.get_session", new_callable=AsyncMock)
-    async def test_no_pane(self, mock_get: AsyncMock) -> None:
+    async def test_no_pane(self, mock_get: AsyncMock, mock_inspect: AsyncMock) -> None:
         mock_get.return_value = _make_session(tmux_pane=None)
+        mock_inspect.return_value = RuntimeInspection(
+            session_id="test-session-1",
+            provider_name="codex",
+            alive=False,
+            readiness=ReadinessState.STOPPED,
+            summary="Pane missing",
+        )
         result = await verify_alive(AsyncMock(), "test-session-1")
         assert result.ok is False
-        assert "no tmux pane" in result.detail
+        assert "Pane missing" in result.detail
 
     @pytest.mark.asyncio
-    @patch("atc.session.ace._pane_is_alive", new_callable=AsyncMock)
+    @patch("atc.session.ace.RuntimeService.inspect_session_record", new_callable=AsyncMock)
     @patch("atc.session.ace.db_ops.get_session", new_callable=AsyncMock)
-    async def test_dead_pane(self, mock_get: AsyncMock, mock_alive: AsyncMock) -> None:
+    async def test_dead_pane(self, mock_get: AsyncMock, mock_inspect: AsyncMock) -> None:
         mock_get.return_value = _make_session()
-        mock_alive.return_value = False
+        mock_inspect.return_value = RuntimeInspection(
+            session_id="test-session-1",
+            provider_name="codex",
+            alive=False,
+            readiness=ReadinessState.STOPPED,
+            summary="runtime session is dead",
+        )
         result = await verify_alive(AsyncMock(), "test-session-1")
         assert result.ok is False
         assert "dead" in result.detail
@@ -106,7 +133,9 @@ class TestVerifyWorking:
     @pytest.mark.asyncio
     @patch("atc.session.ace._capture_pane", new_callable=AsyncMock)
     @patch("atc.session.ace.db_ops.get_session", new_callable=AsyncMock)
-    async def test_output_counts_as_activity(self, mock_get: AsyncMock, mock_capture: AsyncMock) -> None:
+    async def test_output_counts_as_activity(
+        self, mock_get: AsyncMock, mock_capture: AsyncMock
+    ) -> None:
         mock_get.return_value = _make_session(status="idle")
         mock_capture.return_value = "some output"
         result = await verify_working(AsyncMock(), "test-session-1")
@@ -126,7 +155,9 @@ class TestVerifyWorking:
     @pytest.mark.asyncio
     @patch("atc.session.ace._capture_pane", new_callable=AsyncMock)
     @patch("atc.session.ace.db_ops.get_session", new_callable=AsyncMock)
-    async def test_capture_failure_is_handled(self, mock_get: AsyncMock, mock_capture: AsyncMock) -> None:
+    async def test_capture_failure_is_handled(
+        self, mock_get: AsyncMock, mock_capture: AsyncMock
+    ) -> None:
         mock_get.return_value = _make_session(status="idle")
         mock_capture.side_effect = RuntimeError("tmux failed")
         result = await verify_working(AsyncMock(), "test-session-1")
@@ -195,7 +226,9 @@ class TestVerifyProgressing:
     @pytest.mark.asyncio
     @patch("atc.session.ace._capture_pane", new_callable=AsyncMock)
     @patch("atc.session.ace.db_ops.get_session", new_callable=AsyncMock)
-    async def test_error_pattern_traceback(self, mock_get: AsyncMock, mock_capture: AsyncMock) -> None:
+    async def test_error_pattern_traceback(
+        self, mock_get: AsyncMock, mock_capture: AsyncMock
+    ) -> None:
         mock_get.return_value = _make_session(status="working")
         mock_capture.return_value = "Traceback (most recent call last): ..."
         result = await verify_progressing(AsyncMock(), "test-session-1")
@@ -205,7 +238,9 @@ class TestVerifyProgressing:
     @pytest.mark.asyncio
     @patch("atc.session.ace._capture_pane", new_callable=AsyncMock)
     @patch("atc.session.ace.db_ops.get_session", new_callable=AsyncMock)
-    async def test_error_pattern_permission_denied(self, mock_get: AsyncMock, mock_capture: AsyncMock) -> None:
+    async def test_error_pattern_permission_denied(
+        self, mock_get: AsyncMock, mock_capture: AsyncMock
+    ) -> None:
         mock_get.return_value = _make_session(status="working")
         mock_capture.return_value = "Permission denied when opening file"
         result = await verify_progressing(AsyncMock(), "test-session-1")

--- a/tests/unit/test_runtime_service.py
+++ b/tests/unit/test_runtime_service.py
@@ -13,6 +13,7 @@ from atc.runtime.models import (
     RuntimeSessionHandle,
     RuntimeTransport,
     StartRoleRequest,
+    StopRoleRequest,
     TaskAssignmentRequest,
 )
 from atc.runtime.service import RuntimeService
@@ -28,6 +29,7 @@ class DummyProviderRuntime:
         self.spawned_existing: list[StartRoleRequest] = []
         self.instructions: list[InstructionRequest] = []
         self.assignments: list[TaskAssignmentRequest] = []
+        self.stopped: list[tuple[RuntimeSessionHandle, StopRoleRequest | None]] = []
 
     async def prepare_workspace(self, request: StartRoleRequest) -> None:
         self.prepared.append(request)
@@ -57,6 +59,7 @@ class DummyProviderRuntime:
         )
 
     async def stop_role(self, handle: RuntimeSessionHandle, request=None) -> None:
+        self.stopped.append((handle, request))
         return None
 
     async def send_instruction(
@@ -328,3 +331,74 @@ def test_delivery_exception_permission_maps_to_permission_required() -> None:
         )
         is DeliveryReasonCode.PERMISSION_REQUIRED
     )
+
+
+def test_runtime_service_send_instruction_returns_delivery_result() -> None:
+    register_provider_runtime("dummy_runtime_result_instruction", DummyProviderRuntime)
+    service = RuntimeService()
+    handle = asyncio.run(
+        service.start_leader(
+            StartRoleRequest(
+                session_id="sess-result-leader-1",
+                provider_name="dummy_runtime_result_instruction",
+                role=RoleKind.LEADER,
+            )
+        )
+    )
+    request = InstructionRequest(session_id=handle.session_id, message="hello")
+
+    result = asyncio.run(service.assign_project_to_leader(handle, request))
+
+    assert result.session_id == "sess-result-leader-1"
+    assert result.provider_name == "dummy_runtime_result_instruction"
+    assert result.role is RoleKind.LEADER
+    assert result.status == "delivered"
+    assert result.stage == "confirmed_running"
+    assert result.verdict == "accepted"
+    assert result.reason_code == "delivery_unverified"
+    assert result.as_dict()["status"] == "delivered"
+
+
+def test_runtime_service_handle_from_session_record_maps_manager_and_stops_provider() -> None:
+    register_provider_runtime("dummy_runtime_record_stop", DummyProviderRuntime)
+    service = RuntimeService()
+    session = SimpleNamespace(
+        id="sess-record-manager-1",
+        provider="dummy_runtime_record_stop",
+        session_type="manager",
+        project_id="proj-record",
+        tmux_session="atc",
+        tmux_pane="%42",
+    )
+
+    handle = service.handle_from_session_record(session)
+    asyncio.run(
+        service.stop_session_record(session, StopRoleRequest(reason="test-stop", graceful=True))
+    )
+
+    provider = service.get_provider("dummy_runtime_record_stop")
+    stopped_handle, stop_request = provider.stopped[-1]
+    assert handle.role is RoleKind.LEADER
+    assert stopped_handle.session_id == "sess-record-manager-1"
+    assert stopped_handle.tmux_pane == "%42"
+    assert stop_request.reason == "test-stop"
+
+
+def test_runtime_service_inspect_session_record_uses_provider_boundary() -> None:
+    register_provider_runtime("dummy_runtime_record_inspect", DummyProviderRuntime)
+    service = RuntimeService()
+    session = SimpleNamespace(
+        id="sess-record-ace-1",
+        provider="dummy_runtime_record_inspect",
+        session_type="worker",
+        project_id="proj-record",
+        tmux_session="atc",
+        tmux_pane="%99",
+    )
+
+    inspection = asyncio.run(service.inspect_session_record(session))
+
+    assert inspection.session_id == "sess-record-ace-1"
+    assert inspection.provider_name == "dummy_runtime_record_inspect"
+    assert inspection.alive is True
+    assert service.get_handle("sess-record-ace-1").role is RoleKind.ACE


### PR DESCRIPTION
## Summary
- add runtime delivery result surface and DB-record session handle helpers in RuntimeService
- route leader send/stop and Ace liveness/destroy through the shared runtime boundary
- expose truthful leader message delivery states instead of generic sent responses
- make missing-pane stop idempotent and add Phase 5 Playwright/API validation script

## Validation
- ruff check src/atc/api/routers/projects.py src/atc/leader/leader.py src/atc/runtime/models.py src/atc/runtime/service.py src/atc/session/ace.py tests/e2e/test_smoke.py tests/unit/test_creation_reliability.py tests/unit/test_runtime_service.py
- pytest tests/unit/test_runtime_service.py tests/unit/test_codex_runtime.py tests/unit/test_claude_code_runtime.py tests/unit/test_tmux_session_runner.py tests/unit/test_deploy.py tests/unit/test_runtime_interrupts.py tests/unit/test_leader_api.py tests/unit/test_leader_orchestrator.py tests/unit/test_ace_status_api.py tests/unit/test_creation_reliability.py tests/unit/test_reconnect_runtime_semantics.py tests/e2e/test_ace_lifecycle.py tests/e2e/test_smoke.py -q  # 222 passed
- cd frontend && npm run build
- cd frontend && npm test -- --run ProjectView.test.tsx TowerPanel.test.tsx  # 15 passed
- ATC_API_URL=http://127.0.0.1:8420 ATC_UI_URL=http://localhost:5173 ATC_CODEX_COMMAND=/Users/mcole_studio/.local/bin/codex node scripts/playwright/phase5-runtime-boundary.mjs
