### PR TITLE
Fix Phase 7 delivery result propagation

### DIFF
--- a/src/atc/api/delivery.py
+++ b/src/atc/api/delivery.py
@@ -62,7 +62,7 @@ def delivery_response(
             recovery=recovery,
         ).model_dump(exclude_none=True)
 
-    state = result.status
+    state = "submitted" if result.status == "accepted" else result.status
     return DeliveryStatusResponse(
         status=state,
         delivery_state=state,

--- a/src/atc/session/ace.py
+++ b/src/atc/session/ace.py
@@ -577,7 +577,6 @@ async def start_ace(
             logger.error("Session %s: instruction delivery failed, marking error", session_id)
             await transition(session_id, SessionStatus.WORKING, SessionStatus.ERROR, event_bus)
             await db_ops.update_session_status(conn, session_id, SessionStatus.ERROR.value)
-            raise RuntimeError(f"Failed to deliver instruction to session {session_id}")
         return result
     return None
 

--- a/src/atc/tower/controller.py
+++ b/src/atc/tower/controller.py
@@ -26,7 +26,7 @@ from typing import TYPE_CHECKING, Any
 from atc.config import load_settings
 from atc.leader.context_package import build_context_package
 from atc.leader.leader import send_leader_message, start_leader, stop_leader
-from atc.runtime.models import RuntimeDeliveryResult
+from atc.runtime.models import RoleKind, RuntimeDeliveryResult
 from atc.session.state_machine import SessionStatus
 from atc.state import db as db_ops
 from atc.tower.session import send_tower_message, start_tower_session, stop_tower_session
@@ -380,7 +380,7 @@ class TowerController:
             )
 
             # Send kickoff and start background verification loop
-            await self._send_leader_kickoff(leader_session_id, goal)
+            kickoff_delivery = await self._send_leader_kickoff(leader_session_id, goal)
             asyncio.create_task(self._verify_leader_started(project_id, leader_session_id, goal))
 
             # Notify Tower's own Claude session so it knows a Leader is running
@@ -390,6 +390,24 @@ class TowerController:
                 asyncio.create_task(
                     self._notify_tower_goal_started(project_id, leader_session_id, goal)
                 )
+
+            if _delivery_failed(kickoff_delivery):
+                return {
+                    "status": kickoff_delivery.status,
+                    "delivery_state": kickoff_delivery.status,
+                    "message": kickoff_delivery.message
+                    or f"Leader kickoff {kickoff_delivery.status}",
+                    "project_id": project_id,
+                    "session_id": self._current_session_id,
+                    "leader_session_id": leader_session_id,
+                    "context_package": context_package,
+                    "provider": kickoff_delivery.provider_name,
+                    "delivery": kickoff_delivery.as_dict(),
+                    "recovery": (
+                        "inspect Leader runtime/session status before assuming "
+                        "kickoff delivery"
+                    ),
+                }
 
             return {
                 "status": "queued",
@@ -590,10 +608,12 @@ class TowerController:
             logger.exception("Failed to respawn leader for project %s", project_id)
             return None
 
-    async def _send_leader_kickoff(self, session_id: str, goal: str) -> None:
+    async def _send_leader_kickoff(
+        self, session_id: str, goal: str
+    ) -> RuntimeDeliveryResult | None:
         """Send the initial kickoff message to the Leader pane, including context."""
         if not self._current_project_id:
-            return
+            return None
         try:
             # Fetch project metadata and context entries for a rich kickoff prompt
             cursor = await self._db.execute(
@@ -649,10 +669,7 @@ class TowerController:
                     event_bus=self._event_bus,
                 )
                 if _delivery_failed(delivery):
-                    raise ValueError(
-                        delivery.message
-                        or f"Leader instruction {delivery.status}: {delivery.reason_code}"
-                    )
+                    return delivery
             except ValueError as exc:
                 # Pane died between spawn and kickoff — respawn once and retry
                 err_msg = str(exc).lower()
@@ -671,10 +688,9 @@ class TowerController:
                             event_bus=self._event_bus,
                         )
                         if _delivery_failed(retry_delivery):
-                            raise ValueError(
-                                retry_delivery.message or "Leader kickoff retry delivery failed"
-                            ) from exc
+                            return retry_delivery
                         session_id = new_id
+                        delivery = retry_delivery
                     else:
                         raise
                 else:
@@ -684,8 +700,19 @@ class TowerController:
                 session_id,
                 self._current_project_id,
             )
-        except Exception:
+            return delivery
+        except Exception as exc:
             logger.exception("Failed to send kickoff to leader session %s", session_id)
+            return RuntimeDeliveryResult(
+                session_id=session_id,
+                provider_name="unknown",
+                role=RoleKind.LEADER,
+                status="failed",
+                stage="kickoff",
+                verdict="failed",
+                reason_code="kickoff_failed",
+                message=str(exc),
+            )
 
     async def _verify_leader_started(self, project_id: str, session_id: str, goal: str) -> None:
         """Background loop: verify the Leader acknowledged and started working.

--- a/tests/e2e/test_ace_lifecycle.py
+++ b/tests/e2e/test_ace_lifecycle.py
@@ -157,3 +157,39 @@ class TestAceLifecycle:
     def test_destroy_nonexistent_session(self, mock_tmux: AsyncMock, client: TestClient) -> None:
         resp = client.delete("/api/aces/nonexistent")
         assert resp.status_code == 404
+
+    @patch("atc.runtime.service.RuntimeService.send_instruction", new_callable=AsyncMock)
+    def test_start_ace_surfaces_blocked_delivery(
+        self, mock_send: AsyncMock, mock_tmux: AsyncMock, client: TestClient
+    ) -> None:
+        mock_tmux.return_value = "%1"
+        mock_send.return_value = RuntimeDeliveryResult(
+            session_id="session-test",
+            provider_name="codex",
+            role=RoleKind.ACE,
+            status="blocked",
+            stage="interrupted",
+            verdict="blocked",
+            reason_code="auth_required",
+            message="auth required",
+        )
+
+        resp = client.post("/api/projects", json={"name": "blocked-ace-proj"})
+        project_id = resp.json()["id"]
+        resp = client.post(
+            f"/api/projects/{project_id}/aces",
+            json={"name": "worker-blocked"},
+        )
+        session_id = resp.json()["id"]
+
+        resp = client.post(
+            f"/api/aces/{session_id}/start",
+            json={"instruction": "do blocked work"},
+        )
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["status"] == "blocked"
+        assert data["delivery_state"] == "blocked"
+        assert data["delivery"]["reason_code"] == "auth_required"
+        assert "inspect Ace runtime" in data["recovery"]

--- a/tests/unit/test_creation_reliability.py
+++ b/tests/unit/test_creation_reliability.py
@@ -278,8 +278,9 @@ class TestStartAceDelivery:
         )
 
         conn = AsyncMock()
-        with pytest.raises(RuntimeError, match="Failed to deliver instruction"):
-            await start_ace(conn, session.id, instruction="Do work")
+        result = await start_ace(conn, session.id, instruction="Do work")
 
+        assert result is mock_send.return_value
+        assert result.status == "failed"
         mock_update.assert_any_await(conn, session.id, "working")
         mock_update.assert_any_await(conn, session.id, "error")

--- a/tests/unit/test_delivery_api.py
+++ b/tests/unit/test_delivery_api.py
@@ -1,0 +1,24 @@
+"""Tests for API delivery status response helpers."""
+
+from __future__ import annotations
+
+from atc.api.delivery import delivery_response
+from atc.runtime.models import RoleKind, RuntimeDeliveryResult
+
+
+def test_delivery_response_normalizes_accepted_to_submitted() -> None:
+    result = RuntimeDeliveryResult(
+        session_id="session-1",
+        provider_name="codex",
+        role=RoleKind.ACE,
+        status="accepted",
+        stage="submit_attempted",
+        verdict="accepted",
+        reason_code="submit_sent",
+    )
+
+    response = delivery_response(result, message="submitted")
+
+    assert response["status"] == "submitted"
+    assert response["delivery_state"] == "submitted"
+    assert response["delivery"]["status"] == "accepted"

--- a/tests/unit/test_tower_controller.py
+++ b/tests/unit/test_tower_controller.py
@@ -112,7 +112,12 @@ class TestSubmitGoal:
         await create_leader(db, project.id)
         tower = TowerController(db, event_bus)
 
-        result = await tower.submit_goal(project.id, "Build feature X")
+        with patch.object(
+            tower,
+            "_send_leader_kickoff",
+            new=AsyncMock(return_value=None),
+        ):
+            result = await tower.submit_goal(project.id, "Build feature X")
 
         assert result["status"] == "queued"
         assert result["delivery_state"] == "queued"
@@ -174,10 +179,15 @@ class TestSubmitGoal:
         await create_leader(db, project.id)
         tower = TowerController(db, event_bus)
 
-        await tower.submit_goal(project.id, "First goal")
-        await tower.mark_complete()
+        with patch.object(
+            tower,
+            "_send_leader_kickoff",
+            new=AsyncMock(return_value=None),
+        ):
+            await tower.submit_goal(project.id, "First goal")
+            await tower.mark_complete()
 
-        result = await tower.submit_goal(project.id, "Second goal")
+            result = await tower.submit_goal(project.id, "Second goal")
         assert result["status"] == "queued"
 
     async def test_submit_goal_after_error(
@@ -188,10 +198,15 @@ class TestSubmitGoal:
         await create_leader(db, project.id)
         tower = TowerController(db, event_bus)
 
-        await tower.submit_goal(project.id, "First goal")
-        tower._state = TowerState.ERROR  # simulate error
+        with patch.object(
+            tower,
+            "_send_leader_kickoff",
+            new=AsyncMock(return_value=None),
+        ):
+            await tower.submit_goal(project.id, "First goal")
+            tower._state = TowerState.ERROR  # simulate error
 
-        result = await tower.submit_goal(project.id, "Recovery goal")
+            result = await tower.submit_goal(project.id, "Recovery goal")
         assert result["status"] == "queued"
 
 
@@ -677,3 +692,40 @@ class TestAuthBlockDetection:
         assert tower._extract_auth_blocker("Not logged in · Please run /login") is not None
         assert tower._extract_auth_blocker("Run in another terminal: security unlock-keychain") is not None
         assert tower._extract_auth_blocker("All good, working normally") is None
+
+
+@pytest.mark.asyncio
+async def test_submit_goal_returns_observed_kickoff_failure(
+    db, event_bus: EventBus
+) -> None:
+    from atc.runtime.models import RoleKind, RuntimeDeliveryResult
+
+    project = await create_project(db, "failed-kickoff-proj")
+    await create_leader(db, project.id)
+    tower = TowerController(db, event_bus)
+    failed_delivery = RuntimeDeliveryResult(
+        session_id="leader-sess-123",
+        provider_name="codex",
+        role=RoleKind.LEADER,
+        status="blocked",
+        stage="delivery",
+        verdict="blocked",
+        reason_code="auth_required",
+        message="auth required",
+    )
+
+    with patch.object(
+        TowerController,
+        "_send_leader_kickoff",
+        new=AsyncMock(return_value=failed_delivery),
+    ):
+        with patch(
+            "atc.tower.controller.start_leader",
+            new=AsyncMock(return_value="leader-sess-123"),
+        ):
+            result = await tower.submit_goal(project.id, "Build feature X")
+
+    assert result["status"] == "blocked"
+    assert result["delivery_state"] == "blocked"
+    assert result["delivery"]["reason_code"] == "auth_required"
+    assert "inspect Leader runtime" in result["recovery"]


### PR DESCRIPTION
## Summary
- normalize runtime `accepted` helper responses to API/UI `submitted`
- preserve Ace `blocked`/`failed` runtime delivery results instead of raising before the API can surface them
- make Tower goal kickoff return observed blocked/failed delivery truth instead of masking it as queued
- add regression tests for accepted normalization, Ace blocked propagation, and Tower observed kickoff failure

## Validation
- `.venv/bin/pytest tests/unit/test_delivery_api.py tests/unit/test_creation_reliability.py tests/unit/test_tower_controller.py tests/e2e/test_ace_lifecycle.py tests/e2e/test_smoke.py tests/unit/test_leader_api.py tests/unit/test_leader_orchestrator.py tests/unit/test_delivery_tracing.py tests/unit/test_runtime_service.py tests/unit/test_codex_runtime.py tests/unit/test_tmux_substrate.py -q` → 165 passed
- `.venv/bin/python -m py_compile src/atc/api/delivery.py src/atc/session/ace.py src/atc/tower/controller.py tests/unit/test_delivery_api.py tests/unit/test_creation_reliability.py tests/unit/test_tower_controller.py tests/e2e/test_ace_lifecycle.py` → passed
- `PATH=/opt/homebrew/bin:$PATH npm run build` → passed
- Mac Studio Playwright/API evidence: `scripts/playwright/phase7-truthful-delivery.mjs` → passed
  - report: `/Users/mcole_studio/Repository/atc/test-results/phase7-truthful-delivery-2026-06-08T02-08-52-088Z/report.json`
  - screenshots:
    - `/Users/mcole_studio/Repository/atc/test-results/phase7-truthful-delivery-2026-06-08T02-08-52-088Z/00-project-loaded-before-leader-start-ui.png`
    - `/Users/mcole_studio/Repository/atc/test-results/phase7-truthful-delivery-2026-06-08T02-08-52-088Z/01-leader-delivery-state-banner.png`
    - `/Users/mcole_studio/Repository/atc/test-results/phase7-truthful-delivery-2026-06-08T02-08-52-088Z/02-project-ace-assignment-visible.png`

## Ace execution-truth evidence
- Leader-created Ace session: live tmux pane verified
- task assignment pointed to the live Ace session
- Leader instruct response returned `delivery_state: confirmed`
- delivery trace included `agent_output_observed`
- task moved to `in_progress`
