### PR TITLE
Fix Project layout split and Leader status reporting

### DIFF
--- a/docs/codebase_map_frontend.md
+++ b/docs/codebase_map_frontend.md
@@ -13,7 +13,7 @@ ATC’s frontend is a React + Vite SPA wrapped by a very thin Tauri shell. The m
   - Initializes Sentry, wraps app in `ErrorBoundary`, and mounts a `QueryClientProvider`.
   - React Query is configured, but the actual app mostly does not use it yet. Most fetching is manual via `api` and local state.
 - Router and shell: `frontend/src/App.tsx`
-  - Global shell is `TowerBar` on top, route content in the middle, persistent `TowerPanel` on bottom.
+  - Global shell is `TowerBar` on top. Dashboard/project routes use a two-column shell split: route content on the left, persistent `TowerPanel` on the right, with a single shell-owned resize handle between them. Non-Tower routes keep the bottom `TowerPanel` fallback.
   - Routes:
     - `/dashboard` → `pages/Dashboard.tsx`
     - `/projects/:id` → `pages/ProjectView.tsx`

--- a/frontend/src/pages/ProjectView.css
+++ b/frontend/src/pages/ProjectView.css
@@ -35,42 +35,54 @@
   color: var(--color-text-secondary);
 }
 
-/* Left-side project stack, with Tower living in the app shell on the right */
+/*
+ * Project pages are intentionally a single scrollable left column inside the
+ * app-shell's two-column split. The shell-owned Tower resize handle is the only
+ * horizontal divider: dragging Tower wider makes this column narrower and vice
+ * versa. Do not add nested page-level resize handles here.
+ */
 .project-view__layout {
   display: flex;
   flex: 1;
   min-height: 0;
+  overflow: hidden;
 }
 
 .project-view__left {
+  width: 100%;
+  min-width: 0;
+  min-height: 0;
   display: flex;
   flex-direction: column;
-  flex-shrink: 0;
-  min-height: 0;
   overflow-y: auto;
   overflow-x: hidden;
   overscroll-behavior: contain;
   scrollbar-gutter: stable;
-  gap: 0;
+  gap: var(--space-3);
+  padding-right: var(--space-2);
 }
 
-.project-view__tasks {
-  flex-shrink: 0;
-  overflow-y: auto;
+.project-view__leader,
+.project-view__tasks,
+.project-view__aces,
+.project-view__context {
+  flex: 0 0 auto;
 }
 
-/* Aces fills remaining left-column space after tasks */
+.project-view__tasks,
+.project-view__aces,
+.project-view__context {
+  overflow: visible;
+}
+
 .project-view__aces {
-  flex: 1;
-  min-height: 120px;
-  overflow: hidden;
+  min-height: 0;
 }
 
-/* When an Ace is expanded, the panel grows to fill available space */
 .project-view__aces--expanded {
   display: flex;
   flex-direction: column;
-  min-height: 0;
+  min-height: 520px;
 }
 
 .project-view__aces--expanded .ace-console {
@@ -81,15 +93,11 @@
 }
 
 .project-view__leader {
-  flex-shrink: 0;
   display: flex;
   flex-direction: column;
-  min-height: 0;
-  margin-bottom: var(--space-3);
+  min-height: 240px;
 }
 
 .project-view__context {
-  min-height: 180px;
-  overflow-y: auto;
-  margin-top: var(--space-3);
+  min-height: 0;
 }

--- a/frontend/src/pages/ProjectView.tsx
+++ b/frontend/src/pages/ProjectView.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback, useRef, useEffect } from "react";
+import { useState } from "react";
 import { useParams } from "react-router-dom";
 import { useAppContext } from "../context/AppContext";
 import StatusBadge from "../components/common/StatusBadge";
@@ -7,28 +7,7 @@ import TaskBoard from "../components/leader/TaskBoard";
 import AceList from "../components/ace/AceList";
 import AceConsole from "../components/ace/AceConsole";
 import ContextHub from "../components/context/ContextHub";
-import ResizeHandle from "../components/common/ResizeHandle";
 import "./ProjectView.css";
-
-const MIN_LEFT = 280;
-const MIN_TASKS = 120;
-
-function readStorage(key: string, fallback: number): number {
-  try {
-    const v = globalThis.localStorage?.getItem(key);
-    return v !== null && v !== undefined ? Number(v) : fallback;
-  } catch {
-    return fallback;
-  }
-}
-
-function writeStorage(key: string, value: number): void {
-  try {
-    globalThis.localStorage?.setItem(key, String(value));
-  } catch {
-    // Storage can be unavailable in tests or hardened browser contexts.
-  }
-}
 
 export default function ProjectView() {
   const { id } = useParams<{ id: string }>();
@@ -48,80 +27,6 @@ export default function ProjectView() {
     expandedAceId !== null &&
     projectSessions.some((s) => s.id === expandedAceId);
   const activeAceId = expandedAceExists ? expandedAceId : null;
-
-  // Resize state — pixel sizes persisted to localStorage
-  const [leftWidth, setLeftWidth] = useState(() =>
-    readStorage("atc:pv:split", Math.round(window.innerWidth * 0.4))
-  );
-  const [tasksHeight, setTasksHeight] = useState(() =>
-    readStorage("atc:pv:tasks-h", 240)
-  );
-  const [leaderHeight] = useState(() => readStorage("atc:pv:leader-h", 240));
-
-  const layoutRef = useRef<HTMLDivElement>(null);
-
-  useEffect(() => {
-    writeStorage("atc:pv:split", leftWidth);
-  }, [leftWidth]);
-  useEffect(() => {
-    writeStorage("atc:pv:tasks-h", tasksHeight);
-  }, [tasksHeight]);
-  useEffect(() => {
-    writeStorage("atc:pv:leader-h", leaderHeight);
-  }, [leaderHeight]);
-
-  const handleSplitDrag = useCallback(
-    (e: React.MouseEvent) => {
-      e.preventDefault();
-      const startX = e.clientX;
-      const startWidth = leftWidth;
-
-      const onMove = (ev: MouseEvent) => {
-        const containerWidth =
-          layoutRef.current?.offsetWidth ?? window.innerWidth;
-        const next = Math.max(
-          MIN_LEFT,
-          Math.min(
-            startWidth + ev.clientX - startX,
-            containerWidth - 360 - 4
-          )
-        );
-        setLeftWidth(next);
-      };
-
-      const onUp = () => {
-        document.removeEventListener("mousemove", onMove);
-        document.removeEventListener("mouseup", onUp);
-      };
-
-      document.addEventListener("mousemove", onMove);
-      document.addEventListener("mouseup", onUp);
-    },
-    [leftWidth]
-  );
-
-  const handleTasksDrag = useCallback(
-    (e: React.MouseEvent) => {
-      e.preventDefault();
-      const startY = e.clientY;
-      const startHeight = tasksHeight;
-
-      const onMove = (ev: MouseEvent) => {
-        const next = Math.max(MIN_TASKS, startHeight + ev.clientY - startY);
-        setTasksHeight(next);
-      };
-
-      const onUp = () => {
-        document.removeEventListener("mousemove", onMove);
-        document.removeEventListener("mouseup", onUp);
-      };
-
-      document.addEventListener("mousemove", onMove);
-      document.addEventListener("mouseup", onUp);
-    },
-    [tasksHeight]
-  );
-
 
   if (!project) {
     return (
@@ -144,9 +49,9 @@ export default function ProjectView() {
         )}
       </div>
 
-      <div className="project-view__layout" ref={layoutRef}>
-        <aside className="project-view__left" style={{ width: leftWidth }}>
-          <div className="panel project-view__leader" style={{ minHeight: leaderHeight }}>
+      <div className="project-view__layout">
+        <aside className="project-view__left">
+          <div className="panel project-view__leader">
             <LeaderConsole
               projectId={project.id}
               leader={leader}
@@ -155,18 +60,13 @@ export default function ProjectView() {
             />
           </div>
 
-          <div
-            className="panel project-view__tasks"
-            style={{ height: tasksHeight }}
-          >
+          <div className="panel project-view__tasks">
             <TaskBoard
               projectId={project.id}
               taskGraphs={projectTaskGraphs}
               onRefresh={fetchAll}
             />
           </div>
-
-          <ResizeHandle direction="row" onMouseDown={handleTasksDrag} />
 
           <div
             className={`panel project-view__aces${activeAceId ? " project-view__aces--expanded" : ""}`}
@@ -199,8 +99,6 @@ export default function ProjectView() {
             />
           </div>
         </aside>
-
-        <ResizeHandle direction="col" onMouseDown={handleSplitDrag} />
       </div>
     </div>
   );

--- a/src/atc/agents/deploy.py
+++ b/src/atc/agents/deploy.py
@@ -582,15 +582,17 @@ def _build_manager_claude_md(spec: ManagerDeploySpec) -> str:
     hooks_dir = f"/tmp/atc-agents/{spec.leader_id}/.claude/hooks"
     lines.extend(_context_cli_instructions(hooks_dir))
 
+    status_session_id = spec.session_id or spec.leader_id
     lines.extend(
         [
             "## Reporting",
             "",
-            "Use the `atc` CLI to report status:",
+            "Use the `atc` CLI to report status. Always report against this "
+            "Leader's runtime session ID, not the durable leader row ID:",
             "",
             "```bash",
-            f'atc ace status "{spec.leader_id}" working',
-            f'atc ace status "{spec.leader_id}" waiting',
+            f'atc ace status "{status_session_id}" working',
+            f'atc ace status "{status_session_id}" waiting',
             "```",
             "",
         ]

--- a/tests/unit/test_deploy.py
+++ b/tests/unit/test_deploy.py
@@ -367,6 +367,17 @@ class TestDeployManagerFiles:
         assert "Stay under budget" in content
         assert "No force-pushes" in content
 
+    def test_reporting_instructions_use_runtime_session_id(
+        self, manager_spec: ManagerDeploySpec, staging_root: Path
+    ) -> None:
+        manager_spec.session_id = "manager-session-001"
+        result = deploy_manager_files(manager_spec, staging_root=staging_root)
+        content = result.claude_md_path.read_text()
+        assert 'atc ace status "manager-session-001" working' in content
+        assert 'atc ace status "manager-session-001" waiting' in content
+        assert 'atc ace status "leader-bravo" working' not in content
+        assert "runtime session ID" in content
+
     def test_settings_includes_tower_command(
         self, manager_spec: ManagerDeploySpec, staging_root: Path
     ) -> None:


### PR DESCRIPTION
## Summary
- Removed ProjectView-owned resize handles/state so the Project workspace uses the shell-owned two-column Tower/content split as the only horizontal divider.
- Made the Project left column a single vertically scrollable stack with static auto-height Leader, Task, Ace, and Context sections.
- Updated Leader/manager generated reporting instructions to prefer the runtime session ID for `atc ace status ...` calls, with a durable leader ID fallback for compatibility.
- Updated the frontend codebase map to document the current shell split behavior.

## Validation
- `pytest -q tests/unit/test_deploy.py` → 76 passed, 1 warning.
- `cd frontend && npm test -- --run src/pages/__tests__/ProjectView.test.tsx src/layout/towerSplit.test.ts` → 2 files passed, 8 tests passed.
- `ruff check src/atc/agents/deploy.py tests/unit/test_deploy.py` → all checks passed.
- `cd frontend && npm run build` → passed; Vite reported the existing large-chunk warning.
- Playwright UI smoke against local backend/frontend → 10/10 checks passed.

## UI smoke evidence
Report: `/tmp/atc-work/test-results/project-layout-smoke-20260608-092259/report.json`

Screenshots captured locally and attached in the Slack thread:
- `/tmp/atc-work/test-results/project-layout-smoke-20260608-092259/project-layout-top.png`
- `/tmp/atc-work/test-results/project-layout-smoke-20260608-092259/project-layout-scrolled-context.png`
- `/tmp/atc-work/test-results/project-layout-smoke-20260608-092259/project-layout-shared-resizer.png`

Smoke assertions included:
- exactly one shell-owned Tower/content resize handle;
- zero nested ProjectView resize handles;
- Project left column fills the route content pane and scrolls naturally;
- Leader/Tasks/Aces/Context sections render with static heights;
- dragging the shared resizer grows Tower and shrinks the content column;
- no page errors, failed requests, or HTTP 4xx/5xx responses.

Note: dev-mode console emitted Vite/React DevTools messages and transient WebSocket-close warnings during page lifecycle; no Playwright page errors, failed requests, or HTTP 4xx/5xx responses were captured.