### PR TITLE
Filter Project Aces panel to Ace sessions

### DIFF
--- a/frontend/src/pages/ProjectView.tsx
+++ b/frontend/src/pages/ProjectView.tsx
@@ -7,7 +7,14 @@ import TaskBoard from "../components/leader/TaskBoard";
 import AceList from "../components/ace/AceList";
 import AceConsole from "../components/ace/AceConsole";
 import ContextHub from "../components/context/ContextHub";
+import type { Session } from "../types";
 import "./ProjectView.css";
+
+export function getProjectAceSessions(sessions: Session[], projectId?: string) {
+  return sessions.filter(
+    (s) => s.project_id === projectId && s.session_type === "ace",
+  );
+}
 
 export default function ProjectView() {
   const { id } = useParams<{ id: string }>();
@@ -15,7 +22,7 @@ export default function ProjectView() {
   const { projects, sessions, leaders, taskGraphs } = state;
 
   const project = projects.find((p) => p.id === id);
-  const projectSessions = sessions.filter((s) => s.project_id === id);
+  const projectAceSessions = getProjectAceSessions(sessions, id);
   const leader = id ? leaders[id] : undefined;
   const projectTaskGraphs = id ? (taskGraphs[id] ?? []) : [];
 
@@ -25,7 +32,7 @@ export default function ProjectView() {
   // If the expanded Ace was removed, collapse back to list
   const expandedAceExists =
     expandedAceId !== null &&
-    projectSessions.some((s) => s.id === expandedAceId);
+    projectAceSessions.some((s) => s.id === expandedAceId);
   const activeAceId = expandedAceExists ? expandedAceId : null;
 
   if (!project) {
@@ -74,7 +81,7 @@ export default function ProjectView() {
             {activeAceId ? (
               <AceConsole
                 projectId={project.id}
-                sessions={projectSessions}
+                sessions={projectAceSessions}
                 activeAceId={activeAceId}
                 onRefresh={fetchAll}
                 onSelectAce={(sid) => setExpandedAceId(sid)}
@@ -83,7 +90,7 @@ export default function ProjectView() {
             ) : (
               <AceList
                 projectId={project.id}
-                sessions={projectSessions}
+                sessions={projectAceSessions}
                 onRefresh={fetchAll}
                 onExpand={(sid) => setExpandedAceId(sid)}
                 compact

--- a/frontend/src/pages/__tests__/ProjectView.test.tsx
+++ b/frontend/src/pages/__tests__/ProjectView.test.tsx
@@ -4,7 +4,8 @@ import { MemoryRouter, Route, Routes } from "react-router-dom";
 import { render } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { AppProvider } from "../../context/AppContext";
-import ProjectView from "../ProjectView";
+import ProjectView, { getProjectAceSessions } from "../ProjectView";
+import type { Session } from "../../types";
 
 // Mock WebSocket
 class MockWebSocket {
@@ -41,6 +42,25 @@ function renderProjectView(projectId = "test-id") {
   );
 }
 
+function session(overrides: Partial<Session>): Session {
+  return {
+    id: "session-id",
+    project_id: "test-id",
+    session_type: "ace",
+    name: "Ace",
+    status: "idle",
+    task_id: null,
+    host: null,
+    tmux_session: null,
+    tmux_pane: null,
+    alternate_on: false,
+    auto_accept: false,
+    created_at: "2026-06-08T00:00:00Z",
+    updated_at: "2026-06-08T00:00:00Z",
+    ...overrides,
+  };
+}
+
 describe("ProjectView", () => {
   it("renders the project view", () => {
     renderProjectView();
@@ -63,5 +83,20 @@ describe("ProjectView", () => {
     renderProjectView();
     // The task board renders even with empty tasks
     expect(screen.getByTestId("project-view")).toBeInTheDocument();
+  });
+
+  it("passes only Ace sessions to the Project Aces panel", () => {
+    const visible = getProjectAceSessions(
+      [
+        session({ id: "tower", name: "tower-codex", session_type: "tower" }),
+        session({ id: "leader", name: "leader", session_type: "manager" }),
+        session({ id: "ace", name: "Scaffold Ace", session_type: "ace" }),
+        session({ id: "other", project_id: "other-project", session_type: "ace" }),
+      ],
+      "test-id",
+    );
+
+    expect(visible).toHaveLength(1);
+    expect(visible[0]?.name).toBe("Scaffold Ace");
   });
 });


### PR DESCRIPTION
## Summary
- Fix the Project Aces panel to pass only `session_type === "ace"` sessions into `AceList` / `AceConsole`.
- Prevent Tower/manager sessions that enter global app state via WebSocket/state updates from rendering as Ace cards.
- Add a regression test for mixed project sessions.

## Validation
- `cd frontend && PATH="/opt/homebrew/bin:/usr/local/bin:$PATH" npm test -- --run src/pages/__tests__/ProjectView.test.tsx` → 5 tests passed
- `cd frontend && PATH="/opt/homebrew/bin:/usr/local/bin:$PATH" npm run build` → passed with existing Vite chunk-size warning
