### PR TITLE
Add session startup handshake and Ace task pairing

### DIFF
--- a/src/atc/leader/orchestrator.py
+++ b/src/atc/leader/orchestrator.py
@@ -107,7 +107,8 @@ class LeaderOrchestrator:
             project_id=self.project_id,
         )
 
-        ready = get_ready_tasks(task_graphs)
+        active_aces_by_task = await self._active_ace_sessions_by_task()
+        ready = [tg for tg in get_ready_tasks(task_graphs) if tg.id not in active_aces_by_task]
         if not ready:
             return []
 
@@ -124,9 +125,7 @@ class LeaderOrchestrator:
                 )
                 return []
             # Reserve slots atomically before spawning
-            spawnable_count = len(
-                [tg for tg in get_ready_tasks(task_graphs) if tg.id not in self.assignments]
-            )
+            spawnable_count = len([tg for tg in ready if tg.id not in self.assignments])
             slots_to_use = min(available_slots, spawnable_count)
             _GLOBAL_ACTIVE_ACES += slots_to_use
 
@@ -141,6 +140,20 @@ class LeaderOrchestrator:
                 _GLOBAL_ACTIVE_ACES = max(0, _GLOBAL_ACTIVE_ACES - 1)
 
         return new_assignments
+
+    async def _active_ace_sessions_by_task(self) -> dict[str, str]:
+        """Return active Ace sessions keyed by task id to preserve 1:1 pairing."""
+        terminal_statuses = {"completed", "cancelled", "error", "disconnected"}
+        sessions = await db_ops.list_sessions(
+            self.conn,
+            project_id=self.project_id,
+            session_type="ace",
+        )
+        return {
+            session.task_id: session.id
+            for session in sessions
+            if session.task_id and session.status not in terminal_statuses
+        }
 
     async def _spawn_ace_for_task(
         self,

--- a/src/atc/runtime/service.py
+++ b/src/atc/runtime/service.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 from typing import TYPE_CHECKING
 
 from atc.providers.registry import create_provider_runtime, runtime_kwargs_for_provider
@@ -9,7 +10,9 @@ from atc.runtime.errors import RuntimeInvocationError
 from atc.runtime.models import (
     InstructionRequest,
     ReadinessResult,
+    ReadinessState,
     RoleKind,
+    RuntimeBlockReason,
     RuntimeDeliveryResult,
     RuntimeInspection,
     RuntimeSessionHandle,
@@ -28,6 +31,11 @@ from atc.runtime.tracing import (
     trace_event,
 )
 from atc.state.db import get_connection_app_state
+
+_STARTUP_INITIAL_DELAY_SECONDS = 2.0
+_STARTUP_RESOLVE_DELAY_SECONDS = 1.0
+_STARTUP_FINAL_DELAY_SECONDS = 1.0
+_STARTUP_AUTO_RESOLVE_REASONS = {RuntimeBlockReason.TRUST}
 
 if TYPE_CHECKING:
     from atc.providers.base import ProviderRuntime
@@ -189,7 +197,9 @@ class RuntimeService:
             )
             raise
         self._append_spawned_event(request, handle, trace_id)
-        return self.remember_handle(handle)
+        handle = self.remember_handle(handle)
+        await self._initialize_spawned_session(request, handle, trace_id, provider)
+        return handle
 
     async def send_instruction(
         self,
@@ -366,7 +376,135 @@ class RuntimeService:
             )
             raise
         self._append_spawned_event(request, handle, trace_id)
-        return self.remember_handle(handle)
+        handle = self.remember_handle(handle)
+        await self._initialize_spawned_session(request, handle, trace_id, provider)
+        return handle
+
+    async def _initialize_spawned_session(
+        self,
+        request: StartRoleRequest,
+        handle: RuntimeSessionHandle,
+        trace_id: str,
+        provider: ProviderRuntime,
+    ) -> None:
+        """Run the shared post-spawn handshake before any role receives work.
+
+        Tower, Leader, and Ace panes all boot through provider TUIs. Give the
+        TUI time to draw, inspect for startup blockers, auto-answer the narrow
+        set of known safe prompts, then inspect again so callers do not send
+        instructions into a trust/auth/permission question.
+        """
+        await asyncio.sleep(_STARTUP_INITIAL_DELAY_SECONDS)
+        first = await provider.inspect_session(handle)
+        self._append_startup_inspection_event(
+            request,
+            handle,
+            trace_id,
+            first,
+            phase="initial",
+        )
+        if first.readiness is ReadinessState.BLOCKED:
+            resolved = await self._try_resolve_startup_prompt(handle, first)
+            if resolved:
+                await asyncio.sleep(_STARTUP_RESOLVE_DELAY_SECONDS)
+                second = await provider.inspect_session(handle)
+                self._append_startup_inspection_event(
+                    request,
+                    handle,
+                    trace_id,
+                    second,
+                    phase="after_auto_resolve",
+                )
+                await asyncio.sleep(_STARTUP_FINAL_DELAY_SECONDS)
+                final = await provider.inspect_session(handle)
+                self._append_startup_inspection_event(
+                    request,
+                    handle,
+                    trace_id,
+                    final,
+                    phase="final",
+                )
+                return
+        await asyncio.sleep(_STARTUP_FINAL_DELAY_SECONDS)
+        final = await provider.inspect_session(handle)
+        self._append_startup_inspection_event(
+            request,
+            handle,
+            trace_id,
+            final,
+            phase="final",
+        )
+
+    @staticmethod
+    async def _try_resolve_startup_prompt(
+        handle: RuntimeSessionHandle,
+        inspection: RuntimeInspection,
+    ) -> bool:
+        if inspection.block_reason not in _STARTUP_AUTO_RESOLVE_REASONS:
+            return False
+        if not handle.tmux_pane:
+            return False
+        from atc.runtime.tmux.substrate import run_tmux
+
+        await run_tmux("send-keys", "-t", handle.tmux_pane, "Enter")
+        return True
+
+    @staticmethod
+    def _append_startup_inspection_event(
+        request: StartRoleRequest,
+        handle: RuntimeSessionHandle,
+        trace_id: str,
+        inspection: RuntimeInspection,
+        *,
+        phase: str,
+    ) -> None:
+        if inspection.readiness is ReadinessState.BLOCKED:
+            verdict = DeliveryVerdict.BLOCKED
+            if inspection.block_reason is RuntimeBlockReason.TRUST:
+                reason_code = DeliveryReasonCode.TRUST_REQUIRED
+            elif inspection.block_reason in {RuntimeBlockReason.AUTH, RuntimeBlockReason.LOGIN}:
+                reason_code = DeliveryReasonCode.AUTH_REQUIRED
+            elif inspection.block_reason is RuntimeBlockReason.PERMISSION:
+                reason_code = DeliveryReasonCode.PERMISSION_REQUIRED
+            else:
+                reason_code = DeliveryReasonCode.UNKNOWN_PROMPT_BLOCKER
+        elif inspection.readiness is ReadinessState.ERROR:
+            verdict = DeliveryVerdict.FAILED
+            reason_code = DeliveryReasonCode.PROVIDER_ERROR
+        elif inspection.readiness is ReadinessState.STOPPED:
+            verdict = DeliveryVerdict.FAILED
+            reason_code = DeliveryReasonCode.PANE_MISSING
+        else:
+            verdict = DeliveryVerdict.ACCEPTED
+            reason_code = DeliveryReasonCode.SESSION_RUNNING
+        append_trace_event(
+            request.metadata,
+            trace_event(
+                trace_id=trace_id,
+                session_id=handle.session_id,
+                role=handle.role.value,
+                provider=handle.provider_name,
+                pane_id=handle.tmux_pane,
+                action=DeliveryAction.SPAWN,
+                stage=DeliveryStage.CONFIRMED_RUNNING
+                if verdict is DeliveryVerdict.ACCEPTED
+                else DeliveryStage.BLOCKED
+                if verdict is DeliveryVerdict.BLOCKED
+                else DeliveryStage.FAILED,
+                verdict=verdict,
+                reason_code=reason_code,
+                prompt_state_after=inspection.readiness.value,
+                first_output_excerpt=inspection.last_output_excerpt,
+                details={
+                    "startup_phase": phase,
+                    "summary": inspection.summary,
+                    "block_reason": inspection.block_reason.value
+                    if inspection.block_reason is not None
+                    else None,
+                    **inspection.details,
+                },
+            ),
+        )
 
     async def _stop_role(
         self,

--- a/src/atc/session/ace.py
+++ b/src/atc/session/ace.py
@@ -356,6 +356,24 @@ async def create_ace(
         deploy_spec_kwargs: If provided, deploy Ace config files (CLAUDE.md,
             hooks, settings.json) using the real session_id after DB creation.
     """
+    # Keep task execution one-to-one: a task graph entry may have at most one
+    # non-terminal Ace session. Retry paths should reuse/reset the existing Ace
+    # instead of creating extra unpaired workers for the same task.
+    if task_id:
+        existing_sessions = await db_ops.list_sessions(
+            conn,
+            project_id=project_id,
+            session_type="ace",
+        )
+        for existing in existing_sessions:
+            if existing.task_id != task_id:
+                continue
+            if existing.status in {"completed", "cancelled", "error", "disconnected"}:
+                continue
+            raise ValueError(
+                f"Task {task_id} already has active Ace session {existing.id}"
+            )
+
     # Step 1: DB row first — guarantees the UI always sees every entity
     provider_cfg = get_connection_app_state(conn)
     project = await db_ops.get_project(conn, project_id) if project_id else None

--- a/tests/integration/test_creation_reliability.py
+++ b/tests/integration/test_creation_reliability.py
@@ -11,6 +11,7 @@ from unittest.mock import AsyncMock, patch
 import pytest
 
 from atc.core.events import EventBus
+from atc.runtime.models import ReadinessState, RoleKind, RuntimeDeliveryResult, RuntimeInspection
 from atc.session.ace import (
     create_ace,
     start_ace,
@@ -79,7 +80,11 @@ class TestDBFirstCreation:
         assert session is not None
 
     @pytest.mark.asyncio
-    @patch("atc.session.ace._spawn_provider_session", new_callable=AsyncMock, return_value=("atc", "%2"))
+    @patch(
+        "atc.session.ace._spawn_provider_session",
+        new_callable=AsyncMock,
+        return_value=("atc", "%2"),
+    )
     async def test_session_moves_to_idle_on_success(
         self,
         mock_spawn_provider: AsyncMock,
@@ -96,7 +101,40 @@ class TestDBFirstCreation:
         assert session.tmux_pane == "%2"
 
     @pytest.mark.asyncio
-    @patch("atc.session.ace._spawn_provider_session", new_callable=AsyncMock, side_effect=RuntimeError("tmux not available"))
+    @patch(
+        "atc.session.ace._spawn_provider_session",
+        new_callable=AsyncMock,
+        return_value=("atc", "%2"),
+    )
+    async def test_create_ace_rejects_second_active_session_for_same_task(
+        self,
+        mock_spawn_provider: AsyncMock,
+        conn,
+        event_bus: EventBus,
+    ) -> None:
+        project = await db_ops.create_project(conn, "test-project")
+        task = await db_ops.create_task_graph(conn, project.id, "Task A")
+
+        await create_ace(conn, project.id, "test-ace", event_bus=event_bus, task_id=task.id)
+
+        with pytest.raises(ValueError, match="already has active Ace session"):
+            await create_ace(
+                conn,
+                project.id,
+                "duplicate-ace",
+                event_bus=event_bus,
+                task_id=task.id,
+            )
+
+        sessions = await db_ops.list_sessions(conn, project_id=project.id, session_type="ace")
+        assert len(sessions) == 1
+
+    @pytest.mark.asyncio
+    @patch(
+        "atc.session.ace._spawn_provider_session",
+        new_callable=AsyncMock,
+        side_effect=RuntimeError("tmux not available"),
+    )
     async def test_session_moves_to_error_on_failure(
         self,
         mock_spawn_provider: AsyncMock,
@@ -115,7 +153,11 @@ class TestDBFirstCreation:
         assert sessions[0].status == SessionStatus.ERROR.value
 
     @pytest.mark.asyncio
-    @patch("atc.session.ace._spawn_provider_session", new_callable=AsyncMock, return_value=("atc", "%3"))
+    @patch(
+        "atc.session.ace._spawn_provider_session",
+        new_callable=AsyncMock,
+        return_value=("atc", "%3"),
+    )
     async def test_creation_event_published(
         self,
         mock_spawn_provider: AsyncMock,
@@ -142,7 +184,11 @@ class TestAtomicInstructionSending:
 
     @pytest.mark.asyncio
     @patch("atc.session.ace._send_session_instruction", new_callable=AsyncMock)
-    @patch("atc.session.ace._spawn_provider_session", new_callable=AsyncMock, return_value=("atc", "%4"))
+    @patch(
+        "atc.session.ace._spawn_provider_session",
+        new_callable=AsyncMock,
+        return_value=("atc", "%4"),
+    )
     async def test_start_ace_uses_send_instruction(
         self,
         mock_spawn_provider: AsyncMock,
@@ -150,7 +196,12 @@ class TestAtomicInstructionSending:
         conn,
         event_bus: EventBus,
     ) -> None:
-        mock_send.return_value = True
+        mock_send.return_value = RuntimeDeliveryResult(
+            session_id="test-ace",
+            provider_name="codex",
+            role=RoleKind.ACE,
+            status="confirmed",
+        )
 
         project = await db_ops.create_project(conn, "test-project")
         session_id = await create_ace(conn, project.id, "test-ace", event_bus=event_bus)
@@ -161,7 +212,11 @@ class TestAtomicInstructionSending:
 
     @pytest.mark.asyncio
     @patch("atc.session.ace._send_session_instruction", new_callable=AsyncMock)
-    @patch("atc.session.ace._spawn_provider_session", new_callable=AsyncMock, return_value=("atc", "%5"))
+    @patch(
+        "atc.session.ace._spawn_provider_session",
+        new_callable=AsyncMock,
+        return_value=("atc", "%5"),
+    )
     async def test_start_ace_errors_on_failed_delivery(
         self,
         mock_spawn_provider: AsyncMock,
@@ -169,13 +224,18 @@ class TestAtomicInstructionSending:
         conn,
         event_bus: EventBus,
     ) -> None:
-        mock_send.return_value = False  # delivery failed
+        mock_send.return_value = RuntimeDeliveryResult(
+            session_id="test-ace",
+            provider_name="codex",
+            role=RoleKind.ACE,
+            status="failed",
+        )
 
         project = await db_ops.create_project(conn, "test-project")
         session_id = await create_ace(conn, project.id, "test-ace", event_bus=event_bus)
 
-        with pytest.raises(RuntimeError, match="Failed to deliver instruction"):
-            await start_ace(conn, session_id, instruction="do work", event_bus=event_bus)
+        result = await start_ace(conn, session_id, instruction="do work", event_bus=event_bus)
+        assert result.status == "failed"
 
         # Session should be in error state
         session = await db_ops.get_session(conn, session_id)
@@ -187,16 +247,25 @@ class TestVerificationChecks:
     """Integration tests for the verification checks."""
 
     @pytest.mark.asyncio
-    @patch("atc.session.ace._pane_is_alive", new_callable=AsyncMock)
-    @patch("atc.session.ace._spawn_provider_session", new_callable=AsyncMock, return_value=("atc", "%6"))
+    @patch("atc.session.ace.RuntimeService.inspect_session_record", new_callable=AsyncMock)
+    @patch(
+        "atc.session.ace._spawn_provider_session",
+        new_callable=AsyncMock,
+        return_value=("atc", "%6"),
+    )
     async def test_verify_session_alive(
         self,
         mock_spawn_provider: AsyncMock,
-        mock_alive: AsyncMock,
+        mock_inspect: AsyncMock,
         conn,
         event_bus: EventBus,
     ) -> None:
-        mock_alive.return_value = True
+        mock_inspect.return_value = RuntimeInspection(
+            session_id="test-ace",
+            provider_name="codex",
+            alive=True,
+            readiness=ReadinessState.READY,
+        )
 
         project = await db_ops.create_project(conn, "test-project")
         session_id = await create_ace(conn, project.id, "test-ace", event_bus=event_bus)
@@ -205,7 +274,11 @@ class TestVerificationChecks:
 
     @pytest.mark.asyncio
     @patch("atc.session.ace._pane_is_alive", new_callable=AsyncMock)
-    @patch("atc.session.ace._spawn_provider_session", new_callable=AsyncMock, return_value=("atc", "%7"))
+    @patch(
+        "atc.session.ace._spawn_provider_session",
+        new_callable=AsyncMock,
+        return_value=("atc", "%7"),
+    )
     async def test_verify_session_dead_pane(
         self,
         mock_spawn_provider: AsyncMock,

--- a/tests/unit/test_leader_orchestrator.py
+++ b/tests/unit/test_leader_orchestrator.py
@@ -13,6 +13,7 @@ from atc.state.db import (
     _SCHEMA_SQL,
     create_leader,
     create_project,
+    create_session,
     create_task_graph,
     get_connection,
     get_project,
@@ -128,9 +129,12 @@ class TestSpawnAces:
         call_kwargs = mock_create.call_args
         assert call_kwargs is not None
         from atc.agents.factory import get_launch_command
+
         project = await get_project(db, orchestrator.project_id)
         assert project is not None
-        assert call_kwargs.kwargs.get("launch_command") == get_launch_command(project.agent_provider)
+        assert call_kwargs.kwargs.get("launch_command") == get_launch_command(
+            project.agent_provider
+        )
 
     async def test_skips_tasks_with_unmet_deps(
         self,
@@ -193,6 +197,49 @@ class TestSpawnAces:
 
         assignments = await orchestrator.spawn_aces_for_ready_tasks()
         assert len(assignments) == 0
+
+    async def test_skip_task_with_active_ace_session_row(
+        self,
+        mock_create: AsyncMock,
+        db,
+        orchestrator: LeaderOrchestrator,
+    ) -> None:
+        """A task may have only one active Ace, even after orchestrator reloads."""
+        tg = await create_task_graph(db, orchestrator.project_id, "Task A")
+        await create_session(
+            db,
+            orchestrator.project_id,
+            "ace",
+            "ace-task-a",
+            task_id=tg.id,
+            status="idle",
+        )
+
+        assignments = await orchestrator.spawn_aces_for_ready_tasks()
+
+        assert assignments == []
+        mock_create.assert_not_called()
+
+    async def test_allows_new_ace_when_existing_task_ace_is_terminal(
+        self,
+        mock_create: AsyncMock,
+        db,
+        orchestrator: LeaderOrchestrator,
+    ) -> None:
+        tg = await create_task_graph(db, orchestrator.project_id, "Task A")
+        await create_session(
+            db,
+            orchestrator.project_id,
+            "ace",
+            "ace-task-a-old",
+            task_id=tg.id,
+            status="error",
+        )
+
+        assignments = await orchestrator.spawn_aces_for_ready_tasks()
+
+        assert len(assignments) == 1
+        mock_create.assert_called_once()
 
     async def test_marks_task_in_progress(
         self,
@@ -396,7 +443,9 @@ class TestSpawnRetryAssignmentReuse:
         from atc.state import db as db_ops
 
         tg = await create_task_graph(db, orchestrator.project_id, "Task Retry")
-        first, created = await db_ops.assign_task(db, tg.id, "ace-old", f"{orchestrator.leader_id}:{tg.id}")
+        first, created = await db_ops.assign_task(
+            db, tg.id, "ace-old", f"{orchestrator.leader_id}:{tg.id}"
+        )
         assert created is True
         updated = await db_ops.update_task_assignment_status(db, first.assignment_id, "working")
         assert updated is not None
@@ -410,7 +459,10 @@ class TestSpawnRetryAssignmentReuse:
         with (
             patch("atc.leader.orchestrator.create_ace", new=AsyncMock(return_value="ace-new")),
             patch("atc.leader.orchestrator.get_launch_command", return_value="claude"),
-            patch("atc.leader.orchestrator.build_context_package", new=AsyncMock(return_value={"context_entries": []})),
+            patch(
+                "atc.leader.orchestrator.build_context_package",
+                new=AsyncMock(return_value={"context_entries": []}),
+            ),
         ):
             assignment = await orchestrator._spawn_ace_for_task(tg.id, tg.title, tg.description)
 
@@ -495,6 +547,7 @@ class TestMarkTaskDone:
         """
         import atc.leader.orchestrator as orch_mod
         from atc.state import db as db_ops
+
         tg = await create_task_graph(db, orchestrator.project_id, "Task A")
         # Advance through state machine so mark_task_done can mark it done
         await db_ops.update_task_graph_status(db, tg.id, "assigned")
@@ -550,11 +603,9 @@ class TestMarkTaskFailed:
         assert len(captured) == 1
         assert captured[0]["reason"] == "Test failure"
 
-
-# ---------------------------------------------------------------------------
-# get_progress
-# ---------------------------------------------------------------------------
-
+    # ---------------------------------------------------------------------------
+    # get_progress
+    # ---------------------------------------------------------------------------
 
     async def test_failed_counter_decremented_without_in_memory_assignment(
         self,
@@ -564,6 +615,7 @@ class TestMarkTaskFailed:
     ) -> None:
         """Bug #163: mark_task_failed must also decrement counter unconditionally."""
         import atc.leader.orchestrator as orch_mod
+
         tg = await create_task_graph(db, orchestrator.project_id, "Task Fail")
 
         orch_mod._GLOBAL_ACTIVE_ACES = 2

--- a/tests/unit/test_runtime_service.py
+++ b/tests/unit/test_runtime_service.py
@@ -3,12 +3,14 @@ from __future__ import annotations
 import asyncio
 from types import SimpleNamespace
 
+import atc.runtime.service as runtime_service_module
 from atc.providers.registry import register_provider_runtime
 from atc.runtime.models import (
     InstructionRequest,
     ReadinessResult,
     ReadinessState,
     RoleKind,
+    RuntimeBlockReason,
     RuntimeInspection,
     RuntimeSessionHandle,
     RuntimeTransport,
@@ -18,6 +20,10 @@ from atc.runtime.models import (
 )
 from atc.runtime.service import RuntimeService
 from atc.state.db import clear_connection_app_state, set_connection_app_state
+
+runtime_service_module._STARTUP_INITIAL_DELAY_SECONDS = 0.0
+runtime_service_module._STARTUP_RESOLVE_DELAY_SECONDS = 0.0
+runtime_service_module._STARTUP_FINAL_DELAY_SECONDS = 0.0
 
 
 class DummyProviderRuntime:
@@ -233,10 +239,102 @@ def test_runtime_service_spawn_existing_session_adds_trace_events() -> None:
     asyncio.run(service.spawn_existing_session(request))
 
     events = request.metadata["delivery_trace_events"]
-    assert [event["stage"] for event in events] == ["queued", "spawn_started", "spawned"]
+    assert [event["stage"] for event in events[:3]] == ["queued", "spawn_started", "spawned"]
     assert events[-1]["action"] == "spawn"
     assert events[-1]["verdict"] == "accepted"
-    assert events[-1]["reason_code"] == "pane_spawned"
+    assert events[-1]["reason_code"] == "session_running"
+    assert events[-1]["details"]["startup_phase"] == "final"
+
+
+def test_runtime_service_startup_handshake_traces_blocked_auth_without_auto_answer() -> None:
+    class AuthBlockedProvider(DummyProviderRuntime):
+        async def inspect_session(self, handle: RuntimeSessionHandle) -> RuntimeInspection:
+            return RuntimeInspection(
+                session_id=handle.session_id,
+                provider_name=handle.provider_name,
+                alive=True,
+                readiness=ReadinessState.BLOCKED,
+                block_reason=RuntimeBlockReason.AUTH,
+                summary="Blocked on authentication",
+            )
+
+    register_provider_runtime("dummy_runtime_auth_blocked", AuthBlockedProvider)
+    service = RuntimeService()
+    request = StartRoleRequest(
+        session_id="sess-auth-blocked-1",
+        provider_name="dummy_runtime_auth_blocked",
+        role=RoleKind.LEADER,
+    )
+
+    asyncio.run(service.spawn_existing_session(request))
+
+    events = request.metadata["delivery_trace_events"]
+    assert events[-1]["stage"] == "blocked"
+    assert events[-1]["verdict"] == "blocked"
+    assert events[-1]["reason_code"] == "auth_required"
+    assert events[-1]["details"]["startup_phase"] == "final"
+
+
+def test_runtime_service_startup_handshake_auto_resolves_trust(monkeypatch) -> None:
+    send_keys: list[tuple[str, ...]] = []
+
+    async def fake_run_tmux(*args: str) -> str:
+        send_keys.append(args)
+        return ""
+
+    class TrustThenReadyProvider(DummyProviderRuntime):
+        def __init__(self) -> None:
+            super().__init__()
+            self.inspect_count = 0
+
+        async def spawn_existing_session(self, request: StartRoleRequest) -> RuntimeSessionHandle:
+            self.spawned_existing.append(request)
+            return RuntimeSessionHandle(
+                session_id=request.session_id,
+                provider_name=request.provider_name,
+                role=request.role,
+                transport=RuntimeTransport.TMUX,
+                tmux_pane="%42",
+            )
+
+        async def inspect_session(self, handle: RuntimeSessionHandle) -> RuntimeInspection:
+            self.inspect_count += 1
+            if self.inspect_count == 1:
+                return RuntimeInspection(
+                    session_id=handle.session_id,
+                    provider_name=handle.provider_name,
+                    alive=True,
+                    readiness=ReadinessState.BLOCKED,
+                    block_reason=RuntimeBlockReason.TRUST,
+                    summary="Blocked on trust prompt",
+                )
+            return RuntimeInspection(
+                session_id=handle.session_id,
+                provider_name=handle.provider_name,
+                alive=True,
+                readiness=ReadinessState.READY,
+                summary="Ready",
+            )
+
+    monkeypatch.setattr("atc.runtime.tmux.substrate.run_tmux", fake_run_tmux)
+    register_provider_runtime("dummy_runtime_trust_then_ready", TrustThenReadyProvider)
+    service = RuntimeService()
+    request = StartRoleRequest(
+        session_id="sess-trust-1",
+        provider_name="dummy_runtime_trust_then_ready",
+        role=RoleKind.ACE,
+    )
+
+    asyncio.run(service.spawn_existing_session(request))
+
+    assert send_keys == [("send-keys", "-t", "%42", "Enter")]
+    phases = [
+        event["details"].get("startup_phase")
+        for event in request.metadata["delivery_trace_events"]
+    ]
+    assert "initial" in phases
+    assert "after_auto_resolve" in phases
+    assert "final" in phases
 
 
 def test_runtime_service_send_instruction_adds_queued_trace_event() -> None:


### PR DESCRIPTION
## Summary
- Enforce a 1:1 relationship between active Ace sessions and task graph rows.
- Skip spawning a new Ace when a non-terminal Ace already exists for that task, including after orchestrator reloads.
- Reject direct duplicate Ace creation for the same active task.
- Add a common post-spawn startup handshake in `RuntimeService` for Tower, Leader, and Ace sessions before role instructions are sent.
- The handshake sleeps briefly, inspects readiness, auto-resolves known trust prompts by pressing Enter, sleeps/re-inspects, and records startup inspection trace events for trust/auth/permission blockers.

## Validation
- `pytest -q tests/unit/test_runtime_service.py tests/unit/test_leader_orchestrator.py tests/integration/test_creation_reliability.py` → `58 passed, 1 warning`
- `ruff check src/atc/runtime/service.py src/atc/session/ace.py src/atc/leader/orchestrator.py tests/unit/test_runtime_service.py tests/integration/test_creation_reliability.py tests/unit/test_leader_orchestrator.py` → passed
- UI smoke fixture confirmed 1:1 task/Ace counts:
  - 4 tasks
  - 4 Aces
  - 1 shell resize handle
  - 0 ProjectView nested resize handles

## Notes
This is a follow-up to the merged Project layout PR #273. It addresses the feedback that the previous evidence used 4 tasks and 6 Aces, and that new sessions appeared stuck at startup prompts.