### PR TITLE
Hide Tower panel on Context and Usage pages

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,12 +1,25 @@
 import { useCallback, useEffect, useRef, useState } from "react";
-import { BrowserRouter, Routes, Route, Navigate, Outlet, useLocation } from "react-router-dom";
+import {
+  BrowserRouter,
+  Routes,
+  Route,
+  Navigate,
+  Outlet,
+  useLocation,
+} from "react-router-dom";
 import { AppProvider, useAppContext } from "./context/AppContext";
 import ResizeHandle from "./components/common/ResizeHandle";
 import TowerBar from "./components/tower/TowerBar";
 import TowerPanel from "./components/tower/TowerPanel";
 import UpdateBanner from "./components/common/UpdateBanner";
 import { useUpdater } from "./hooks/useUpdater";
-import { clampTowerWidth, isSideTowerRoute, readStoredTowerWidth, SIDE_TOWER_WIDTH_KEY } from "./layout/towerSplit";
+import {
+  clampTowerWidth,
+  isSideTowerRoute,
+  readStoredTowerWidth,
+  shouldShowTowerPanel,
+  SIDE_TOWER_WIDTH_KEY,
+} from "./layout/towerSplit";
 import Dashboard from "./pages/Dashboard";
 import ProjectView from "./pages/ProjectView";
 import UsagePage from "./pages/UsagePage";
@@ -25,7 +38,17 @@ function StartupGate({ children }: { children: React.ReactNode }) {
 
   if (backendError) {
     return (
-      <div style={{ display: "flex", flexDirection: "column", alignItems: "center", justifyContent: "center", height: "100vh", gap: 12, color: "#ef4444" }}>
+      <div
+        style={{
+          display: "flex",
+          flexDirection: "column",
+          alignItems: "center",
+          justifyContent: "center",
+          height: "100vh",
+          gap: 12,
+          color: "#ef4444",
+        }}
+      >
         <span style={{ fontSize: 16 }}>Failed to connect to ATC backend</span>
         <span style={{ fontSize: 13, color: "#9ca3af" }}>{backendError}</span>
       </div>
@@ -33,7 +56,17 @@ function StartupGate({ children }: { children: React.ReactNode }) {
   }
 
   return (
-    <div style={{ display: "flex", flexDirection: "column", alignItems: "center", justifyContent: "center", height: "100vh", gap: 12, color: "#9ca3af" }}>
+    <div
+      style={{
+        display: "flex",
+        flexDirection: "column",
+        alignItems: "center",
+        justifyContent: "center",
+        height: "100vh",
+        gap: 12,
+        color: "#9ca3af",
+      }}
+    >
       <span style={{ fontSize: 16 }}>Starting ATC...</span>
     </div>
   );
@@ -42,6 +75,7 @@ function StartupGate({ children }: { children: React.ReactNode }) {
 function Layout() {
   const updater = useUpdater();
   const location = useLocation();
+  const showTower = shouldShowTowerPanel(location.pathname);
   const showSideTower = isSideTowerRoute(location.pathname);
   const shellBodyRef = useRef<HTMLDivElement>(null);
   const [towerWidth, setTowerWidth] = useState(readStoredTowerWidth);
@@ -56,7 +90,8 @@ function Layout() {
     }
 
     const syncWidth = () => {
-      const containerWidth = shellBodyRef.current?.offsetWidth ?? window.innerWidth;
+      const containerWidth =
+        shellBodyRef.current?.offsetWidth ?? window.innerWidth;
       setTowerWidth((current) => clampTowerWidth(current, containerWidth));
     };
 
@@ -72,7 +107,8 @@ function Layout() {
       const startWidth = towerWidth;
 
       const onMove = (ev: MouseEvent) => {
-        const containerWidth = shellBodyRef.current?.offsetWidth ?? window.innerWidth;
+        const containerWidth =
+          shellBodyRef.current?.offsetWidth ?? window.innerWidth;
         const delta = startX - ev.clientX;
         setTowerWidth(clampTowerWidth(startWidth + delta, containerWidth));
       };
@@ -104,15 +140,23 @@ function Layout() {
       <div
         ref={shellBodyRef}
         className={`app-shell__body${showSideTower ? " app-shell__body--side-tower" : ""}`}
-        style={showSideTower ? { ["--tower-width" as string]: `${towerWidth}px` } : undefined}
+        style={
+          showSideTower
+            ? { ["--tower-width" as string]: `${towerWidth}px` }
+            : undefined
+        }
       >
         <main className="app-shell__main">
           <Outlet context={updater} />
         </main>
-        {showSideTower && <ResizeHandle direction="col" onMouseDown={handleTowerResize} />}
-        <div className="app-shell__tower">
-          <TowerPanel orientation={showSideTower ? "side" : "bottom"} />
-        </div>
+        {showSideTower && (
+          <ResizeHandle direction="col" onMouseDown={handleTowerResize} />
+        )}
+        {showTower && (
+          <div className="app-shell__tower">
+            <TowerPanel orientation={showSideTower ? "side" : "bottom"} />
+          </div>
+        )}
       </div>
     </div>
   );

--- a/frontend/src/layout/towerSplit.test.ts
+++ b/frontend/src/layout/towerSplit.test.ts
@@ -1,11 +1,24 @@
 import { describe, expect, it } from "vitest";
-import { clampTowerWidth, isSideTowerRoute, SIDE_TOWER_DEFAULT_WIDTH, SIDE_TOWER_MIN_WIDTH } from "./towerSplit";
+import {
+  clampTowerWidth,
+  isSideTowerRoute,
+  shouldShowTowerPanel,
+  SIDE_TOWER_DEFAULT_WIDTH,
+  SIDE_TOWER_MIN_WIDTH,
+} from "./towerSplit";
 
 describe("towerSplit", () => {
   it("matches the shell routes that should show the side tower", () => {
     expect(isSideTowerRoute("/dashboard")).toBe(true);
     expect(isSideTowerRoute("/projects/abc")).toBe(true);
     expect(isSideTowerRoute("/usage")).toBe(false);
+  });
+
+  it("hides the tower panel on utility pages", () => {
+    expect(shouldShowTowerPanel("/dashboard")).toBe(true);
+    expect(shouldShowTowerPanel("/projects/abc")).toBe(true);
+    expect(shouldShowTowerPanel("/usage")).toBe(false);
+    expect(shouldShowTowerPanel("/context")).toBe(false);
   });
 
   it("clamps the width to the minimum", () => {
@@ -18,6 +31,8 @@ describe("towerSplit", () => {
   });
 
   it("keeps widths already inside the allowed range", () => {
-    expect(clampTowerWidth(SIDE_TOWER_DEFAULT_WIDTH, 1400)).toBe(SIDE_TOWER_DEFAULT_WIDTH);
+    expect(clampTowerWidth(SIDE_TOWER_DEFAULT_WIDTH, 1400)).toBe(
+      SIDE_TOWER_DEFAULT_WIDTH,
+    );
   });
 });

--- a/frontend/src/layout/towerSplit.ts
+++ b/frontend/src/layout/towerSplit.ts
@@ -3,8 +3,12 @@ export const SIDE_TOWER_MIN_WIDTH = 320;
 export const SIDE_TOWER_MAX_RATIO = 0.55;
 export const SIDE_TOWER_DEFAULT_WIDTH = 520;
 
-export function isSideTowerRoute(pathname: string) {
+export function shouldShowTowerPanel(pathname: string) {
   return pathname === "/dashboard" || pathname.startsWith("/projects/");
+}
+
+export function isSideTowerRoute(pathname: string) {
+  return shouldShowTowerPanel(pathname);
 }
 
 export function readStoredTowerWidth() {


### PR DESCRIPTION
## Summary
- Hide the Tower/brain panel entirely on `/context` and `/usage` routes.
- Keep Tower visible on Dashboard and Project pages where it is part of the operator workflow.
- Add route utility coverage so Context and Usage stay utility pages without the Tower panel.

## Validation
- `cd frontend && PATH="/opt/homebrew/bin:/usr/local/bin:$PATH" npm test -- --run src/layout/towerSplit.test.ts` → 5 tests passed
- `cd frontend && PATH="/opt/homebrew/bin:/usr/local/bin:$PATH" npm run build` → passed with existing Vite chunk-size warning

Note: broader pre-existing tests for UsagePage/ContextHub have stale text expectations and React `act(...)` warnings unrelated to this route-shell change.
