### PR TITLE
Add Phase 6 runtime state reconciliation

### DIFF
--- a/scripts/playwright/phase6-reconcile.mjs
+++ b/scripts/playwright/phase6-reconcile.mjs
@@ -1,0 +1,195 @@
+import { chromium } from '../../frontend/node_modules/@playwright/test/index.mjs';
+import fs from 'node:fs';
+import path from 'node:path';
+
+const stamp = new Date().toISOString().replace(/[:.]/g, '-');
+const root = path.resolve(new URL('../..', import.meta.url).pathname);
+const outDir = path.join(root, 'test-results', `phase6-reconcile-${stamp}`);
+const baseUrl = process.env.ATC_UI_URL || 'http://localhost:5173';
+const apiUrl = process.env.ATC_API_URL || 'http://127.0.0.1:8420';
+
+fs.mkdirSync(outDir, { recursive: true });
+
+const checks = [];
+const events = [];
+const consoleMessages = [];
+const failedRequests = [];
+let screenshotIndex = 0;
+let project = null;
+let task = null;
+let dryRun = null;
+let repairRun = null;
+let repairedTask = null;
+let auditEvents = [];
+
+function check(name, ok, detail = '') {
+  checks.push({ name, ok, detail });
+  console.log(`${ok ? 'PASS' : 'FAIL'} ${name}${detail ? ` — ${detail}` : ''}`);
+  if (!ok) throw new Error(`${name}: ${detail}`);
+}
+
+function note(name, detail = '') {
+  events.push({ t: new Date().toISOString(), name, detail });
+  console.log(`${name}${detail ? ` — ${detail}` : ''}`);
+}
+
+async function screenshot(page, name) {
+  const file = path.join(outDir, `${String(screenshotIndex++).padStart(2, '0')}-${name}.png`);
+  await page.screenshot({ path: file, fullPage: true });
+  note('SCREENSHOT', file);
+  return file;
+}
+
+async function api(route, options = {}) {
+  const res = await fetch(`${apiUrl}${route}`, {
+    headers: { 'Content-Type': 'application/json', ...(options.headers || {}) },
+    ...options,
+  });
+  const text = await res.text();
+  let body;
+  try {
+    body = text ? JSON.parse(text) : null;
+  } catch {
+    body = text;
+  }
+  return { ok: res.ok, status: res.status, body };
+}
+
+const browser = await chromium.launch({ headless: true });
+const page = await browser.newPage({ viewport: { width: 1365, height: 768 }, deviceScaleFactor: 1 });
+page.on('console', (msg) => {
+  if (['error', 'warning'].includes(msg.type())) {
+    consoleMessages.push({ type: msg.type(), text: msg.text() });
+  }
+});
+page.on('pageerror', (err) => consoleMessages.push({ type: 'pageerror', text: err.message }));
+page.on('requestfailed', (req) => failedRequests.push({ url: req.url(), failure: req.failure()?.errorText }));
+page.on('response', (res) => {
+  if (res.status() >= 400 && !res.url().includes('/@vite')) {
+    failedRequests.push({ url: res.url(), status: res.status() });
+  }
+});
+
+try {
+  const health = await api('/api/health');
+  check('Backend health responds', health.ok, JSON.stringify(health.body));
+
+  const projectResp = await api('/api/projects', {
+    method: 'POST',
+    body: JSON.stringify({
+      name: `Phase 6 Reconcile ${stamp.slice(0, 19)}`,
+      description: 'Temporary Phase 6 validation project.',
+      agent_provider: 'codex',
+    }),
+  });
+  check('Temporary project created', projectResp.ok, JSON.stringify(projectResp.body));
+  project = projectResp.body;
+
+  const taskResp = await api(`/api/projects/${project.id}/task-graphs`, {
+    method: 'POST',
+    body: JSON.stringify({
+      title: 'Phase 6 orphaned task validation',
+      description: 'Assigned to a missing Ace so reconcile can detect and safely repair it.',
+      status: 'assigned',
+      assigned_ace_id: `missing-ace-${stamp}`,
+    }),
+  });
+  check('Temporary orphaned task created', taskResp.ok, JSON.stringify(taskResp.body));
+  task = taskResp.body;
+
+  dryRun = await api('/api/orchestration/reconcile', {
+    method: 'POST',
+    body: JSON.stringify({ repair: false }),
+  });
+  check('Reconcile dry-run endpoint succeeds', dryRun.ok, JSON.stringify(dryRun.body));
+  const dryFinding = dryRun.body?.findings?.find((entry) => entry.task_graph_id === task.id);
+  check('Dry-run reports orphaned task finding', Boolean(dryFinding), JSON.stringify(dryRun.body));
+  check('Dry-run does not mutate state', dryFinding?.repair_status === 'not_requested', JSON.stringify(dryFinding));
+  check(
+    'Dry-run recommends reset for reassignment',
+    dryFinding?.recommended_action === 'reset_task_for_reassignment',
+    JSON.stringify(dryFinding),
+  );
+
+  const beforeRepair = await api(`/api/task-graphs/${task.id}`);
+  check(
+    'Task remains assigned before repair',
+    beforeRepair.body?.status === 'assigned' && beforeRepair.body?.assigned_ace_id,
+    JSON.stringify(beforeRepair.body),
+  );
+
+  repairRun = await api('/api/orchestration/reconcile', {
+    method: 'POST',
+    body: JSON.stringify({ repair: true }),
+  });
+  check('Reconcile repair endpoint succeeds', repairRun.ok, JSON.stringify(repairRun.body));
+  const repairFinding = repairRun.body?.findings?.find((entry) => entry.task_graph_id === task.id);
+  check('Repair reports the same orphaned task', Boolean(repairFinding), JSON.stringify(repairRun.body));
+  check('Repair status is applied', repairFinding?.repair_status === 'applied', JSON.stringify(repairFinding));
+
+  const repairedTaskResp = await api(`/api/task-graphs/${task.id}`);
+  check('Repaired task fetch succeeds', repairedTaskResp.ok, JSON.stringify(repairedTaskResp.body));
+  repairedTask = repairedTaskResp.body;
+  check(
+    'Repair resets task to todo and clears Ace assignment',
+    repairedTask.status === 'todo' && repairedTask.assigned_ace_id === null,
+    JSON.stringify(repairedTask),
+  );
+
+  const eventsResp = await api(`/api/app-events?category=reconcile&project_id=${project.id}&limit=20`);
+  check('Reconcile audit events are queryable', eventsResp.ok, JSON.stringify(eventsResp.body));
+  auditEvents = eventsResp.body || [];
+  check('Reconcile repair wrote an audit event', auditEvents.length >= 1, JSON.stringify(auditEvents));
+
+  await page.goto(`${baseUrl}/`, { waitUntil: 'networkidle', timeout: 30000 });
+  await page.getByText(project.name).first().waitFor({ timeout: 15000 });
+  await screenshot(page, 'dashboard-phase6-project-visible');
+
+  await page.goto(`${baseUrl}/projects/${project.id}`, { waitUntil: 'networkidle', timeout: 30000 });
+  await page.getByText(project.name).first().waitFor({ timeout: 15000 });
+  await screenshot(page, 'project-phase6-reconcile-visible');
+
+  check('No failed browser requests', failedRequests.length === 0, JSON.stringify(failedRequests));
+  const pageErrors = consoleMessages.filter((entry) => entry.type === 'pageerror');
+  check('No page errors', pageErrors.length === 0, JSON.stringify(pageErrors));
+
+  const report = {
+    outDir,
+    baseUrl,
+    apiUrl,
+    project,
+    task,
+    dryRun: dryRun.body,
+    repairRun: repairRun.body,
+    repairedTask,
+    auditEvents,
+    checks,
+    events,
+    consoleMessages,
+    failedRequests,
+  };
+  fs.writeFileSync(path.join(outDir, 'report.json'), JSON.stringify(report, null, 2));
+  console.log(`REPORT ${path.join(outDir, 'report.json')}`);
+} catch (err) {
+  checks.push({
+    name: 'Phase 6 Playwright/API validation completed without throw',
+    ok: false,
+    detail: err?.stack || err?.message || String(err),
+  });
+  await screenshot(page, 'failure');
+  fs.writeFileSync(
+    path.join(outDir, 'report.json'),
+    JSON.stringify(
+      { outDir, checks, events, consoleMessages, failedRequests, project, task, dryRun, repairRun, repairedTask },
+      null,
+      2,
+    ),
+  );
+  process.exitCode = 1;
+} finally {
+  await browser.close();
+}
+
+if (checks.some((entry) => !entry.ok)) {
+  process.exitCode = 1;
+}

--- a/src/atc/api/app.py
+++ b/src/atc/api/app.py
@@ -678,6 +678,7 @@ def create_app(settings: Settings | None = None) -> FastAPI:
         orchestration,
         projects,
         qa,
+        reconcile,
         system,
         task_graphs,
         tasks,
@@ -701,6 +702,7 @@ def create_app(settings: Settings | None = None) -> FastAPI:
     app.include_router(context.router, prefix="/api", tags=["context"])
     app.include_router(memory.router, prefix="/api/memory", tags=["memory"])
     app.include_router(orchestration.router, prefix="/api/orchestration", tags=["orchestration"])
+    app.include_router(reconcile.router, prefix="/api/orchestration", tags=["orchestration"])
     app.include_router(backup.router, prefix="/api/backup", tags=["backup"])
     app.include_router(qa.router, prefix="/api/qa", tags=["qa"])
     app.include_router(system.router, prefix="/api/system", tags=["system"])

--- a/src/atc/api/routers/reconcile.py
+++ b/src/atc/api/routers/reconcile.py
@@ -1,0 +1,36 @@
+"""Runtime/orchestration reconciliation endpoints."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from fastapi import APIRouter, Request
+from pydantic import BaseModel
+
+from atc.session.reconcile import reconcile_runtime_state
+
+router = APIRouter()
+
+
+class ReconcileRequest(BaseModel):
+    repair: bool = False
+
+
+class ReconcileResponse(BaseModel):
+    repair: bool
+    summary: dict[str, int]
+    findings: list[dict[str, Any]]
+
+
+@router.post("/reconcile", response_model=ReconcileResponse)
+async def reconcile_state(body: ReconcileRequest, request: Request) -> ReconcileResponse:
+    """Detect and optionally repair DB/runtime drift.
+
+    Use ``repair=false`` for a dry structured scan. Use ``repair=true`` to apply
+    safe repairs: stale active sessions are marked disconnected and orphaned
+    active task graph entries are reset for reassignment.
+    """
+
+    result = await reconcile_runtime_state(request.app.state.db, repair=body.repair)
+    payload = result.as_dict()
+    return ReconcileResponse(**payload)

--- a/src/atc/session/reconcile.py
+++ b/src/atc/session/reconcile.py
@@ -1,0 +1,340 @@
+"""Reconcile believed orchestration state against runtime reality.
+
+Phase 6 runtime/orchestration hardening lives here: callers can run a dry
+scan to get structured findings, or enable safe repairs for drift that ATC
+can correct without operator judgement.
+"""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, field
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING, Any, Literal
+
+from atc.runtime.models import ReadinessState
+from atc.runtime.service import RuntimeService
+from atc.state import db as db_ops
+
+if TYPE_CHECKING:
+    import aiosqlite  # type: ignore[import-not-found]
+
+FindingKind = Literal[
+    "stale_active_session",
+    "orphaned_task",
+    "runtime_blocked",
+    "provider_mismatch",
+]
+FindingSeverity = Literal["info", "warning", "error"]
+RepairAction = Literal[
+    "none",
+    "mark_stale",
+    "reset_task_for_reassignment",
+    "require_operator_intervention",
+]
+RepairStatus = Literal["not_requested", "applied", "skipped", "failed"]
+
+ACTIVE_SESSION_STATUSES = {"connecting", "idle", "working", "waiting", "paused"}
+ACTIVE_TASK_STATUSES = {"assigned", "in_progress"}
+ACTIVE_ASSIGNMENT_STATUSES = {"assigned", "working"}
+
+
+def _now() -> str:
+    return datetime.now(UTC).isoformat()
+
+
+@dataclass(slots=True)
+class ReconcileFinding:
+    """Structured drift finding produced by a reconcile scan."""
+
+    kind: FindingKind
+    severity: FindingSeverity
+    entity_type: str
+    entity_id: str
+    reason_code: str
+    message: str
+    recommended_action: RepairAction
+    project_id: str | None = None
+    session_id: str | None = None
+    task_graph_id: str | None = None
+    repair_status: RepairStatus = "not_requested"
+    repair_error: str | None = None
+    details: dict[str, Any] = field(default_factory=dict)
+
+    def as_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(slots=True)
+class ReconcileResult:
+    """Result from a reconcile scan/repair pass."""
+
+    repair: bool
+    findings: list[ReconcileFinding]
+
+    @property
+    def summary(self) -> dict[str, int]:
+        total = len(self.findings)
+        applied = sum(1 for finding in self.findings if finding.repair_status == "applied")
+        failed = sum(1 for finding in self.findings if finding.repair_status == "failed")
+        by_kind: dict[str, int] = {}
+        for finding in self.findings:
+            by_kind[finding.kind] = by_kind.get(finding.kind, 0) + 1
+        return {"total": total, "applied": applied, "failed": failed, **by_kind}
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "repair": self.repair,
+            "summary": self.summary,
+            "findings": [finding.as_dict() for finding in self.findings],
+        }
+
+
+async def reconcile_runtime_state(
+    conn: aiosqlite.Connection,
+    *,
+    repair: bool = False,
+    runtime_service: RuntimeService | None = None,
+) -> ReconcileResult:
+    """Detect and optionally repair DB/runtime drift.
+
+    Safe automated repairs currently cover:
+    - active DB sessions whose tmux/provider runtime is no longer alive;
+    - assigned/in-progress task graph entries with no bound live Ace.
+
+    Unsafe drift, such as provider mismatch or runtime blockers, is reported as
+    an operator-intervention finding and left unchanged.
+    """
+
+    service = runtime_service or RuntimeService()
+    findings: list[ReconcileFinding] = []
+
+    sessions = await db_ops.list_sessions(conn)
+    session_by_id = {session.id: session for session in sessions}
+    live_session_ids: set[str] = set()
+
+    for session in sessions:
+        if session.status not in ACTIVE_SESSION_STATUSES or not session.tmux_pane:
+            continue
+        try:
+            inspection = await service.inspect_session_record(session)
+        except Exception as exc:
+            # Provider inspection failure means reality is unknown, not success.
+            finding = ReconcileFinding(
+                kind="stale_active_session",
+                severity="warning",
+                entity_type="session",
+                entity_id=session.id,
+                session_id=session.id,
+                project_id=session.project_id,
+                reason_code="runtime_inspection_failed",
+                message="Active session could not be inspected by the runtime service.",
+                recommended_action="require_operator_intervention",
+                repair_status="skipped" if repair else "not_requested",
+                details={
+                    "status": session.status,
+                    "tmux_pane": session.tmux_pane,
+                    "error_type": type(exc).__name__,
+                    "error": str(exc),
+                },
+            )
+            findings.append(finding)
+            if repair:
+                await _audit_finding(conn, finding)
+            continue
+
+        if inspection.alive:
+            live_session_ids.add(session.id)
+            if inspection.readiness == ReadinessState.BLOCKED:
+                finding = ReconcileFinding(
+                    kind="runtime_blocked",
+                    severity="warning",
+                    entity_type="session",
+                    entity_id=session.id,
+                    session_id=session.id,
+                    project_id=session.project_id,
+                    reason_code=(
+                        inspection.block_reason.value
+                        if inspection.block_reason is not None
+                        else "runtime_blocked"
+                    ),
+                    message="Runtime session is alive but blocked by provider/operator state.",
+                    recommended_action="require_operator_intervention",
+                    repair_status="skipped" if repair else "not_requested",
+                    details={
+                        "status": session.status,
+                        "readiness": inspection.readiness.value,
+                        "summary": inspection.summary,
+                    },
+                )
+                findings.append(finding)
+            continue
+
+        finding = ReconcileFinding(
+            kind="stale_active_session",
+            severity="warning",
+            entity_type="session",
+            entity_id=session.id,
+            session_id=session.id,
+            project_id=session.project_id,
+            reason_code="runtime_not_alive",
+            message="DB marks session active, but runtime inspection reports it is not alive.",
+            recommended_action="mark_stale",
+            details={
+                "status": session.status,
+                "tmux_session": session.tmux_session,
+                "tmux_pane": session.tmux_pane,
+                "readiness": inspection.readiness.value,
+                "summary": inspection.summary,
+            },
+        )
+        findings.append(finding)
+        if repair:
+            await _mark_session_stale(conn, finding)
+
+    current_provider = _current_default_provider(conn)
+    if current_provider:
+        for session in sessions:
+            if (
+                session.status in ACTIVE_SESSION_STATUSES
+                and session.provider
+                and session.provider != current_provider
+            ):
+                findings.append(
+                    ReconcileFinding(
+                        kind="provider_mismatch",
+                        severity="warning",
+                        entity_type="session",
+                        entity_id=session.id,
+                        session_id=session.id,
+                        project_id=session.project_id,
+                        reason_code="provider_mismatch",
+                        message="Active session provider differs from current default provider.",
+                        recommended_action="require_operator_intervention",
+                        repair_status="skipped" if repair else "not_requested",
+                        details={
+                            "session_provider": session.provider,
+                            "current_default_provider": current_provider,
+                            "status": session.status,
+                        },
+                    )
+                )
+
+    for task in await db_ops.list_task_graphs(conn):
+        if task.status not in ACTIVE_TASK_STATUSES:
+            continue
+        ace_id = task.assigned_ace_id
+        ace = session_by_id.get(ace_id) if ace_id else None
+        ace_live = (
+            ace is not None
+            and ace.session_type == "ace"
+            and ace.id in live_session_ids
+        )
+        if ace_live:
+            continue
+        reason = "missing_assigned_ace" if not ace_id else "assigned_ace_not_live"
+        finding = ReconcileFinding(
+            kind="orphaned_task",
+            severity="warning",
+            entity_type="task_graph",
+            entity_id=task.id,
+            task_graph_id=task.id,
+            session_id=ace_id,
+            project_id=task.project_id,
+            reason_code=reason,
+            message="Task graph is active but has no bound live Ace session.",
+            recommended_action="reset_task_for_reassignment",
+            details={
+                "task_status": task.status,
+                "assigned_ace_id": ace_id,
+                "ace_status": ace.status if ace is not None else None,
+            },
+        )
+        findings.append(finding)
+        if repair:
+            await _reset_orphaned_task(conn, finding)
+
+    return ReconcileResult(repair=repair, findings=findings)
+
+
+async def _mark_session_stale(
+    conn: aiosqlite.Connection,
+    finding: ReconcileFinding,
+) -> None:
+    try:
+        expected_status = str(finding.details.get("status") or "")
+        expected_pane = finding.details.get("tmux_pane")
+        now = _now()
+        cursor = await conn.execute(
+            """UPDATE sessions
+               SET status = ?, tmux_session = NULL, tmux_pane = NULL, updated_at = ?
+               WHERE id = ? AND status = ? AND tmux_pane IS ?""",
+            ("disconnected", now, finding.entity_id, expected_status, expected_pane),
+        )
+        await conn.commit()
+        if cursor.rowcount == 0:
+            finding.repair_status = "skipped"
+            finding.repair_error = "session changed before stale repair could apply"
+        else:
+            finding.repair_status = "applied"
+        await _audit_finding(conn, finding)
+    except Exception as exc:
+        finding.repair_status = "failed"
+        finding.repair_error = str(exc)
+        await _audit_finding(conn, finding)
+
+
+async def _reset_orphaned_task(
+    conn: aiosqlite.Connection,
+    finding: ReconcileFinding,
+) -> None:
+    try:
+        task_id = finding.entity_id
+        expected_assignee = finding.details.get("assigned_ace_id")
+        task = await db_ops.get_task_graph(conn, task_id)
+        if (
+            task is None
+            or task.status not in ACTIVE_TASK_STATUSES
+            or task.assigned_ace_id != expected_assignee
+        ):
+            finding.repair_status = "skipped"
+            finding.repair_error = "task assignment changed before orphan repair could apply"
+            await _audit_finding(conn, finding)
+            return
+
+        for assignment in await db_ops.list_task_assignments(conn, task_graph_id=task_id):
+            if assignment.status in ACTIVE_ASSIGNMENT_STATUSES:
+                await db_ops.update_task_assignment_status(conn, assignment.assignment_id, "failed")
+        task = await db_ops.get_task_graph(conn, task_id)
+        if task is not None and task.status == "in_progress":
+            await db_ops.update_task_graph_status(conn, task_id, "assigned")
+        task = await db_ops.get_task_graph(conn, task_id)
+        if task is not None and task.status == "assigned":
+            await db_ops.update_task_graph_status(conn, task_id, "todo")
+        await db_ops.update_task_graph(conn, task_id, assigned_ace_id=None)
+        finding.repair_status = "applied"
+        await _audit_finding(conn, finding)
+    except Exception as exc:
+        finding.repair_status = "failed"
+        finding.repair_error = str(exc)
+        await _audit_finding(conn, finding)
+
+
+async def _audit_finding(conn: aiosqlite.Connection, finding: ReconcileFinding) -> None:
+    await db_ops.create_app_event(
+        conn,
+        level=finding.severity,
+        category="reconcile",
+        message=finding.message,
+        detail=finding.as_dict(),
+        project_id=finding.project_id,
+        session_id=finding.session_id,
+    )
+
+
+def _current_default_provider(conn: aiosqlite.Connection) -> str | None:
+    app_state = db_ops.get_connection_app_state(conn)
+    if app_state is None:
+        app_state = getattr(getattr(conn, "_connection", None), "app_state", None)
+    settings = getattr(app_state, "settings", None) if app_state is not None else None
+    agent_provider = getattr(settings, "agent_provider", None) if settings is not None else None
+    return getattr(agent_provider, "default", None)

--- a/tests/unit/test_reconcile.py
+++ b/tests/unit/test_reconcile.py
@@ -1,0 +1,283 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+if TYPE_CHECKING:
+    from pathlib import Path
+from fastapi.testclient import TestClient
+
+from atc.api.app import create_app
+from atc.config import Settings
+from atc.runtime.models import ReadinessState, RuntimeInspection
+from atc.session.reconcile import (
+    ReconcileFinding,
+    _mark_session_stale,
+    _reset_orphaned_task,
+    reconcile_runtime_state,
+)
+from atc.state import db as db_ops
+
+
+async def _make_project_and_session(conn, *, status: str = "working"):
+    project = await db_ops.create_project(conn, "phase6-project", agent_provider="codex")
+    session = await db_ops.create_session(
+        conn,
+        project.id,
+        "ace",
+        "ace-phase6",
+        provider="codex",
+        status=status,
+    )
+    await db_ops.update_session_tmux(conn, session.id, "atc", "%missing")
+    return project, await db_ops.get_session(conn, session.id)
+
+
+@pytest.mark.asyncio
+async def test_reconcile_marks_stale_active_session_disconnected(tmp_path: Path) -> None:
+    db_path = str(tmp_path / "phase6.db")
+    await db_ops.run_migrations(db_path)
+    async with db_ops.get_connection(db_path) as conn:
+        _project, session = await _make_project_and_session(conn)
+        assert session is not None
+        service = AsyncMock()
+        service.inspect_session_record.return_value = RuntimeInspection(
+            session_id=session.id,
+            provider_name="codex",
+            alive=False,
+            readiness=ReadinessState.STOPPED,
+            summary="pane missing",
+        )
+
+        result = await reconcile_runtime_state(conn, repair=True, runtime_service=service)
+
+        assert result.summary["stale_active_session"] == 1
+        finding = result.findings[0]
+        assert finding.reason_code == "runtime_not_alive"
+        assert finding.repair_status == "applied"
+        repaired = await db_ops.get_session(conn, session.id)
+        assert repaired is not None
+        assert repaired.status == "disconnected"
+        assert repaired.tmux_pane is None
+        events = await db_ops.list_app_events(conn, session_id=session.id)
+        assert events
+        assert events[0].category == "reconcile"
+
+
+@pytest.mark.asyncio
+async def test_reconcile_resets_orphaned_task_for_reassignment(tmp_path: Path) -> None:
+    db_path = str(tmp_path / "phase6-orphan.db")
+    await db_ops.run_migrations(db_path)
+    async with db_ops.get_connection(db_path) as conn:
+        project = await db_ops.create_project(conn, "phase6-orphan", agent_provider="codex")
+        task = await db_ops.create_task_graph(
+            conn,
+            project.id,
+            "orphaned task",
+            status="assigned",
+            assigned_ace_id="missing-ace-session",
+        )
+
+        result = await reconcile_runtime_state(conn, repair=True, runtime_service=AsyncMock())
+
+        assert result.summary["orphaned_task"] == 1
+        finding = result.findings[0]
+        assert finding.reason_code == "assigned_ace_not_live"
+        assert finding.repair_status == "applied"
+        repaired = await db_ops.get_task_graph(conn, task.id)
+        assert repaired is not None
+        assert repaired.status == "todo"
+        assert repaired.assigned_ace_id is None
+        events = await db_ops.list_app_events(conn, session_id="missing-ace-session")
+        assert events
+        assert events[0].category == "reconcile"
+
+
+def test_reconcile_api_reports_orphaned_task(tmp_path: Path) -> None:
+    db_path = str(tmp_path / "phase6-api.db")
+    settings = Settings(database={"path": db_path})  # type: ignore[arg-type]
+    app = create_app(settings)
+    with (
+        patch("atc.leader.leader._accept_trust_dialog", new_callable=AsyncMock, return_value=False),
+        patch("atc.tower.controller.TowerController.start_session", new_callable=AsyncMock),
+        TestClient(app) as client,
+    ):
+        project = client.post("/api/projects", json={"name": "phase6-api"}).json()
+        task = client.post(
+            f"/api/projects/{project['id']}/task-graphs",
+            json={
+                "title": "api orphan",
+                "status": "assigned",
+                "assigned_ace_id": "api-missing-ace",
+            },
+        ).json()
+
+        dry = client.post("/api/orchestration/reconcile", json={"repair": False})
+        assert dry.status_code == 200
+        data = dry.json()
+        assert data["summary"]["orphaned_task"] == 1
+        assert data["findings"][0]["repair_status"] == "not_requested"
+
+        repaired = client.post("/api/orchestration/reconcile", json={"repair": True})
+        assert repaired.status_code == 200
+        assert repaired.json()["findings"][0]["repair_status"] == "applied"
+        task_after = client.get(f"/api/task-graphs/{task['id']}").json()
+        assert task_after["status"] == "todo"
+        assert task_after["assigned_ace_id"] is None
+
+
+@pytest.mark.asyncio
+async def test_reconcile_inspection_failure_is_not_auto_repaired(tmp_path: Path) -> None:
+    db_path = str(tmp_path / "phase6-inspection-failure.db")
+    await db_ops.run_migrations(db_path)
+    async with db_ops.get_connection(db_path) as conn:
+        _project, session = await _make_project_and_session(conn)
+        assert session is not None
+        service = AsyncMock()
+        service.inspect_session_record.side_effect = RuntimeError("tmux unavailable")
+
+        result = await reconcile_runtime_state(conn, repair=True, runtime_service=service)
+
+        finding = result.findings[0]
+        assert finding.reason_code == "runtime_inspection_failed"
+        assert finding.recommended_action == "require_operator_intervention"
+        assert finding.repair_status == "skipped"
+        unchanged = await db_ops.get_session(conn, session.id)
+        assert unchanged is not None
+        assert unchanged.status == "working"
+        assert unchanged.tmux_pane == "%missing"
+
+
+@pytest.mark.asyncio
+async def test_reconcile_blocked_session_is_reported_not_repaired(tmp_path: Path) -> None:
+    db_path = str(tmp_path / "phase6-blocked.db")
+    await db_ops.run_migrations(db_path)
+    async with db_ops.get_connection(db_path) as conn:
+        _project, session = await _make_project_and_session(conn)
+        assert session is not None
+        service = AsyncMock()
+        service.inspect_session_record.return_value = RuntimeInspection(
+            session_id=session.id,
+            provider_name="codex",
+            alive=True,
+            readiness=ReadinessState.BLOCKED,
+            summary="Blocked on trust prompt",
+        )
+
+        result = await reconcile_runtime_state(conn, repair=True, runtime_service=service)
+
+        finding = result.findings[0]
+        assert finding.kind == "runtime_blocked"
+        assert finding.repair_status == "skipped"
+        unchanged = await db_ops.get_session(conn, session.id)
+        assert unchanged is not None
+        assert unchanged.status == "working"
+        assert unchanged.tmux_pane == "%missing"
+
+
+@pytest.mark.asyncio
+async def test_reconcile_task_assignee_must_be_live_ace(tmp_path: Path) -> None:
+    db_path = str(tmp_path / "phase6-live-non-ace.db")
+    await db_ops.run_migrations(db_path)
+    async with db_ops.get_connection(db_path) as conn:
+        project = await db_ops.create_project(conn, "phase6-non-ace", agent_provider="codex")
+        leader = await db_ops.create_session(
+            conn,
+            project.id,
+            "leader",
+            "leader-phase6",
+            provider="codex",
+            status="idle",
+        )
+        await db_ops.update_session_tmux(conn, leader.id, "atc", "%leader")
+        task = await db_ops.create_task_graph(
+            conn,
+            project.id,
+            "assigned to leader",
+            status="assigned",
+            assigned_ace_id=leader.id,
+        )
+        service = AsyncMock()
+        service.inspect_session_record.return_value = RuntimeInspection(
+            session_id=leader.id,
+            provider_name="codex",
+            alive=True,
+            readiness=ReadinessState.READY,
+        )
+
+        result = await reconcile_runtime_state(conn, repair=True, runtime_service=service)
+
+        finding = next(item for item in result.findings if item.task_graph_id == task.id)
+        assert finding.kind == "orphaned_task"
+        assert finding.repair_status == "applied"
+        repaired = await db_ops.get_task_graph(conn, task.id)
+        assert repaired is not None
+        assert repaired.status == "todo"
+        assert repaired.assigned_ace_id is None
+
+
+@pytest.mark.asyncio
+async def test_stale_session_repair_skips_if_session_changed(tmp_path: Path) -> None:
+    db_path = str(tmp_path / "phase6-session-guard.db")
+    await db_ops.run_migrations(db_path)
+    async with db_ops.get_connection(db_path) as conn:
+        _project, session = await _make_project_and_session(conn)
+        assert session is not None
+        await db_ops.update_session_tmux(conn, session.id, "atc", "%new-pane")
+        finding = ReconcileFinding(
+            kind="stale_active_session",
+            severity="warning",
+            entity_type="session",
+            entity_id=session.id,
+            reason_code="runtime_not_alive",
+            message="stale",
+            recommended_action="mark_stale",
+            session_id=session.id,
+            details={"status": "working", "tmux_pane": "%missing"},
+        )
+
+        await _mark_session_stale(conn, finding)
+
+        assert finding.repair_status == "skipped"
+        unchanged = await db_ops.get_session(conn, session.id)
+        assert unchanged is not None
+        assert unchanged.status == "working"
+        assert unchanged.tmux_pane == "%new-pane"
+
+
+@pytest.mark.asyncio
+async def test_orphaned_task_repair_skips_if_assignment_changed(tmp_path: Path) -> None:
+    db_path = str(tmp_path / "phase6-task-guard.db")
+    await db_ops.run_migrations(db_path)
+    async with db_ops.get_connection(db_path) as conn:
+        project = await db_ops.create_project(conn, "phase6-task-guard", agent_provider="codex")
+        task = await db_ops.create_task_graph(
+            conn,
+            project.id,
+            "guarded task",
+            status="assigned",
+            assigned_ace_id="old-ace",
+        )
+        await db_ops.update_task_graph(conn, task.id, assigned_ace_id="new-ace")
+        finding = ReconcileFinding(
+            kind="orphaned_task",
+            severity="warning",
+            entity_type="task_graph",
+            entity_id=task.id,
+            reason_code="assigned_ace_not_live",
+            message="orphaned",
+            recommended_action="reset_task_for_reassignment",
+            task_graph_id=task.id,
+            session_id="old-ace",
+            details={"assigned_ace_id": "old-ace", "task_status": "assigned"},
+        )
+
+        await _reset_orphaned_task(conn, finding)
+
+        assert finding.repair_status == "skipped"
+        unchanged = await db_ops.get_task_graph(conn, task.id)
+        assert unchanged is not None
+        assert unchanged.status == "assigned"
+        assert unchanged.assigned_ace_id == "new-ace"


### PR DESCRIPTION
## Summary
- add a provider-neutral runtime reconciliation service for Phase 6 believed-vs-actual state checks
- expose `POST /api/orchestration/reconcile` with dry-run and safe repair modes
- detect stale active sessions, runtime-blocked sessions, provider mismatches, and orphaned active task graph entries
- safely repair stale sessions by marking them disconnected and orphaned tasks by resetting them for reassignment with audit app events
- add Phase 6 Playwright/API evidence coverage

## Validation
- `ruff check src/atc/session/reconcile.py src/atc/api/routers/reconcile.py tests/unit/test_reconcile.py`
- `python -m py_compile src/atc/api/app.py src/atc/api/routers/reconcile.py src/atc/session/reconcile.py`
- `pytest tests/unit/test_reconcile.py tests/unit/test_reconnect_runtime_semantics.py tests/unit/test_runtime_service.py tests/unit/test_task_graphs.py tests/e2e/test_smoke.py -q` → 90 passed
- `pytest tests/unit/test_reconcile.py tests/unit/test_reconnect_runtime_semantics.py tests/unit/test_runtime_service.py tests/unit/test_codex_runtime.py tests/unit/test_claude_code_runtime.py tests/unit/test_tmux_session_runner.py tests/unit/test_deploy.py tests/unit/test_creation_reliability.py tests/unit/test_task_graphs.py tests/e2e/test_smoke.py tests/e2e/test_ace_lifecycle.py -q` → 221 passed
- clean-DB `node scripts/playwright/phase0-baseline.mjs` → passed
- clean-DB `node scripts/playwright/phase6-reconcile.mjs` → passed
