### PR TITLE
fix: enforce Codex classifier delivery blockers

### DIFF
--- a/src/atc/providers/codex/classifier.py
+++ b/src/atc/providers/codex/classifier.py
@@ -10,7 +10,10 @@ import re
 
 from atc.providers.classifiers import RecoveryCapabilities, RuntimeClassification
 from atc.runtime.interrupts import (
+    RuntimeInterrupt,
+    RuntimeInterruptDisposition,
     RuntimeInterruptSpec,
+    RuntimeInterruptType,
     detect_runtime_interrupt,
     interrupt_prompt_state,
 )
@@ -22,6 +25,7 @@ from atc.runtime.models import (
     RuntimeBlockReason,
     RuntimeState,
 )
+from atc.runtime.tracing import DeliveryReasonCode
 
 CODEX_PROMPT_RE = re.compile(r"(^|\n)\s*(❯|>)\s*$|(^|\n)\s*›\s+(?!\d+\.)", re.MULTILINE)
 
@@ -64,13 +68,6 @@ _DEFAULT_PROMPT_TRIGGERS = (
     "implement {feature}",
     "explain this codebase",
 )
-_UNSUBMITTED_PROMPT_TRIGGERS = (
-    "implement ",
-    "fix ",
-    "add ",
-    "update ",
-)
-
 _INTERRUPT_SPEC = RuntimeInterruptSpec(
     trust_triggers=_TRUST_TRIGGERS,
     permission_triggers=_PERMISSION_TRIGGERS,
@@ -118,8 +115,10 @@ class CodexRuntimeClassifier:
                 diagnostics=interrupt.to_trace_details(),
             )
 
-        lower = excerpt.lower()
-        if _contains_any(lower, _UPDATE_TRIGGERS):
+        active_region = _active_region(excerpt)
+        active_lower = active_region.lower()
+        prompt_text = _latest_prompt_text(excerpt)
+        if _contains_any(active_lower, _UPDATE_TRIGGERS):
             return RuntimeClassification(
                 runtime_state=RuntimeState.BLOCKED,
                 delivery_state=DeliveryState.BLOCKED,
@@ -133,7 +132,7 @@ class CodexRuntimeClassifier:
                 requires_operator=True,
                 diagnostics={"codex_observation": "update_prompt"},
             )
-        if _contains_any(lower, _POST_UPDATE_STALE_TRIGGERS):
+        if _contains_any(active_lower, _POST_UPDATE_STALE_TRIGGERS):
             return RuntimeClassification(
                 runtime_state=RuntimeState.STALE,
                 delivery_state=DeliveryState.FAILED,
@@ -147,7 +146,7 @@ class CodexRuntimeClassifier:
                 requires_operator=True,
                 diagnostics={"codex_observation": "stale_after_update"},
             )
-        if _contains_any(lower, _DEFAULT_PROMPT_TRIGGERS):
+        if _contains_any(active_lower, _DEFAULT_PROMPT_TRIGGERS):
             return RuntimeClassification(
                 runtime_state=RuntimeState.IDLE_AT_DEFAULT_PROMPT,
                 delivery_state=DeliveryState.PROMPT_VISIBLE,
@@ -159,7 +158,7 @@ class CodexRuntimeClassifier:
                 recovery_state=RecoveryState.NOT_NEEDED,
                 diagnostics={"codex_observation": "default_prompt"},
             )
-        if self._looks_unsubmitted_prompt(excerpt):
+        if prompt_text is not None and prompt_text.strip():
             return RuntimeClassification(
                 runtime_state=RuntimeState.IDLE,
                 delivery_state=DeliveryState.PAYLOAD_WRITTEN,
@@ -241,17 +240,34 @@ class CodexRuntimeClassifier:
             return None
         return detect_runtime_interrupt(excerpt, _INTERRUPT_SPEC)
 
-    def _looks_unsubmitted_prompt(self, excerpt: str) -> bool:
-        lines = [line.strip().lower() for line in excerpt.splitlines() if line.strip()]
-        if not lines:
-            return False
-        latest = lines[-1]
-        if not latest.startswith(("›", ">", "❯")):
-            return False
-        prompt_text = latest.lstrip("›>❯ ").strip()
-        if not prompt_text:
-            return False
-        return _contains_any(prompt_text, _UNSUBMITTED_PROMPT_TRIGGERS)
+    def blocking_interrupt_for_excerpt(self, excerpt: str) -> RuntimeInterrupt | None:
+        classification = self.classify_excerpt(excerpt)
+        if classification.blocker_reason is BlockerReason.RUNTIME_UPDATE_REQUIRED:
+            return RuntimeInterrupt(
+                interrupt_type=RuntimeInterruptType.UNKNOWN_PROMPT_BLOCKER,
+                disposition=RuntimeInterruptDisposition.BLOCKING,
+                reason_code=DeliveryReasonCode.RUNTIME_UPDATE_REQUIRED,
+                readiness=ReadinessState.BLOCKED,
+                block_reason=RuntimeBlockReason.PROVIDER_PROMPT,
+                summary=classification.summary or "Runtime update required",
+                operator_action="inspect_or_update_runtime",
+                matched_trigger=classification.provider_observation,
+            )
+        if classification.blocker_reason is BlockerReason.PROMPT_NOT_SUBMITTED:
+            return RuntimeInterrupt(
+                interrupt_type=RuntimeInterruptType.UNKNOWN_PROMPT_BLOCKER,
+                disposition=RuntimeInterruptDisposition.BLOCKING,
+                reason_code=DeliveryReasonCode.PROMPT_NOT_SUBMITTED,
+                readiness=ReadinessState.BLOCKED,
+                block_reason=RuntimeBlockReason.PROVIDER_PROMPT,
+                summary=classification.summary or "Prompt text is visible but not submitted",
+                operator_action="submit_or_clear_prompt",
+                matched_trigger=classification.provider_observation,
+            )
+        interrupt = self.detect_interrupt(excerpt)
+        if interrupt is not None and interrupt.disposition is RuntimeInterruptDisposition.BLOCKING:
+            return interrupt
+        return None
 
 
 def _contains_any(text: str, triggers: tuple[str, ...]) -> bool:
@@ -267,4 +283,30 @@ def _blocker_reason_for_interrupt(reason_code: str) -> BlockerReason:
         return BlockerReason.RUNTIME_PERMISSION_REQUIRED
     if reason_code == "provider_error":
         return BlockerReason.PROVIDER_ERROR
+    if reason_code == "runtime_update_required":
+        return BlockerReason.RUNTIME_UPDATE_REQUIRED
+    if reason_code == "prompt_not_submitted":
+        return BlockerReason.PROMPT_NOT_SUBMITTED
     return BlockerReason.UNKNOWN_PROMPT_BLOCKER
+
+
+def _active_region(excerpt: str) -> str:
+    marker_index = max(
+        excerpt.rfind("\n› "),
+        excerpt.rfind("\n> "),
+        excerpt.rfind("\n❯ "),
+    )
+    if marker_index < 0:
+        return excerpt
+    return excerpt[marker_index:]
+
+
+def _latest_prompt_text(excerpt: str) -> str | None:
+    for line in reversed(excerpt.splitlines()):
+        stripped = line.strip()
+        if not stripped:
+            continue
+        if stripped.startswith(("›", ">", "❯")):
+            return stripped.lstrip("›>❯ ").strip()
+        return None
+    return None

--- a/src/atc/providers/codex/runtime.py
+++ b/src/atc/providers/codex/runtime.py
@@ -98,7 +98,7 @@ class CodexRuntime(ProviderRuntime):
             provider_name=self.provider_name,
             prompt_state_for_excerpt=self.classifier.prompt_state_for_excerpt,
             terminal_verdict_for_observation=self._terminal_verdict_for_observation,
-            interrupt_detector=self._detect_interrupt,
+            interrupt_detector=self.classifier.blocking_interrupt_for_excerpt,
         )
         await runner.deliver_instruction(
             handle=handle,
@@ -326,6 +326,18 @@ class CodexRuntime(ProviderRuntime):
                 stage=DeliveryStage.BLOCKED,
                 verdict=DeliveryVerdict.BLOCKED,
                 reason_code=DeliveryReasonCode.PERMISSION_REQUIRED,
+            )
+        if after_state == "blocked:runtime_update_required":
+            return RunnerTerminalVerdict(
+                stage=DeliveryStage.BLOCKED,
+                verdict=DeliveryVerdict.BLOCKED,
+                reason_code=DeliveryReasonCode.RUNTIME_UPDATE_REQUIRED,
+            )
+        if after_state == "prompt_visible:not_submitted":
+            return RunnerTerminalVerdict(
+                stage=DeliveryStage.BLOCKED,
+                verdict=DeliveryVerdict.BLOCKED,
+                reason_code=DeliveryReasonCode.PROMPT_NOT_SUBMITTED,
             )
         if CODEX_PROMPT_RE.search(output):
             return RunnerTerminalVerdict(

--- a/src/atc/runtime/tracing.py
+++ b/src/atc/runtime/tracing.py
@@ -76,6 +76,8 @@ class DeliveryReasonCode(StrEnum):
     TRUST_REQUIRED = "trust_required"
     PERMISSION_REQUIRED = "permission_required"
     WELCOME_SCREEN = "welcome_screen"
+    RUNTIME_UPDATE_REQUIRED = "runtime_update_required"
+    PROMPT_NOT_SUBMITTED = "prompt_not_submitted"
     UNKNOWN_PROMPT_BLOCKER = "unknown_prompt_blocker"
     DELIVERY_UNVERIFIED = "delivery_unverified"
     PROVIDER_ERROR = "provider_error"
@@ -298,6 +300,8 @@ def _blocker_reason(reason_code: str) -> BlockerReason | None:
         DeliveryReasonCode.TRUST_REQUIRED.value: BlockerReason.RUNTIME_TRUST_REQUIRED,
         DeliveryReasonCode.PERMISSION_REQUIRED.value: BlockerReason.RUNTIME_PERMISSION_REQUIRED,
         DeliveryReasonCode.WELCOME_SCREEN.value: BlockerReason.DEFAULT_PROMPT_VISIBLE,
+        DeliveryReasonCode.RUNTIME_UPDATE_REQUIRED.value: BlockerReason.RUNTIME_UPDATE_REQUIRED,
+        DeliveryReasonCode.PROMPT_NOT_SUBMITTED.value: BlockerReason.PROMPT_NOT_SUBMITTED,
         DeliveryReasonCode.UNKNOWN_PROMPT_BLOCKER.value: BlockerReason.UNKNOWN_PROMPT_BLOCKER,
         DeliveryReasonCode.PROVIDER_ERROR.value: BlockerReason.PROVIDER_ERROR,
         DeliveryReasonCode.UNKNOWN_ERROR.value: BlockerReason.UNKNOWN_ERROR,

--- a/tests/unit/test_provider_classifiers.py
+++ b/tests/unit/test_provider_classifiers.py
@@ -65,7 +65,7 @@ def test_codex_default_prompt_is_idle_not_active_work() -> None:
 
 
 def test_codex_visible_unsubmitted_prompt_is_not_submitted() -> None:
-    result = _classifier().classify_excerpt("\n› Add runtime health command")
+    result = _classifier().classify_excerpt("\n› Review PR #287")
 
     assert result.runtime_state is RuntimeState.IDLE
     assert result.delivery_state is DeliveryState.PAYLOAD_WRITTEN
@@ -136,3 +136,31 @@ def test_codex_prompt_state_uses_classifier_output() -> None:
     )
     assert classifier.prompt_state_for_excerpt("\n› Add tests") == "prompt_visible:not_submitted"
     assert classifier.prompt_state_for_excerpt("\n› ") == "ready"
+
+
+def test_codex_stale_scrollback_is_ignored_when_latest_prompt_is_ready() -> None:
+    classifier = _classifier()
+
+    update_result = classifier.classify_excerpt(
+        "A new version of Codex is available. Update Codex?\n\n› "
+    )
+    default_result = classifier.classify_excerpt("\n› Implement {feature}\n\n› ")
+
+    assert update_result.runtime_state is RuntimeState.READY
+    assert update_result.blocker_reason is None
+    assert default_result.runtime_state is RuntimeState.READY
+    assert default_result.blocker_reason is None
+
+
+def test_codex_classifier_blocks_delivery_for_update_and_unsubmitted_prompts() -> None:
+    classifier = _classifier()
+
+    update_interrupt = classifier.blocking_interrupt_for_excerpt(
+        "A new version of Codex is available. Update Codex?"
+    )
+    unsubmitted_interrupt = classifier.blocking_interrupt_for_excerpt("\n› Review PR #287")
+
+    assert update_interrupt is not None
+    assert update_interrupt.reason_code.value == "runtime_update_required"
+    assert unsubmitted_interrupt is not None
+    assert unsubmitted_interrupt.reason_code.value == "prompt_not_submitted"


### PR DESCRIPTION
## Summary
- Follow-up to Phase 2 after focused provider-encapsulation review.
- Route Codex delivery blocking through the provider-owned classifier for runtime update and visible-unsubmitted prompt states.
- Add neutral delivery reason codes for `runtime_update_required` and `prompt_not_submitted` so runtime truth metadata is explicit.
- Avoid stale scrollback false blockers by classifying update/default prompt states from the active/latest prompt region.
- Treat any visible prompt text as unsubmitted, instead of relying on a small verb allowlist.

## Validation
- `ruff check src/atc/runtime/tracing.py src/atc/providers/classifiers.py src/atc/providers/codex/classifier.py src/atc/providers/codex/runtime.py tests/unit/test_provider_classifiers.py tests/unit/test_codex_runtime_classifier.py tests/unit/test_runtime_truth.py tests/unit/test_delivery_api.py`
- `pytest tests/unit/test_provider_classifiers.py tests/unit/test_codex_runtime_classifier.py tests/unit/test_runtime_truth.py tests/unit/test_delivery_api.py tests/unit/test_tmux_session_runner.py tests/unit/test_tower_controller.py tests/unit/test_leader_api.py -q` — 75 passed, 1 existing FastAPI/Starlette deprecation warning
- `PATH=/opt/homebrew/opt/node/bin:/opt/homebrew/bin:$PATH npm run build`
- Existing Phase 2 Playwright baseline smoke evidence remains unchanged by this backend-only fix: 13/13 checks passed at `/private/tmp/atc-work/screenshots/playwright-atc-2026-06-12T03-57-25-825Z/report.json`
