### PR TITLE
feat: add runtime truth schema plumbing

### DIFF
--- a/src/atc/api/delivery.py
+++ b/src/atc/api/delivery.py
@@ -34,6 +34,13 @@ class DeliveryStatusResponse(BaseModel):
     leader_session_id: str | None = None
     provider: str | None = None
     delivery: dict[str, Any] | None = None
+    runtime_state: str | None = None
+    truth_delivery_state: str | None = None
+    blocker_reason: str | None = None
+    last_activity_at: str | None = None
+    last_inspected_at: str | None = None
+    provider_diagnostics: dict[str, Any] | None = None
+    recovery_recommendation: dict[str, Any] | None = None
     recovery: str | None = None
 
 
@@ -72,6 +79,15 @@ def delivery_response(
         leader_session_id=leader_session_id,
         provider=result.provider_name,
         delivery=result.as_dict(),
+        runtime_state=result.runtime_state.value if result.runtime_state else None,
+        truth_delivery_state=result.delivery_state.value if result.delivery_state else None,
+        blocker_reason=result.blocker_reason.value if result.blocker_reason else None,
+        last_activity_at=result.last_activity_at,
+        last_inspected_at=result.last_inspected_at,
+        provider_diagnostics=result.provider_diagnostics or None,
+        recovery_recommendation=result.recovery_recommendation.as_dict()
+        if result.recovery_recommendation
+        else None,
         recovery=recovery if not result.ok else None,
     ).model_dump(exclude_none=True)
 

--- a/src/atc/runtime/models.py
+++ b/src/atc/runtime/models.py
@@ -48,6 +48,79 @@ class RuntimeBlockReason(StrEnum):
     UNKNOWN = "unknown"
 
 
+class RuntimeState(StrEnum):
+    """Provider-neutral runtime truth states.
+
+    These states describe what ATC can prove about the live runtime/pane, not
+    whether a product task has been assigned or completed.
+    """
+
+    MISSING = "missing"
+    STARTING = "starting"
+    READY = "ready"
+    ACTIVE = "active"
+    IDLE = "idle"
+    IDLE_AT_DEFAULT_PROMPT = "idle_at_default_prompt"
+    BLOCKED = "blocked"
+    STALE = "stale"
+    COMPLETE = "complete"
+    FAILED = "failed"
+
+
+class DeliveryState(StrEnum):
+    """Provider-neutral delivery truth states for prompts/instructions."""
+
+    NOT_STARTED = "not_started"
+    QUEUED_UNVERIFIED = "queued_unverified"
+    RUNTIME_CREATED = "runtime_created"
+    PROMPT_VISIBLE = "prompt_visible"
+    PAYLOAD_WRITTEN = "payload_written"
+    SUBMIT_SENT = "submit_sent"
+    SUBMITTED_PENDING_ACCEPTANCE = "submitted_pending_acceptance"
+    ACCEPTED_ACTIVE = "accepted_active"
+    BLOCKED = "blocked"
+    FAILED = "failed"
+
+
+class BlockerReason(StrEnum):
+    """Stable blocker reason codes shared by API, CLI, UI, and recovery."""
+
+    PANE_MISSING = "pane_missing"
+    RUNTIME_UPDATE_REQUIRED = "runtime_update_required"
+    RUNTIME_AUTH_REQUIRED = "runtime_auth_required"
+    RUNTIME_TRUST_REQUIRED = "runtime_trust_required"
+    RUNTIME_PERMISSION_REQUIRED = "runtime_permission_required"
+    DEFAULT_PROMPT_VISIBLE = "default_prompt_visible"
+    PROMPT_NOT_SUBMITTED = "prompt_not_submitted"
+    PROVIDER_ERROR = "provider_error"
+    TOOL_SERVER_ERROR = "tool_server_error"
+    LEADER_NO_ACTIVITY = "leader_no_activity"
+    ACE_DISPATCH_FAILED = "ace_dispatch_failed"
+    STALE_AFTER_UPDATE = "stale_after_update"
+    UNKNOWN_PROMPT_BLOCKER = "unknown_prompt_blocker"
+    DELIVERY_UNVERIFIED = "delivery_unverified"
+    EMPTY_PAYLOAD = "empty_payload"
+    UNKNOWN_ERROR = "unknown_error"
+
+
+class RecoveryState(StrEnum):
+    """Provider-neutral recovery lifecycle states."""
+
+    NOT_NEEDED = "not_needed"
+    QUEUED = "queued"
+    INSPECTING = "inspecting"
+    RUNTIME_UPDATE_REQUIRED = "runtime_update_required"
+    UPDATING = "updating"
+    RESTART_REQUIRED = "restart_required"
+    RESTARTING = "restarting"
+    KICKOFF_RESENDING = "kickoff_resending"
+    DISPATCH_RESENDING = "dispatch_resending"
+    VERIFYING = "verifying"
+    RECOVERED = "recovered"
+    BLOCKED = "blocked"
+    FAILED = "failed"
+
+
 class WrapperExitCode(IntEnum):
     """Stable exit codes for the provider CLI wrapper."""
 
@@ -165,6 +238,55 @@ class RuntimeInspection:
 
 
 @dataclass(slots=True)
+class RecoveryRecommendation:
+    """Operator-facing recovery guidance derived from runtime truth."""
+
+    state: RecoveryState
+    command: str | None = None
+    safety: str = "inspect_first"
+    message: str | None = None
+    requires_operator: bool = False
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "state": self.state.value,
+            "command": self.command,
+            "safety": self.safety,
+            "message": self.message,
+            "requires_operator": self.requires_operator,
+        }
+
+
+@dataclass(slots=True)
+class RuntimeTruthSnapshot:
+    """Additive runtime truth metadata that can be persisted or returned by APIs."""
+
+    runtime_state: RuntimeState
+    delivery_state: DeliveryState
+    blocker_reason: BlockerReason | None = None
+    last_activity_at: str | None = None
+    last_inspected_at: str | None = None
+    provider: str | None = None
+    provider_diagnostics: dict[str, Any] = field(default_factory=dict)
+    recovery_recommendation: RecoveryRecommendation | None = None
+
+    def as_dict(self) -> dict[str, Any]:
+        data: dict[str, Any] = {
+            "runtime_state": self.runtime_state.value,
+            "delivery_state": self.delivery_state.value,
+            "blocker_reason": self.blocker_reason.value if self.blocker_reason else None,
+            "last_activity_at": self.last_activity_at,
+            "last_inspected_at": self.last_inspected_at,
+            "provider": self.provider,
+            "provider_diagnostics": self.provider_diagnostics,
+            "recovery_recommendation": self.recovery_recommendation.as_dict()
+            if self.recovery_recommendation
+            else None,
+        }
+        return {key: value for key, value in data.items() if value is not None}
+
+
+@dataclass(slots=True)
 class RuntimeDeliveryResult:
     """Provider-neutral result for a runtime delivery attempt."""
 
@@ -178,6 +300,13 @@ class RuntimeDeliveryResult:
     trace_id: str | None = None
     message: str | None = None
     details: dict[str, Any] = field(default_factory=dict)
+    runtime_state: RuntimeState | None = None
+    delivery_state: DeliveryState | None = None
+    blocker_reason: BlockerReason | None = None
+    last_activity_at: str | None = None
+    last_inspected_at: str | None = None
+    provider_diagnostics: dict[str, Any] = field(default_factory=dict)
+    recovery_recommendation: RecoveryRecommendation | None = None
 
     @property
     def ok(self) -> bool:
@@ -195,4 +324,13 @@ class RuntimeDeliveryResult:
             "trace_id": self.trace_id,
             "message": self.message,
             "details": self.details,
+            "runtime_state": self.runtime_state.value if self.runtime_state else None,
+            "truth_delivery_state": self.delivery_state.value if self.delivery_state else None,
+            "blocker_reason": self.blocker_reason.value if self.blocker_reason else None,
+            "last_activity_at": self.last_activity_at,
+            "last_inspected_at": self.last_inspected_at,
+            "provider_diagnostics": self.provider_diagnostics,
+            "recovery_recommendation": self.recovery_recommendation.as_dict()
+            if self.recovery_recommendation
+            else None,
         }

--- a/src/atc/runtime/service.py
+++ b/src/atc/runtime/service.py
@@ -8,14 +8,19 @@ from typing import TYPE_CHECKING
 from atc.providers.registry import create_provider_runtime, runtime_kwargs_for_provider
 from atc.runtime.errors import RuntimeInvocationError
 from atc.runtime.models import (
+    BlockerReason,
+    DeliveryState,
     InstructionRequest,
     ReadinessResult,
     ReadinessState,
+    RecoveryRecommendation,
+    RecoveryState,
     RoleKind,
     RuntimeBlockReason,
     RuntimeDeliveryResult,
     RuntimeInspection,
     RuntimeSessionHandle,
+    RuntimeState,
     RuntimeTransport,
     StartRoleRequest,
     StopRoleRequest,
@@ -627,6 +632,23 @@ class RuntimeService:
             else:
                 status = "queued"
         details = latest.get("details", {}) if isinstance(latest, dict) else {}
+        truth = metadata.get("runtime_truth")
+        truth_data = truth if isinstance(truth, dict) else {}
+        recovery = truth_data.get("recovery_recommendation")
+        recovery_data = recovery if isinstance(recovery, dict) else {}
+        recovery_recommendation = None
+        if recovery_data.get("state"):
+            recovery_recommendation = RecoveryRecommendation(
+                state=RecoveryState(str(recovery_data["state"])),
+                command=str(recovery_data["command"])
+                if recovery_data.get("command") is not None
+                else None,
+                safety=str(recovery_data.get("safety") or "inspect_first"),
+                message=str(recovery_data["message"])
+                if recovery_data.get("message") is not None
+                else None,
+                requires_operator=bool(recovery_data.get("requires_operator", False)),
+            )
         return RuntimeDeliveryResult(
             session_id=handle.session_id,
             provider_name=handle.provider_name,
@@ -642,6 +664,25 @@ class RuntimeService:
             else None,
             message=message,
             details=details if isinstance(details, dict) else {},
+            runtime_state=RuntimeState(str(truth_data["runtime_state"]))
+            if truth_data.get("runtime_state")
+            else None,
+            delivery_state=DeliveryState(str(truth_data["delivery_state"]))
+            if truth_data.get("delivery_state")
+            else None,
+            blocker_reason=BlockerReason(str(truth_data["blocker_reason"]))
+            if truth_data.get("blocker_reason")
+            else None,
+            last_activity_at=str(truth_data["last_activity_at"])
+            if truth_data.get("last_activity_at")
+            else None,
+            last_inspected_at=str(truth_data["last_inspected_at"])
+            if truth_data.get("last_inspected_at")
+            else None,
+            provider_diagnostics=truth_data.get("provider_diagnostics", {})
+            if isinstance(truth_data.get("provider_diagnostics"), dict)
+            else {},
+            recovery_recommendation=recovery_recommendation,
         )
 
     @staticmethod

--- a/src/atc/runtime/tracing.py
+++ b/src/atc/runtime/tracing.py
@@ -6,11 +6,21 @@ UI/API callers remain compatible while delivery attempts become observable.
 
 from __future__ import annotations
 
+import re
 from dataclasses import asdict, dataclass, field
 from datetime import UTC, datetime
 from enum import StrEnum
 from typing import Any
 from uuid import uuid4
+
+from atc.runtime.models import (
+    BlockerReason,
+    DeliveryState,
+    RecoveryRecommendation,
+    RecoveryState,
+    RuntimeState,
+    RuntimeTruthSnapshot,
+)
 
 
 class DeliveryAction(StrEnum):
@@ -72,6 +82,15 @@ class DeliveryReasonCode(StrEnum):
     UNKNOWN_ERROR = "unknown_error"
 
 
+_SECRET_KEY_RE = re.compile(
+    r"(api[_-]?key|auth|authorization|bearer|cookie|credential|password|secret|token)",
+    re.IGNORECASE,
+)
+_SECRET_VALUE_RE = re.compile(
+    r"(?i)(api[_-]?key|authorization|bearer|password|secret|token)(\s*[:=]\s*)([^\s,;]+)"
+)
+
+
 @dataclass(slots=True)
 class DeliveryTraceEvent:
     """A structured event emitted while spawning or instructing a runtime session."""
@@ -129,15 +148,190 @@ def trace_event(
         else str(reason_code),
         prompt_state_before=prompt_state_before,
         prompt_state_after=prompt_state_after,
-        first_output_excerpt=_trim_excerpt(first_output_excerpt),
-        details=details or {},
+        first_output_excerpt=_trim_excerpt(redact_runtime_value(first_output_excerpt)),
+        details=redact_runtime_value(details or {}),
     )
 
 
 def append_trace_event(metadata: dict[str, Any], event: DeliveryTraceEvent) -> DeliveryTraceEvent:
+    """Append a trace event and update additive runtime truth metadata."""
+
     metadata.setdefault("delivery_trace_id", event.trace_id)
     metadata.setdefault("delivery_trace_events", []).append(event.to_dict())
+    truth = runtime_truth_from_trace_event(event)
+    metadata["runtime_truth"] = truth.as_dict()
+    metadata["runtime_state"] = truth.runtime_state.value
+    metadata["truth_delivery_state"] = truth.delivery_state.value
+    # Keep the existing ``delivery_state`` key provider-neutral only when no
+    # legacy caller has already populated it. Existing API fields remain intact.
+    metadata.setdefault("delivery_state", truth.delivery_state.value)
+    if truth.blocker_reason is not None:
+        metadata["blocker_reason"] = truth.blocker_reason.value
+    else:
+        metadata.pop("blocker_reason", None)
+    metadata["last_inspected_at"] = truth.last_inspected_at
+    if truth.last_activity_at is not None:
+        metadata["last_activity_at"] = truth.last_activity_at
+    metadata["provider_diagnostics"] = truth.provider_diagnostics
+    if truth.recovery_recommendation is not None:
+        metadata["recovery_recommendation"] = truth.recovery_recommendation.as_dict()
+    else:
+        metadata.pop("recovery_recommendation", None)
     return event
+
+
+def runtime_truth_from_trace_event(event: DeliveryTraceEvent) -> RuntimeTruthSnapshot:
+    """Build a provider-neutral runtime truth snapshot from one trace event."""
+
+    blocker = _blocker_reason(event.reason_code)
+    delivery_state = _delivery_state(event.stage, event.verdict, event.reason_code)
+    runtime_state = _runtime_state(event.stage, event.verdict, event.reason_code, blocker)
+    recovery = _recovery_recommendation(blocker)
+    diagnostics: dict[str, Any] = {
+        "trace_stage": event.stage,
+        "trace_verdict": event.verdict,
+        "trace_reason_code": event.reason_code,
+        "action": event.action,
+    }
+    if event.prompt_state_before is not None:
+        diagnostics["prompt_state_before"] = event.prompt_state_before
+    if event.prompt_state_after is not None:
+        diagnostics["prompt_state_after"] = event.prompt_state_after
+    if event.first_output_excerpt is not None:
+        diagnostics["first_output_excerpt"] = event.first_output_excerpt
+    diagnostics.update(event.details)
+    return RuntimeTruthSnapshot(
+        runtime_state=runtime_state,
+        delivery_state=delivery_state,
+        blocker_reason=blocker,
+        last_activity_at=event.timestamp
+        if delivery_state is DeliveryState.ACCEPTED_ACTIVE
+        else None,
+        last_inspected_at=event.timestamp,
+        provider=event.provider,
+        provider_diagnostics=redact_runtime_value(diagnostics),
+        recovery_recommendation=recovery,
+    )
+
+
+def redact_runtime_value(value: Any) -> Any:
+    """Redact secrets from provider diagnostics before storage or API exposure."""
+
+    if isinstance(value, dict):
+        redacted: dict[str, Any] = {}
+        for key, item in value.items():
+            key_text = str(key)
+            if _SECRET_KEY_RE.search(key_text):
+                redacted[key_text] = "[REDACTED]"
+            else:
+                redacted[key_text] = redact_runtime_value(item)
+        return redacted
+    if isinstance(value, list):
+        return [redact_runtime_value(item) for item in value]
+    if isinstance(value, tuple):
+        return tuple(redact_runtime_value(item) for item in value)
+    if isinstance(value, str):
+        return _SECRET_VALUE_RE.sub(
+            lambda match: f"{match.group(1)}{match.group(2)}[REDACTED]", value
+        )
+    return value
+
+
+def _delivery_state(stage: str, verdict: str, reason_code: str) -> DeliveryState:
+    if verdict == DeliveryVerdict.BLOCKED.value or stage == DeliveryStage.BLOCKED.value:
+        return DeliveryState.BLOCKED
+    if verdict == DeliveryVerdict.FAILED.value or stage == DeliveryStage.FAILED.value:
+        return DeliveryState.FAILED
+    if stage == DeliveryStage.QUEUED.value:
+        return DeliveryState.QUEUED_UNVERIFIED
+    if stage in {DeliveryStage.SPAWN_STARTED.value, DeliveryStage.SPAWNED.value}:
+        return DeliveryState.RUNTIME_CREATED
+    if stage == DeliveryStage.WRITE_STARTED.value:
+        return DeliveryState.PROMPT_VISIBLE
+    if stage == DeliveryStage.WRITTEN_TO_PTY.value:
+        return DeliveryState.PAYLOAD_WRITTEN
+    if (
+        stage == DeliveryStage.SUBMIT_ATTEMPTED.value
+        or reason_code == DeliveryReasonCode.SUBMIT_SENT.value
+    ):
+        return DeliveryState.SUBMIT_SENT
+    if stage in {DeliveryStage.AGENT_OUTPUT_OBSERVED.value, DeliveryStage.CONFIRMED_RUNNING.value}:
+        return DeliveryState.ACCEPTED_ACTIVE
+    if stage == DeliveryStage.PROMPT_CLEARED.value:
+        return DeliveryState.SUBMITTED_PENDING_ACCEPTANCE
+    return DeliveryState.SUBMITTED_PENDING_ACCEPTANCE
+
+
+def _runtime_state(
+    stage: str,
+    verdict: str,
+    reason_code: str,
+    blocker: BlockerReason | None,
+) -> RuntimeState:
+    if reason_code == DeliveryReasonCode.PANE_MISSING.value:
+        return RuntimeState.MISSING
+    if blocker is not None or verdict == DeliveryVerdict.BLOCKED.value:
+        return RuntimeState.BLOCKED
+    if verdict == DeliveryVerdict.FAILED.value:
+        return RuntimeState.FAILED
+    if stage in {DeliveryStage.QUEUED.value, DeliveryStage.SPAWN_STARTED.value}:
+        return RuntimeState.STARTING
+    if stage == DeliveryStage.SPAWNED.value:
+        return RuntimeState.READY
+    if stage in {
+        DeliveryStage.WRITE_STARTED.value,
+        DeliveryStage.WRITTEN_TO_PTY.value,
+        DeliveryStage.SUBMIT_ATTEMPTED.value,
+        DeliveryStage.PROMPT_CLEARED.value,
+    }:
+        return RuntimeState.READY
+    if stage in {DeliveryStage.AGENT_OUTPUT_OBSERVED.value, DeliveryStage.CONFIRMED_RUNNING.value}:
+        return RuntimeState.ACTIVE
+    return RuntimeState.IDLE
+
+
+def _blocker_reason(reason_code: str) -> BlockerReason | None:
+    mapping = {
+        DeliveryReasonCode.PANE_MISSING.value: BlockerReason.PANE_MISSING,
+        DeliveryReasonCode.EMPTY_PAYLOAD.value: BlockerReason.EMPTY_PAYLOAD,
+        DeliveryReasonCode.AUTH_REQUIRED.value: BlockerReason.RUNTIME_AUTH_REQUIRED,
+        DeliveryReasonCode.TRUST_REQUIRED.value: BlockerReason.RUNTIME_TRUST_REQUIRED,
+        DeliveryReasonCode.PERMISSION_REQUIRED.value: BlockerReason.RUNTIME_PERMISSION_REQUIRED,
+        DeliveryReasonCode.WELCOME_SCREEN.value: BlockerReason.DEFAULT_PROMPT_VISIBLE,
+        DeliveryReasonCode.UNKNOWN_PROMPT_BLOCKER.value: BlockerReason.UNKNOWN_PROMPT_BLOCKER,
+        DeliveryReasonCode.PROVIDER_ERROR.value: BlockerReason.PROVIDER_ERROR,
+        DeliveryReasonCode.UNKNOWN_ERROR.value: BlockerReason.UNKNOWN_ERROR,
+        DeliveryReasonCode.PROMPT_STILL_VISIBLE.value: BlockerReason.PROMPT_NOT_SUBMITTED,
+        DeliveryReasonCode.PROMPT_NOT_READY.value: BlockerReason.PROMPT_NOT_SUBMITTED,
+    }
+    return mapping.get(reason_code)
+
+
+def _recovery_recommendation(blocker: BlockerReason | None) -> RecoveryRecommendation | None:
+    if blocker is None:
+        return None
+    if blocker in {
+        BlockerReason.RUNTIME_AUTH_REQUIRED,
+        BlockerReason.RUNTIME_PERMISSION_REQUIRED,
+        BlockerReason.UNKNOWN_PROMPT_BLOCKER,
+    }:
+        return RecoveryRecommendation(
+            state=RecoveryState.BLOCKED,
+            safety="operator_required",
+            message=f"Runtime blocked by {blocker.value}; inspect provider pane before recovery.",
+            requires_operator=True,
+        )
+    if blocker in {BlockerReason.PANE_MISSING, BlockerReason.PROVIDER_ERROR}:
+        return RecoveryRecommendation(
+            state=RecoveryState.RESTART_REQUIRED,
+            safety="inspect_first",
+            message=f"Runtime blocked by {blocker.value}; inspect health before restart.",
+        )
+    return RecoveryRecommendation(
+        state=RecoveryState.INSPECTING,
+        safety="inspect_first",
+        message=f"Runtime blocked by {blocker.value}; inspect before mutating state.",
+    )
 
 
 def _trim_excerpt(excerpt: str | None, *, limit: int = 500) -> str | None:

--- a/tests/unit/test_delivery_api.py
+++ b/tests/unit/test_delivery_api.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from atc.api.delivery import delivery_response
-from atc.runtime.models import RoleKind, RuntimeDeliveryResult
+from atc.runtime.models import DeliveryState, RoleKind, RuntimeDeliveryResult, RuntimeState
 
 
 def test_delivery_response_normalizes_accepted_to_submitted() -> None:
@@ -22,3 +22,30 @@ def test_delivery_response_normalizes_accepted_to_submitted() -> None:
     assert response["status"] == "submitted"
     assert response["delivery_state"] == "submitted"
     assert response["delivery"]["status"] == "accepted"
+
+
+def test_delivery_response_exposes_additive_runtime_truth_fields() -> None:
+    result = RuntimeDeliveryResult(
+        session_id="session-1",
+        provider_name="codex",
+        role=RoleKind.LEADER,
+        status="delivered",
+        stage="confirmed_running",
+        verdict="accepted",
+        reason_code="session_running",
+        runtime_state=RuntimeState.ACTIVE,
+        delivery_state=DeliveryState.ACCEPTED_ACTIVE,
+        last_activity_at="2026-06-12T00:00:00+00:00",
+        last_inspected_at="2026-06-12T00:00:00+00:00",
+        provider_diagnostics={"trace_stage": "confirmed_running"},
+    )
+
+    response = delivery_response(result)
+
+    assert response["delivery_state"] == "delivered"
+    assert response["runtime_state"] == "active"
+    assert response["truth_delivery_state"] == "accepted_active"
+    assert response["last_activity_at"] == "2026-06-12T00:00:00+00:00"
+    assert response["provider_diagnostics"] == {"trace_stage": "confirmed_running"}
+    assert response["delivery"]["runtime_state"] == "active"
+    assert response["delivery"]["truth_delivery_state"] == "accepted_active"

--- a/tests/unit/test_runtime_truth.py
+++ b/tests/unit/test_runtime_truth.py
@@ -1,0 +1,145 @@
+"""Tests for provider-neutral runtime truth metadata."""
+
+from __future__ import annotations
+
+from atc.runtime.models import (
+    BlockerReason,
+    DeliveryState,
+    RecoveryState,
+    RuntimeState,
+)
+from atc.runtime.tracing import (
+    DeliveryAction,
+    DeliveryReasonCode,
+    DeliveryStage,
+    DeliveryVerdict,
+    append_trace_event,
+    new_trace_id,
+    redact_runtime_value,
+    runtime_truth_from_trace_event,
+    trace_event,
+)
+
+
+def test_trace_event_updates_runtime_truth_metadata_for_submit_sent() -> None:
+    metadata: dict[str, object] = {
+        "blocker_reason": "pane_missing",
+        "recovery_recommendation": {"state": "restart_required"},
+    }
+    trace_id = new_trace_id()
+    event = trace_event(
+        trace_id=trace_id,
+        session_id="session-1",
+        role="leader",
+        provider="codex",
+        pane_id="%7",
+        action=DeliveryAction.INSTRUCTION,
+        stage=DeliveryStage.SUBMIT_ATTEMPTED,
+        verdict=DeliveryVerdict.ACCEPTED,
+        reason_code=DeliveryReasonCode.SUBMIT_SENT,
+        prompt_state_before="ready",
+        prompt_state_after="submitted",
+    )
+
+    append_trace_event(metadata, event)
+
+    assert metadata["runtime_state"] == RuntimeState.READY.value
+    assert metadata["truth_delivery_state"] == DeliveryState.SUBMIT_SENT.value
+    assert metadata["delivery_state"] == DeliveryState.SUBMIT_SENT.value
+    assert metadata["last_inspected_at"] == event.timestamp
+    assert metadata["provider_diagnostics"] == {
+        "trace_stage": "submit_attempted",
+        "trace_verdict": "accepted",
+        "trace_reason_code": "submit_sent",
+        "action": "instruction",
+        "prompt_state_before": "ready",
+        "prompt_state_after": "submitted",
+    }
+    assert "blocker_reason" not in metadata
+    assert "recovery_recommendation" not in metadata
+
+
+def test_unverified_confirmed_running_is_not_a_blocker() -> None:
+    event = trace_event(
+        trace_id="trace-1",
+        session_id="session-1",
+        role="leader",
+        provider="codex",
+        pane_id="%1",
+        action=DeliveryAction.INSTRUCTION,
+        stage=DeliveryStage.CONFIRMED_RUNNING,
+        verdict=DeliveryVerdict.ACCEPTED,
+        reason_code=DeliveryReasonCode.DELIVERY_UNVERIFIED,
+    )
+
+    truth = runtime_truth_from_trace_event(event)
+
+    assert truth.runtime_state is RuntimeState.ACTIVE
+    assert truth.delivery_state is DeliveryState.ACCEPTED_ACTIVE
+    assert truth.blocker_reason is None
+    assert truth.recovery_recommendation is None
+
+
+def test_blocked_trace_maps_to_blocker_and_recovery_recommendation() -> None:
+    event = trace_event(
+        trace_id="trace-1",
+        session_id="session-1",
+        role="ace",
+        provider="codex",
+        pane_id="%9",
+        action=DeliveryAction.TASK_ASSIGNMENT,
+        stage=DeliveryStage.BLOCKED,
+        verdict=DeliveryVerdict.BLOCKED,
+        reason_code=DeliveryReasonCode.AUTH_REQUIRED,
+        details={"token": "super-secret-token", "visible": "ok"},
+    )
+
+    truth = runtime_truth_from_trace_event(event)
+
+    assert truth.runtime_state is RuntimeState.BLOCKED
+    assert truth.delivery_state is DeliveryState.BLOCKED
+    assert truth.blocker_reason is BlockerReason.RUNTIME_AUTH_REQUIRED
+    assert truth.provider_diagnostics["token"] == "[REDACTED]"
+    assert truth.provider_diagnostics["visible"] == "ok"
+    assert truth.recovery_recommendation is not None
+    assert truth.recovery_recommendation.state is RecoveryState.BLOCKED
+    assert truth.recovery_recommendation.requires_operator is True
+
+
+def test_active_trace_records_last_activity() -> None:
+    event = trace_event(
+        trace_id="trace-1",
+        session_id="session-1",
+        role="leader",
+        provider="codex",
+        pane_id="%1",
+        action=DeliveryAction.INSTRUCTION,
+        stage=DeliveryStage.AGENT_OUTPUT_OBSERVED,
+        verdict=DeliveryVerdict.CONFIRMED,
+        reason_code=DeliveryReasonCode.AGENT_OUTPUT,
+    )
+
+    truth = runtime_truth_from_trace_event(event)
+
+    assert truth.runtime_state is RuntimeState.ACTIVE
+    assert truth.delivery_state is DeliveryState.ACCEPTED_ACTIVE
+    assert truth.last_activity_at == event.timestamp
+    assert truth.last_inspected_at == event.timestamp
+
+
+def test_secret_redaction_handles_nested_diagnostics_and_excerpt_text() -> None:
+    redacted = redact_runtime_value(
+        {
+            "provider_diagnostics": {
+                "api_key": "sk-test",
+                "nested": ["Authorization: Bearer abc123", {"password": "pw"}],
+                "excerpt": "token=abc123 regular text",
+            }
+        }
+    )
+
+    diagnostics = redacted["provider_diagnostics"]
+    assert diagnostics["api_key"] == "[REDACTED]"
+    assert diagnostics["nested"][0] == "Authorization: [REDACTED] abc123"
+    assert diagnostics["nested"][1]["password"] == "[REDACTED]"
+    assert diagnostics["excerpt"] == "token=[REDACTED] regular text"


### PR DESCRIPTION
## Summary
- Add provider-neutral runtime truth enums and snapshots for runtime state, delivery state, blocker reason, and recovery state.
- Derive additive runtime truth metadata from delivery trace events without leaking provider-specific classifications into Tower/Leader/Ace orchestration.
- Surface truth fields in delivery API responses while preserving existing optimistic delivery_state compatibility.
- Add tests for trace-to-truth mapping, recovery recommendations, redaction, and API response exposure.

## Validation
- ruff check src/atc/runtime src/atc/api/delivery.py tests/unit/test_runtime_truth.py tests/unit/test_delivery_api.py
- pytest tests/unit/test_tmux_session_runner.py tests/unit/test_tower_controller.py tests/unit/test_leader_api.py tests/unit/test_delivery_api.py tests/unit/test_runtime_truth.py -q
- PATH=/opt/homebrew/opt/node/bin:/opt/homebrew/bin:$PATH npm run build (frontend)
- Playwright baseline smoke: node playwright-smoke-atc.mjs (13 checks passed; screenshots captured under screenshots/playwright-atc-2026-06-12T03-20-32-184Z/)

## Notes
- Full ruff across the repo still reports pre-existing lint violations outside this change.
- Full pytest collection still reports pre-existing tests/unit/test_ace_trust_dialog.py import error for _DIALOG_TRIGGERS.