### PR TITLE
Fix Phase 5 runtime delivery follow-ups

### DIFF
--- a/scripts/playwright/phase5-runtime-boundary.mjs
+++ b/scripts/playwright/phase5-runtime-boundary.mjs
@@ -83,7 +83,6 @@ try {
       name: `Phase 5 Runtime Boundary ${stamp.slice(0, 19)}`,
       description: 'Temporary Phase 5 validation project.',
       agent_provider: 'codex',
-      auto_kickoff: false,
     }),
   });
   check('Temporary project created', projectResp.ok, JSON.stringify(projectResp.body));
@@ -91,7 +90,7 @@ try {
 
   const leaderStart = await api(`/api/projects/${project.id}/leader/start`, {
     method: 'POST',
-    body: JSON.stringify({ goal: 'Phase 5 validation: runtime delivery boundary.' }),
+    body: JSON.stringify({ goal: 'Phase 5 validation: runtime delivery boundary.', auto_kickoff: false }),
   });
   check('Leader start endpoint succeeds', leaderStart.ok, JSON.stringify(leaderStart.body));
   leaderSessionId = leaderStart.body?.session_id;

--- a/src/atc/leader/leader.py
+++ b/src/atc/leader/leader.py
@@ -20,7 +20,7 @@ from atc.agents.deploy import ManagerDeploySpec, deploy_manager_files
 from atc.runtime.models import InstructionRequest, StopRoleRequest
 from atc.runtime.service import RuntimeService
 from atc.session.ace import _accept_trust_dialog as _accept_trust_dialog  # noqa: F401
-from atc.session.ace import _spawn_provider_session
+from atc.session.ace import _persist_delivery_trace_events, _spawn_provider_session
 from atc.session.state_machine import SessionStatus, transition
 from atc.state import db as db_ops
 from atc.state.db import get_connection_app_state
@@ -336,12 +336,18 @@ async def send_leader_message(
 
     runtime = RuntimeService()
     handle = runtime.handle_from_session_record(session)
-    result = await runtime.assign_project_to_leader(
-        handle,
-        InstructionRequest(
-            session_id=session.id,
-            message=message,
-            metadata={"source": "leader_message"},
-        ),
+    request = InstructionRequest(
+        session_id=session.id,
+        message=message,
+        metadata={"source": "leader_message"},
     )
+    try:
+        result = await runtime.assign_project_to_leader(handle, request)
+    finally:
+        await _persist_delivery_trace_events(
+            conn,
+            session_id=session.id,
+            project_id=session.project_id,
+            trace_events=request.metadata.get("delivery_trace_events", []),
+        )
     return result

--- a/src/atc/session/ace.py
+++ b/src/atc/session/ace.py
@@ -506,7 +506,7 @@ async def _send_session_instruction(
         message=instruction,
     )
     try:
-        await service.send_instruction(handle, request)
+        result = await service.send_instruction(handle, request)
     finally:
         await _persist_delivery_trace_events(
             conn,
@@ -514,7 +514,14 @@ async def _send_session_instruction(
             project_id=session.project_id,
             trace_events=request.metadata.get("delivery_trace_events", []),
         )
-    return True
+    if not result.ok:
+        logger.error(
+            "Session %s: runtime delivery %s (%s)",
+            session.id,
+            result.status,
+            result.reason_code,
+        )
+    return result.ok
 
 
 async def _persist_delivery_trace_events(

--- a/src/atc/tower/controller.py
+++ b/src/atc/tower/controller.py
@@ -26,8 +26,9 @@ from typing import TYPE_CHECKING, Any
 from atc.config import load_settings
 from atc.leader.context_package import build_context_package
 from atc.leader.leader import send_leader_message, start_leader, stop_leader
-from atc.state import db as db_ops
+from atc.runtime.models import RuntimeDeliveryResult
 from atc.session.state_machine import SessionStatus
+from atc.state import db as db_ops
 from atc.tower.session import send_tower_message, start_tower_session, stop_tower_session
 
 if TYPE_CHECKING:
@@ -37,6 +38,12 @@ if TYPE_CHECKING:
     from atc.core.events import EventBus
 
 logger = logging.getLogger(__name__)
+
+
+def _delivery_failed(result: object) -> bool:
+    """Return true when a runtime delivery result is explicitly not ok."""
+
+    return isinstance(result, RuntimeDeliveryResult) and not result.ok
 
 
 class TowerState(enum.StrEnum):
@@ -249,9 +256,7 @@ class TowerController:
             raise TowerBusyError(self._state, project_id)
 
         if self._budget_constrained:
-            logger.warning(
-                "Skipping new Ace spawn — budget constrained (project %s)", project_id
-            )
+            logger.warning("Skipping new Ace spawn — budget constrained (project %s)", project_id)
             raise BudgetConstrainedError(project_id)
 
         if self._active_ace_count >= self._max_concurrent_aces:
@@ -376,9 +381,7 @@ class TowerController:
 
             # Send kickoff and start background verification loop
             await self._send_leader_kickoff(leader_session_id, goal)
-            asyncio.create_task(
-                self._verify_leader_started(project_id, leader_session_id, goal)
-            )
+            asyncio.create_task(self._verify_leader_started(project_id, leader_session_id, goal))
 
             # Notify Tower's own Claude session so it knows a Leader is running
             # and can begin monitoring.  Best-effort — don't fail the whole goal
@@ -511,8 +514,7 @@ class TowerController:
             }
 
         cursor = await self._db.execute(
-            "SELECT status, COUNT(*) as cnt FROM task_graphs "
-            "WHERE project_id = ? GROUP BY status",
+            "SELECT status, COUNT(*) as cnt FROM task_graphs WHERE project_id = ? GROUP BY status",
             (self._current_project_id,),
         )
         rows = await cursor.fetchall()
@@ -631,12 +633,17 @@ class TowerController:
             kickoff_msg = "\n".join(lines)
 
             try:
-                await send_leader_message(
+                delivery = await send_leader_message(
                     self._db,
                     self._current_project_id,
                     kickoff_msg,
                     event_bus=self._event_bus,
                 )
+                if _delivery_failed(delivery):
+                    raise ValueError(
+                        delivery.message
+                        or f"Leader instruction {delivery.status}: {delivery.reason_code}"
+                    )
             except ValueError as exc:
                 # Pane died between spawn and kickoff — respawn once and retry
                 err_msg = str(exc).lower()
@@ -648,12 +655,16 @@ class TowerController:
                     new_id = await self._respawn_leader(self._current_project_id, goal)
                     if new_id:
                         # Retry kickoff with fresh session
-                        await send_leader_message(
+                        retry_delivery = await send_leader_message(
                             self._db,
                             self._current_project_id,
                             kickoff_msg,
                             event_bus=self._event_bus,
                         )
+                        if _delivery_failed(retry_delivery):
+                            raise ValueError(
+                                retry_delivery.message or "Leader kickoff retry delivery failed"
+                            ) from exc
                         session_id = new_id
                     else:
                         raise
@@ -665,13 +676,9 @@ class TowerController:
                 self._current_project_id,
             )
         except Exception:
-            logger.exception(
-                "Failed to send kickoff to leader session %s", session_id
-            )
+            logger.exception("Failed to send kickoff to leader session %s", session_id)
 
-    async def _verify_leader_started(
-        self, project_id: str, session_id: str, goal: str
-    ) -> None:
+    async def _verify_leader_started(self, project_id: str, session_id: str, goal: str) -> None:
         """Background loop: verify the Leader acknowledged and started working.
 
         Waits ~10s after kickoff, checks for output, and retries the kickoff
@@ -703,12 +710,17 @@ class TowerController:
                 max_retries,
             )
             try:
-                await send_leader_message(
+                delivery = await send_leader_message(
                     self._db,
                     project_id,
                     "Please continue with your goal.",
                     event_bus=self._event_bus,
                 )
+                if _delivery_failed(delivery):
+                    raise ValueError(
+                        delivery.message
+                        or f"Leader nudge {delivery.status}: {delivery.reason_code}"
+                    )
             except ValueError as exc:
                 # Pane is dead — respawn the leader and resend the kickoff
                 err_msg = str(exc).lower()
@@ -731,9 +743,7 @@ class TowerController:
                         break
                 logger.exception("Failed to send nudge to leader session %s", session_id)
             except Exception:
-                logger.exception(
-                    "Failed to send nudge to leader session %s", session_id
-                )
+                logger.exception("Failed to send nudge to leader session %s", session_id)
             await asyncio.sleep(retry_wait)
 
         # Final check after last retry
@@ -988,7 +998,9 @@ class TowerController:
                         self._max_concurrent_aces,
                     )
             except Exception:
-                logger.debug("Could not look up session type for %s during status change", session_id)
+                logger.debug(
+                    "Could not look up session type for %s during status change", session_id
+                )
 
         if session_id != self._leader_session_id:
             return
@@ -1040,6 +1052,4 @@ class BudgetConstrainedError(Exception):
 
     def __init__(self, project_id: str) -> None:
         self.project_id = project_id
-        super().__init__(
-            f"Budget constrained — new Ace spawns paused for project {project_id}"
-        )
+        super().__init__(f"Budget constrained — new Ace spawns paused for project {project_id}")

--- a/tests/e2e/test_ace_lifecycle.py
+++ b/tests/e2e/test_ace_lifecycle.py
@@ -14,6 +14,7 @@ from fastapi.testclient import TestClient
 
 from atc.api.app import create_app
 from atc.config import Settings
+from atc.runtime.models import RoleKind, RuntimeDeliveryResult
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -77,9 +78,21 @@ class TestAceLifecycle:
         names = {a["name"] for a in aces}
         assert names == {"ace-a", "ace-b"}
 
-    def test_full_lifecycle(self, mock_tmux: AsyncMock, client: TestClient) -> None:
+    @patch("atc.runtime.service.RuntimeService.send_instruction", new_callable=AsyncMock)
+    def test_full_lifecycle(
+        self, mock_send: AsyncMock, mock_tmux: AsyncMock, client: TestClient
+    ) -> None:
         """Create → start → message → stop → destroy."""
         mock_tmux.return_value = "%1"
+        mock_send.return_value = RuntimeDeliveryResult(
+            session_id="session-test",
+            provider_name="claude_code",
+            role=RoleKind.ACE,
+            status="delivered",
+            stage="confirmed_running",
+            verdict="accepted",
+            reason_code="delivery_unverified",
+        )
 
         resp = client.post("/api/projects", json={"name": "lifecycle-proj"})
         project_id = resp.json()["id"]

--- a/tests/unit/test_creation_reliability.py
+++ b/tests/unit/test_creation_reliability.py
@@ -12,10 +12,11 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 
-from atc.runtime.models import ReadinessState, RuntimeInspection
+from atc.runtime.models import ReadinessState, RoleKind, RuntimeDeliveryResult, RuntimeInspection
 from atc.session.ace import (
     VerificationResult,
     _get_alternate_on,
+    start_ace,
     verify_alive,
     verify_progressing,
     verify_working,
@@ -254,3 +255,31 @@ class TestVerificationResult:
         assert result.ok is True
         assert result.phase == "alive"
         assert result.detail == "all good"
+
+
+class TestStartAceDelivery:
+    @pytest.mark.asyncio
+    @patch("atc.session.ace.db_ops.update_session_status", new_callable=AsyncMock)
+    @patch("atc.session.ace.RuntimeService.send_instruction", new_callable=AsyncMock)
+    @patch("atc.session.ace.db_ops.get_session", new_callable=AsyncMock)
+    async def test_failed_delivery_marks_session_error(
+        self, mock_get: AsyncMock, mock_send: AsyncMock, mock_update: AsyncMock
+    ) -> None:
+        session = _make_session(status="idle")
+        mock_get.return_value = session
+        mock_send.return_value = RuntimeDeliveryResult(
+            session_id=session.id,
+            provider_name="codex",
+            role=RoleKind.ACE,
+            status="failed",
+            stage="delivery_failed",
+            verdict="failed",
+            reason_code="delivery_failed",
+        )
+
+        conn = AsyncMock()
+        with pytest.raises(RuntimeError, match="Failed to deliver instruction"):
+            await start_ace(conn, session.id, instruction="Do work")
+
+        mock_update.assert_any_await(conn, session.id, "working")
+        mock_update.assert_any_await(conn, session.id, "error")


### PR DESCRIPTION
## Summary
- preserve delivery trace persistence for leader messages now routed through RuntimeService
- make Ace instruction send return failed/blocked runtime delivery results as failed starts
- make Tower kickoff/nudge paths inspect RuntimeDeliveryResult instead of exceptions only
- correct Phase 5 Playwright validation to disable auto-kickoff on leader start
- update lifecycle tests to patch RuntimeService delivery boundary

## Validation
- node --check scripts/playwright/phase5-runtime-boundary.mjs
- ruff check src/atc/session/ace.py src/atc/leader/leader.py tests/unit/test_creation_reliability.py tests/e2e/test_ace_lifecycle.py tests/e2e/test_smoke.py tests/unit/test_runtime_service.py
- python -m py_compile src/atc/tower/controller.py
- pytest tests/unit/test_creation_reliability.py tests/e2e/test_ace_lifecycle.py tests/e2e/test_smoke.py tests/unit/test_runtime_service.py -q  # 64 passed
- pytest tests/unit/test_runtime_service.py tests/unit/test_codex_runtime.py tests/unit/test_claude_code_runtime.py tests/unit/test_tmux_session_runner.py tests/unit/test_deploy.py tests/unit/test_runtime_interrupts.py tests/unit/test_leader_api.py tests/unit/test_leader_orchestrator.py tests/unit/test_ace_status_api.py tests/unit/test_creation_reliability.py tests/unit/test_reconnect_runtime_semantics.py tests/e2e/test_ace_lifecycle.py tests/e2e/test_smoke.py -q  # 223 passed before final raise-style patch; focused suite rerun after patch

Note: src/atc/tower/controller.py has pre-existing full-file ruff debt; this PR py-compiles it and validates changed behavior through targeted tests.
