### PR TITLE
Make role instruction files provider neutral

### DIFF
--- a/src/atc/agents/base.py
+++ b/src/atc/agents/base.py
@@ -11,11 +11,11 @@ import enum
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
 
-from atc.state.models import Project, Session
-
 if TYPE_CHECKING:
     from collections.abc import AsyncIterator
     from pathlib import Path
+
+    from atc.state.models import Project, Session
 
 
 class SessionStatus(enum.Enum):
@@ -129,7 +129,7 @@ class AgentProvider(Protocol):
             session_id: Unique identifier for this session.
             working_dir: Working directory for the agent process.
             env: Extra environment variables to pass.
-            context_file: Optional path to a CLAUDE.md to copy into working_dir.
+            context_file: Optional path to role instructions to copy into working_dir.
             role: Role hint for the session (``tower``, ``leader``, or ``ace``).
 
         Returns:
@@ -152,8 +152,8 @@ class AgentProvider(Protocol):
         Args:
             session_id: Unique identifier for the session being prepared.
             working_dir: Directory to create if it does not exist.
-            context_file: Optional CLAUDE.md to copy into working_dir.
-                Skipped if working_dir/CLAUDE.md already exists.
+            context_file: Optional role instructions to copy into working_dir.
+                Providers may write AGENTS.md plus compatibility filenames.
         """
         ...
 

--- a/src/atc/agents/claude_provider.py
+++ b/src/atc/agents/claude_provider.py
@@ -27,7 +27,11 @@ from atc.agents.base import (
 )
 from atc.agents.claude_runtime import (
     accept_startup_dialogs,
+)
+from atc.agents.claude_runtime import (
     send_instruction as claude_send_instruction,
+)
+from atc.agents.claude_runtime import (
     wait_for_prompt as claude_wait_for_prompt,
 )
 from atc.terminal.control import send_instruction_async
@@ -254,34 +258,34 @@ class ClaudeCodeProvider:
         working_dir: str,
         context_file: Path | None = None,
     ) -> None:
-        """Create working_dir and optionally copy context_file to CLAUDE.md.
+        """Create working_dir and optionally copy role instructions.
 
-        Skips the copy if working_dir/CLAUDE.md already exists so we never
-        overwrite a file deployed by AceDeploySpec / ManagerDeploySpec.
+        Writes provider-neutral AGENTS.md plus CLAUDE.md for Claude Code
+        compatibility. Existing files are preserved so we never overwrite files
+        deployed by AceDeploySpec / ManagerDeploySpec.
         """
         import os as _os
 
         _os.makedirs(working_dir, exist_ok=True)
-        logger.debug(
-            "prepare_workspace: ensured %s exists (session %s)", working_dir, session_id
-        )
+        logger.debug("prepare_workspace: ensured %s exists (session %s)", working_dir, session_id)
 
         if context_file is not None:
-            dest = Path(working_dir) / "CLAUDE.md"
-            if not dest.exists():
-                shutil.copy2(str(context_file), str(dest))
-                logger.info(
-                    "prepare_workspace: copied %s → %s (session %s)",
-                    context_file,
-                    dest,
-                    session_id,
-                )
-            else:
-                logger.debug(
-                    "prepare_workspace: %s already exists, skipping copy (session %s)",
-                    dest,
-                    session_id,
-                )
+            for filename in ("AGENTS.md", "CLAUDE.md"):
+                dest = Path(working_dir) / filename
+                if not dest.exists():
+                    shutil.copy2(str(context_file), str(dest))
+                    logger.info(
+                        "prepare_workspace: copied %s → %s (session %s)",
+                        context_file,
+                        dest,
+                        session_id,
+                    )
+                else:
+                    logger.debug(
+                        "prepare_workspace: %s already exists, skipping copy (session %s)",
+                        dest,
+                        session_id,
+                    )
 
     async def is_ready(self, session_id: str) -> bool:
         """Return True when the session's tmux pane shows an idle Claude prompt."""

--- a/src/atc/agents/codex_provider.py
+++ b/src/atc/agents/codex_provider.py
@@ -72,13 +72,24 @@ class CodexProvider:
         self._check_tmux_available()
 
         if working_dir:
-            await self.prepare_workspace(session_id, working_dir=working_dir, context_file=context_file)
+            await self.prepare_workspace(
+                session_id, working_dir=working_dir, context_file=context_file
+            )
 
         from atc.session.ace import _ensure_tmux_session
 
         await _ensure_tmux_session(self._tmux_session)
 
-        tmux_args = [_TMUX_CMD, "new-window", "-t", self._tmux_session, "-d", "-P", "-F", "#{pane_id}"]
+        tmux_args = [
+            _TMUX_CMD,
+            "new-window",
+            "-t",
+            self._tmux_session,
+            "-d",
+            "-P",
+            "-F",
+            "#{pane_id}",
+        ]
         if working_dir:
             tmux_args.extend(["-c", working_dir])
         tmux_args.append(self._codex_command)
@@ -114,10 +125,16 @@ class CodexProvider:
 
         _os.makedirs(working_dir, exist_ok=True)
         if context_file is not None:
-            dest = Path(working_dir) / "CLAUDE.md"
-            if not dest.exists():
-                shutil.copy2(str(context_file), str(dest))
-                logger.info("prepare_workspace: copied %s → %s (session %s)", context_file, dest, session_id)
+            for filename in ("AGENTS.md", "CLAUDE.md"):
+                dest = Path(working_dir) / filename
+                if not dest.exists():
+                    shutil.copy2(str(context_file), str(dest))
+                    logger.info(
+                        "prepare_workspace: copied %s → %s (session %s)",
+                        context_file,
+                        dest,
+                        session_id,
+                    )
 
     async def is_ready(self, session_id: str) -> bool:
         tracked = self._sessions.get(session_id)
@@ -166,8 +183,12 @@ class CodexProvider:
         tracked = self._get_tracked(session_id)
         try:
             proc = await asyncio.create_subprocess_exec(
-                _TMUX_CMD, "kill-pane", "-t", tracked.pane_id,
-                stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.PIPE,
+                _TMUX_CMD,
+                "kill-pane",
+                "-t",
+                tracked.pane_id,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
             )
             await proc.communicate()
         except OSError as exc:
@@ -181,7 +202,8 @@ class CodexProvider:
     async def _tmux_query(self, *args: str) -> str:
         try:
             proc = await asyncio.create_subprocess_exec(
-                _TMUX_CMD, *args,
+                _TMUX_CMD,
+                *args,
                 stdout=asyncio.subprocess.PIPE,
                 stderr=asyncio.subprocess.PIPE,
             )

--- a/src/atc/agents/deploy.py
+++ b/src/atc/agents/deploy.py
@@ -1,7 +1,8 @@
 """Agent deployment SOT — single source of truth for all agent configuration files.
 
-Writes CLAUDE.md, .claude/settings.json, and hook scripts into a staging
-directory (typically /tmp/{session_id}/) before launching an Ace or Manager.
+Writes provider-neutral AGENTS.md instructions, Claude-compatible CLAUDE.md,
+.claude/settings.json, and hook scripts into a staging directory (typically
+/tmp/{session_id}/) before launching an Ace or Manager.
 Hook scripts report status back to the ATC API via the ``atc`` CLI.
 """
 
@@ -55,12 +56,18 @@ class DeployedFiles:
     files: list[str]
 
     @property
-    def claude_md_path(self) -> Path:
-        return self.root / "CLAUDE.md"
-
-    @property
     def agents_md_path(self) -> Path:
         return self.root / "AGENTS.md"
+
+    @property
+    def instructions_md_path(self) -> Path:
+        """Provider-neutral ATC role instructions."""
+        return self.agents_md_path
+
+    @property
+    def claude_md_path(self) -> Path:
+        """Claude Code compatibility copy of the provider-neutral instructions."""
+        return self.root / "CLAUDE.md"
 
     @property
     def settings_path(self) -> Path:
@@ -69,6 +76,14 @@ class DeployedFiles:
     @property
     def manifest_path(self) -> Path:
         return self.root / ".manifest.json"
+
+
+def _write_instruction_files(root: Path, content: str) -> list[str]:
+    """Write provider-neutral instructions plus provider compatibility copies."""
+    return [
+        _write_file(root / "AGENTS.md", content),
+        _write_file(root / "CLAUDE.md", content),
+    ]
 
 
 @dataclass(frozen=True)
@@ -142,7 +157,7 @@ def deploy_ace_files(
     *,
     staging_root: Path | None = None,
 ) -> DeployedFiles:
-    """Write CLAUDE.md, .claude/settings.json, and hooks for an Ace session.
+    """Write role instructions, .claude/settings.json, and hooks for an Ace session.
 
     Args:
         spec: Deployment specification for the Ace.
@@ -165,10 +180,9 @@ def deploy_ace_files(
     # Code skips the "Do you trust this project?" dialog.
     _write_user_trust_settings(root)
 
-    # CLAUDE.md
-    claude_md = _build_ace_claude_md(spec)
-    written.append(_write_file(root / "CLAUDE.md", claude_md))
-    written.append(_write_file(root / "AGENTS.md", claude_md))
+    # Role instructions: AGENTS.md is provider-neutral; CLAUDE.md is a compatibility copy.
+    instructions_md = _build_ace_instructions_md(spec)
+    written.extend(_write_instruction_files(root, instructions_md))
 
     # .claude/settings.json
     settings = _build_settings(
@@ -199,7 +213,7 @@ def deploy_manager_files(
     *,
     staging_root: Path | None = None,
 ) -> DeployedFiles:
-    """Write CLAUDE.md, .claude/settings.json, and hooks for a Manager/Leader session.
+    """Write role instructions, .claude/settings.json, and hooks for a Manager/Leader session.
 
     Args:
         spec: Deployment specification for the Manager.
@@ -222,10 +236,9 @@ def deploy_manager_files(
     # Code skips the "Do you trust this project?" dialog.
     _write_user_trust_settings(root)
 
-    # CLAUDE.md
-    claude_md = _build_manager_claude_md(spec)
-    written.append(_write_file(root / "CLAUDE.md", claude_md))
-    written.append(_write_file(root / "AGENTS.md", claude_md))
+    # Role instructions: AGENTS.md is provider-neutral; CLAUDE.md is a compatibility copy.
+    instructions_md = _build_manager_instructions_md(spec)
+    written.extend(_write_instruction_files(root, instructions_md))
 
     # .claude/settings.json
     # Leaders must NOT create or edit files — that's the Ace's job.
@@ -263,7 +276,7 @@ def deploy_tower_files(
     *,
     staging_root: Path | None = None,
 ) -> DeployedFiles:
-    """Write CLAUDE.md, .claude/settings.json, and hooks for a Tower session.
+    """Write role instructions, .claude/settings.json, and hooks for a Tower session.
 
     Args:
         spec: Deployment specification for the Tower.
@@ -286,10 +299,9 @@ def deploy_tower_files(
     # Code skips the "Do you trust this project?" dialog.
     _write_user_trust_settings(root)
 
-    # CLAUDE.md
-    claude_md = _build_tower_claude_md(spec)
-    written.append(_write_file(root / "CLAUDE.md", claude_md))
-    written.append(_write_file(root / "AGENTS.md", claude_md))
+    # Role instructions: AGENTS.md is provider-neutral; CLAUDE.md is a compatibility copy.
+    instructions_md = _build_tower_instructions_md(spec)
+    written.extend(_write_instruction_files(root, instructions_md))
 
     # .claude/settings.json
     settings = _build_settings(
@@ -344,12 +356,12 @@ def cleanup_deployed_files(root: Path) -> None:
 
 
 # ---------------------------------------------------------------------------
-# CLAUDE.md builders
+# Instruction Markdown builders
 # ---------------------------------------------------------------------------
 
 
-def _build_ace_claude_md(spec: AceDeploySpec) -> str:
-    """Build the CLAUDE.md content for an Ace session."""
+def _build_ace_instructions_md(spec: AceDeploySpec) -> str:
+    """Build the provider-neutral instruction content for an Ace session."""
     lines = [
         f"# {spec.project_name} — Ace Session",
         "",
@@ -440,8 +452,8 @@ def _build_ace_claude_md(spec: AceDeploySpec) -> str:
     return "\n".join(lines)
 
 
-def _build_manager_claude_md(spec: ManagerDeploySpec) -> str:
-    """Build the CLAUDE.md content for a Manager/Leader session."""
+def _build_manager_instructions_md(spec: ManagerDeploySpec) -> str:
+    """Build the provider-neutral instruction content for a Manager/Leader session."""
     lines = [
         f"# {spec.project_name} — Leader Session",
         "",
@@ -611,8 +623,8 @@ def _build_manager_claude_md(spec: ManagerDeploySpec) -> str:
     return "\n".join(lines)
 
 
-def _build_tower_claude_md(spec: TowerDeploySpec) -> str:
-    """Build the CLAUDE.md content for a Tower session."""
+def _build_tower_instructions_md(spec: TowerDeploySpec) -> str:
+    """Build the provider-neutral instruction content for a Tower session."""
     lines = [
         f"# {spec.project_name} — Tower Session",
         "",
@@ -647,7 +659,7 @@ def _build_tower_claude_md(spec: TowerDeploySpec) -> str:
         "5. If leader fails 3 times: report to user with a summary and ask how to proceed",
         "",
         "**CRITICAL — NEVER paste context, goals, or project details into the Leader terminal.**",
-        "Leader already has everything it needs in its CLAUDE.md. Only send short nudges.",
+        "Leader already has everything it needs in its role instructions. Only send short nudges.",
         "Wrong: `atc leader message ... --message 'Build a web app that does X. '",
         "       `'Requirements: ...'`",
         "Right: `atc leader message ... --message 'Please continue with your goal.'`",
@@ -775,7 +787,7 @@ def _build_settings(
 
 
 def _context_cli_instructions(hooks_dir: str) -> list[str]:
-    """Return CLAUDE.md lines explaining the context read/write scripts."""
+    """Return instruction lines explaining the context read/write scripts."""
     return [
         "## Context Read/Write",
         "",

--- a/src/atc/cli/ace.py
+++ b/src/atc/cli/ace.py
@@ -1,6 +1,6 @@
 """``atc ace`` subcommands — status reporting from Ace and Manager sessions.
 
-These commands are called by agents (via CLAUDE.md instructions) and by hook
+These commands are called by agents (via role instructions) and by hook
 scripts (PostToolUse, Stop) to report session status back to the ATC API.
 """
 

--- a/src/atc/leader/leader.py
+++ b/src/atc/leader/leader.py
@@ -180,25 +180,31 @@ async def start_leader(
             deployed.root,
         )
 
-        # Copy CLAUDE.md (and .claude/) from staging dir into repo_path so that
-        # Claude Code picks up the leader instructions when starting in the repo.
+        # Copy provider-neutral instructions (and provider compatibility files)
+        # into repo_path so the selected CLI agent picks up the leader role.
         if spec.repo_path and Path(spec.repo_path) != deployed.root:
             import shutil as _shutil
 
             dest = Path(spec.repo_path)
             dest.mkdir(parents=True, exist_ok=True)
-            claude_md_src = deployed.root / "CLAUDE.md"
-            if claude_md_src.exists():
-                _shutil.copy2(claude_md_src, dest / "CLAUDE.md")
-                logger.info("Copied leader CLAUDE.md to repo_path: %s", dest)
-            else:
-                logger.warning("CLAUDE.md not found at %s, skipping copy", deployed.root)
+            for instructions_src in (deployed.agents_md_path, deployed.claude_md_path):
+                if instructions_src.exists():
+                    _shutil.copy2(instructions_src, dest / instructions_src.name)
+                    logger.info(
+                        "Copied leader instructions %s to repo_path: %s",
+                        instructions_src.name,
+                        dest,
+                    )
+                else:
+                    logger.warning(
+                        "%s not found at %s, skipping copy", instructions_src.name, deployed.root
+                    )
             claude_src = deployed.root / ".claude"
             if claude_src.exists():
                 _shutil.copytree(claude_src, dest / ".claude", dirs_exist_ok=True)
 
         # Use repo_path if available so Claude Code starts in the actual repo;
-        # fall back to staging dir so it finds the deployed CLAUDE.md and hooks.
+        # fall back to staging dir so it finds the deployed instructions and hooks.
         # Ensure the directory exists — tmux silently falls back to $HOME if the
         # working_dir does not exist, causing Claude Code to start in the wrong place.
         if spec.repo_path:
@@ -213,7 +219,7 @@ async def start_leader(
             from atc.runtime.models import RoleKind, StartRoleRequest
             from atc.runtime.service import RuntimeService
 
-            _cmp = deployed.claude_md_path
+            _cmp = deployed.instructions_md_path
             _ctx = str(_cmp) if _cmp.exists() else None
             await RuntimeService().prepare_workspace(
                 StartRoleRequest(
@@ -238,7 +244,9 @@ async def start_leader(
             project_id=project_id,
             session_type="manager",
             working_dir=working_dir,
-            context_file=deployed.claude_md_path if deployed.claude_md_path.exists() else None,
+            context_file=deployed.instructions_md_path
+            if deployed.instructions_md_path.exists()
+            else None,
         )
         await db_ops.update_session_tmux(conn, session.id, tmux_session, pane_id)
 

--- a/src/atc/session/ace.py
+++ b/src/atc/session/ace.py
@@ -370,9 +370,7 @@ async def create_ace(
                 continue
             if existing.status in {"completed", "cancelled", "error", "disconnected"}:
                 continue
-            raise ValueError(
-                f"Task {task_id} already has active Ace session {existing.id}"
-            )
+            raise ValueError(f"Task {task_id} already has active Ace session {existing.id}")
 
     # Step 1: DB row first — guarantees the UI always sees every entity
     provider_cfg = get_connection_app_state(conn)
@@ -438,8 +436,8 @@ async def create_ace(
                         role=RoleKind.ACE,
                         project_id=project_id,
                         working_dir=effective_working_dir,
-                        context_ref=str(deployed.claude_md_path)
-                        if deployed and deployed.claude_md_path.exists()
+                        context_ref=str(deployed.instructions_md_path)
+                        if deployed and deployed.instructions_md_path.exists()
                         else None,
                     )
                 )
@@ -456,8 +454,8 @@ async def create_ace(
             project_id=project_id,
             session_type="ace",
             working_dir=effective_working_dir,
-            context_file=deployed.claude_md_path
-            if deployed and deployed.claude_md_path.exists()
+            context_file=deployed.instructions_md_path
+            if deployed and deployed.instructions_md_path.exists()
             else None,
             launch_command=launch_command,
         )

--- a/src/atc/tower/session.py
+++ b/src/atc/tower/session.py
@@ -64,8 +64,7 @@ async def _resolve_tower_project_id(conn: aiosqlite.Connection) -> str:
         conn,
         "Tower Workspace",
         description=(
-            "Auto-created by Tower on first start. "
-            "Safe to delete once you add real projects."
+            "Auto-created by Tower on first start. Safe to delete once you add real projects."
         ),
     )
     await conn.commit()
@@ -106,6 +105,7 @@ async def start_tower_session(
     )
     rows = await cursor.fetchall()
     from atc.state.db import _row_to_session
+
     existing = [_row_to_session(r) for r in rows]
     for sess in existing:
         if sess.status in (SessionStatus.ERROR.value, SessionStatus.DISCONNECTED.value):
@@ -209,7 +209,9 @@ async def start_tower_session(
             project_id=project_id,
             session_type="tower",
             working_dir=working_dir,
-            context_file=deployed.claude_md_path if deployed.claude_md_path.exists() else None,
+            context_file=deployed.instructions_md_path
+            if deployed.instructions_md_path.exists()
+            else None,
         )
         await db_ops.update_session_tmux(conn, session.id, tmux_session, pane_id)
 
@@ -300,7 +302,7 @@ def _log_working_dir_contents(working_dir: str, session_id: str, caller: str) ->
     path that will be passed as -c to tmux (i.e. where Claude Code starts).
     """
     logger.warning(
-        "=== TOWER DEBUG [%s] session=%s ===\n" "  working_dir: %s\n" "  working_dir exists: %s",
+        "=== TOWER DEBUG [%s] session=%s ===\n  working_dir: %s\n  working_dir exists: %s",
         caller,
         session_id,
         working_dir,

--- a/tests/unit/test_deploy.py
+++ b/tests/unit/test_deploy.py
@@ -622,6 +622,7 @@ class TestDeployedFiles:
         df = DeployedFiles(root=tmp_path / "test", files=[])
         assert df.claude_md_path == tmp_path / "test" / "CLAUDE.md"
         assert df.agents_md_path == tmp_path / "test" / "AGENTS.md"
+        assert df.instructions_md_path == df.agents_md_path
         assert df.settings_path == tmp_path / "test" / ".claude" / "settings.json"
         assert df.manifest_path == tmp_path / "test" / ".manifest.json"
 

--- a/tests/unit/test_provider_abstraction.py
+++ b/tests/unit/test_provider_abstraction.py
@@ -32,7 +32,7 @@ class TestPrepareWorkspace:
     @pytest.mark.asyncio
     async def test_copies_context_file(self, tmp_path: Path) -> None:
         provider = ClaudeCodeProvider()
-        context_file = tmp_path / "src_CLAUDE.md"
+        context_file = tmp_path / "AGENTS.md"
         context_file.write_text("# Leader instructions\n")
 
         working_dir = tmp_path / "workspace"
@@ -43,9 +43,10 @@ class TestPrepareWorkspace:
             context_file=context_file,
         )
 
-        dest = working_dir / "CLAUDE.md"
-        assert dest.exists()
-        assert dest.read_text() == "# Leader instructions\n"
+        for filename in ("AGENTS.md", "CLAUDE.md"):
+            dest = working_dir / filename
+            assert dest.exists()
+            assert dest.read_text() == "# Leader instructions\n"
 
     @pytest.mark.asyncio
     async def test_does_not_overwrite_existing_claude_md(self, tmp_path: Path) -> None:
@@ -66,6 +67,7 @@ class TestPrepareWorkspace:
         )
 
         assert existing.read_text() == "# Existing instructions\n"
+        assert (working_dir / "AGENTS.md").read_text() == "# New instructions\n"
 
     @pytest.mark.asyncio
     async def test_no_context_file_still_creates_dir(self, tmp_path: Path) -> None:
@@ -75,6 +77,7 @@ class TestPrepareWorkspace:
         await provider.prepare_workspace("sess-4", working_dir=str(target))
 
         assert target.is_dir()
+        assert not (target / "AGENTS.md").exists()
         assert not (target / "CLAUDE.md").exists()
 
 
@@ -155,7 +158,9 @@ class TestHandleStartup:
             status=SessionStatus.STARTING,
         )
 
-        with patch("atc.agents.claude_provider.accept_startup_dialogs", new_callable=AsyncMock) as mock_startup:
+        with patch(
+            "atc.agents.claude_provider.accept_startup_dialogs", new_callable=AsyncMock
+        ) as mock_startup:
             await provider.handle_startup("sess-start")
 
         mock_startup.assert_awaited_once()


### PR DESCRIPTION
## Summary
- Treat `AGENTS.md` as the provider-neutral ATC role-instruction file and expose it via `DeployedFiles.instructions_md_path`.
- Keep writing `CLAUDE.md` as a compatibility copy for Claude Code so existing Claude launches keep working.
- Pass the provider-neutral instruction file through Tower/Leader/Ace spawn and workspace prep paths.
- Update Claude/Codex workspace preparation to copy instructions to both `AGENTS.md` and `CLAUDE.md` without overwriting existing files.
- Rename internal builder wording from Claude-specific `CLAUDE.md` language to provider-neutral instruction language where it affects behavior/docs.

## Why
`CLAUDE.md` was originally used because Claude Code auto-loads that file. ATC now supports multiple CLI agents, so the source of truth should be provider-neutral while retaining compatibility files for providers that require them.

## Validation
- `pytest -q tests/unit/test_deploy.py tests/unit/test_provider_abstraction.py tests/unit/test_e2e_wiring.py::TestTowerToLeaderWiring::test_start_leader_deploys_config`
  - `85 passed`
- `ruff check src/atc/agents/deploy.py src/atc/leader/leader.py src/atc/session/ace.py src/atc/tower/session.py src/atc/agents/base.py src/atc/agents/claude_provider.py src/atc/agents/codex_provider.py src/atc/cli/ace.py tests/unit/test_deploy.py tests/unit/test_provider_abstraction.py`
  - passed
