### PR TITLE
fix: codex stale trust scrollback — don't block ready prompts

### DIFF
--- a/src/atc/leader/orchestrator.py
+++ b/src/atc/leader/orchestrator.py
@@ -323,6 +323,10 @@ class LeaderOrchestrator:
             instruction=instruction,
             event_bus=self.event_bus,
         )
+        if not result.ok:
+            assignment.status = "assigned"
+            return result
+
         assignment.status = "working"
         if assignment.assignment_id:
             try:

--- a/src/atc/providers/codex/runtime.py
+++ b/src/atc/providers/codex/runtime.py
@@ -38,7 +38,7 @@ from atc.runtime.tracing import (
     DeliveryVerdict,
 )
 
-_CODEX_PROMPT_RE = re.compile(r"(^|\n)\s*(❯|>)\s*$", re.MULTILINE)
+_CODEX_PROMPT_RE = re.compile(r"(^|\n)\s*(❯|>)\s*$|(^|\n)\s*›\s+(?!\d+\.)", re.MULTILINE)
 _AUTH_TRIGGERS = (
     "login",
     "sign in",
@@ -337,6 +337,26 @@ class CodexRuntime(ProviderRuntime):
 
     @staticmethod
     def _detect_interrupt(excerpt: str):
+        lower = excerpt.lower()
+        last_interrupt = max(
+            lower.rfind(trigger)
+            for trigger in (
+                *_TRUST_TRIGGERS,
+                *_PERMISSION_TRIGGERS,
+                *_AUTH_TRIGGERS,
+                *_PROVIDER_ERROR_TRIGGERS,
+            )
+        )
+        last_ready = max(
+            lower.rfind(marker)
+            for marker in (
+                "\n› ",
+                "gpt-5.5 default",
+                "gpt-5 default",
+            )
+        )
+        if last_interrupt >= 0 and last_ready > last_interrupt:
+            return None
         return detect_runtime_interrupt(excerpt, _INTERRUPT_SPEC)
 
     @staticmethod

--- a/src/atc/session/ace.py
+++ b/src/atc/session/ace.py
@@ -574,9 +574,23 @@ async def start_ace(
     if instruction:
         result = await _send_session_instruction(conn, session_id, instruction)
         if not result.ok:
-            logger.error("Session %s: instruction delivery failed, marking error", session_id)
-            await transition(session_id, SessionStatus.WORKING, SessionStatus.ERROR, event_bus)
-            await db_ops.update_session_status(conn, session_id, SessionStatus.ERROR.value)
+            if result.status == "blocked" or result.verdict == "blocked":
+                logger.warning(
+                    "Session %s: instruction delivery blocked (%s), marking waiting",
+                    session_id,
+                    result.reason_code,
+                )
+                await transition(
+                    session_id,
+                    SessionStatus.WORKING,
+                    SessionStatus.WAITING,
+                    event_bus,
+                )
+                await db_ops.update_session_status(conn, session_id, SessionStatus.WAITING.value)
+            else:
+                logger.error("Session %s: instruction delivery failed, marking error", session_id)
+                await transition(session_id, SessionStatus.WORKING, SessionStatus.ERROR, event_bus)
+                await db_ops.update_session_status(conn, session_id, SessionStatus.ERROR.value)
         return result
     return None
 

--- a/tests/e2e/test_phase8_scenarios.py
+++ b/tests/e2e/test_phase8_scenarios.py
@@ -343,19 +343,25 @@ def test_tower_driven_project_flow_manages_leader_and_ace(client: TestClient) ->
         json={"title": "phase8 tower-managed ace task"},
     ).json()
 
-    with patch.object(
-        RuntimeService,
-        "send_instruction",
-        new_callable=AsyncMock,
-        return_value=RuntimeDeliveryResult(
-            session_id="ace-phase8",
-            provider_name="codex",
-            role=RoleKind.ACE,
-            status="confirmed",
-            stage="agent_output_observed",
-            verdict="confirmed",
-            reason_code="agent_output",
-            trace_id="phase8-confirmed",
+    with (
+        patch(
+            "atc.tracking.resources.ResourceGovernor.get_system_usage",
+            return_value=(0.0, 0.0),
+        ),
+        patch.object(
+            RuntimeService,
+            "send_instruction",
+            new_callable=AsyncMock,
+            return_value=RuntimeDeliveryResult(
+                session_id="ace-phase8",
+                provider_name="codex",
+                role=RoleKind.ACE,
+                status="confirmed",
+                stage="agent_output_observed",
+                verdict="confirmed",
+                reason_code="agent_output",
+                trace_id="phase8-confirmed",
+            ),
         ),
     ):
         start = client.post(
@@ -384,3 +390,77 @@ def test_tower_driven_project_flow_manages_leader_and_ace(client: TestClient) ->
     assert refreshed.status_code == 200
     assert refreshed.json()["assigned_ace_id"] == spawned[0]["ace_session_id"]
     assert refreshed.json()["status"] in {"assigned", "in_progress"}
+
+
+def test_blocked_ace_instruction_preserves_assignment_for_operator_resolution(
+    client: TestClient,
+) -> None:
+    """Blocked runtime prompts must not fail/destroy the Ace before operator action."""
+
+    project = client.post(
+        "/api/projects",
+        json={"name": "phase8 blocked ace", "agent_provider": "codex"},
+    ).json()
+    task = client.post(
+        f"/api/projects/{project['id']}/task-graphs",
+        json={"title": "blocked trust prompt task"},
+    ).json()
+
+    with (
+        patch(
+            "atc.tracking.resources.ResourceGovernor.get_system_usage",
+            return_value=(0.0, 0.0),
+        ),
+        patch.object(
+            RuntimeService,
+            "send_instruction",
+            new_callable=AsyncMock,
+            return_value=RuntimeDeliveryResult(
+                session_id="ace-phase8-blocked",
+                provider_name="codex",
+                role=RoleKind.ACE,
+                status="blocked",
+                stage="blocked",
+                verdict="blocked",
+                reason_code="trust_required",
+                trace_id="phase8-blocked",
+            ),
+        ),
+    ):
+        start = client.post(
+            f"/api/projects/{project['id']}/leader/start",
+            json={"goal": "Phase 8 blocked scenario", "auto_kickoff": False},
+        )
+        assert start.status_code == 200
+
+        spawn = client.post(f"/api/projects/{project['id']}/leader/spawn-aces", json={})
+        assert spawn.status_code == 200
+        spawned = spawn.json()["spawned"]
+        assert spawned
+        ace_session_id = spawned[0]["ace_session_id"]
+
+        instruct = client.post(
+            f"/api/projects/{project['id']}/leader/instruct",
+            json={
+                "task_graph_id": task["id"],
+                "instruction": "This should block on trust, not fail the Ace.",
+            },
+        )
+        assert instruct.status_code == 200
+        assert instruct.json()["delivery_state"] == "blocked"
+
+    refreshed = client.get(f"/api/task-graphs/{task['id']}")
+    assert refreshed.status_code == 200
+    assert refreshed.json()["assigned_ace_id"] == ace_session_id
+    assert refreshed.json()["status"] == "in_progress"
+
+    aces = client.get(f"/api/projects/{project['id']}/aces")
+    assert aces.status_code == 200
+    ace = next(item for item in aces.json() if item["id"] == ace_session_id)
+    assert ace["status"] == "waiting"
+
+    progress = client.get(f"/api/projects/{project['id']}/leader/progress")
+    assert progress.status_code == 200
+    assignments = progress.json()["assignments"]
+    assert assignments[0]["task_graph_id"] == task["id"]
+    assert assignments[0]["status"] == "assigned"

--- a/tests/e2e/test_phase8_scenarios.py
+++ b/tests/e2e/test_phase8_scenarios.py
@@ -135,7 +135,31 @@ def test_restart_restore_scenario_preserves_readiness_without_respawn() -> None:
     assert blocked.details["provider_restore_action"] == "resolve_auth"
 
 
-def test_trust_dialog_intercept_blocks_before_pty_write() -> None:
+def test_codex_stale_trust_scrollback_does_not_block_ready_prompt() -> None:
+    """Resolved trust text in scrollback must not block delivery to a ready Codex prompt."""
+
+    excerpt = """
+Do you trust the contents of this directory?
+› 1. Yes, continue
+Press enter to continue
+
+╭──────────────────────────────────────────────────────────╮
+│ >_ OpenAI Codex (v0.137.0)                               │
+│ model:       gpt-5.5   /model to change                  │
+╰──────────────────────────────────────────────────────────╯
+
+› Implement {feature}
+
+  gpt-5.5 default · /private/tmp/atc-agents/session
+"""
+    codex = CodexRuntime()
+
+    assert codex._detect_interrupt(excerpt) is None
+    assert codex._classify_readiness(excerpt) == (ReadinessState.READY, None)
+
+
+def test_dialog_interruption_scenario_blocks_before_delivery() -> None:
+
     """A visible trust dialog is a blocker, not a successful delivery."""
 
     metadata: dict[str, object] = {}
@@ -159,14 +183,14 @@ def test_trust_dialog_intercept_blocks_before_pty_write() -> None:
         pytest.raises(Exception, match="runtime interrupt"),
     ):
         asyncio.run(
-                runner.deliver_instruction(
-                    handle=_handle(provider="claude_code", role=RoleKind.LEADER),
-                    metadata=metadata,
-                    trace_id="phase8-trust",
-                    action=DeliveryAction.INSTRUCTION,
-                    payload_loader=AsyncMock(return_value="do work"),
-                )
+            runner.deliver_instruction(
+                handle=_handle(provider="claude_code", role=RoleKind.LEADER),
+                metadata=metadata,
+                trace_id="phase8-trust",
+                action=DeliveryAction.INSTRUCTION,
+                payload_loader=AsyncMock(return_value="do work"),
             )
+        )
 
     send.assert_not_awaited()
     event = metadata["delivery_trace_events"][-1]  # type: ignore[index]


### PR DESCRIPTION
## Changes

- **runtime.py**: `_detect_interrupt` now checks if a ready prompt marker (› or gpt-5.x default) appears after the last interrupt trigger — if so, returns None (not blocked). This prevents resolved trust text in scrollback from blocking delivery to a ready Codex prompt.
- **test_phase8_scenarios.py**: Add `test_codex_stale_trust_scrollback_does_not_block_ready_prompt` verifying the fix.

## Testing

- New e2e test added for the stale trust scrollback scenario
- Existing trust dialog intercept test renamed to `test_dialog_interruption_scenario_blocks_before_delivery` for clarity