### PR TITLE
Implement Phase 7 truthful delivery status

### DIFF
--- a/frontend/src/components/leader/LeaderConsole.tsx
+++ b/frontend/src/components/leader/LeaderConsole.tsx
@@ -6,7 +6,7 @@ import StatusBadge from "../common/StatusBadge";
 import ConfirmPopover from "../common/ConfirmPopover";
 import GitHubPanel from "../dashboard/GitHubPanel";
 import BudgetPanel from "./BudgetPanel";
-import type { Leader, Project } from "../../types";
+import type { DeliveryStatusResponse, Leader, Project } from "../../types";
 import "./LeaderConsole.css";
 
 interface LeaderConsoleProps {
@@ -33,6 +33,7 @@ export default function LeaderConsole({
   const [goal, setGoal] = useState("");
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [deliveryStatus, setDeliveryStatus] = useState<DeliveryStatusResponse | null>(null);
   const [activeTab, setActiveTab] = useState<Tab>("github");
   const autoStarted = useRef(false);
   const userStopped = useRef(false);
@@ -74,12 +75,14 @@ export default function LeaderConsole({
     userStopped.current = false;
     setLoading(true);
     setError(null);
+    setDeliveryStatus(null);
     try {
-      const res = await api.post<{ session_id?: string }>(
+      const res = await api.post<DeliveryStatusResponse>(
         `/projects/${projectId}/leader/start`,
         { goal: goal.trim() || null },
       );
       setGoal("");
+      setDeliveryStatus(res);
       // Update session_id immediately so the terminal can subscribe
       if (res.session_id) {
         dispatch({
@@ -167,6 +170,14 @@ export default function LeaderConsole({
       {error && (
         <div className="leader-console__error" role="alert">
           {error}
+        </div>
+      )}
+
+      {deliveryStatus && (
+        <div className="leader-console__error" data-testid="leader-delivery-state">
+          Delivery state: <strong>{deliveryStatus.delivery_state}</strong>
+          {deliveryStatus.message ? ` — ${deliveryStatus.message}` : ""}
+          {deliveryStatus.recovery ? ` Recovery: ${deliveryStatus.recovery}` : ""}
         </div>
       )}
 

--- a/frontend/src/components/tower/TowerConsole.tsx
+++ b/frontend/src/components/tower/TowerConsole.tsx
@@ -3,6 +3,7 @@ import { useAppContext } from "../../context/AppContext";
 import { useTerminal } from "../../hooks/useTerminal";
 import { api } from "../../utils/api";
 import StatusBadge from "../common/StatusBadge";
+import type { DeliveryStatusResponse } from "../../types";
 import "./TowerConsole.css";
 
 /**
@@ -19,6 +20,7 @@ export default function TowerConsole() {
   const [goal, setGoal] = useState("");
   const [projectId, setProjectId] = useState("");
   const [loading, setLoading] = useState(false);
+  const [deliveryStatus, setDeliveryStatus] = useState<DeliveryStatusResponse | null>(null);
   const [providerSwitchPending, setProviderSwitchPending] = useState(false);
   const autoStarted = useRef(false);
   const userStopped = useRef(false);
@@ -86,6 +88,7 @@ export default function TowerConsole() {
     if (!projectId) return;
     userStopped.current = false;
     setLoading(true);
+    setDeliveryStatus(null);
     try {
       if (isTerminalProvider) {
         const res = await api.post<{ session_id?: string }>("/tower/start", {
@@ -98,11 +101,12 @@ export default function TowerConsole() {
           });
         }
       } else {
-        const res = await api.post<{ session_id?: string }>("/tower/goal", {
+        const res = await api.post<DeliveryStatusResponse>("/tower/goal", {
           project_id: projectId,
           goal: goal.trim() || null,
         });
         setGoal("");
+        setDeliveryStatus(res);
         if (res.session_id) {
           dispatch({
             type: "SET_TOWER_DETAIL",
@@ -239,6 +243,14 @@ export default function TowerConsole() {
           >
             {loading ? "Restarting..." : "Restart Tower for selected project"}
           </button>
+        </div>
+      )}
+
+      {deliveryStatus && (
+        <div className="tower-console__error" data-testid="tower-delivery-state">
+          Delivery state: <strong>{deliveryStatus.delivery_state}</strong>
+          {deliveryStatus.message ? ` — ${deliveryStatus.message}` : ""}
+          {deliveryStatus.recovery ? ` Recovery: ${deliveryStatus.recovery}` : ""}
         </div>
       )}
 

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -215,6 +215,26 @@ export interface FeatureFlag {
   updated_at: string;
 }
 
+export interface DeliveryStatusResponse {
+  status: string;
+  delivery_state: "queued" | "submitted" | "started" | "delivered" | "confirmed" | "blocked" | "failed" | string;
+  message?: string;
+  session_id?: string;
+  project_id?: string;
+  leader_session_id?: string;
+  provider?: string;
+  recovery?: string;
+  delivery?: {
+    status?: string;
+    stage?: string | null;
+    verdict?: string | null;
+    reason_code?: string | null;
+    trace_id?: string | null;
+    message?: string | null;
+    details?: Record<string, unknown>;
+  };
+}
+
 export interface AppState {
   projects: Project[];
   leaders: Record<string, Leader>;

--- a/scripts/playwright/phase7-truthful-delivery.mjs
+++ b/scripts/playwright/phase7-truthful-delivery.mjs
@@ -1,0 +1,229 @@
+import { chromium } from '../../frontend/node_modules/@playwright/test/index.mjs';
+import { execFileSync } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+
+const stamp = new Date().toISOString().replace(/[:.]/g, '-');
+const root = path.resolve(new URL('../..', import.meta.url).pathname);
+const outDir = path.join(root, 'test-results', `phase7-truthful-delivery-${stamp}`);
+const baseUrl = process.env.ATC_UI_URL || 'http://localhost:5173';
+const apiUrl = process.env.ATC_API_URL || 'http://127.0.0.1:8420';
+
+fs.mkdirSync(outDir, { recursive: true });
+
+const checks = [];
+const events = [];
+const consoleMessages = [];
+const failedRequests = [];
+let screenshotIndex = 0;
+let project = null;
+let task = null;
+let leaderStart = null;
+let spawnResult = null;
+let instructResult = null;
+let ace = null;
+let refreshedTask = null;
+let deliveryEvents = [];
+let tmuxEvidence = null;
+
+function check(name, ok, detail = '') {
+  checks.push({ name, ok, detail });
+  console.log(`${ok ? 'PASS' : 'FAIL'} ${name}${detail ? ` — ${detail}` : ''}`);
+  if (!ok) throw new Error(`${name}: ${detail}`);
+}
+
+function note(name, detail = '') {
+  events.push({ t: new Date().toISOString(), name, detail });
+  console.log(`${name}${detail ? ` — ${detail}` : ''}`);
+}
+
+async function screenshot(page, name) {
+  const file = path.join(outDir, `${String(screenshotIndex++).padStart(2, '0')}-${name}.png`);
+  await page.screenshot({ path: file, fullPage: true });
+  note('SCREENSHOT', file);
+  return file;
+}
+
+async function api(route, options = {}) {
+  const res = await fetch(`${apiUrl}${route}`, {
+    headers: { 'Content-Type': 'application/json', ...(options.headers || {}) },
+    ...options,
+  });
+  const text = await res.text();
+  let body;
+  try {
+    body = text ? JSON.parse(text) : null;
+  } catch {
+    body = text;
+  }
+  return { ok: res.ok, status: res.status, body };
+}
+
+function inspectTmuxPane(session) {
+  if (!session?.tmux_pane) return { alive: false, detail: 'missing tmux_pane' };
+  try {
+    const out = execFileSync('tmux', ['display-message', '-p', '-t', session.tmux_pane, '#{pane_id} #{pane_dead}'], {
+      encoding: 'utf8',
+      timeout: 5000,
+    }).trim();
+    return { alive: out.includes(session.tmux_pane) && out.endsWith('0'), detail: out };
+  } catch (err) {
+    return { alive: false, detail: err?.message || String(err) };
+  }
+}
+
+const browser = await chromium.launch({ headless: true });
+const page = await browser.newPage({ viewport: { width: 1365, height: 768 }, deviceScaleFactor: 1 });
+page.on('console', (msg) => {
+  if (['error', 'warning'].includes(msg.type())) {
+    consoleMessages.push({ type: msg.type(), text: msg.text() });
+  }
+});
+page.on('pageerror', (err) => consoleMessages.push({ type: 'pageerror', text: err.message }));
+page.on('requestfailed', (req) => failedRequests.push({ url: req.url(), failure: req.failure()?.errorText }));
+page.on('response', (res) => {
+  if (res.status() >= 400 && !res.url().includes('/@vite')) {
+    failedRequests.push({ url: res.url(), status: res.status() });
+  }
+});
+
+try {
+  const health = await api('/api/health');
+  check('Backend health responds', health.ok, JSON.stringify(health.body));
+
+  const projectResp = await api('/api/projects', {
+    method: 'POST',
+    body: JSON.stringify({
+      name: `Phase 7 Truth ${stamp.slice(0, 19)}`,
+      description: 'Temporary Phase 7 truthful delivery validation project.',
+      agent_provider: 'codex',
+    }),
+  });
+  check('Temporary project created', projectResp.ok, JSON.stringify(projectResp.body));
+  project = projectResp.body;
+
+  const taskResp = await api(`/api/projects/${project.id}/task-graphs`, {
+    method: 'POST',
+    body: JSON.stringify({
+      title: 'Phase 7 Ace delivery truth task',
+      description: 'Disposable validation task proving Leader-created Ace assignment truth.',
+      status: 'todo',
+    }),
+  });
+  check('Temporary task created', taskResp.ok, JSON.stringify(taskResp.body));
+  task = taskResp.body;
+
+  leaderStart = await api(`/api/projects/${project.id}/leader/start`, {
+    method: 'POST',
+    body: JSON.stringify({
+      goal: 'Validate truthful delivery status wording and create one Ace for a disposable task.',
+      auto_kickoff: true,
+    }),
+  });
+  check('Leader start endpoint succeeds', leaderStart.ok, JSON.stringify(leaderStart.body));
+  check('Leader start truthfully reports queued kickoff', leaderStart.body?.delivery_state === 'queued', JSON.stringify(leaderStart.body));
+  check('Leader start explains queued is not proof', /not prove|not proof|queued/i.test(leaderStart.body?.recovery || leaderStart.body?.message || ''), JSON.stringify(leaderStart.body));
+
+  await page.goto(`${baseUrl}/projects/${project.id}`, { waitUntil: 'networkidle', timeout: 30000 });
+  await page.getByText(project.name).first().waitFor({ timeout: 15000 });
+  await screenshot(page, 'project-loaded-before-leader-start-ui');
+
+  const leaderBanner = page.getByTestId('leader-delivery-state');
+  await page.getByTestId('leader-console').waitFor({ timeout: 15000 });
+  if (await leaderBanner.count()) {
+    await leaderBanner.first().waitFor({ timeout: 15000 });
+    const bannerText = await leaderBanner.first().innerText();
+    check('Leader UI surfaces delivery state banner', /Delivery state:/i.test(bannerText), bannerText);
+    await screenshot(page, 'leader-delivery-state-banner');
+  } else {
+    note('Leader UI banner not present after API start; API contract remains authoritative for this run');
+  }
+
+  spawnResult = await api(`/api/projects/${project.id}/leader/spawn-aces`, { method: 'POST', body: JSON.stringify({}) });
+  check('Leader spawn-aces endpoint succeeds', spawnResult.ok, JSON.stringify(spawnResult.body));
+  check('Leader created at least one Ace assignment', (spawnResult.body?.spawned || []).length >= 1, JSON.stringify(spawnResult.body));
+  const spawned = spawnResult.body.spawned[0];
+
+  const acesResp = await api(`/api/projects/${project.id}/aces`);
+  check('Ace list endpoint succeeds', acesResp.ok, JSON.stringify(acesResp.body));
+  ace = (acesResp.body || []).find((entry) => entry.id === spawned.ace_session_id);
+  check('Leader-created Ace session is listed', Boolean(ace), JSON.stringify(acesResp.body));
+  check('Leader-created session is an Ace', ace?.session_type === 'ace', JSON.stringify(ace));
+  tmuxEvidence = inspectTmuxPane(ace);
+  check('Leader-created Ace tmux pane is live', tmuxEvidence.alive, JSON.stringify(tmuxEvidence));
+
+  instructResult = await api(`/api/projects/${project.id}/leader/instruct`, {
+    method: 'POST',
+    body: JSON.stringify({
+      task_graph_id: spawned.task_graph_id,
+      instruction: 'Acknowledge this Phase 7 validation assignment and wait for further instruction.',
+    }),
+  });
+  check('Leader instruct endpoint succeeds', instructResult.ok, JSON.stringify(instructResult.body));
+  check('Leader instruct does not return sent/accepted ambiguity', !['sent', 'accepted'].includes(instructResult.body?.status), JSON.stringify(instructResult.body));
+  check('Leader instruct returns delivery_state', Boolean(instructResult.body?.delivery_state), JSON.stringify(instructResult.body));
+  check(
+    'Ace delivery is delivered/confirmed or explicitly blocked/failed',
+    ['delivered', 'confirmed', 'blocked', 'failed'].includes(instructResult.body?.delivery_state),
+    JSON.stringify(instructResult.body),
+  );
+
+  const taskGraphResp = await api(`/api/task-graphs/${spawned.task_graph_id}`);
+  check('Assigned task fetch succeeds', taskGraphResp.ok, JSON.stringify(taskGraphResp.body));
+  refreshedTask = taskGraphResp.body;
+  check('Task assignment points to the live Ace session', refreshedTask.assigned_ace_id === ace.id, JSON.stringify(refreshedTask));
+  check('Task is in working/in-progress state after instruction', ['assigned', 'in_progress'].includes(refreshedTask.status), JSON.stringify(refreshedTask));
+
+  const eventsResp = await api(`/api/app-events?category=delivery_trace&project_id=${project.id}&limit=50`);
+  check('Delivery trace events endpoint succeeds', eventsResp.ok, JSON.stringify(eventsResp.body));
+  deliveryEvents = eventsResp.body || [];
+  check('Runtime delivery trace evidence exists', deliveryEvents.length >= 1, JSON.stringify(deliveryEvents));
+
+  await page.goto(`${baseUrl}/projects/${project.id}`, { waitUntil: 'networkidle', timeout: 30000 });
+  await page.getByText(project.name).first().waitFor({ timeout: 15000 });
+  await page.getByTestId('ace-list').waitFor({ timeout: 15000 });
+  await screenshot(page, 'project-ace-assignment-visible');
+
+  check('No failed browser requests', failedRequests.length === 0, JSON.stringify(failedRequests));
+  const pageErrors = consoleMessages.filter((entry) => entry.type === 'pageerror');
+  check('No page errors', pageErrors.length === 0, JSON.stringify(pageErrors));
+
+  const report = {
+    outDir,
+    baseUrl,
+    apiUrl,
+    project,
+    task,
+    leaderStart: leaderStart.body,
+    spawnResult: spawnResult.body,
+    instructResult: instructResult.body,
+    ace,
+    refreshedTask,
+    tmuxEvidence,
+    deliveryEvents,
+    checks,
+    events,
+    consoleMessages,
+    failedRequests,
+  };
+  fs.writeFileSync(path.join(outDir, 'report.json'), JSON.stringify(report, null, 2));
+  console.log(`REPORT ${path.join(outDir, 'report.json')}`);
+} catch (err) {
+  checks.push({
+    name: 'Phase 7 Playwright/API validation completed without throw',
+    ok: false,
+    detail: err?.stack || err?.message || String(err),
+  });
+  await screenshot(page, 'failure');
+  fs.writeFileSync(
+    path.join(outDir, 'report.json'),
+    JSON.stringify({ outDir, checks, events, consoleMessages, failedRequests, project, task, leaderStart, spawnResult, instructResult, ace, refreshedTask, tmuxEvidence, deliveryEvents }, null, 2),
+  );
+  process.exitCode = 1;
+} finally {
+  await browser.close();
+}
+
+if (checks.some((entry) => !entry.ok)) {
+  process.exitCode = 1;
+}

--- a/src/atc/api/delivery.py
+++ b/src/atc/api/delivery.py
@@ -1,0 +1,98 @@
+"""Shared API helpers for truthful runtime delivery status responses."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from pydantic import BaseModel, Field
+
+if TYPE_CHECKING:
+    from atc.runtime.models import RuntimeDeliveryResult
+
+
+class DeliveryStatusResponse(BaseModel):
+    """Provider-neutral API response for terminal/runtime delivery attempts.
+
+    ``status`` is the highest guarantee the endpoint can truthfully make:
+    - queued: work was scheduled asynchronously and has not been delivered yet
+    - submitted: the app attempted a low-level tmux/key delivery but has no provider ack
+    - delivered/confirmed: provider/runtime delivery returned positive evidence
+    - blocked/failed: delivery did not complete and requires recovery/operator action
+    """
+
+    status: str
+    delivery_state: str = Field(
+        ...,
+        description=(
+            "Truthful delivery guarantee: "
+            "queued|submitted|delivered|confirmed|blocked|failed"
+        ),
+    )
+    message: str | None = None
+    session_id: str | None = None
+    project_id: str | None = None
+    leader_session_id: str | None = None
+    provider: str | None = None
+    delivery: dict[str, Any] | None = None
+    recovery: str | None = None
+
+
+def delivery_response(
+    result: RuntimeDeliveryResult | None,
+    *,
+    fallback_state: str = "submitted",
+    message: str | None = None,
+    session_id: str | None = None,
+    project_id: str | None = None,
+    leader_session_id: str | None = None,
+    provider: str | None = None,
+    recovery: str | None = None,
+) -> dict[str, Any]:
+    """Build a truthful response from an optional runtime delivery result."""
+
+    if result is None:
+        return DeliveryStatusResponse(
+            status=fallback_state,
+            delivery_state=fallback_state,
+            message=message,
+            session_id=session_id,
+            project_id=project_id,
+            leader_session_id=leader_session_id,
+            provider=provider,
+            recovery=recovery,
+        ).model_dump(exclude_none=True)
+
+    state = result.status
+    return DeliveryStatusResponse(
+        status=state,
+        delivery_state=state,
+        message=result.message or message,
+        session_id=result.session_id,
+        project_id=project_id,
+        leader_session_id=leader_session_id,
+        provider=result.provider_name,
+        delivery=result.as_dict(),
+        recovery=recovery if not result.ok else None,
+    ).model_dump(exclude_none=True)
+
+
+def queued_response(
+    *,
+    message: str,
+    session_id: str | None = None,
+    project_id: str | None = None,
+    leader_session_id: str | None = None,
+    provider: str | None = None,
+) -> dict[str, Any]:
+    """Response for async work that has only been queued, not verified."""
+
+    return DeliveryStatusResponse(
+        status="queued",
+        delivery_state="queued",
+        message=message,
+        session_id=session_id,
+        project_id=project_id,
+        leader_session_id=leader_session_id,
+        provider=provider,
+        recovery="watch runtime/session status; queued does not prove delivery",
+    ).model_dump(exclude_none=True)

--- a/src/atc/api/routers/aces.py
+++ b/src/atc/api/routers/aces.py
@@ -19,6 +19,7 @@ from typing import Any
 from fastapi import APIRouter, HTTPException, Request
 from pydantic import BaseModel
 
+from atc.api.delivery import delivery_response
 from atc.core.errors import CreationFailedError, SessionNotFoundError, SessionStaleError
 from atc.session import ace as ace_ops
 from atc.session.state_machine import InvalidTransitionError
@@ -150,16 +151,32 @@ async def create_ace(project_id: str, body: CreateAceRequest, request: Request) 
 
 
 @router.post("/aces/{session_id}/start")
-async def start_ace(session_id: str, body: StartAceRequest, request: Request) -> dict[str, str]:
+async def start_ace(session_id: str, body: StartAceRequest, request: Request) -> dict[str, object]:
     db = await _get_db(request)
     event_bus = await _get_event_bus(request)
     try:
-        await ace_ops.start_ace(db, session_id, instruction=body.instruction, event_bus=event_bus)
+        result = await ace_ops.start_ace(
+            db, session_id, instruction=body.instruction, event_bus=event_bus
+        )
     except ValueError as e:
         raise SessionNotFoundError(str(e)) from None
     except InvalidTransitionError as e:
         raise SessionStaleError(str(e)) from None
-    return {"status": "started"}
+    except RuntimeError as e:
+        raise SessionStaleError(str(e)) from None
+    return delivery_response(
+        result,
+        fallback_state="started" if body.instruction is None else "submitted",
+        message=(
+            "Ace session started; no instruction delivery was requested"
+            if body.instruction is None
+            else "Ace instruction submitted; provider acknowledgement is not verified"
+        ),
+        session_id=session_id,
+        recovery="inspect Ace runtime/session status for delivery confirmation"
+        if body.instruction is not None
+        else None,
+    )
 
 
 @router.post("/aces/{session_id}/stop")
@@ -265,7 +282,7 @@ async def message_ace(
     session_id: str,
     body: MessageRequest,
     request: Request,
-) -> dict[str, str]:
+) -> dict[str, object]:
     db = await _get_db(request)
     event_bus = await _get_event_bus(request)
 
@@ -288,7 +305,15 @@ async def message_ace(
             pass
 
     await _send_keys(session.tmux_pane, body.message)
-    return {"status": "sent"}
+    return delivery_response(
+        None,
+        fallback_state="submitted",
+        message="Message submitted to Ace terminal; provider acknowledgement is not verified",
+        session_id=session_id,
+        project_id=session.project_id,
+        provider=session.provider,
+        recovery="inspect Ace runtime/session status and task assignment state for confirmation",
+    )
 
 
 @router.delete("/aces/{session_id}", status_code=204)

--- a/src/atc/api/routers/leader.py
+++ b/src/atc/api/routers/leader.py
@@ -17,6 +17,7 @@ from typing import Any
 from fastapi import APIRouter, HTTPException, Request
 from pydantic import BaseModel, Field
 
+from atc.api.delivery import delivery_response
 from atc.leader.decomposer import TaskSpec, decompose_goal
 from atc.leader.orchestrator import LeaderOrchestrator
 from atc.state import db as db_ops
@@ -275,19 +276,27 @@ async def instruct_ace(
     project_id: str,
     body: InstructRequest,
     request: Request,
-) -> dict[str, str]:
+) -> dict[str, object]:
     """Send a work instruction to the Ace assigned to a task."""
     orch = await _get_or_create_orchestrator(request, project_id)
 
     try:
-        await orch.send_instruction_to_ace(
+        result = await orch.send_instruction_to_ace(
             body.task_graph_id,
             body.instruction,
         )
     except ValueError as exc:
         raise HTTPException(status_code=404, detail=str(exc)) from exc
+    except LifecycleTransitionError as exc:
+        raise HTTPException(status_code=409, detail=_transition_error_detail(exc)) from None
 
-    return {"status": "sent"}
+    return delivery_response(
+        result,
+        fallback_state="submitted",
+        message="Ace instruction submitted; provider acknowledgement is not verified",
+        project_id=project_id,
+        recovery="inspect Ace runtime/session status and task assignment state for confirmation",
+    )
 
 
 @router.post("/projects/{project_id}/leader/task-done")

--- a/src/atc/api/routers/projects.py
+++ b/src/atc/api/routers/projects.py
@@ -17,6 +17,7 @@ import logging
 from fastapi import APIRouter, HTTPException, Request
 from pydantic import BaseModel
 
+from atc.api.delivery import delivery_response, queued_response
 from atc.core.errors import CreationFailedError
 from atc.leader import leader as leader_ops
 from atc.runtime.models import RuntimeDeliveryResult
@@ -456,7 +457,21 @@ async def start_leader(
 
         _asyncio.ensure_future(_kickoff())
 
-    return {"status": "started", "session_id": session_id}
+    if body.goal and body.auto_kickoff:
+        return queued_response(
+            message="Leader session started; auto-kickoff queued and awaiting runtime verification",
+            project_id=project_id,
+            leader_session_id=session_id,
+            session_id=session_id,
+        )
+    return {
+        "status": "started",
+        "delivery_state": "started",
+        "session_id": session_id,
+        "leader_session_id": session_id,
+        "project_id": project_id,
+        "message": "Leader session started; no kickoff delivery was requested",
+    }
 
 
 @router.post("/{project_id}/leader/stop")
@@ -481,9 +496,13 @@ async def send_leader_message(
         raise HTTPException(status_code=409, detail=str(e)) from None
     except RuntimeError as e:
         raise HTTPException(status_code=409, detail=f"Leader pane unavailable: {e}") from None
-    if isinstance(result, RuntimeDeliveryResult):
-        return {"status": result.status, "delivery": result.as_dict()}
-    return {"status": "delivered"}
+    return delivery_response(
+        result if isinstance(result, RuntimeDeliveryResult) else None,
+        fallback_state="submitted",
+        message="Leader message submitted; provider acknowledgement is not verified",
+        project_id=project_id,
+        recovery="inspect Leader runtime/session status for delivery confirmation",
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/src/atc/api/routers/tower.py
+++ b/src/atc/api/routers/tower.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 from fastapi import APIRouter, HTTPException, Request
 from pydantic import BaseModel
 
+from atc.api.delivery import delivery_response
 from atc.tower.controller import TowerBusyError, TowerController
 
 router = APIRouter()
@@ -183,8 +184,12 @@ async def submit_goal(body: GoalRequest, request: Request) -> dict:
 
 
 @router.post("/message")
-async def send_message(body: MessageRequest, request: Request) -> dict[str, str]:
-    """Send a message to Tower's Claude Code terminal."""
+async def send_message(body: MessageRequest, request: Request) -> dict[str, object]:
+    """Submit a message to Tower's terminal.
+
+    This endpoint can only prove the low-level tmux key submission completed;
+    it does not prove the provider read, accepted, or acted on the message.
+    """
     tower = _get_tower(request)
 
     try:
@@ -196,7 +201,12 @@ async def send_message(body: MessageRequest, request: Request) -> dict[str, str]
             status_code=409, detail=f"Tower pane unavailable: {exc}"
         ) from exc
 
-    return {"status": "sent"}
+    return delivery_response(
+        None,
+        fallback_state="submitted",
+        message="Message submitted to Tower terminal; provider acknowledgement is not verified",
+        recovery="inspect Tower runtime/session status for delivery confirmation",
+    )
 
 
 @router.post("/complete")

--- a/src/atc/leader/orchestrator.py
+++ b/src/atc/leader/orchestrator.py
@@ -317,13 +317,30 @@ class LeaderOrchestrator:
         if assignment is None:
             raise ValueError(f"No Ace assigned to task graph {task_graph_id}")
 
-        await start_ace(
+        result = await start_ace(
             self.conn,
             assignment.ace_session_id,
             instruction=instruction,
             event_bus=self.event_bus,
         )
         assignment.status = "working"
+        if assignment.assignment_id:
+            try:
+                await db_ops.update_task_assignment_status(
+                    self.conn,
+                    assignment.assignment_id,
+                    "working",
+                )
+            except LifecycleTransitionError as exc:
+                self._record_transition_block(exc)
+                raise
+            except ValueError:
+                logger.debug(
+                    "Assignment %s disappeared while instructing task %s",
+                    assignment.assignment_id,
+                    task_graph_id,
+                )
+        return result
 
     async def mark_task_done(self, task_graph_id: str) -> None:
         """Mark a task graph entry as done and clean up its Ace session."""

--- a/src/atc/session/ace.py
+++ b/src/atc/session/ace.py
@@ -470,7 +470,7 @@ async def _send_session_instruction(
     conn: aiosqlite.Connection,
     session_id: str,
     instruction: str,
-) -> bool:
+):
     """Send an instruction through the new runtime service/provider contract."""
     from atc.runtime.models import (
         InstructionRequest,
@@ -521,7 +521,7 @@ async def _send_session_instruction(
             result.status,
             result.reason_code,
         )
-    return result.ok
+    return result
 
 
 async def _persist_delivery_trace_events(
@@ -555,7 +555,7 @@ async def start_ace(
     *,
     instruction: str | None = None,
     event_bus: EventBus | None = None,
-) -> None:
+):
     """Start an ace session — send an instruction to its tmux pane.
 
     Uses atomic instruction sending with TUI readiness check and
@@ -572,12 +572,14 @@ async def start_ace(
     await db_ops.update_session_status(conn, session_id, SessionStatus.WORKING.value)
 
     if instruction:
-        delivered = await _send_session_instruction(conn, session_id, instruction)
-        if not delivered:
+        result = await _send_session_instruction(conn, session_id, instruction)
+        if not result.ok:
             logger.error("Session %s: instruction delivery failed, marking error", session_id)
             await transition(session_id, SessionStatus.WORKING, SessionStatus.ERROR, event_bus)
             await db_ops.update_session_status(conn, session_id, SessionStatus.ERROR.value)
             raise RuntimeError(f"Failed to deliver instruction to session {session_id}")
+        return result
+    return None
 
 
 async def stop_ace(

--- a/src/atc/tower/controller.py
+++ b/src/atc/tower/controller.py
@@ -392,11 +392,20 @@ class TowerController:
                 )
 
             return {
-                "status": "accepted",
+                "status": "queued",
+                "delivery_state": "queued",
+                "message": (
+                    "Goal queued; Leader session was created and kickoff verification "
+                    "is still pending"
+                ),
                 "project_id": project_id,
                 "session_id": self._current_session_id,
                 "leader_session_id": leader_session_id,
                 "context_package": context_package,
+                "recovery": (
+                    "watch Tower/Leader status and runtime traces; queued is not proof "
+                    "the Leader acted on the goal"
+                ),
             }
 
         except Exception:

--- a/tests/e2e/test_ace_lifecycle.py
+++ b/tests/e2e/test_ace_lifecycle.py
@@ -111,7 +111,10 @@ class TestAceLifecycle:
             json={"instruction": "echo hello"},
         )
         assert resp.status_code == 200
-        assert resp.json()["status"] == "started"
+        data = resp.json()
+        assert data["status"] == "delivered"
+        assert data["delivery_state"] == "delivered"
+        assert data["delivery"]["reason_code"] == "delivery_unverified"
 
         # Message
         resp = client.post(
@@ -119,7 +122,10 @@ class TestAceLifecycle:
             json={"message": "do something"},
         )
         assert resp.status_code == 200
-        assert resp.json()["status"] == "sent"
+        data = resp.json()
+        assert data["status"] == "submitted"
+        assert data["delivery_state"] == "submitted"
+        assert "provider acknowledgement" in data["message"]
 
         # Stop
         resp = client.post(f"/api/aces/{session_id}/stop")

--- a/tests/e2e/test_smoke.py
+++ b/tests/e2e/test_smoke.py
@@ -126,7 +126,9 @@ class TestLeaderLifecycle:
         )
         assert resp.status_code == 200
         data = resp.json()
-        assert data["status"] == "started"
+        assert data["status"] == "queued"
+        assert data["delivery_state"] == "queued"
+        assert "does not prove" in data["recovery"]
         assert "session_id" in data
 
     def test_start_and_stop_leader(
@@ -165,7 +167,10 @@ class TestLeaderLifecycle:
             json={"message": "Hello leader"},
         )
         assert resp.status_code == 200
-        assert resp.json()["status"] == "delivered"
+        data = resp.json()
+        assert data["status"] == "submitted"
+        assert data["delivery_state"] == "submitted"
+        assert "provider acknowledgement" in data["message"]
         mock_send.assert_called()
 
     def test_send_leader_message_surfaces_blocked_delivery(
@@ -287,7 +292,9 @@ class TestTowerStatus:
         resp = client.post("/api/tower/goal", json={"project_id": project_id, "goal": "Ship v1"})
         assert resp.status_code == 200
         data = resp.json()
-        assert data["status"] == "accepted"
+        assert data["status"] == "queued"
+        assert data["delivery_state"] == "queued"
+        assert "not proof" in data["recovery"]
         assert data["project_id"] == project_id
         assert "session_id" in data
         assert "context_package" in data

--- a/tests/unit/test_leader_api.py
+++ b/tests/unit/test_leader_api.py
@@ -282,3 +282,61 @@ class TestCleanupEndpoint:
 
         assert result["status"] == "cleaned_up"
         assert project.id not in leader_module._orchestrators
+
+
+@pytest.mark.asyncio
+async def test_instruct_returns_delivery_state_and_marks_assignment_working(
+    db, project_with_leader, mock_request,
+) -> None:
+    from atc.api.routers.leader import InstructRequest, instruct_ace
+    from atc.runtime.models import RoleKind, RuntimeDeliveryResult
+    from atc.state.db import assign_task, create_session, create_task_graph, get_task_assignment
+
+    project, leader = project_with_leader
+    task = await create_task_graph(db, project.id, "Truthful Ace work")
+    ace = await create_session(
+        db,
+        project_id=project.id,
+        session_type="ace",
+        name="ace-truthful-work",
+        status="idle",
+        provider="codex",
+        task_id=task.id,
+    )
+    idempotency_key = f"{leader.id}:{task.id}"
+    assignment, _ = await assign_task(db, task.id, ace.id, idempotency_key)
+
+    orch = LeaderOrchestrator(project.id, leader.id, db, event_bus=mock_request.app.state.event_bus)
+    orch.assignments[task.id] = AceAssignment(
+        ace_session_id=ace.id,
+        task_graph_id=task.id,
+        task_title=task.title,
+        assignment_id=idempotency_key,
+        status="assigned",
+    )
+    leader_module._orchestrators[project.id] = orch
+
+    delivery = RuntimeDeliveryResult(
+        session_id=ace.id,
+        provider_name="codex",
+        role=RoleKind.ACE,
+        status="delivered",
+        stage="delivery",
+        verdict="confirmed",
+        trace_id="trace-phase7",
+        message="instruction delivered",
+    )
+
+    with patch("atc.leader.orchestrator.start_ace", new=AsyncMock(return_value=delivery)):
+        response = await instruct_ace(
+            project.id,
+            InstructRequest(task_graph_id=task.id, instruction="Work this task"),
+            mock_request,
+        )
+
+    assert response["status"] == "delivered"
+    assert response["delivery_state"] == "delivered"
+    assert response["delivery"]["trace_id"] == "trace-phase7"
+    refreshed = await get_task_assignment(db, idempotency_key)
+    assert refreshed is not None
+    assert refreshed.status == "working"

--- a/tests/unit/test_tower_controller.py
+++ b/tests/unit/test_tower_controller.py
@@ -114,7 +114,9 @@ class TestSubmitGoal:
 
         result = await tower.submit_goal(project.id, "Build feature X")
 
-        assert result["status"] == "accepted"
+        assert result["status"] == "queued"
+        assert result["delivery_state"] == "queued"
+        assert "not proof" in result["recovery"]
         assert result["project_id"] == project.id
         assert result["leader_session_id"] == "leader-sess-123"
         assert result["context_package"]["goal"] == "Build feature X"
@@ -176,7 +178,7 @@ class TestSubmitGoal:
         await tower.mark_complete()
 
         result = await tower.submit_goal(project.id, "Second goal")
-        assert result["status"] == "accepted"
+        assert result["status"] == "queued"
 
     async def test_submit_goal_after_error(
         self, mock_start: AsyncMock, db, event_bus: EventBus
@@ -190,7 +192,7 @@ class TestSubmitGoal:
         tower._state = TowerState.ERROR  # simulate error
 
         result = await tower.submit_goal(project.id, "Recovery goal")
-        assert result["status"] == "accepted"
+        assert result["status"] == "queued"
 
 
 @patch("atc.tower.controller.stop_leader", new_callable=AsyncMock)


### PR DESCRIPTION
## Summary
- replace optimistic `accepted`/`started`/`sent` API/UI wording with explicit delivery states (`queued`, `submitted`, provider-confirmed, blocked/failed)
- propagate runtime delivery results through Tower/Leader/Ace endpoints and preserve recovery text when delivery is not proven
- add UI delivery-state banners for Tower/Leader flows
- add Phase 7 Playwright/API evidence script that validates Leader-created live Ace assignment, tmux pane liveness, task assignment truth, and delivery trace evidence

## Validation
- `.venv/bin/pytest tests/e2e/test_smoke.py tests/e2e/test_ace_lifecycle.py tests/unit/test_leader_api.py tests/unit/test_tower_controller.py tests/unit/test_leader_orchestrator.py tests/unit/test_delivery_tracing.py tests/unit/test_runtime_service.py tests/unit/test_codex_runtime.py tests/unit/test_tmux_substrate.py -q` → `141 passed, 1 warning`
- `.venv/bin/ruff check src/atc/api/delivery.py src/atc/api/routers/tower.py src/atc/api/routers/projects.py src/atc/api/routers/leader.py src/atc/api/routers/aces.py src/atc/session/ace.py src/atc/leader/orchestrator.py tests/e2e/test_smoke.py tests/e2e/test_ace_lifecycle.py` → passed
- `PATH=/opt/homebrew/bin:$PATH npm run build` → passed
- `node --check scripts/playwright/phase7-truthful-delivery.mjs` → passed
- Mac Studio Playwright/API evidence → passed; report: `/Users/mcole_studio/Repository/atc/test-results/phase7-truthful-delivery-2026-06-08T01-57-09-467Z/report.json`

## Playwright/Ace execution-truth evidence
- Leader start returns `delivery_state: queued` with recovery text that queued does not prove delivery.
- Leader-created Ace session exists and is listed as `session_type: ace`.
- Ace tmux pane is live: `%699 0`.
- Leader instruct returns `delivery_state: confirmed` with runtime trace `agent_output_observed`.
- Task assignment points to live Ace session `40a1ca7b-f3ea-4f57-9f79-7e47075631b1` and task is `in_progress`.
- Delivery trace events include queued/write/submitted/agent-output-observed stages.

Screenshots:
- `/Users/mcole_studio/Repository/atc/test-results/phase7-truthful-delivery-2026-06-08T01-57-09-467Z/00-project-loaded-before-leader-start-ui.png`
- `/Users/mcole_studio/Repository/atc/test-results/phase7-truthful-delivery-2026-06-08T01-57-09-467Z/01-leader-delivery-state-banner.png`
- `/Users/mcole_studio/Repository/atc/test-results/phase7-truthful-delivery-2026-06-08T01-57-09-467Z/02-project-ace-assignment-visible.png`
