### PR TITLE
Ensure Leader receives Tower goal context

### DIFF
--- a/src/atc/api/routers/context.py
+++ b/src/atc/api/routers/context.py
@@ -289,9 +289,27 @@ async def list_session_context(
     if effective_scope not in _VALID_SCOPES:
         raise HTTPException(status_code=422, detail=f"Invalid scope: {effective_scope}")
 
-    entries = await db_ops.list_context_entries_by_scope(
-        db, effective_scope, session_id=session_id,
-    )
+    if scope is None:
+        # Default helper behavior should mirror what the agent can actually
+        # see: Leaders inherit global + project context plus their own session
+        # entries; Aces inherit global + project + parent Leader + own entries.
+        # Project-level goal entries shown in the UI must therefore be visible
+        # from deployed context_read.sh scripts too.
+        parent_session_id = None
+        if effective_scope == "ace":
+            leader = await db_ops.get_leader_by_project(db, session.project_id)
+            parent_session_id = leader.session_id if leader else None
+        entries = await db_ops.get_context_for_agent(
+            db,
+            effective_scope,
+            project_id=session.project_id,
+            session_id=session_id,
+            parent_session_id=parent_session_id,
+        )
+    else:
+        entries = await db_ops.list_context_entries_by_scope(
+            db, effective_scope, session_id=session_id,
+        )
     if restricted is not None:
         entries = [e for e in entries if e.restricted is restricted]
     if key is not None:

--- a/src/atc/leader/leader.py
+++ b/src/atc/leader/leader.py
@@ -49,6 +49,7 @@ def _build_manager_deploy_spec(
     goal: str,
     *,
     project_id: str | None = None,
+    session_id: str | None = None,
     repo_path: str | None = None,
     github_repo: str | None = None,
     context_entries: list[dict[str, Any]] | None = None,
@@ -60,6 +61,7 @@ def _build_manager_deploy_spec(
         project_name=project_name,
         goal=goal,
         project_id=project_id,
+        session_id=session_id,
         repo_path=repo_path,
         github_repo=github_repo,
         context_entries=context_entries or [],
@@ -164,13 +166,12 @@ async def start_leader(
             project_name=ctx.get("project_name") or (project.name if project else ""),
             goal=goal or leader.goal or "",
             project_id=project_id,
+            session_id=session.id,
             repo_path=ctx.get("repo_path") or (project.repo_path if project else None),
             github_repo=ctx.get("github_repo") or (project.github_repo if project else None),
             context_entries=ctx.get("context_entries"),
             api_base_url=_api_url,
         )
-        # Pass the real session_id so hooks reference the correct ID
-        spec.session_id = session.id
         deployed = deploy_manager_files(spec)
         logger.info(
             "Deployed manager config for leader %s (session %s) → %s",

--- a/tests/unit/test_context_api.py
+++ b/tests/unit/test_context_api.py
@@ -9,13 +9,13 @@ import pytest
 from atc.state.db import (
     _SCHEMA_SQL,
     create_context_entry,
+    create_leader,
     create_project,
     create_session,
     get_connection,
     get_context_entry,
     run_migrations,
 )
-
 
 # ---------------------------------------------------------------------------
 # Fixtures
@@ -425,7 +425,6 @@ async def http_db():
 @pytest.fixture
 def http_app(http_db):
     """FastAPI app with db wired into state."""
-    from unittest.mock import MagicMock
 
     from fastapi import FastAPI
 
@@ -708,6 +707,27 @@ class TestHTTPSessionEndpoints:
         assert resp.status_code == 200
         assert len(resp.json()) == 1
         assert resp.json()[0]["scope"] == "leader"
+
+    async def test_leader_session_context_inherits_project_goal(self, client, http_db) -> None:
+        project = await create_project(http_db, "portfolio")
+        session = await create_session(http_db, project.id, "manager", "leader-1")
+        await create_leader(http_db, project.id, goal="Build a profile page portfolio")
+        await create_context_entry(
+            http_db,
+            "project",
+            "goal",
+            "text",
+            "Build a profile page portfolio",
+            project_id=project.id,
+            updated_by="tower",
+        )
+
+        resp = await client.get(f"/api/sessions/{session.id}/context")
+
+        assert resp.status_code == 200
+        keys = {entry["key"]: entry for entry in resp.json()}
+        assert keys["goal"]["scope"] == "project"
+        assert keys["goal"]["value"] == "Build a profile page portfolio"
 
     async def test_filter_session_by_restricted(self, client, http_db) -> None:
         project = await create_project(http_db, "test-proj")

--- a/tests/unit/test_e2e_wiring.py
+++ b/tests/unit/test_e2e_wiring.py
@@ -57,11 +57,15 @@ class TestBuildManagerDeploySpec:
             leader_id="leader-1",
             project_name="Phoenix",
             goal="Ship the MVP",
+            project_id="project-1",
+            session_id="session-1",
             repo_path="/home/user/phoenix",
             github_repo="acme/phoenix",
         )
         assert isinstance(spec, ManagerDeploySpec)
         assert spec.leader_id == "leader-1"
+        assert spec.project_id == "project-1"
+        assert spec.session_id == "session-1"
         assert spec.project_name == "Phoenix"
         assert spec.goal == "Ship the MVP"
         assert spec.repo_path == "/home/user/phoenix"
@@ -135,6 +139,8 @@ class TestTowerToLeaderWiring:
         assert isinstance(spec, ManagerDeploySpec)
         assert spec.goal == "Build feature X"
         assert spec.project_name == "test-proj"
+        assert spec.session_id is not None
+        assert spec.session_id != spec.leader_id
 
     @patch("atc.leader.leader._spawn_provider_session", new_callable=AsyncMock, return_value=("atc", "%1"))
     @patch("atc.leader.leader.deploy_manager_files")


### PR DESCRIPTION
## Summary
- Pass the runtime Leader session ID into `ManagerDeploySpec` before writing Leader `CLAUDE.md` / `AGENTS.md`, so deployed instructions and helper scripts are generated from one consistent spec at spawn time.
- Make `/api/sessions/{session_id}/context` default to the same inherited context visibility as the agent runtime instead of only session-scoped rows.
  - Leader helper reads now include project context such as the Tower-seeded `goal` entry.
  - Explicit `?scope=` filters still return only that scope.
- Add regression coverage for Leader project-goal context inheritance and Leader deploy spec session IDs.

## Validation
- `pytest -q tests/unit/test_context_api.py::TestHTTPSessionEndpoints::test_leader_session_context_inherits_project_goal tests/unit/test_e2e_wiring.py::TestBuildManagerDeploySpec::test_basic_spec tests/unit/test_e2e_wiring.py::TestTowerToLeaderWiring::test_start_leader_deploys_config tests/unit/test_deploy.py::TestContextHookScripts::test_manager_context_scripts_use_session_id tests/unit/test_tower_respawn.py`
  - `10 passed`
- `ruff check src/atc/leader/leader.py src/atc/api/routers/context.py`
  - passed
- `ruff check --select I,F401 tests/unit/test_context_api.py tests/unit/test_e2e_wiring.py`
  - passed

## Smoke evidence
Ran a disposable Tower→Leader handoff with provider spawning and delivery mocked, using goal:
`Build a profile page portfolio website populated with realistic mock data.`

Observed:
- Leader `CLAUDE.md` contains the goal.
- Leader `CLAUDE.md` contains the runtime session ID used by reporting/hooks.
- Leader inherited context includes `goal` and `project_description`.
- The captured kickoff message includes the full goal under `## Goal`.
