### PR TITLE
feat: verify Leader kickoff startup

### DIFF
--- a/src/atc/api/routers/projects.py
+++ b/src/atc/api/routers/projects.py
@@ -17,9 +17,14 @@ import logging
 from fastapi import APIRouter, HTTPException, Request
 from pydantic import BaseModel
 
-from atc.api.delivery import delivery_response, queued_response
+from atc.api.delivery import delivery_response
 from atc.core.errors import CreationFailedError
 from atc.leader import leader as leader_ops
+from atc.leader.kickoff import (
+    build_leader_kickoff_message,
+    persist_leader_kickoff_payload,
+    verify_leader_kickoff_delivery,
+)
 from atc.runtime.models import RuntimeDeliveryResult
 from atc.state import db as db_ops
 
@@ -372,104 +377,76 @@ async def start_leader(
                 except Exception:
                     pass
 
-    # Auto-kickoff: send mission brief to the leader pane so it starts working.
-    # This mirrors what TowerController._send_leader_kickoff() does, but runs
-    # directly from the API for standalone (non-Tower) usage.
-    if body.goal and body.auto_kickoff:
-        import asyncio as _asyncio
+    kickoff_delivery = None
+    kickoff_payload = None
 
+    # Auto-kickoff: send mission brief to the leader pane so it starts working.
+    # Phase 3 performs this synchronously enough to return a truthful kickoff
+    # delivery verdict instead of only optimistic queued state.
+    if body.goal:
         from atc.leader.leader import send_leader_message as _send_leader_msg
 
-        async def _kickoff() -> None:
-            import logging as _logging
-
-            _log = _logging.getLogger(__name__)
-            # Build kickoff message
-            cursor = await db.execute(
-                "SELECT name, description, repo_path, github_repo FROM projects WHERE id = ?",
-                (project_id,),
-            )
-            row = await cursor.fetchone()
-            project_name = row[0] if row else "Unknown"
-            description = row[1] if row else None
-            repo_path = row[2] if row else None
-            lines = [
-                f"# Mission Brief — {project_name}",
-                "",
-                "## Goal",
-                body.goal,
-                "",
-            ]
-            if description:
-                lines += ["## Project Description", description, ""]
-            if repo_path:
-                lines += ["## Repository", f"Local path: {repo_path}", ""]
-            lines += [
-                "## Your Instructions",
-                "You are the project Leader, not the implementer.",
-                "Do NOT write product files yourself.",
-                "Operate through the ATC orchestration API only.",
-                "",
-                "1. First decompose the goal into well-scoped tasks via POST "
-                "/api/projects/{project_id}/leader/decompose.",
-                "2. Then spawn Aces for ready tasks via POST "
-                "/api/projects/{project_id}/leader/spawn-aces.",
-                "3. Then instruct spawned Aces via POST "
-                "/api/projects/{project_id}/leader/instruct.",
-                "4. Monitor progress via GET /api/projects/{project_id}/leader/progress.",
-                "5. Drive the project to completion by delegating, not by coding directly.",
-                "",
-                f"Project ID: {project_id}",
-                "Begin NOW by decomposing, not by exploring the workspace.",
-            ]
-            kickoff_msg = "\n".join(lines)
-
-            # Retry loop: wait for the leader pane to be ready before sending.
-            # The pane needs time to start Claude Code and clear startup dialogs.
-            # send_leader_message internally calls wait_for_prompt, so we just
-            # need to retry on ValueError (pane dead/not ready) for up to 60s.
-            deadline = _asyncio.get_event_loop().time() + 60
-            attempt = 0
-            while _asyncio.get_event_loop().time() < deadline:
-                attempt += 1
-                await _asyncio.sleep(5)  # wait for pane to initialise
-                try:
-                    await _send_leader_msg(db, project_id, kickoff_msg, event_bus=event_bus)
-                    _log.info(
-                        "Auto-kickoff sent to leader for project %s (attempt %d)",
-                        project_id,
-                        attempt,
-                    )
-                    return
-                except ValueError as exc:
-                    _log.debug(
-                        "Auto-kickoff attempt %d for project %s: %s", attempt, project_id, exc
-                    )
-                    # Pane not ready yet — retry
-                except Exception:
-                    _log.exception(
-                        "Auto-kickoff failed for project %s on attempt %d", project_id, attempt
-                    )
-                    return  # non-retryable error
-            _log.warning(
-                "Auto-kickoff timed out for project %s after %d attempts", project_id, attempt
-            )
-
-        _asyncio.ensure_future(_kickoff())
+        cursor = await db.execute(
+            "SELECT name, description, repo_path, github_repo FROM projects WHERE id = ?",
+            (project_id,),
+        )
+        row = await cursor.fetchone()
+        project_name = row[0] if row else "Unknown"
+        description = row[1] if row else None
+        repo_path = row[2] if row else None
+        github_repo = row[3] if row else None
+        kickoff_msg = build_leader_kickoff_message(
+            project_id=project_id,
+            project_name=project_name,
+            goal=body.goal,
+            description=description,
+            repo_path=repo_path,
+            github_repo=github_repo,
+            api_style="explicit-api",
+        )
+        kickoff_payload = await persist_leader_kickoff_payload(
+            db,
+            project_id=project_id,
+            goal=body.goal,
+            message=kickoff_msg,
+            source="leader-start-api",
+            auto_kickoff=body.auto_kickoff,
+        )
+        if body.auto_kickoff:
+            try:
+                kickoff_delivery = await _send_leader_msg(
+                    db, project_id, kickoff_msg, event_bus=event_bus
+                )
+            except ValueError as exc:
+                raise HTTPException(status_code=409, detail=str(exc)) from None
+            except RuntimeError as exc:
+                raise HTTPException(
+                    status_code=409, detail=f"Leader pane unavailable: {exc}"
+                ) from None
 
     if body.goal and body.auto_kickoff:
-        return queued_response(
-            message="Leader session started; auto-kickoff queued and awaiting runtime verification",
+        response = delivery_response(
+            kickoff_delivery,
+            fallback_state="queued",
+            message="Leader session started; kickoff delivery is awaiting provider verification",
             project_id=project_id,
             leader_session_id=session_id,
             session_id=session_id,
+            recovery="inspect Leader runtime/session status before normal monitoring",
         )
+        verification = verify_leader_kickoff_delivery(kickoff_delivery)
+        response.update(verification.as_dict())
+        response["kickoff_payload_persisted"] = kickoff_payload is not None
+        return response
     return {
         "status": "started",
         "delivery_state": "started",
         "session_id": session_id,
         "leader_session_id": session_id,
         "project_id": project_id,
+        "kickoff_verified": False,
+        "kickoff_state": "not_requested",
+        "kickoff_payload_persisted": kickoff_payload is not None,
         "message": "Leader session started; no kickoff delivery was requested",
     }
 

--- a/src/atc/leader/kickoff.py
+++ b/src/atc/leader/kickoff.py
@@ -1,0 +1,257 @@
+"""Leader kickoff payload persistence and verification helpers.
+
+Phase 3 keeps the kickoff contract provider-neutral: front doors and Tower see
+runtime truth fields and kickoff verification state, while provider-specific
+prompt classification remains inside provider adapters.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    import aiosqlite  # type: ignore[import-not-found]
+
+from atc.runtime.models import BlockerReason, DeliveryState, RuntimeDeliveryResult, RuntimeState
+from atc.state import db as db_ops
+
+
+@dataclass(slots=True)
+class LeaderKickoffPayload:
+    """Persisted source-of-truth kickoff payload for Leader recovery."""
+
+    project_id: str
+    goal: str
+    message: str
+    source: str
+    auto_kickoff: bool = True
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "project_id": self.project_id,
+            "goal": self.goal,
+            "message": self.message,
+            "source": self.source,
+            "auto_kickoff": self.auto_kickoff,
+        }
+
+
+@dataclass(slots=True)
+class LeaderKickoffVerification:
+    """Provider-neutral Leader kickoff verification verdict."""
+
+    kickoff_verified: bool
+    kickoff_state: str
+    runtime_created: bool
+    payload_written: bool
+    submit_sent: bool
+    provider_accepted: bool
+    leader_began_work: bool
+    blocker_reason: str | None = None
+    message: str | None = None
+
+    def as_dict(self) -> dict[str, Any]:
+        data: dict[str, Any] = {
+            "kickoff_verified": self.kickoff_verified,
+            "kickoff_state": self.kickoff_state,
+            "runtime_created": self.runtime_created,
+            "payload_written": self.payload_written,
+            "submit_sent": self.submit_sent,
+            "provider_accepted": self.provider_accepted,
+            "leader_began_work": self.leader_began_work,
+        }
+        if self.blocker_reason:
+            data["blocker_reason"] = self.blocker_reason
+        if self.message:
+            data["message"] = self.message
+        return data
+
+
+def build_leader_kickoff_message(
+    *,
+    project_id: str,
+    project_name: str,
+    goal: str,
+    description: str | None = None,
+    repo_path: str | None = None,
+    github_repo: str | None = None,
+    context_rows: list[tuple[str, str]] | None = None,
+    api_style: str = "compact",
+) -> str:
+    """Build the Leader mission brief used by API/Tower kickoff paths."""
+
+    lines = [
+        f"# Mission Brief — {project_name}",
+        "",
+        "## Goal",
+        goal,
+        "",
+    ]
+    if description:
+        lines += ["## Project Description", description, ""]
+    if repo_path:
+        lines += ["## Repository", f"Local path: {repo_path}", ""]
+    if github_repo:
+        lines += [f"GitHub: {github_repo}", ""]
+    if context_rows:
+        lines += ["## Project Context", ""]
+        for key, val in context_rows:
+            if key not in {"goal", "project_description", "repo_path", "github_repo"}:
+                lines += [f"**{key}:** {val}", ""]
+    lines += ["## Your Instructions"]
+    if api_style == "explicit-api":
+        lines += [
+            "You are the project Leader, not the implementer.",
+            "Do NOT write product files yourself.",
+            "Operate through the ATC orchestration API only.",
+            "",
+            "1. First decompose the goal into well-scoped tasks via POST "
+            f"/api/projects/{project_id}/leader/decompose.",
+            "2. Then spawn Aces for ready tasks via POST "
+            f"/api/projects/{project_id}/leader/spawn-aces.",
+            "3. Then instruct spawned Aces via POST "
+            f"/api/projects/{project_id}/leader/instruct.",
+            f"4. Monitor progress via GET /api/projects/{project_id}/leader/progress.",
+            "5. Drive the project to completion by delegating, not by coding directly.",
+            "",
+            f"Project ID: {project_id}",
+            "Begin NOW by decomposing, not by exploring the workspace.",
+        ]
+    else:
+        lines += [
+            "1. Decompose the goal into well-scoped tasks using the API.",
+            "2. Spawn Aces for each ready task.",
+            "3. Monitor progress and drive to completion.",
+            "4. Report back to Tower when done.",
+            "",
+            "Begin NOW. Do not ask for clarification — start decomposing.",
+        ]
+    return "\n".join(lines)
+
+
+async def persist_leader_kickoff_payload(
+    conn: aiosqlite.Connection,
+    *,
+    project_id: str,
+    goal: str,
+    message: str,
+    source: str,
+    auto_kickoff: bool = True,
+) -> LeaderKickoffPayload:
+    """Persist original kickoff payload on the Leader context for deterministic recovery."""
+
+    leader = await db_ops.get_leader_by_project(conn, project_id)
+    if leader is None:
+        raise ValueError(f"No leader found for project {project_id}")
+    context: dict[str, Any]
+    if isinstance(leader.context, dict):
+        context = dict(leader.context)
+    elif leader.context:
+        try:
+            parsed = json.loads(leader.context)
+            context = parsed if isinstance(parsed, dict) else {}
+        except json.JSONDecodeError:
+            context = {}
+    else:
+        context = {}
+    payload = LeaderKickoffPayload(
+        project_id=project_id,
+        goal=goal,
+        message=message,
+        source=source,
+        auto_kickoff=auto_kickoff,
+    )
+    context["leader_kickoff_payload"] = payload.as_dict()
+    context["leader_original_goal"] = goal
+    await conn.execute(
+        "UPDATE leaders SET context = ?, goal = ?, updated_at = datetime('now') WHERE id = ?",
+        (json.dumps(context), goal, leader.id),
+    )
+    await conn.commit()
+    return payload
+
+
+def verify_leader_kickoff_delivery(
+    result: RuntimeDeliveryResult | None,
+) -> LeaderKickoffVerification:
+    """Classify a kickoff delivery result into explicit startup guarantees."""
+
+    if result is None:
+        return LeaderKickoffVerification(
+            kickoff_verified=False,
+            kickoff_state="queued_unverified",
+            runtime_created=False,
+            payload_written=False,
+            submit_sent=False,
+            provider_accepted=False,
+            leader_began_work=False,
+            message="Kickoff delivery was queued but not observed",
+        )
+
+    delivery = result.delivery_state
+    runtime_state = result.runtime_state
+    blocker = result.blocker_reason
+    runtime_created = delivery in {
+        DeliveryState.RUNTIME_CREATED,
+        DeliveryState.PROMPT_VISIBLE,
+        DeliveryState.PAYLOAD_WRITTEN,
+        DeliveryState.SUBMIT_SENT,
+        DeliveryState.SUBMITTED_PENDING_ACCEPTANCE,
+        DeliveryState.ACCEPTED_ACTIVE,
+        DeliveryState.BLOCKED,
+    } or runtime_state in {
+        RuntimeState.READY,
+        RuntimeState.ACTIVE,
+        RuntimeState.BLOCKED,
+        RuntimeState.IDLE,
+        RuntimeState.IDLE_AT_DEFAULT_PROMPT,
+    }
+    payload_written = delivery in {
+        DeliveryState.PAYLOAD_WRITTEN,
+        DeliveryState.SUBMIT_SENT,
+        DeliveryState.SUBMITTED_PENDING_ACCEPTANCE,
+        DeliveryState.ACCEPTED_ACTIVE,
+    }
+    submit_sent = delivery in {
+        DeliveryState.SUBMIT_SENT,
+        DeliveryState.SUBMITTED_PENDING_ACCEPTANCE,
+        DeliveryState.ACCEPTED_ACTIVE,
+    }
+    provider_accepted = delivery is DeliveryState.ACCEPTED_ACTIVE or result.status in {
+        "confirmed",
+        "delivered",
+    }
+    leader_began_work = (
+        runtime_state is RuntimeState.ACTIVE
+        or delivery is DeliveryState.ACCEPTED_ACTIVE
+    )
+    kickoff_verified = bool(result.ok and provider_accepted and leader_began_work)
+
+    if blocker is not None or result.status in {"blocked", "failed"}:
+        state = "blocked" if result.status == "blocked" else "failed"
+    elif kickoff_verified:
+        state = "accepted_active"
+    elif submit_sent:
+        state = "submitted_pending_acceptance"
+    elif payload_written:
+        state = "payload_written"
+    elif delivery is DeliveryState.PROMPT_VISIBLE:
+        state = "prompt_visible"
+    elif delivery is DeliveryState.RUNTIME_CREATED:
+        state = "runtime_created"
+    else:
+        state = "queued_unverified"
+
+    return LeaderKickoffVerification(
+        kickoff_verified=kickoff_verified,
+        kickoff_state=state,
+        runtime_created=runtime_created,
+        payload_written=payload_written,
+        submit_sent=submit_sent,
+        provider_accepted=provider_accepted,
+        leader_began_work=leader_began_work,
+        blocker_reason=blocker.value if isinstance(blocker, BlockerReason) else None,
+        message=result.message,
+    )

--- a/src/atc/tower/controller.py
+++ b/src/atc/tower/controller.py
@@ -25,6 +25,11 @@ from typing import TYPE_CHECKING, Any
 
 from atc.config import load_settings
 from atc.leader.context_package import build_context_package
+from atc.leader.kickoff import (
+    build_leader_kickoff_message,
+    persist_leader_kickoff_payload,
+    verify_leader_kickoff_delivery,
+)
 from atc.leader.leader import send_leader_message, start_leader, stop_leader
 from atc.runtime.models import RoleKind, RuntimeDeliveryResult
 from atc.session.state_machine import SessionStatus
@@ -379,14 +384,19 @@ class TowerController:
                 },
             )
 
-            # Send kickoff and start background verification loop
+            # Send kickoff and derive a provider-neutral startup verification verdict.
             kickoff_delivery = await self._send_leader_kickoff(leader_session_id, goal)
-            asyncio.create_task(self._verify_leader_started(project_id, leader_session_id, goal))
+            verification = verify_leader_kickoff_delivery(kickoff_delivery)
+            kickoff_payload_persisted = await self._leader_kickoff_payload_persisted(project_id)
+            if verification.kickoff_verified:
+                asyncio.create_task(
+                    self._verify_leader_started(project_id, leader_session_id, goal)
+                )
 
-            # Notify Tower's own Claude session so it knows a Leader is running
-            # and can begin monitoring.  Best-effort — don't fail the whole goal
-            # submission if Tower's terminal isn't ready yet.
-            if self._current_session_id:
+            # Notify Tower's own Claude session only after the kickoff has verified
+            # enough runtime truth for normal monitoring. Blocked/unverified startup
+            # stays surfaced as startup state instead of triggering a monitoring loop.
+            if self._current_session_id and verification.kickoff_verified:
                 asyncio.create_task(
                     self._notify_tower_goal_started(project_id, leader_session_id, goal)
                 )
@@ -403,6 +413,8 @@ class TowerController:
                     "context_package": context_package,
                     "provider": kickoff_delivery.provider_name,
                     "delivery": kickoff_delivery.as_dict(),
+                    **verification.as_dict(),
+                    "kickoff_payload_persisted": kickoff_payload_persisted,
                     "recovery": (
                         "inspect Leader runtime/session status before assuming "
                         "kickoff delivery"
@@ -411,7 +423,9 @@ class TowerController:
 
             return {
                 "status": "queued",
-                "delivery_state": "queued",
+                "delivery_state": verification.kickoff_state,
+                **verification.as_dict(),
+                "kickoff_payload_persisted": kickoff_payload_persisted,
                 "message": (
                     "Goal queued; Leader session was created and kickoff verification "
                     "is still pending"
@@ -606,6 +620,19 @@ class TowerController:
             logger.exception("Failed to respawn leader for project %s", project_id)
             return None
 
+    async def _leader_kickoff_payload_persisted(self, project_id: str) -> bool:
+        leader = await db_ops.get_leader_by_project(self._db, project_id)
+        if leader is None or not leader.context:
+            return False
+        if isinstance(leader.context, dict):
+            context = leader.context
+        else:
+            try:
+                context = json.loads(leader.context)
+            except json.JSONDecodeError:
+                return False
+        return isinstance(context, dict) and bool(context.get("leader_kickoff_payload"))
+
     async def _send_leader_kickoff(
         self, session_id: str, goal: str
     ) -> RuntimeDeliveryResult | None:
@@ -632,34 +659,23 @@ class TowerController:
             )
             context_rows = await cursor.fetchall()
 
-            lines = [
-                f"# Mission Brief — {project_name}",
-                "",
-                "## Goal",
-                goal,
-                "",
-            ]
-            if description:
-                lines += ["## Project Description", description, ""]
-            if repo_path:
-                lines += ["## Repository", f"Local path: {repo_path}", ""]
-            if github_repo:
-                lines += [f"GitHub: {github_repo}", ""]
-            if context_rows:
-                lines += ["## Project Context", ""]
-                for key, val in context_rows:
-                    if key not in ("goal", "project_description", "repo_path", "github_repo"):
-                        lines += [f"**{key}:** {val}", ""]
-            lines += [
-                "## Your Instructions",
-                "1. Decompose the goal into well-scoped tasks using the API.",
-                "2. Spawn Aces for each ready task.",
-                "3. Monitor progress and drive to completion.",
-                "4. Report back to Tower when done.",
-                "",
-                "Begin NOW. Do not ask for clarification — start decomposing.",
-            ]
-            kickoff_msg = "\n".join(lines)
+            kickoff_msg = build_leader_kickoff_message(
+                project_id=self._current_project_id,
+                project_name=project_name,
+                goal=goal,
+                description=description,
+                repo_path=repo_path,
+                github_repo=github_repo,
+                context_rows=context_rows,
+            )
+            await persist_leader_kickoff_payload(
+                self._db,
+                project_id=self._current_project_id,
+                goal=goal,
+                message=kickoff_msg,
+                source="tower-submit-goal",
+                auto_kickoff=True,
+            )
 
             try:
                 delivery = await send_leader_message(

--- a/tests/unit/test_leader_kickoff.py
+++ b/tests/unit/test_leader_kickoff.py
@@ -1,0 +1,139 @@
+"""Tests for Leader kickoff payload persistence and verification."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from atc.leader.kickoff import (
+    build_leader_kickoff_message,
+    persist_leader_kickoff_payload,
+    verify_leader_kickoff_delivery,
+)
+from atc.runtime.models import (
+    DeliveryState,
+    RoleKind,
+    RuntimeDeliveryResult,
+    RuntimeState,
+)
+from atc.state.db import (
+    _SCHEMA_SQL,
+    create_leader,
+    create_project,
+    get_connection,
+    run_migrations,
+)
+
+
+@pytest.fixture
+async def db():
+    await run_migrations(":memory:")
+    async with get_connection(":memory:") as conn:
+        await conn.executescript(_SCHEMA_SQL)
+        await conn.commit()
+        yield conn
+
+
+@pytest.mark.asyncio
+async def test_persist_leader_kickoff_payload_is_recoverable(db) -> None:
+    project = await create_project(db, "kickoff-proj")
+    await create_leader(db, project.id, goal="old goal")
+    message = build_leader_kickoff_message(
+        project_id=project.id,
+        project_name=project.name,
+        goal="Build runtime truth",
+        description="phase 3",
+        api_style="explicit-api",
+    )
+
+    payload = await persist_leader_kickoff_payload(
+        db,
+        project_id=project.id,
+        goal="Build runtime truth",
+        message=message,
+        source="test",
+    )
+
+    cursor = await db.execute(
+        "SELECT context, goal FROM leaders WHERE project_id = ?", (project.id,)
+    )
+    context_json, goal = await cursor.fetchone()
+    context = json.loads(context_json)
+    assert goal == "Build runtime truth"
+    assert payload.goal == "Build runtime truth"
+    assert context["leader_original_goal"] == "Build runtime truth"
+    assert context["leader_kickoff_payload"]["message"] == message
+    assert context["leader_kickoff_payload"]["source"] == "test"
+    assert f"/api/projects/{project.id}/leader/decompose" in message
+    assert "/api/projects/{project_id}" not in message
+
+
+def test_verify_leader_kickoff_accepts_active_delivery() -> None:
+    result = RuntimeDeliveryResult(
+        session_id="leader-1",
+        provider_name="codex",
+        role=RoleKind.LEADER,
+        status="confirmed",
+        stage="agent_output_observed",
+        verdict="confirmed",
+        reason_code="agent_output",
+        runtime_state=RuntimeState.ACTIVE,
+        delivery_state=DeliveryState.ACCEPTED_ACTIVE,
+    )
+
+    verification = verify_leader_kickoff_delivery(result)
+
+    assert verification.kickoff_verified is True
+    assert verification.kickoff_state == "accepted_active"
+    assert verification.runtime_created is True
+    assert verification.payload_written is True
+    assert verification.submit_sent is True
+    assert verification.provider_accepted is True
+    assert verification.leader_began_work is True
+
+
+def test_verify_leader_kickoff_distinguishes_pending_submission() -> None:
+    result = RuntimeDeliveryResult(
+        session_id="leader-1",
+        provider_name="codex",
+        role=RoleKind.LEADER,
+        status="accepted",
+        stage="submit_attempted",
+        verdict="accepted",
+        reason_code="submit_sent",
+        runtime_state=RuntimeState.READY,
+        delivery_state=DeliveryState.SUBMIT_SENT,
+    )
+
+    verification = verify_leader_kickoff_delivery(result)
+
+    assert verification.kickoff_verified is False
+    assert verification.kickoff_state == "submitted_pending_acceptance"
+    assert verification.payload_written is True
+    assert verification.submit_sent is True
+    assert verification.provider_accepted is False
+    assert verification.leader_began_work is False
+
+
+def test_verify_leader_kickoff_reports_blocker() -> None:
+    from atc.runtime.models import BlockerReason
+
+    result = RuntimeDeliveryResult(
+        session_id="leader-1",
+        provider_name="codex",
+        role=RoleKind.LEADER,
+        status="blocked",
+        stage="blocked",
+        verdict="blocked",
+        reason_code="runtime_update_required",
+        runtime_state=RuntimeState.BLOCKED,
+        delivery_state=DeliveryState.BLOCKED,
+        blocker_reason=BlockerReason.RUNTIME_UPDATE_REQUIRED,
+    )
+
+    verification = verify_leader_kickoff_delivery(result)
+
+    assert verification.kickoff_verified is False
+    assert verification.kickoff_state == "blocked"
+    assert verification.blocker_reason == "runtime_update_required"

--- a/tests/unit/test_leader_start_api.py
+++ b/tests/unit/test_leader_start_api.py
@@ -1,0 +1,100 @@
+"""Tests for Leader start kickoff verification API output."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from atc.runtime.models import DeliveryState, RoleKind, RuntimeDeliveryResult, RuntimeState
+from atc.state.db import _SCHEMA_SQL, create_leader, create_project, get_connection, run_migrations
+
+
+@pytest.fixture
+async def db():
+    await run_migrations(":memory:")
+    async with get_connection(":memory:") as conn:
+        await conn.executescript(_SCHEMA_SQL)
+        await conn.commit()
+        yield conn
+
+
+@pytest.fixture
+def mock_request(db):
+    request = MagicMock()
+    request.app.state.db = db
+    request.app.state.event_bus = None
+    return request
+
+
+@pytest.mark.asyncio
+async def test_leader_start_returns_verified_kickoff_and_persists_payload(
+    db,
+    mock_request,
+) -> None:
+    from atc.api.routers.projects import LeaderStartRequest, start_leader
+
+    project = await create_project(db, "phase3", description="verify startup")
+    await create_leader(db, project.id)
+    delivery = RuntimeDeliveryResult(
+        session_id="leader-session-1",
+        provider_name="codex",
+        role=RoleKind.LEADER,
+        status="confirmed",
+        stage="agent_output_observed",
+        verdict="confirmed",
+        reason_code="agent_output",
+        runtime_state=RuntimeState.ACTIVE,
+        delivery_state=DeliveryState.ACCEPTED_ACTIVE,
+    )
+
+    with (
+        patch(
+            "atc.api.routers.projects.leader_ops.start_leader",
+            new=AsyncMock(return_value="leader-session-1"),
+        ),
+        patch("atc.leader.leader.send_leader_message", new=AsyncMock(return_value=delivery)),
+    ):
+        response = await start_leader(
+            project.id,
+            LeaderStartRequest(goal="Build kickoff verification"),
+            mock_request,
+        )
+
+    assert response["kickoff_verified"] is True
+    assert response["kickoff_state"] == "accepted_active"
+    assert response["truth_delivery_state"] == "accepted_active"
+    assert response["runtime_state"] == "active"
+    assert response["kickoff_payload_persisted"] is True
+
+    cursor = await db.execute("SELECT context FROM leaders WHERE project_id = ?", (project.id,))
+    context_json = (await cursor.fetchone())[0]
+    context = json.loads(context_json)
+    assert context["leader_original_goal"] == "Build kickoff verification"
+    assert context["leader_kickoff_payload"]["message"].startswith("# Mission Brief")
+
+
+@pytest.mark.asyncio
+async def test_leader_start_without_auto_kickoff_still_persists_goal_payload(
+    db,
+    mock_request,
+) -> None:
+    from atc.api.routers.projects import LeaderStartRequest, start_leader
+
+    project = await create_project(db, "phase3-no-kickoff")
+    await create_leader(db, project.id)
+
+    with patch(
+        "atc.api.routers.projects.leader_ops.start_leader",
+        new=AsyncMock(return_value="leader-session-1"),
+    ):
+        response = await start_leader(
+            project.id,
+            LeaderStartRequest(goal="Recover me later", auto_kickoff=False),
+            mock_request,
+        )
+
+    assert response["kickoff_verified"] is False
+    assert response["kickoff_state"] == "not_requested"
+    assert response["kickoff_payload_persisted"] is True

--- a/tests/unit/test_tower_controller.py
+++ b/tests/unit/test_tower_controller.py
@@ -120,7 +120,10 @@ class TestSubmitGoal:
             result = await tower.submit_goal(project.id, "Build feature X")
 
         assert result["status"] == "queued"
-        assert result["delivery_state"] == "queued"
+        assert result["delivery_state"] == "queued_unverified"
+        assert result["kickoff_verified"] is False
+        assert result["kickoff_state"] == "queued_unverified"
+        assert result["kickoff_payload_persisted"] is False
         assert "not proof" in result["recovery"]
         assert result["project_id"] == project.id
         assert result["leader_session_id"] == "leader-sess-123"


### PR DESCRIPTION
## Summary
- Add provider-neutral Leader kickoff helpers for building/persisting the original kickoff payload and deriving explicit startup verification fields.
- Persist `leader_kickoff_payload` and `leader_original_goal` on the Leader context so future recovery can deterministically restart from the original goal/message.
- Make `POST /api/projects/{project_id}/leader/start` return a stronger kickoff verdict when `auto_kickoff=true` instead of only optimistic queued state.
- Update Tower goal submission to surface `kickoff_verified`/`kickoff_state` and only notify Tower's runtime for normal monitoring after kickoff verification is strong enough.

## Validation
- `ruff check src/atc/leader/kickoff.py src/atc/api/routers/projects.py src/atc/tower/controller.py tests/unit/test_leader_kickoff.py tests/unit/test_leader_start_api.py`
- `pytest tests/unit/test_leader_kickoff.py tests/unit/test_leader_start_api.py tests/unit/test_tower_controller.py tests/unit/test_leader_api.py tests/unit/test_delivery_api.py tests/unit/test_provider_classifiers.py -q` — 70 passed, 1 existing FastAPI/Starlette deprecation warning
- `PATH=/opt/homebrew/opt/node/bin:/opt/homebrew/bin:$PATH npm run build`
- Playwright baseline smoke: 13/13 checks passed
  - Report: `/private/tmp/atc-work/screenshots/playwright-atc-2026-06-12T04-20-17-983Z/report.json`
  - Screenshots:
    - `/private/tmp/atc-work/screenshots/playwright-atc-2026-06-12T04-20-17-983Z/01-dashboard-initial.png`
    - `/private/tmp/atc-work/screenshots/playwright-atc-2026-06-12T04-20-17-983Z/08-usage.png`
    - `/private/tmp/atc-work/screenshots/playwright-atc-2026-06-12T04-20-17-983Z/12-context.png`

## Notes
- This remains provider-neutral: provider-specific prompt classification stays in provider classifiers from Phase 2.
- Full repo test/lint still has known unrelated baseline issues; this PR uses targeted changed-boundary validation.
