### PR TITLE
Phase 8 scenario regression suite

### DIFF
--- a/docs/runtime_orchestration_refactor_phases.md
+++ b/docs/runtime_orchestration_refactor_phases.md
@@ -250,6 +250,8 @@ Playwright evidence should be stored under a timestamped project-local `screensh
 - Old duplicated recovery/delivery code is removed or clearly quarantined.
 - Docs and code agree on runtime/orchestration responsibilities.
 
+**Phase 8 scenario suite:** `tests/e2e/test_phase8_scenarios.py` is the regression boundary for the final runtime/orchestration cluster. It covers restart/restore classification, trust/permission prompt blocking before PTY writes, partial Ace delivery failure recovery, stale active-session reconcile repair, explicit retry-path task transitions, and Tower-driven Leader/Ace management with truthful delivery state. Remaining compatibility shims are intentionally narrow: Codex/current migrated delivery paths use the shared runner, while Claude's direct tmux-control delivery remains a provider-local compatibility path covered by the same interrupt/recovery scenario expectations until it is migrated.
+
 ## Suggested PR sequence
 
 1. **PR A:** Phase 0 validation notes + Phase 1 trace model skeleton.

--- a/src/atc/tower/controller.py
+++ b/src/atc/tower/controller.py
@@ -580,8 +580,6 @@ class TowerController:
     async def _respawn_leader(self, project_id: str, goal: str) -> str | None:
         """Respawn a dead leader and return the new session_id, or None on failure."""
         try:
-            from atc.leader.leader import stop_leader
-
             logger.info("Respawning dead leader for project %s", project_id)
             # Wipe the dead session link from the leader row so start_leader
             # creates a fresh session instead of reusing the corpse.
@@ -627,7 +625,9 @@ class TowerController:
             github_repo = row[3] if row else None
 
             cursor = await self._db.execute(
-                "SELECT key, value FROM context_entries WHERE project_id = ? AND scope = 'project' ORDER BY created_at ASC",
+                "SELECT key, value FROM context_entries "
+                "WHERE project_id = ? AND scope = 'project' "
+                "ORDER BY created_at ASC",
                 (self._current_project_id,),
             )
             context_rows = await cursor.fetchall()
@@ -635,14 +635,14 @@ class TowerController:
             lines = [
                 f"# Mission Brief — {project_name}",
                 "",
-                f"## Goal",
+                "## Goal",
                 goal,
                 "",
             ]
             if description:
                 lines += ["## Project Description", description, ""]
             if repo_path:
-                lines += [f"## Repository", f"Local path: {repo_path}", ""]
+                lines += ["## Repository", f"Local path: {repo_path}", ""]
             if github_repo:
                 lines += [f"GitHub: {github_repo}", ""]
             if context_rows:
@@ -829,64 +829,10 @@ class TowerController:
             f"Project ID: {project_id}\n\n"
             f"Begin monitoring. Check progress with:\n"
             f"  curl -s http://127.0.0.1:8420/api/projects/{project_id}/leader/progress\n"
-            f"Send nudges if stuck:\n"
-            f"  atc leader message --project-id {project_id} --message 'Please continue with your goal.'\n"
-            f"\nDo NOT write code or create files yourself — delegate to the Leader only."
-        )
-
-        try:
-            await send_tower_message(
-                self._db,
-                self._current_session_id,
-                notification,
-                event_bus=self._event_bus,
-            )
-            logger.info(
-                "Sent goal notification to Tower session %s (project %s)",
-                self._current_session_id,
-                project_id,
-            )
-        except Exception as exc:
-            logger.warning(
-                "Could not notify Tower session %s of new goal: %s",
-                self._current_session_id,
-                exc,
-            )
-
-    async def _on_leader_output(self, data: dict[str, Any]) -> None:
-        """Capture PTY output from the Leader session for monitoring.
-
-        After submit_goal() starts a Leader, Tower's Claude session needs to
-        know the goal and leader session ID so it can begin monitoring.
-        This is fire-and-forget: if Tower's terminal isn't ready, we log and move on.
-        """
-        if not self._current_session_id:
-            return
-
-        # Wait briefly for Tower's pane to be ready before sending
-        await asyncio.sleep(3.0)
-
-        # Look up the project name for a friendlier message
-        try:
-            cursor = await self._db.execute(
-                "SELECT name FROM projects WHERE id = ?",
-                (project_id,),
-            )
-            row = await cursor.fetchone()
-            project_name = row[0] if row else project_id[:8]
-        except Exception:
-            project_name = project_id[:8]
-
-        notification = (
-            f"[ATC] Leader started for project '{project_name}'.\n"
-            f"Goal: {goal}\n"
-            f"Leader session: {leader_session_id}\n"
-            f"Project ID: {project_id}\n\n"
-            f"Begin monitoring. Check progress with:\n"
-            f"  curl -s http://127.0.0.1:8420/api/projects/{project_id}/leader/progress\n"
-            f"Send nudges if stuck:\n"
-            f"  atc leader message --project-id {project_id} --message 'Please continue with your goal.'\n"
-            f"\nDo NOT write code or create files yourself — delegate to the Leader only."
+            "Send nudges if stuck:\n"
+            f"  atc leader message --project-id {project_id} "
+            "--message 'Please continue with your goal.'\n"
+            "\nDo NOT write code or create files yourself — delegate to the Leader only."
         )
 
         try:
@@ -1016,8 +962,8 @@ class TowerController:
         new_status = data.get("new_status")
 
         # Decrement active counter when any leader/ace session reaches a terminal status
-        _TERMINAL_STATUSES = {"disconnected", "error", "completed", "cancelled"}
-        if new_status in _TERMINAL_STATUSES:
+        terminal_statuses = {"disconnected", "error", "completed", "cancelled"}
+        if new_status in terminal_statuses:
             # Look up session type to decide if this counts against our limit
             try:
                 cursor = await self._db.execute(

--- a/tests/e2e/test_phase8_scenarios.py
+++ b/tests/e2e/test_phase8_scenarios.py
@@ -1,0 +1,386 @@
+"""Phase 8 scenario regression suite for runtime/orchestration guarantees.
+
+These tests intentionally stitch together the known regression cluster from
+``docs/runtime_orchestration_refactor_phases.md`` so future phases cannot satisfy
+only isolated unit contracts while regressing the operator workflow.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import TYPE_CHECKING
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from atc.api.app import create_app
+from atc.config import Settings
+from atc.providers.claude_code.runtime import ClaudeCodeRuntime
+from atc.providers.codex.runtime import CodexRuntime
+from atc.runtime.models import (
+    ReadinessState,
+    RoleKind,
+    RuntimeDeliveryResult,
+    RuntimeInspection,
+    RuntimeSessionHandle,
+    RuntimeTransport,
+)
+from atc.runtime.service import RuntimeService
+from atc.runtime.tmux.runner import TmuxSessionRunner
+from atc.runtime.tracing import (
+    DeliveryAction,
+    DeliveryReasonCode,
+    DeliveryStage,
+    DeliveryVerdict,
+)
+from atc.session.reconcile import reconcile_runtime_state
+from atc.state import db as db_ops
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+@pytest.fixture
+def client(tmp_path: Path) -> TestClient:
+    db_path = str(tmp_path / "phase8-api.db")
+    settings = Settings(database={"path": db_path})  # type: ignore[arg-type]
+    app = create_app(settings)
+    with (
+        patch("atc.leader.leader._accept_trust_dialog", new_callable=AsyncMock, return_value=False),
+        patch("atc.tower.controller.TowerController.start_session", new_callable=AsyncMock),
+        TestClient(app) as c,
+    ):
+        yield c
+
+
+def _handle(
+    session_id: str = "sess-phase8",
+    *,
+    provider: str = "codex",
+    role: RoleKind = RoleKind.ACE,
+    pane: str = "%phase8",
+) -> RuntimeSessionHandle:
+    return RuntimeSessionHandle(
+        session_id=session_id,
+        provider_name=provider,
+        role=role,
+        transport=RuntimeTransport.TMUX,
+        tmux_session="atc",
+        tmux_pane=pane,
+    )
+
+
+async def _create_project_session_task(
+    db_path: str,
+    *,
+    session_status: str = "working",
+    task_status: str = "in_progress",
+):
+    await db_ops.run_migrations(db_path)
+    async with db_ops.get_connection(db_path) as conn:
+        project = await db_ops.create_project(conn, "phase8-project", agent_provider="codex")
+        ace = await db_ops.create_session(
+            conn,
+            project.id,
+            "ace",
+            "phase8-ace",
+            provider="codex",
+            status=session_status,
+        )
+        await db_ops.update_session_tmux(conn, ace.id, "atc", "%phase8")
+        task = await db_ops.create_task_graph(
+            conn,
+            project.id,
+            "phase8 task",
+            status=task_status,
+            assigned_ace_id=ace.id,
+        )
+        return project, await db_ops.get_session(conn, ace.id), task
+
+
+def test_restart_restore_scenario_preserves_readiness_without_respawn() -> None:
+    """Restart/restore must inspect existing runtime state and classify blockers."""
+
+    codex = CodexRuntime()
+    claude = ClaudeCodeRuntime()
+
+    with (
+        patch("atc.providers.codex.runtime.pane_exists", AsyncMock(return_value=True)),
+        patch(
+            "atc.providers.codex.runtime.capture_pane_text",
+            AsyncMock(return_value="ready\n>\n"),
+        ),
+    ):
+        ready = asyncio.run(codex.restore_session(_handle("codex-ready")))
+
+    with (
+        patch("atc.providers.claude_code.runtime.pane_exists", AsyncMock(return_value=True)),
+        patch(
+            "atc.providers.claude_code.runtime.capture_pane_text",
+            AsyncMock(return_value="Please login with your API key"),
+        ),
+    ):
+        blocked = asyncio.run(
+            claude.restore_session(
+                _handle("claude-blocked", provider="claude_code", role=RoleKind.LEADER)
+            )
+        )
+
+    assert ready.alive is True
+    assert ready.readiness is ReadinessState.READY
+    assert ready.details["restore_usable"] is True
+    assert blocked.readiness is ReadinessState.BLOCKED
+    assert blocked.details["restore_needs_attention"] is True
+    assert blocked.details["provider_restore_action"] == "resolve_auth"
+
+
+def test_trust_dialog_intercept_blocks_before_pty_write() -> None:
+    """A visible trust dialog is a blocker, not a successful delivery."""
+
+    metadata: dict[str, object] = {}
+    runner = TmuxSessionRunner(
+        tmux_session="atc",
+        provider_name="claude_code",
+        prompt_state_for_excerpt=lambda text: "ready" if "❯" in text else "busy",
+        terminal_verdict_for_observation=lambda _text, _state, _after: pytest.fail(
+            "terminal verdict must not run when trust dialog blocks before write"
+        ),
+        interrupt_detector=ClaudeCodeRuntime()._detect_interrupt,
+    )
+
+    with (
+        patch("atc.runtime.tmux.runner.pane_exists", AsyncMock(return_value=True)),
+        patch(
+            "atc.runtime.tmux.runner.capture_pane_text",
+            AsyncMock(return_value="Do you trust this folder?"),
+        ),
+        patch("atc.runtime.tmux.runner.send_bracketed_instruction", AsyncMock()) as send,
+        pytest.raises(Exception, match="runtime interrupt"),
+    ):
+        asyncio.run(
+                runner.deliver_instruction(
+                    handle=_handle(provider="claude_code", role=RoleKind.LEADER),
+                    metadata=metadata,
+                    trace_id="phase8-trust",
+                    action=DeliveryAction.INSTRUCTION,
+                    payload_loader=AsyncMock(return_value="do work"),
+                )
+            )
+
+    send.assert_not_awaited()
+    event = metadata["delivery_trace_events"][-1]  # type: ignore[index]
+    assert event["stage"] == DeliveryStage.BLOCKED.value
+    assert event["verdict"] == DeliveryVerdict.BLOCKED.value
+    assert event["reason_code"] == DeliveryReasonCode.TRUST_REQUIRED.value
+
+
+def test_permission_prompt_intercept_blocks_before_pty_write() -> None:
+    """A visible permission prompt is a blocker, not pasted-behind-agent output."""
+
+    metadata: dict[str, object] = {}
+    runner = TmuxSessionRunner(
+        tmux_session="atc",
+        provider_name="codex",
+        prompt_state_for_excerpt=CodexRuntime()._prompt_state_for_excerpt,
+        terminal_verdict_for_observation=lambda _text, _state, _after: pytest.fail(
+            "terminal verdict must not run when permission prompt blocks before write"
+        ),
+        interrupt_detector=CodexRuntime()._detect_interrupt,
+    )
+
+    with (
+        patch("atc.runtime.tmux.runner.pane_exists", AsyncMock(return_value=True)),
+        patch(
+            "atc.runtime.tmux.runner.capture_pane_text",
+            AsyncMock(return_value="Allow this command to continue?"),
+        ),
+        patch("atc.runtime.tmux.runner.send_bracketed_instruction", AsyncMock()) as send,
+        pytest.raises(Exception, match="runtime interrupt"),
+    ):
+        asyncio.run(
+                runner.deliver_instruction(
+                    handle=_handle(),
+                    metadata=metadata,
+                    trace_id="phase8-permission",
+                    action=DeliveryAction.INSTRUCTION,
+                    payload_loader=AsyncMock(return_value="do work"),
+                )
+            )
+
+    send.assert_not_awaited()
+    event = metadata["delivery_trace_events"][-1]  # type: ignore[index]
+    assert event["stage"] == DeliveryStage.BLOCKED.value
+    assert event["reason_code"] == DeliveryReasonCode.PERMISSION_REQUIRED.value
+
+
+@pytest.mark.asyncio
+async def test_ace_retry_after_partial_failure_marks_error_then_reconcile_resets(
+    tmp_path: Path,
+) -> None:
+    """Partial Ace delivery failure must be visible and recoverable by reconcile."""
+
+    db_path = str(tmp_path / "phase8-partial-failure.db")
+    _project, ace, task = await _create_project_session_task(db_path)
+    assert ace is not None
+
+    async with db_ops.get_connection(db_path) as conn:
+        # Simulate a delivery path that marked the session erroneous after a partial
+        # failure, then was retried by marking the task assigned again to a stale Ace.
+        await db_ops.update_session_status(conn, ace.id, "error")
+        failed = await db_ops.get_session(conn, ace.id)
+        assert failed is not None
+        assert failed.status == "error"
+
+        await db_ops.update_task_graph_status(conn, task.id, "assigned")
+        service = AsyncMock()
+        service.inspect_session_record.return_value = RuntimeInspection(
+            session_id=ace.id,
+            provider_name="codex",
+            alive=False,
+            readiness=ReadinessState.STOPPED,
+            summary="pane missing after partial failure",
+        )
+
+        result = await reconcile_runtime_state(conn, repair=True, runtime_service=service)
+
+        task_after = await db_ops.get_task_graph(conn, task.id)
+        session_after = await db_ops.get_session(conn, ace.id)
+
+    assert result.summary["orphaned_task"] >= 1
+    assert task_after is not None
+    assert task_after.status == "todo"
+    assert task_after.assigned_ace_id is None
+    assert session_after is not None
+    assert session_after.status == "error"
+
+
+@pytest.mark.asyncio
+async def test_stale_active_session_recovery_quarantines_unknown_runtime(
+    tmp_path: Path,
+) -> None:
+    """Stale active-session recovery repairs only proven stale panes."""
+
+    db_path = str(tmp_path / "phase8-stale-recovery.db")
+    await _create_project_session_task(db_path, session_status="working")
+
+    async with db_ops.get_connection(db_path) as conn:
+        service = AsyncMock()
+        service.inspect_session_record.return_value = RuntimeInspection(
+            session_id="phase8",
+            provider_name="codex",
+            alive=False,
+            readiness=ReadinessState.STOPPED,
+            summary="pane missing",
+        )
+
+        result = await reconcile_runtime_state(conn, repair=True, runtime_service=service)
+        finding = next(item for item in result.findings if item.kind == "stale_active_session")
+        repaired = await db_ops.get_session(conn, finding.session_id or finding.entity_id)
+
+    assert finding.reason_code == "runtime_not_alive"
+    assert finding.repair_status == "applied"
+    assert repaired is not None
+    assert repaired.status == "disconnected"
+    assert repaired.tmux_pane is None
+
+
+def test_retry_path_task_transitions_are_explicit(client: TestClient) -> None:
+    """Retry paths must bridge through allowed task states, not jump silently."""
+
+    project = client.post(
+        "/api/projects",
+        json={"name": "phase8 retry path", "agent_provider": "codex"},
+    ).json()
+    task = client.post(
+        f"/api/projects/{project['id']}/task-graphs",
+        json={"title": "retry me", "status": "todo"},
+    ).json()
+    start = client.post(
+        f"/api/projects/{project['id']}/leader/start",
+        json={"goal": "Phase 8 retry path", "auto_kickoff": False},
+    )
+    assert start.status_code == 200
+    spawn = client.post(f"/api/projects/{project['id']}/leader/spawn-aces", json={})
+    assert spawn.status_code == 200
+    spawned = spawn.json()["spawned"]
+    assert spawned
+    assert spawned[0]["task_graph_id"] == task["id"]
+
+    after_spawn = client.get(f"/api/task-graphs/{task['id']}")
+    assert after_spawn.status_code == 200
+    assert after_spawn.json()["status"] == "in_progress"
+    assert after_spawn.json()["assigned_ace_id"] == spawned[0]["ace_session_id"]
+
+    errored = client.patch(
+        f"/api/task-graphs/{task['id']}/status",
+        json={"status": "error"},
+    )
+    assert errored.status_code == 200
+    retried_status = client.patch(
+        f"/api/task-graphs/{task['id']}/status",
+        json={"status": "todo"},
+    )
+    assert retried_status.status_code == 200
+    retried = client.patch(
+        f"/api/task-graphs/{task['id']}",
+        json={"assigned_ace_id": None},
+    )
+    assert retried.status_code == 200
+    assert retried.json()["status"] == "todo"
+    assert retried.json()["assigned_ace_id"] is None
+
+
+def test_tower_driven_project_flow_manages_leader_and_ace(client: TestClient) -> None:
+    """Tower-driven project flow must create Leader/Ace state with truthful delivery."""
+
+    project = client.post(
+        "/api/projects",
+        json={"name": "phase8 tower flow", "agent_provider": "codex"},
+    ).json()
+    task = client.post(
+        f"/api/projects/{project['id']}/task-graphs",
+        json={"title": "phase8 tower-managed ace task"},
+    ).json()
+
+    with patch.object(
+        RuntimeService,
+        "send_instruction",
+        new_callable=AsyncMock,
+        return_value=RuntimeDeliveryResult(
+            session_id="ace-phase8",
+            provider_name="codex",
+            role=RoleKind.ACE,
+            status="confirmed",
+            stage="agent_output_observed",
+            verdict="confirmed",
+            reason_code="agent_output",
+            trace_id="phase8-confirmed",
+        ),
+    ):
+        start = client.post(
+            f"/api/projects/{project['id']}/leader/start",
+            json={"goal": "Phase 8 scenario", "auto_kickoff": False},
+        )
+        assert start.status_code == 200
+        assert start.json()["delivery_state"] == "started"
+
+        spawn = client.post(f"/api/projects/{project['id']}/leader/spawn-aces", json={})
+        assert spawn.status_code == 200
+        spawned = spawn.json()["spawned"]
+        assert spawned
+
+        instruct = client.post(
+            f"/api/projects/{project['id']}/leader/instruct",
+            json={
+                "task_graph_id": task["id"],
+                "instruction": "Phase 8 scenario assignment",
+            },
+        )
+        assert instruct.status_code == 200
+        assert instruct.json()["delivery_state"] == "confirmed"
+
+    refreshed = client.get(f"/api/task-graphs/{task['id']}")
+    assert refreshed.status_code == 200
+    assert refreshed.json()["assigned_ace_id"] == spawned[0]["ace_session_id"]
+    assert refreshed.json()["status"] in {"assigned", "in_progress"}


### PR DESCRIPTION
## Summary
- add Phase 8 end-to-end scenario regression coverage for the known runtime/orchestration cluster
- cover restart/restore classification, trust/permission prompt blockers, partial failure recovery, stale session reconcile repair, retry transitions, and Tower-driven Leader/Ace management
- remove an obsolete duplicated Tower output handler and document the remaining quarantined compatibility shim boundary

## Validation
- `.venv/bin/pytest tests/e2e/test_phase8_scenarios.py tests/e2e/test_smoke.py tests/e2e/test_ace_lifecycle.py tests/unit/test_claude_code_runtime.py tests/unit/test_codex_runtime.py tests/unit/test_reconcile.py tests/unit/test_runtime_service.py tests/unit/test_tmux_substrate.py tests/unit/test_delivery_tracing.py tests/unit/test_tower_controller.py tests/unit/test_leader_orchestrator.py -q` → 160 passed, 1 warning
- `.venv/bin/ruff check tests/e2e/test_phase8_scenarios.py src/atc/tower/controller.py` → passed
- `npm run build` → passed
- Dashboard/Usage Playwright baseline → 13/13 passed
- Ace execution-truth Playwright/API validation → 24/24 passed

## Evidence artifacts
- Baseline UI report: `/Users/mcole_studio/Repository/screenshots/playwright-atc-2026-06-08T02-38-32-491Z/report.json`
- Ace execution-truth report: `/Users/mcole_studio/Repository/atc/test-results/phase7-truthful-delivery-2026-06-08T02-38-19-833Z/report.json`
