### PR TITLE
feat: add provider runtime classifiers

### DIFF
--- a/src/atc/providers/classifiers.py
+++ b/src/atc/providers/classifiers.py
@@ -1,0 +1,110 @@
+"""Provider-owned runtime classification contracts.
+
+Classifiers translate provider-specific terminal observations into ATC's
+provider-neutral runtime truth vocabulary. Core Tower/Leader/Ace orchestration
+must consume these neutral fields instead of matching provider prompt text.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Protocol, runtime_checkable
+
+from atc.runtime.models import (
+    BlockerReason,
+    DeliveryState,
+    ReadinessState,
+    RecoveryState,
+    RuntimeBlockReason,
+    RuntimeState,
+)
+
+
+@dataclass(frozen=True, slots=True)
+class RecoveryCapabilities:
+    """Provider recovery capabilities discovered or declared by a classifier."""
+
+    can_detect_update_prompt: bool = False
+    can_accept_update_prompt: bool = False
+    requires_fresh_session_after_update: bool = False
+    can_detect_default_prompt: bool = False
+    can_detect_unsubmitted_prompt: bool = False
+    can_detect_auth_prompt: bool = False
+    can_detect_trust_prompt: bool = False
+    can_detect_permission_prompt: bool = False
+
+    def as_dict(self) -> dict[str, bool]:
+        return {
+            "can_detect_update_prompt": self.can_detect_update_prompt,
+            "can_accept_update_prompt": self.can_accept_update_prompt,
+            "requires_fresh_session_after_update": self.requires_fresh_session_after_update,
+            "can_detect_default_prompt": self.can_detect_default_prompt,
+            "can_detect_unsubmitted_prompt": self.can_detect_unsubmitted_prompt,
+            "can_detect_auth_prompt": self.can_detect_auth_prompt,
+            "can_detect_trust_prompt": self.can_detect_trust_prompt,
+            "can_detect_permission_prompt": self.can_detect_permission_prompt,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class RuntimeClassification:
+    """Provider-neutral classification for one terminal/runtime observation."""
+
+    runtime_state: RuntimeState
+    delivery_state: DeliveryState
+    readiness: ReadinessState
+    block_reason: RuntimeBlockReason | None = None
+    blocker_reason: BlockerReason | None = None
+    summary: str | None = None
+    prompt_state: str | None = None
+    provider_observation: str | None = None
+    recovery_state: RecoveryState = RecoveryState.NOT_NEEDED
+    requires_operator: bool = False
+    diagnostics: dict[str, object] = field(default_factory=dict)
+
+    @property
+    def is_blocking(self) -> bool:
+        return self.blocker_reason is not None or self.readiness in {
+            ReadinessState.BLOCKED,
+            ReadinessState.ERROR,
+            ReadinessState.STOPPED,
+        }
+
+    def as_details(self) -> dict[str, object]:
+        details: dict[str, object] = {
+            "runtime_state": self.runtime_state.value,
+            "delivery_state": self.delivery_state.value,
+            "readiness": self.readiness.value,
+            "recovery_state": self.recovery_state.value,
+        }
+        if self.block_reason is not None:
+            details["block_reason"] = self.block_reason.value
+        if self.blocker_reason is not None:
+            details["blocker_reason"] = self.blocker_reason.value
+        if self.prompt_state is not None:
+            details["prompt_state"] = self.prompt_state
+        if self.provider_observation is not None:
+            details["provider_observation"] = self.provider_observation
+        if self.requires_operator:
+            details["requires_operator"] = True
+        if self.diagnostics:
+            details["provider_diagnostics"] = self.diagnostics
+        return details
+
+
+@runtime_checkable
+class RuntimeProviderClassifier(Protocol):
+    """Provider-owned runtime inspection/classification contract."""
+
+    provider_name: str
+
+    def classify_excerpt(
+        self, excerpt: str, *, pane_missing: bool = False
+    ) -> RuntimeClassification:
+        """Classify a terminal excerpt into ATC provider-neutral runtime truth."""
+
+    def prompt_state_for_excerpt(self, excerpt: str) -> str:
+        """Return compact provider-neutral prompt state text for delivery traces."""
+
+    def recovery_capabilities(self) -> RecoveryCapabilities:
+        """Return provider recovery capabilities without performing recovery."""

--- a/src/atc/providers/codex/classifier.py
+++ b/src/atc/providers/codex/classifier.py
@@ -1,0 +1,270 @@
+"""Codex runtime classifier.
+
+Codex-specific prompt matching lives here so orchestration, Tower, Leader, Ace,
+REST, CLI, and MCP only see provider-neutral runtime truth.
+"""
+
+from __future__ import annotations
+
+import re
+
+from atc.providers.classifiers import RecoveryCapabilities, RuntimeClassification
+from atc.runtime.interrupts import (
+    RuntimeInterruptSpec,
+    detect_runtime_interrupt,
+    interrupt_prompt_state,
+)
+from atc.runtime.models import (
+    BlockerReason,
+    DeliveryState,
+    ReadinessState,
+    RecoveryState,
+    RuntimeBlockReason,
+    RuntimeState,
+)
+
+CODEX_PROMPT_RE = re.compile(r"(^|\n)\s*(❯|>)\s*$|(^|\n)\s*›\s+(?!\d+\.)", re.MULTILINE)
+
+_AUTH_TRIGGERS = (
+    "login",
+    "sign in",
+    "authentication",
+    "api key",
+)
+_TRUST_TRIGGERS = (
+    "trust this folder",
+    "do you trust",
+    "trust the contents",
+)
+_PERMISSION_TRIGGERS = (
+    "allow command",
+    "allow this command",
+    "approve command",
+    "permission",
+)
+_PROVIDER_ERROR_TRIGGERS = (
+    "failed to start provider",
+    "failed to start codex",
+    "failed to start claude",
+)
+_UPDATE_TRIGGERS = (
+    "update available",
+    "a new version of codex is available",
+    "new codex version available",
+    "codex update available",
+    "update codex",
+)
+_POST_UPDATE_STALE_TRIGGERS = (
+    "codex has been updated",
+    "restart codex",
+    "please restart codex",
+    "relaunch codex",
+)
+_DEFAULT_PROMPT_TRIGGERS = (
+    "implement {feature}",
+    "explain this codebase",
+)
+_UNSUBMITTED_PROMPT_TRIGGERS = (
+    "implement ",
+    "fix ",
+    "add ",
+    "update ",
+)
+
+_INTERRUPT_SPEC = RuntimeInterruptSpec(
+    trust_triggers=_TRUST_TRIGGERS,
+    permission_triggers=_PERMISSION_TRIGGERS,
+    login_triggers=_AUTH_TRIGGERS,
+    provider_error_triggers=_PROVIDER_ERROR_TRIGGERS,
+)
+
+
+class CodexRuntimeClassifier:
+    """Classify Codex pane excerpts behind provider-neutral ATC states."""
+
+    provider_name = "codex"
+
+    def classify_excerpt(
+        self, excerpt: str, *, pane_missing: bool = False
+    ) -> RuntimeClassification:
+        if pane_missing:
+            return RuntimeClassification(
+                runtime_state=RuntimeState.MISSING,
+                delivery_state=DeliveryState.FAILED,
+                readiness=ReadinessState.STOPPED,
+                blocker_reason=BlockerReason.PANE_MISSING,
+                summary="Pane missing",
+                prompt_state="missing:pane",
+                provider_observation="pane_missing",
+                recovery_state=RecoveryState.RESTART_REQUIRED,
+                requires_operator=True,
+            )
+
+        interrupt = self.detect_interrupt(excerpt)
+        if interrupt is not None:
+            return RuntimeClassification(
+                runtime_state=RuntimeState.FAILED
+                if interrupt.readiness is ReadinessState.ERROR
+                else RuntimeState.BLOCKED,
+                delivery_state=DeliveryState.BLOCKED,
+                readiness=interrupt.readiness,
+                block_reason=interrupt.block_reason,
+                blocker_reason=_blocker_reason_for_interrupt(interrupt.reason_code.value),
+                summary=interrupt.summary,
+                prompt_state=interrupt_prompt_state(interrupt, interrupt.readiness.value),
+                provider_observation=interrupt.interrupt_type.value,
+                recovery_state=RecoveryState.BLOCKED,
+                requires_operator=True,
+                diagnostics=interrupt.to_trace_details(),
+            )
+
+        lower = excerpt.lower()
+        if _contains_any(lower, _UPDATE_TRIGGERS):
+            return RuntimeClassification(
+                runtime_state=RuntimeState.BLOCKED,
+                delivery_state=DeliveryState.BLOCKED,
+                readiness=ReadinessState.BLOCKED,
+                block_reason=RuntimeBlockReason.PROVIDER_PROMPT,
+                blocker_reason=BlockerReason.RUNTIME_UPDATE_REQUIRED,
+                summary="Codex runtime update prompt visible",
+                prompt_state="blocked:runtime_update_required",
+                provider_observation="codex_update_prompt",
+                recovery_state=RecoveryState.RUNTIME_UPDATE_REQUIRED,
+                requires_operator=True,
+                diagnostics={"codex_observation": "update_prompt"},
+            )
+        if _contains_any(lower, _POST_UPDATE_STALE_TRIGGERS):
+            return RuntimeClassification(
+                runtime_state=RuntimeState.STALE,
+                delivery_state=DeliveryState.FAILED,
+                readiness=ReadinessState.STOPPED,
+                block_reason=RuntimeBlockReason.PROVIDER_PROMPT,
+                blocker_reason=BlockerReason.STALE_AFTER_UPDATE,
+                summary="Codex session is stale after update/reload",
+                prompt_state="stale:after_update",
+                provider_observation="codex_stale_after_update",
+                recovery_state=RecoveryState.RESTART_REQUIRED,
+                requires_operator=True,
+                diagnostics={"codex_observation": "stale_after_update"},
+            )
+        if _contains_any(lower, _DEFAULT_PROMPT_TRIGGERS):
+            return RuntimeClassification(
+                runtime_state=RuntimeState.IDLE_AT_DEFAULT_PROMPT,
+                delivery_state=DeliveryState.PROMPT_VISIBLE,
+                readiness=ReadinessState.READY,
+                blocker_reason=BlockerReason.DEFAULT_PROMPT_VISIBLE,
+                summary="Codex default starter prompt visible",
+                prompt_state="idle_at_default_prompt",
+                provider_observation="codex_default_prompt",
+                recovery_state=RecoveryState.NOT_NEEDED,
+                diagnostics={"codex_observation": "default_prompt"},
+            )
+        if self._looks_unsubmitted_prompt(excerpt):
+            return RuntimeClassification(
+                runtime_state=RuntimeState.IDLE,
+                delivery_state=DeliveryState.PAYLOAD_WRITTEN,
+                readiness=ReadinessState.READY,
+                blocker_reason=BlockerReason.PROMPT_NOT_SUBMITTED,
+                summary="Codex prompt contains visible unsubmitted text",
+                prompt_state="prompt_visible:not_submitted",
+                provider_observation="codex_prompt_not_submitted",
+                recovery_state=RecoveryState.NOT_NEEDED,
+                diagnostics={"codex_observation": "prompt_not_submitted"},
+            )
+        if CODEX_PROMPT_RE.search(excerpt):
+            return RuntimeClassification(
+                runtime_state=RuntimeState.READY,
+                delivery_state=DeliveryState.PROMPT_VISIBLE,
+                readiness=ReadinessState.READY,
+                summary="Codex prompt ready",
+                prompt_state=ReadinessState.READY.value,
+                provider_observation="codex_ready_prompt",
+            )
+        if excerpt.strip():
+            return RuntimeClassification(
+                runtime_state=RuntimeState.ACTIVE,
+                delivery_state=DeliveryState.ACCEPTED_ACTIVE,
+                readiness=ReadinessState.BUSY,
+                summary="Codex output active",
+                prompt_state=ReadinessState.BUSY.value,
+                provider_observation="codex_active_output",
+            )
+        return RuntimeClassification(
+            runtime_state=RuntimeState.STARTING,
+            delivery_state=DeliveryState.SUBMITTED_PENDING_ACCEPTANCE,
+            readiness=ReadinessState.BUSY,
+            summary="Codex runtime starting or awaiting output",
+            prompt_state=ReadinessState.BUSY.value,
+            provider_observation="codex_no_output_yet",
+        )
+
+    def prompt_state_for_excerpt(self, excerpt: str) -> str:
+        classification = self.classify_excerpt(excerpt)
+        if classification.prompt_state:
+            return classification.prompt_state
+        if classification.block_reason is not None:
+            return f"{classification.readiness.value}:{classification.block_reason.value}"
+        return classification.readiness.value
+
+    def recovery_capabilities(self) -> RecoveryCapabilities:
+        return RecoveryCapabilities(
+            can_detect_update_prompt=True,
+            can_accept_update_prompt=False,
+            requires_fresh_session_after_update=True,
+            can_detect_default_prompt=True,
+            can_detect_unsubmitted_prompt=True,
+            can_detect_auth_prompt=True,
+            can_detect_trust_prompt=True,
+            can_detect_permission_prompt=True,
+        )
+
+    def detect_interrupt(self, excerpt: str):
+        lower = excerpt.lower()
+        last_interrupt = max(
+            lower.rfind(trigger)
+            for trigger in (
+                *_TRUST_TRIGGERS,
+                *_PERMISSION_TRIGGERS,
+                *_AUTH_TRIGGERS,
+                *_PROVIDER_ERROR_TRIGGERS,
+            )
+        )
+        last_ready = max(
+            lower.rfind(marker)
+            for marker in (
+                "\n› ",
+                "gpt-5.5 default",
+                "gpt-5 default",
+            )
+        )
+        if last_interrupt >= 0 and last_ready > last_interrupt:
+            return None
+        return detect_runtime_interrupt(excerpt, _INTERRUPT_SPEC)
+
+    def _looks_unsubmitted_prompt(self, excerpt: str) -> bool:
+        lines = [line.strip().lower() for line in excerpt.splitlines() if line.strip()]
+        if not lines:
+            return False
+        latest = lines[-1]
+        if not latest.startswith(("›", ">", "❯")):
+            return False
+        prompt_text = latest.lstrip("›>❯ ").strip()
+        if not prompt_text:
+            return False
+        return _contains_any(prompt_text, _UNSUBMITTED_PROMPT_TRIGGERS)
+
+
+def _contains_any(text: str, triggers: tuple[str, ...]) -> bool:
+    return any(trigger in text for trigger in triggers)
+
+
+def _blocker_reason_for_interrupt(reason_code: str) -> BlockerReason:
+    if reason_code == "auth_required":
+        return BlockerReason.RUNTIME_AUTH_REQUIRED
+    if reason_code == "trust_required":
+        return BlockerReason.RUNTIME_TRUST_REQUIRED
+    if reason_code == "permission_required":
+        return BlockerReason.RUNTIME_PERMISSION_REQUIRED
+    if reason_code == "provider_error":
+        return BlockerReason.PROVIDER_ERROR
+    return BlockerReason.UNKNOWN_PROMPT_BLOCKER

--- a/src/atc/providers/codex/runtime.py
+++ b/src/atc/providers/codex/runtime.py
@@ -2,14 +2,8 @@
 
 from __future__ import annotations
 
-import re
-
 from atc.providers.base import ProviderRuntime
-from atc.runtime.interrupts import (
-    RuntimeInterruptSpec,
-    detect_runtime_interrupt,
-    interrupt_prompt_state,
-)
+from atc.providers.codex.classifier import CODEX_PROMPT_RE, CodexRuntimeClassifier
 from atc.runtime.models import (
     InstructionRequest,
     ReadinessResult,
@@ -38,36 +32,6 @@ from atc.runtime.tracing import (
     DeliveryVerdict,
 )
 
-_CODEX_PROMPT_RE = re.compile(r"(^|\n)\s*(❯|>)\s*$|(^|\n)\s*›\s+(?!\d+\.)", re.MULTILINE)
-_AUTH_TRIGGERS = (
-    "login",
-    "sign in",
-    "authentication",
-    "api key",
-)
-_TRUST_TRIGGERS = (
-    "trust this folder",
-    "do you trust",
-    "trust the contents",
-)
-_PERMISSION_TRIGGERS = (
-    "allow command",
-    "allow this command",
-    "approve command",
-    "permission",
-)
-_PROVIDER_ERROR_TRIGGERS = (
-    "failed to start provider",
-    "failed to start codex",
-    "failed to start claude",
-)
-_INTERRUPT_SPEC = RuntimeInterruptSpec(
-    trust_triggers=_TRUST_TRIGGERS,
-    permission_triggers=_PERMISSION_TRIGGERS,
-    login_triggers=_AUTH_TRIGGERS,
-    provider_error_triggers=_PROVIDER_ERROR_TRIGGERS,
-)
-
 
 class CodexRuntime(ProviderRuntime):
     """Minimal first-pass Codex runtime on the new contract."""
@@ -82,6 +46,7 @@ class CodexRuntime(ProviderRuntime):
     ) -> None:
         self.tmux_session = tmux_session
         self.codex_command = codex_command
+        self.classifier = CodexRuntimeClassifier()
 
     async def prepare_workspace(self, request: StartRoleRequest) -> None:
         if request.working_dir:
@@ -131,7 +96,7 @@ class CodexRuntime(ProviderRuntime):
         runner = TmuxSessionRunner(
             tmux_session=self.tmux_session,
             provider_name=self.provider_name,
-            prompt_state_for_excerpt=self._prompt_state_for_excerpt,
+            prompt_state_for_excerpt=self.classifier.prompt_state_for_excerpt,
             terminal_verdict_for_observation=self._terminal_verdict_for_observation,
             interrupt_detector=self._detect_interrupt,
         )
@@ -182,31 +147,32 @@ class CodexRuntime(ProviderRuntime):
         handle: RuntimeSessionHandle,
     ) -> RuntimeInspection:
         if not handle.tmux_pane or not await pane_exists(handle.tmux_pane):
+            classification = self.classifier.classify_excerpt("", pane_missing=True)
             return RuntimeInspection(
                 session_id=handle.session_id,
                 provider_name=self.provider_name,
                 alive=False,
-                readiness=ReadinessState.STOPPED,
-                summary="Pane missing",
+                readiness=classification.readiness,
+                block_reason=classification.block_reason,
+                summary=classification.summary,
+                details=classification.as_details(),
             )
 
         excerpt = await capture_pane_text(handle.tmux_pane, lines=40)
-        interrupt = self._detect_interrupt(excerpt)
-        readiness, block_reason = self._classify_readiness(excerpt)
-        summary = (
-            interrupt.summary if interrupt else self._summary_for_state(readiness, block_reason)
-        )
+        classification = self.classifier.classify_excerpt(excerpt)
         inspection = RuntimeInspection(
             session_id=handle.session_id,
             provider_name=self.provider_name,
             alive=True,
-            readiness=readiness,
-            block_reason=block_reason,
-            summary=summary,
+            readiness=classification.readiness,
+            block_reason=classification.block_reason,
+            summary=classification.summary,
             last_output_excerpt=excerpt,
+            details=classification.as_details(),
         )
-        if interrupt is not None:
-            inspection.details.update(interrupt.to_trace_details())
+        inspection.details["recovery_capabilities"] = (
+            self.classifier.recovery_capabilities().as_dict()
+        )
         inspection.details["provider_runtime_hint"] = self._runtime_hint_for_inspection(inspection)
         inspection.details["provider_runtime_action"] = self._runtime_action_for_inspection(
             inspection
@@ -319,45 +285,8 @@ class CodexRuntime(ProviderRuntime):
             return "respawn"
         return "inspect"
 
-    def _classify_readiness(self, excerpt: str) -> tuple[ReadinessState, RuntimeBlockReason | None]:
-        if _CODEX_PROMPT_RE.search(excerpt):
-            return ReadinessState.READY, None
-        interrupt = self._detect_interrupt(excerpt)
-        if interrupt is not None:
-            return interrupt.readiness, interrupt.block_reason
-        return ReadinessState.BUSY, None
-
-    def _prompt_state_for_excerpt(self, excerpt: str) -> str:
-        if _CODEX_PROMPT_RE.search(excerpt):
-            return ReadinessState.READY.value
-        readiness, block_reason = self._classify_readiness(excerpt)
-        interrupt = self._detect_interrupt(excerpt)
-        fallback = f"{readiness.value}:{block_reason.value}" if block_reason else readiness.value
-        return interrupt_prompt_state(interrupt, fallback)
-
-    @staticmethod
-    def _detect_interrupt(excerpt: str):
-        lower = excerpt.lower()
-        last_interrupt = max(
-            lower.rfind(trigger)
-            for trigger in (
-                *_TRUST_TRIGGERS,
-                *_PERMISSION_TRIGGERS,
-                *_AUTH_TRIGGERS,
-                *_PROVIDER_ERROR_TRIGGERS,
-            )
-        )
-        last_ready = max(
-            lower.rfind(marker)
-            for marker in (
-                "\n› ",
-                "gpt-5.5 default",
-                "gpt-5 default",
-            )
-        )
-        if last_interrupt >= 0 and last_ready > last_interrupt:
-            return None
-        return detect_runtime_interrupt(excerpt, _INTERRUPT_SPEC)
+    def _detect_interrupt(self, excerpt: str):
+        return self.classifier.detect_interrupt(excerpt)
 
     @staticmethod
     def _delivery_action_from_metadata(metadata: dict[str, object]) -> DeliveryAction:
@@ -398,7 +327,7 @@ class CodexRuntime(ProviderRuntime):
                 verdict=DeliveryVerdict.BLOCKED,
                 reason_code=DeliveryReasonCode.PERMISSION_REQUIRED,
             )
-        if _CODEX_PROMPT_RE.search(output):
+        if CODEX_PROMPT_RE.search(output):
             return RunnerTerminalVerdict(
                 stage=DeliveryStage.PROMPT_CLEARED,
                 verdict=DeliveryVerdict.ACCEPTED,

--- a/tests/unit/test_codex_runtime_classifier.py
+++ b/tests/unit/test_codex_runtime_classifier.py
@@ -1,0 +1,70 @@
+"""Codex runtime integration tests for provider-owned classification."""
+
+from __future__ import annotations
+
+import pytest
+
+from atc.providers.codex import runtime as codex_runtime
+from atc.providers.codex.runtime import CodexRuntime
+from atc.runtime.models import (
+    BlockerReason,
+    DeliveryState,
+    ReadinessState,
+    RoleKind,
+    RuntimeSessionHandle,
+    RuntimeState,
+    RuntimeTransport,
+)
+
+
+def _handle() -> RuntimeSessionHandle:
+    return RuntimeSessionHandle(
+        session_id="session-1",
+        provider_name="codex",
+        role=RoleKind.LEADER,
+        transport=RuntimeTransport.TMUX,
+        tmux_session="atc-test",
+        tmux_pane="%1",
+    )
+
+
+@pytest.mark.asyncio
+async def test_codex_runtime_inspection_uses_classifier_details(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def fake_pane_exists(_pane: str) -> bool:
+        return True
+
+    async def fake_capture_pane_text(_pane: str, *, lines: int) -> str:
+        assert lines == 40
+        return "A new version of Codex is available. Update Codex?"
+
+    monkeypatch.setattr(codex_runtime, "pane_exists", fake_pane_exists)
+    monkeypatch.setattr(codex_runtime, "capture_pane_text", fake_capture_pane_text)
+
+    inspection = await CodexRuntime(tmux_session="atc-test").inspect_session(_handle())
+
+    assert inspection.readiness is ReadinessState.BLOCKED
+    assert inspection.summary == "Codex runtime update prompt visible"
+    assert inspection.details["runtime_state"] == RuntimeState.BLOCKED.value
+    assert inspection.details["delivery_state"] == DeliveryState.BLOCKED.value
+    assert inspection.details["blocker_reason"] == BlockerReason.RUNTIME_UPDATE_REQUIRED.value
+    assert inspection.details["provider_observation"] == "codex_update_prompt"
+    assert inspection.details["recovery_capabilities"]["can_detect_update_prompt"] is True
+
+
+@pytest.mark.asyncio
+async def test_codex_runtime_missing_pane_uses_neutral_missing_classification(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def fake_pane_exists(_pane: str) -> bool:
+        return False
+
+    monkeypatch.setattr(codex_runtime, "pane_exists", fake_pane_exists)
+
+    inspection = await CodexRuntime(tmux_session="atc-test").inspect_session(_handle())
+
+    assert inspection.alive is False
+    assert inspection.readiness is ReadinessState.STOPPED
+    assert inspection.details["runtime_state"] == RuntimeState.MISSING.value
+    assert inspection.details["blocker_reason"] == BlockerReason.PANE_MISSING.value

--- a/tests/unit/test_provider_classifiers.py
+++ b/tests/unit/test_provider_classifiers.py
@@ -1,0 +1,138 @@
+"""Tests for provider-owned runtime classifiers."""
+
+from __future__ import annotations
+
+from atc.providers.classifiers import RuntimeProviderClassifier
+from atc.providers.codex.classifier import CodexRuntimeClassifier
+from atc.runtime.models import (
+    BlockerReason,
+    DeliveryState,
+    ReadinessState,
+    RecoveryState,
+    RuntimeBlockReason,
+    RuntimeState,
+)
+
+
+def _classifier() -> CodexRuntimeClassifier:
+    return CodexRuntimeClassifier()
+
+
+def test_codex_classifier_satisfies_provider_contract() -> None:
+    classifier = _classifier()
+
+    assert isinstance(classifier, RuntimeProviderClassifier)
+    assert classifier.provider_name == "codex"
+
+    capabilities = classifier.recovery_capabilities()
+    assert capabilities.can_detect_update_prompt is True
+    assert capabilities.requires_fresh_session_after_update is True
+    assert capabilities.can_detect_default_prompt is True
+    assert capabilities.can_detect_unsubmitted_prompt is True
+
+
+def test_codex_update_prompt_maps_to_neutral_update_blocker() -> None:
+    result = _classifier().classify_excerpt(
+        "A new version of Codex is available. Update Codex? [y/N]"
+    )
+
+    assert result.runtime_state is RuntimeState.BLOCKED
+    assert result.delivery_state is DeliveryState.BLOCKED
+    assert result.readiness is ReadinessState.BLOCKED
+    assert result.block_reason is RuntimeBlockReason.PROVIDER_PROMPT
+    assert result.blocker_reason is BlockerReason.RUNTIME_UPDATE_REQUIRED
+    assert result.recovery_state is RecoveryState.RUNTIME_UPDATE_REQUIRED
+    assert result.provider_observation == "codex_update_prompt"
+
+
+def test_codex_stale_after_update_maps_to_stale_restart_required() -> None:
+    result = _classifier().classify_excerpt("Codex has been updated. Please restart Codex.")
+
+    assert result.runtime_state is RuntimeState.STALE
+    assert result.blocker_reason is BlockerReason.STALE_AFTER_UPDATE
+    assert result.recovery_state is RecoveryState.RESTART_REQUIRED
+    assert result.provider_observation == "codex_stale_after_update"
+
+
+def test_codex_default_prompt_is_idle_not_active_work() -> None:
+    result = _classifier().classify_excerpt("\n› Implement {feature}\n  Explain this codebase")
+
+    assert result.runtime_state is RuntimeState.IDLE_AT_DEFAULT_PROMPT
+    assert result.delivery_state is DeliveryState.PROMPT_VISIBLE
+    assert result.readiness is ReadinessState.READY
+    assert result.blocker_reason is BlockerReason.DEFAULT_PROMPT_VISIBLE
+    assert result.provider_observation == "codex_default_prompt"
+
+
+def test_codex_visible_unsubmitted_prompt_is_not_submitted() -> None:
+    result = _classifier().classify_excerpt("\n› Add runtime health command")
+
+    assert result.runtime_state is RuntimeState.IDLE
+    assert result.delivery_state is DeliveryState.PAYLOAD_WRITTEN
+    assert result.blocker_reason is BlockerReason.PROMPT_NOT_SUBMITTED
+    assert result.prompt_state == "prompt_visible:not_submitted"
+
+
+def test_codex_ready_prompt_is_prompt_visible_without_blocker() -> None:
+    result = _classifier().classify_excerpt("\nmodel: gpt-5.5 default\n› ")
+
+    assert result.runtime_state is RuntimeState.READY
+    assert result.delivery_state is DeliveryState.PROMPT_VISIBLE
+    assert result.blocker_reason is None
+    assert result.prompt_state == "ready"
+
+
+def test_codex_active_output_maps_to_accepted_active() -> None:
+    result = _classifier().classify_excerpt(
+        "Thinking...\nI need inspect the repository and run tests."
+    )
+
+    assert result.runtime_state is RuntimeState.ACTIVE
+    assert result.delivery_state is DeliveryState.ACCEPTED_ACTIVE
+    assert result.readiness is ReadinessState.BUSY
+    assert result.provider_observation == "codex_active_output"
+
+
+def test_codex_missing_pane_maps_to_pane_missing() -> None:
+    result = _classifier().classify_excerpt("", pane_missing=True)
+
+    assert result.runtime_state is RuntimeState.MISSING
+    assert result.delivery_state is DeliveryState.FAILED
+    assert result.blocker_reason is BlockerReason.PANE_MISSING
+    assert result.recovery_state is RecoveryState.RESTART_REQUIRED
+    assert result.requires_operator is True
+
+
+def test_codex_auth_trust_permission_and_provider_error_are_neutral_blockers() -> None:
+    cases = [
+        ("Sign in to continue", BlockerReason.RUNTIME_AUTH_REQUIRED, RuntimeBlockReason.AUTH),
+        (
+            "Do you trust this folder?",
+            BlockerReason.RUNTIME_TRUST_REQUIRED,
+            RuntimeBlockReason.TRUST,
+        ),
+        (
+            "Allow command to run before continuing",
+            BlockerReason.RUNTIME_PERMISSION_REQUIRED,
+            RuntimeBlockReason.PERMISSION,
+        ),
+        ("Failed to start Codex", BlockerReason.PROVIDER_ERROR, RuntimeBlockReason.PROVIDER_PROMPT),
+    ]
+
+    for excerpt, blocker_reason, block_reason in cases:
+        result = _classifier().classify_excerpt(excerpt)
+        assert result.delivery_state is DeliveryState.BLOCKED
+        assert result.blocker_reason is blocker_reason
+        assert result.block_reason is block_reason
+        assert result.requires_operator is True
+
+
+def test_codex_prompt_state_uses_classifier_output() -> None:
+    classifier = _classifier()
+
+    assert (
+        classifier.prompt_state_for_excerpt("\n› Implement {feature}")
+        == "idle_at_default_prompt"
+    )
+    assert classifier.prompt_state_for_excerpt("\n› Add tests") == "prompt_visible:not_submitted"
+    assert classifier.prompt_state_for_excerpt("\n› ") == "ready"


### PR DESCRIPTION
## Summary
- Add a provider-owned runtime classifier contract for mapping terminal observations into ATC's provider-neutral runtime truth fields.
- Add a Codex classifier slice for update prompts, stale-after-update states, default starter prompts, visible unsubmitted prompts, active output, missing panes, provider errors, and auth/trust/permission gates.
- Wire Codex runtime inspection and trace prompt-state classification through the Codex classifier so Tower/Leader/Ace-facing logic receives neutral states/details instead of matching Codex prompt strings.

## Validation
- `ruff check src/atc/providers/classifiers.py src/atc/providers/codex/classifier.py src/atc/providers/codex/runtime.py tests/unit/test_provider_classifiers.py tests/unit/test_codex_runtime_classifier.py tests/unit/test_runtime_truth.py tests/unit/test_delivery_api.py`
- `pytest tests/unit/test_provider_classifiers.py tests/unit/test_codex_runtime_classifier.py tests/unit/test_runtime_truth.py tests/unit/test_delivery_api.py tests/unit/test_tmux_session_runner.py tests/unit/test_tower_controller.py tests/unit/test_leader_api.py -q` — 73 passed, 1 existing FastAPI/Starlette deprecation warning
- `PATH=/opt/homebrew/opt/node/bin:/opt/homebrew/bin:$PATH npm run build`
- Playwright baseline smoke: 13/13 checks passed
  - Report: `/private/tmp/atc-work/screenshots/playwright-atc-2026-06-12T03-57-25-825Z/report.json`
  - Screenshots:
    - `/private/tmp/atc-work/screenshots/playwright-atc-2026-06-12T03-57-25-825Z/01-dashboard-initial.png`
    - `/private/tmp/atc-work/screenshots/playwright-atc-2026-06-12T03-57-25-825Z/08-usage.png`
    - `/private/tmp/atc-work/screenshots/playwright-atc-2026-06-12T03-57-25-825Z/12-context.png`
- Static prompt-string scan: Codex-specific default/update prompt strings are limited to the Codex classifier/tests; provider auth/trust/permission trigger strings remain provider-owned.
