### PR TITLE
feat: verify Ace dispatch before work state

### DIFF
--- a/src/atc/leader/dispatch.py
+++ b/src/atc/leader/dispatch.py
@@ -1,0 +1,141 @@
+"""Ace dispatch verification helpers.
+
+Leader-owned dispatch verification keeps task assignment state separate from
+runtime truth: an Ace assignment exists when a task is paired with a session,
+but the task is only working after the Ace runtime accepts/starts the payload.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from atc.runtime.models import BlockerReason, DeliveryState, RuntimeDeliveryResult, RuntimeState
+
+
+@dataclass(slots=True)
+class AceDispatchVerification:
+    dispatch_verified: bool
+    dispatch_delivery_state: str
+    runtime_created: bool
+    payload_written: bool
+    submit_sent: bool
+    provider_accepted: bool
+    ace_began_work: bool
+    assigned_task_id: str | None = None
+    blocker_reason: str | None = None
+    repair_recommendation: str | None = None
+    message: str | None = None
+
+    def as_dict(self) -> dict[str, Any]:
+        data: dict[str, Any] = {
+            "dispatch_verified": self.dispatch_verified,
+            "dispatch_delivery_state": self.dispatch_delivery_state,
+            "runtime_created": self.runtime_created,
+            "payload_written": self.payload_written,
+            "submit_sent": self.submit_sent,
+            "provider_accepted": self.provider_accepted,
+            "ace_began_work": self.ace_began_work,
+        }
+        if self.assigned_task_id:
+            data["assigned_task_id"] = self.assigned_task_id
+        if self.blocker_reason:
+            data["blocker_reason"] = self.blocker_reason
+        if self.repair_recommendation:
+            data["repair_recommendation"] = self.repair_recommendation
+        if self.message:
+            data["message"] = self.message
+        return data
+
+
+def verify_ace_dispatch_delivery(
+    result: RuntimeDeliveryResult | None,
+    *,
+    task_graph_id: str | None = None,
+) -> AceDispatchVerification:
+    """Convert runtime delivery output into provider-neutral Ace dispatch truth."""
+
+    if result is None:
+        return AceDispatchVerification(
+            dispatch_verified=False,
+            dispatch_delivery_state="queued_unverified",
+            runtime_created=False,
+            payload_written=False,
+            submit_sent=False,
+            provider_accepted=False,
+            ace_began_work=False,
+            assigned_task_id=task_graph_id,
+            repair_recommendation="inspect Ace runtime before marking task working",
+            message="Ace dispatch was queued but not observed",
+        )
+
+    delivery = result.delivery_state
+    runtime_state = result.runtime_state
+    blocker = result.blocker_reason
+    runtime_created = delivery in {
+        DeliveryState.RUNTIME_CREATED,
+        DeliveryState.PROMPT_VISIBLE,
+        DeliveryState.PAYLOAD_WRITTEN,
+        DeliveryState.SUBMIT_SENT,
+        DeliveryState.SUBMITTED_PENDING_ACCEPTANCE,
+        DeliveryState.ACCEPTED_ACTIVE,
+        DeliveryState.BLOCKED,
+    } or runtime_state in {
+        RuntimeState.READY,
+        RuntimeState.ACTIVE,
+        RuntimeState.BLOCKED,
+        RuntimeState.IDLE,
+        RuntimeState.IDLE_AT_DEFAULT_PROMPT,
+    }
+    payload_written = delivery in {
+        DeliveryState.PAYLOAD_WRITTEN,
+        DeliveryState.SUBMIT_SENT,
+        DeliveryState.SUBMITTED_PENDING_ACCEPTANCE,
+        DeliveryState.ACCEPTED_ACTIVE,
+    }
+    submit_sent = delivery in {
+        DeliveryState.SUBMIT_SENT,
+        DeliveryState.SUBMITTED_PENDING_ACCEPTANCE,
+        DeliveryState.ACCEPTED_ACTIVE,
+    }
+    provider_accepted = delivery is DeliveryState.ACCEPTED_ACTIVE or result.status in {
+        "confirmed",
+        "delivered",
+    }
+    ace_began_work = (
+        runtime_state is RuntimeState.ACTIVE or delivery is DeliveryState.ACCEPTED_ACTIVE
+    )
+    dispatch_verified = bool(result.ok and provider_accepted and ace_began_work)
+
+    if blocker is not None or result.status in {"blocked", "failed"}:
+        state = "blocked" if result.status == "blocked" else "failed"
+    elif dispatch_verified:
+        state = "accepted_active"
+    elif submit_sent:
+        state = "submitted_pending_acceptance"
+    elif payload_written:
+        state = "payload_written"
+    elif delivery is DeliveryState.PROMPT_VISIBLE:
+        state = "prompt_visible"
+    elif delivery is DeliveryState.RUNTIME_CREATED:
+        state = "runtime_created"
+    else:
+        state = "queued_unverified"
+
+    repair = None
+    if not dispatch_verified:
+        repair = "inspect Ace runtime and re-dispatch only if the payload is safe/idempotent"
+
+    return AceDispatchVerification(
+        dispatch_verified=dispatch_verified,
+        dispatch_delivery_state=state,
+        runtime_created=runtime_created,
+        payload_written=payload_written,
+        submit_sent=submit_sent,
+        provider_accepted=provider_accepted,
+        ace_began_work=ace_began_work,
+        assigned_task_id=task_graph_id,
+        blocker_reason=blocker.value if isinstance(blocker, BlockerReason) else None,
+        repair_recommendation=repair,
+        message=result.message,
+    )

--- a/src/atc/leader/orchestrator.py
+++ b/src/atc/leader/orchestrator.py
@@ -24,6 +24,7 @@ from atc.agents.deploy import AceDeploySpec, cleanup_deployed_files, deploy_ace_
 from atc.agents.factory import get_launch_command
 from atc.leader.context_package import build_context_package
 from atc.leader.decomposer import get_completion_status, get_ready_tasks
+from atc.leader.dispatch import verify_ace_dispatch_delivery
 from atc.session.ace import create_ace, destroy_ace, start_ace
 from atc.state import db as db_ops
 from atc.state.transitions import LifecycleTransitionError
@@ -41,6 +42,7 @@ async def _get_global_lock() -> asyncio.Lock:
     if _GLOBAL_LOCK is None:
         _GLOBAL_LOCK = asyncio.Lock()
     return _GLOBAL_LOCK
+
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -61,6 +63,10 @@ class AceAssignment:
     task_title: str
     assignment_id: str = ""  # idempotency key for assign_task
     status: str = "assigned"  # assigned|working|done|failed
+    dispatch_delivery_state: str = "queued_unverified"
+    dispatch_verified: bool = False
+    blocker_reason: str | None = None
+    last_activity_at: str | None = None
     deployed_root: Path | None = None  # staging dir for cleanup
 
 
@@ -256,24 +262,8 @@ class LeaderOrchestrator:
                 title,
             )
 
-        # Transition the task to in_progress now that the Ace is running.
-        # Retry/idempotent paths can reuse a terminal assignment row whose
-        # task_graph may already have been reset to todo, so bridge through
-        # assigned first when needed instead of tripping the state machine.
-        task_graph = await db_ops.get_task_graph(self.conn, task_graph_id)
-        if task_graph is not None:
-            if task_graph.status == "todo":
-                task_graph = await db_ops.update_task_graph_status(
-                    self.conn,
-                    task_graph_id,
-                    "assigned",
-                )
-            if task_graph is not None and task_graph.status == "assigned":
-                await db_ops.update_task_graph_status(
-                    self.conn,
-                    task_graph_id,
-                    "in_progress",
-                )
+        # The DB assignment transition moves the task graph to assigned.
+        # Do not promote to in_progress until Ace dispatch is verified.
 
         deployed = deploy_ace_files(
             AceDeploySpec(
@@ -324,8 +314,8 @@ class LeaderOrchestrator:
         self,
         task_graph_id: str,
         instruction: str,
-    ) -> None:
-        """Send a work instruction to the Ace assigned to a task graph entry."""
+    ) -> Any:
+        """Send a work instruction and promote work state only after verification."""
         assignment = self.assignments.get(task_graph_id)
         if assignment is None:
             raise ValueError(f"No Ace assigned to task graph {task_graph_id}")
@@ -336,8 +326,36 @@ class LeaderOrchestrator:
             instruction=instruction,
             event_bus=self.event_bus,
         )
-        if not result.ok:
+        verification = verify_ace_dispatch_delivery(result, task_graph_id=task_graph_id)
+        assignment.dispatch_delivery_state = verification.dispatch_delivery_state
+        assignment.dispatch_verified = verification.dispatch_verified
+        assignment.blocker_reason = verification.blocker_reason
+
+        if assignment.assignment_id:
+            persisted_assignment = await db_ops.update_task_assignment_dispatch(
+                self.conn,
+                assignment.assignment_id,
+                dispatch_delivery_state=verification.dispatch_delivery_state,
+                dispatch_verified=verification.dispatch_verified,
+                blocker_reason=verification.blocker_reason,
+                last_activity=verification.ace_began_work,
+            )
+            if persisted_assignment is not None:
+                assignment.last_activity_at = persisted_assignment.last_activity_at
+
+        if not verification.dispatch_verified:
             assignment.status = "assigned"
+            if self.event_bus:
+                await self.event_bus.publish(
+                    "leader_ace_dispatch_unverified",
+                    {
+                        "leader_id": self.leader_id,
+                        "project_id": self.project_id,
+                        "task_graph_id": task_graph_id,
+                        "session_id": assignment.ace_session_id,
+                        **verification.as_dict(),
+                    },
+                )
             return result
 
         assignment.status = "working"
@@ -357,6 +375,29 @@ class LeaderOrchestrator:
                     assignment.assignment_id,
                     task_graph_id,
                 )
+
+        task_graph = await db_ops.get_task_graph(self.conn, task_graph_id)
+        if task_graph is not None:
+            if task_graph.status == "todo":
+                task_graph = await db_ops.update_task_graph_status(
+                    self.conn,
+                    task_graph_id,
+                    "assigned",
+                )
+            if task_graph is not None and task_graph.status == "assigned":
+                await db_ops.update_task_graph_status(self.conn, task_graph_id, "in_progress")
+
+        if self.event_bus:
+            await self.event_bus.publish(
+                "leader_ace_dispatch_verified",
+                {
+                    "leader_id": self.leader_id,
+                    "project_id": self.project_id,
+                    "task_graph_id": task_graph_id,
+                    "session_id": assignment.ace_session_id,
+                    **verification.as_dict(),
+                },
+            )
         return result
 
     async def mark_task_done(self, task_graph_id: str) -> None:
@@ -572,6 +613,10 @@ class LeaderOrchestrator:
                 "ace_session_id": a.ace_session_id,
                 "task_title": a.task_title,
                 "status": a.status,
+                "dispatch_delivery_state": a.dispatch_delivery_state,
+                "dispatch_verified": a.dispatch_verified,
+                "blocker_reason": a.blocker_reason,
+                "last_activity_at": a.last_activity_at,
             }
             for a in self.assignments.values()
         ]

--- a/src/atc/state/db.py
+++ b/src/atc/state/db.py
@@ -14,7 +14,6 @@ import uuid
 from contextlib import asynccontextmanager, contextmanager
 from datetime import UTC, datetime
 from pathlib import Path
-import re
 from time import sleep
 from typing import TYPE_CHECKING, Any
 
@@ -26,12 +25,12 @@ from atc.state.models import (
     FeatureFlag,
     GitHubPR,
     Leader,
+    OrchestrationOperation,
     Project,
     ProjectBudget,
     QALoopRun,
     Session,
     SessionHeartbeat,
-    OrchestrationOperation,
     TaskAssignment,
     TaskGraph,
     UsageEvent,
@@ -468,13 +467,18 @@ CREATE TABLE IF NOT EXISTS feature_flags (
 CREATE UNIQUE INDEX IF NOT EXISTS idx_feature_flags_key ON feature_flags(key);
 
 CREATE TABLE IF NOT EXISTS task_assignments (
-    id              TEXT PRIMARY KEY,
-    task_graph_id   TEXT NOT NULL REFERENCES task_graphs(id) ON DELETE CASCADE,
-    ace_session_id  TEXT NOT NULL,
-    assignment_id   TEXT NOT NULL UNIQUE,
-    status          TEXT NOT NULL DEFAULT 'assigned',
-    created_at      TEXT NOT NULL,
-    updated_at      TEXT NOT NULL
+    id                      TEXT PRIMARY KEY,
+    task_graph_id           TEXT NOT NULL REFERENCES task_graphs(id) ON DELETE CASCADE,
+    ace_session_id          TEXT NOT NULL,
+    assignment_id           TEXT NOT NULL UNIQUE,
+    status                  TEXT NOT NULL DEFAULT 'assigned',
+    dispatch_delivery_state TEXT NOT NULL DEFAULT 'queued_unverified',
+    dispatch_verified       INTEGER NOT NULL DEFAULT 0,
+    last_activity_at        TEXT,
+    assigned_task_id        TEXT,
+    blocker_reason          TEXT,
+    created_at              TEXT NOT NULL,
+    updated_at              TEXT NOT NULL
 );
 
 CREATE INDEX IF NOT EXISTS idx_task_assignments_task_graph
@@ -572,7 +576,19 @@ async def run_migrations(db_path: str) -> None:
             await db.execute("ALTER TABLE tower_memory ADD COLUMN embedding BLOB")
             await db.commit()
 
-
+        # --- task_assignments dispatch truth fields ---
+        task_assignment_columns = {
+            "dispatch_delivery_state": "TEXT NOT NULL DEFAULT 'queued_unverified'",
+            "dispatch_verified": "INTEGER NOT NULL DEFAULT 0",
+            "last_activity_at": "TEXT",
+            "assigned_task_id": "TEXT",
+            "blocker_reason": "TEXT",
+        }
+        for column, ddl in task_assignment_columns.items():
+            if not await _has_column(db, "task_assignments", column):
+                logger.info("Migration: adding task_assignments.%s column", column)
+                await db.execute(f"ALTER TABLE task_assignments ADD COLUMN {column} {ddl}")
+                await db.commit()
 
 
 async def _ensure_schema_migrations_table(db: aiosqlite.Connection) -> None:
@@ -610,8 +626,27 @@ async def _apply_file_migrations(db: aiosqlite.Connection) -> None:
             )
             await db.commit()
             continue
-        if path.name == "015_session_provider_scope.sql":
-            if await _has_column(db, "sessions", "provider"):
+        if path.name == "015_session_provider_scope.sql" and await _has_column(
+            db, "sessions", "provider"
+        ):
+            logger.info("Migration skip: %s already applied structurally", path.name)
+            await db.execute(
+                "INSERT INTO schema_migrations (version, applied_at) VALUES (?, ?)",
+                (path.name, _now()),
+            )
+            await db.commit()
+            continue
+        if path.name == "016_task_assignment_dispatch_truth.sql":
+            dispatch_columns = [
+                "dispatch_delivery_state",
+                "dispatch_verified",
+                "last_activity_at",
+                "assigned_task_id",
+                "blocker_reason",
+            ]
+            if all(
+                [await _has_column(db, "task_assignments", column) for column in dispatch_columns]
+            ):
                 logger.info("Migration skip: %s already applied structurally", path.name)
                 await db.execute(
                     "INSERT INTO schema_migrations (version, applied_at) VALUES (?, ?)",
@@ -935,8 +970,9 @@ async def create_session(
     )
     await db.execute(
         """INSERT INTO sessions
-           (id, project_id, session_type, task_id, name, status, provider, scope_type, scope_id, host,
-            tmux_session, tmux_pane, alternate_on, auto_accept, created_at, updated_at)
+           (id, project_id, session_type, task_id, name, status, provider,
+            scope_type, scope_id, host, tmux_session, tmux_pane, alternate_on,
+            auto_accept, created_at, updated_at)
            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
         (
             session.id,
@@ -1000,7 +1036,9 @@ async def update_session_status(
     """Update session status and updated_at timestamp."""
     if clear_tmux:
         await db.execute(
-            "UPDATE sessions SET status = ?, tmux_session = NULL, tmux_pane = NULL, updated_at = ? WHERE id = ?",
+            """UPDATE sessions
+               SET status = ?, tmux_session = NULL, tmux_pane = NULL, updated_at = ?
+               WHERE id = ?""",
             (status, _now(), session_id),
         )
     else:
@@ -1247,6 +1285,8 @@ _ASSIGNMENT_TRANSITIONS: dict[str, set[str]] = {
 
 def _row_to_task_assignment(row: aiosqlite.Row) -> TaskAssignment:
     d = dict(row)
+    if "dispatch_verified" in d:
+        d["dispatch_verified"] = bool(d["dispatch_verified"])
     return TaskAssignment(**d)
 
 
@@ -1314,12 +1354,26 @@ async def assign_task(
             ace_session_id=ace_session_id,
             assignment_id=existing.assignment_id,
             status="assigned",
+            dispatch_delivery_state="queued_unverified",
+            dispatch_verified=False,
+            assigned_task_id=task_graph_id,
             created_at=existing.created_at,
             updated_at=now,
         )
         await db.execute(
-            "UPDATE task_assignments SET ace_session_id = ?, status = ?, updated_at = ? WHERE assignment_id = ?",
-            (ace_session_id, assignment.status, assignment.updated_at, assignment.assignment_id),
+            """UPDATE task_assignments
+               SET ace_session_id = ?, status = ?, dispatch_delivery_state = ?,
+                   dispatch_verified = 0, last_activity_at = NULL,
+                   assigned_task_id = ?, blocker_reason = NULL, updated_at = ?
+               WHERE assignment_id = ?""",
+            (
+                ace_session_id,
+                assignment.status,
+                assignment.dispatch_delivery_state,
+                task_graph_id,
+                assignment.updated_at,
+                assignment.assignment_id,
+            ),
         )
     else:
         assignment = TaskAssignment(
@@ -1328,20 +1382,28 @@ async def assign_task(
             ace_session_id=ace_session_id,
             assignment_id=assignment_id,
             status="assigned",
+            dispatch_delivery_state="queued_unverified",
+            dispatch_verified=False,
+            assigned_task_id=task_graph_id,
             created_at=now,
             updated_at=now,
         )
 
         await db.execute(
             """INSERT INTO task_assignments
-               (id, task_graph_id, ace_session_id, assignment_id, status, created_at, updated_at)
-               VALUES (?, ?, ?, ?, ?, ?, ?)""",
+               (id, task_graph_id, ace_session_id, assignment_id, status,
+                dispatch_delivery_state, dispatch_verified, assigned_task_id,
+                created_at, updated_at)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
             (
                 assignment.id,
                 assignment.task_graph_id,
                 assignment.ace_session_id,
                 assignment.assignment_id,
                 assignment.status,
+                assignment.dispatch_delivery_state,
+                1 if assignment.dispatch_verified else 0,
+                assignment.assigned_task_id,
                 assignment.created_at,
                 assignment.updated_at,
             ),
@@ -1437,6 +1499,40 @@ async def update_task_assignment_status(
 # ---------------------------------------------------------------------------
 # Heartbeat CRUD
 # ---------------------------------------------------------------------------
+
+
+async def update_task_assignment_dispatch(
+    db: aiosqlite.Connection,
+    assignment_id: str,
+    *,
+    dispatch_delivery_state: str,
+    dispatch_verified: bool,
+    blocker_reason: str | None = None,
+    last_activity: bool = False,
+) -> TaskAssignment | None:
+    """Update provider-neutral runtime truth for an Ace dispatch."""
+
+    existing = await get_task_assignment(db, assignment_id)
+    if existing is None:
+        return None
+    now = _now()
+    last_activity_at = now if last_activity else existing.last_activity_at
+    await db.execute(
+        """UPDATE task_assignments
+           SET dispatch_delivery_state = ?, dispatch_verified = ?,
+               blocker_reason = ?, last_activity_at = ?, updated_at = ?
+           WHERE assignment_id = ?""",
+        (
+            dispatch_delivery_state,
+            1 if dispatch_verified else 0,
+            blocker_reason,
+            last_activity_at,
+            now,
+            assignment_id,
+        ),
+    )
+    await db.commit()
+    return await get_task_assignment(db, assignment_id)
 
 
 async def register_heartbeat(
@@ -1653,8 +1749,6 @@ async def delete_feature_flag(db: aiosqlite.Connection, key: str) -> bool:
     return bool(cursor.rowcount > 0)
 
 
-
-
 def _row_to_orchestration_operation(row: aiosqlite.Row) -> OrchestrationOperation:
     d = dict(row)
     return OrchestrationOperation(**d)
@@ -1697,7 +1791,8 @@ async def create_orchestration_operation(
     )
     await db.execute(
         """INSERT INTO orchestration_operations
-           (operation_id, operation_type, session_id, request_payload, response_payload, status, created_at, updated_at)
+           (operation_id, operation_type, session_id, request_payload,
+            response_payload, status, created_at, updated_at)
            VALUES (?, ?, ?, ?, ?, ?, ?, ?)""",
         (
             op.operation_id,

--- a/src/atc/state/migrations/versions/016_task_assignment_dispatch_truth.sql
+++ b/src/atc/state/migrations/versions/016_task_assignment_dispatch_truth.sql
@@ -1,0 +1,24 @@
+-- Add provider-neutral Ace dispatch truth to task assignments.
+--
+-- Assignment lifecycle (assigned/working/done/failed) remains separate from
+-- runtime delivery truth so task work is not promoted merely because an Ace
+-- session exists or a prompt was queued.
+
+ALTER TABLE task_assignments
+    ADD COLUMN dispatch_delivery_state TEXT NOT NULL DEFAULT 'queued_unverified';
+
+ALTER TABLE task_assignments
+    ADD COLUMN dispatch_verified INTEGER NOT NULL DEFAULT 0;
+
+ALTER TABLE task_assignments
+    ADD COLUMN last_activity_at TEXT;
+
+ALTER TABLE task_assignments
+    ADD COLUMN assigned_task_id TEXT;
+
+ALTER TABLE task_assignments
+    ADD COLUMN blocker_reason TEXT;
+
+UPDATE task_assignments
+SET assigned_task_id = task_graph_id
+WHERE assigned_task_id IS NULL;

--- a/src/atc/state/models.py
+++ b/src/atc/state/models.py
@@ -229,8 +229,8 @@ class TaskGraph:
 class TaskAssignment:
     """Tracks a single assignment of an Ace session to a task graph entry.
 
-    The ``assignment_id`` is a caller-supplied idempotency key.  Inserting
-    a duplicate ``assignment_id`` is a no-op.
+    ``status`` is the assignment lifecycle. Dispatch fields hold runtime truth
+    and prevent ``assigned`` from being confused with active Ace work.
     """
 
     id: str
@@ -238,6 +238,11 @@ class TaskAssignment:
     ace_session_id: str
     assignment_id: str
     status: str = "assigned"  # assigned|working|done|failed
+    dispatch_delivery_state: str = "queued_unverified"
+    dispatch_verified: bool = False
+    last_activity_at: str | None = None
+    assigned_task_id: str | None = None
+    blocker_reason: str | None = None
     created_at: str = ""
     updated_at: str = ""
 

--- a/tests/unit/test_ace_dispatch.py
+++ b/tests/unit/test_ace_dispatch.py
@@ -1,0 +1,80 @@
+"""Tests for provider-neutral Ace dispatch verification."""
+
+from __future__ import annotations
+
+from atc.leader.dispatch import verify_ace_dispatch_delivery
+from atc.runtime.models import (
+    BlockerReason,
+    DeliveryState,
+    RoleKind,
+    RuntimeDeliveryResult,
+    RuntimeState,
+)
+
+
+def _result(
+    *,
+    status: str,
+    runtime_state: RuntimeState | None,
+    delivery_state: DeliveryState | None,
+    blocker_reason: BlockerReason | None = None,
+) -> RuntimeDeliveryResult:
+    return RuntimeDeliveryResult(
+        session_id="ace-1",
+        provider_name="codex",
+        role=RoleKind.ACE,
+        status=status,
+        runtime_state=runtime_state,
+        delivery_state=delivery_state,
+        blocker_reason=blocker_reason,
+    )
+
+
+def test_accepted_active_dispatch_is_verified() -> None:
+    verification = verify_ace_dispatch_delivery(
+        _result(
+            status="confirmed",
+            runtime_state=RuntimeState.ACTIVE,
+            delivery_state=DeliveryState.ACCEPTED_ACTIVE,
+        ),
+        task_graph_id="task-1",
+    )
+
+    assert verification.dispatch_verified is True
+    assert verification.dispatch_delivery_state == "accepted_active"
+    assert verification.provider_accepted is True
+    assert verification.ace_began_work is True
+    assert verification.assigned_task_id == "task-1"
+
+
+def test_submitted_pending_acceptance_is_not_working() -> None:
+    verification = verify_ace_dispatch_delivery(
+        _result(
+            status="accepted",
+            runtime_state=RuntimeState.READY,
+            delivery_state=DeliveryState.SUBMITTED_PENDING_ACCEPTANCE,
+        ),
+        task_graph_id="task-1",
+    )
+
+    assert verification.dispatch_verified is False
+    assert verification.dispatch_delivery_state == "submitted_pending_acceptance"
+    assert verification.submit_sent is True
+    assert verification.ace_began_work is False
+    assert verification.repair_recommendation is not None
+
+
+def test_blocked_dispatch_preserves_reason() -> None:
+    verification = verify_ace_dispatch_delivery(
+        _result(
+            status="blocked",
+            runtime_state=RuntimeState.BLOCKED,
+            delivery_state=DeliveryState.BLOCKED,
+            blocker_reason=BlockerReason.DEFAULT_PROMPT_VISIBLE,
+        ),
+        task_graph_id="task-1",
+    )
+
+    assert verification.dispatch_verified is False
+    assert verification.dispatch_delivery_state == "blocked"
+    assert verification.blocker_reason == "default_prompt_visible"

--- a/tests/unit/test_leader_api.py
+++ b/tests/unit/test_leader_api.py
@@ -6,8 +6,9 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+# We need to reset the module-level orchestrator cache between tests
+from atc.api.routers import leader as leader_module
 from atc.core.events import EventBus
-from atc.leader.decomposer import DecompositionResult, TaskSpec
 from atc.leader.orchestrator import AceAssignment, LeaderOrchestrator
 from atc.state.db import (
     _SCHEMA_SQL,
@@ -18,10 +19,6 @@ from atc.state.db import (
     run_migrations,
     update_task_graph_status,
 )
-from atc.state.models import TaskGraph
-
-# We need to reset the module-level orchestrator cache between tests
-from atc.api.routers import leader as leader_module
 
 
 @pytest.fixture
@@ -43,6 +40,7 @@ def event_bus() -> EventBus:
 def clear_orchestrator_cache():
     """Clear the orchestrator cache and global counter before each test."""
     from atc.leader import orchestrator as orch_mod
+
     leader_module._orchestrators.clear()
     orch_mod._GLOBAL_ACTIVE_ACES = 0
     yield
@@ -83,7 +81,10 @@ def mock_request(db, event_bus):
 @pytest.mark.asyncio
 class TestDecomposeEndpoint:
     async def test_decompose_creates_task_graphs(
-        self, db, project_with_leader, mock_request,
+        self,
+        db,
+        project_with_leader,
+        mock_request,
     ) -> None:
         from atc.api.routers.leader import DecomposeRequest, decompose
 
@@ -103,10 +104,13 @@ class TestDecomposeEndpoint:
         mock_request.app.state.tower_controller.get_progress.assert_awaited()
 
     async def test_decompose_no_leader_returns_404(
-        self, db, mock_request,
+        self,
+        db,
+        mock_request,
     ) -> None:
-        from atc.api.routers.leader import DecomposeRequest, decompose
         from fastapi import HTTPException
+
+        from atc.api.routers.leader import DecomposeRequest, decompose
 
         project = await create_project(db, "orphan-proj")
         body = DecomposeRequest(task_specs=[{"title": "Task A"}])
@@ -116,10 +120,14 @@ class TestDecomposeEndpoint:
         assert exc_info.value.status_code == 404
 
     async def test_decompose_empty_specs_returns_422(
-        self, db, project_with_leader, mock_request,
+        self,
+        db,
+        project_with_leader,
+        mock_request,
     ) -> None:
-        from atc.api.routers.leader import DecomposeRequest, decompose
         from fastapi import HTTPException
+
+        from atc.api.routers.leader import DecomposeRequest, decompose
 
         project, _ = project_with_leader
         body = DecomposeRequest(task_specs=[])
@@ -129,7 +137,10 @@ class TestDecomposeEndpoint:
         assert exc_info.value.status_code == 422
 
     async def test_decompose_with_dependencies(
-        self, db, project_with_leader, mock_request,
+        self,
+        db,
+        project_with_leader,
+        mock_request,
     ) -> None:
         from atc.api.routers.leader import DecomposeRequest, decompose
 
@@ -157,7 +168,11 @@ class TestDecomposeEndpoint:
 @pytest.mark.asyncio
 class TestSpawnAcesEndpoint:
     async def test_spawn_returns_assignments(
-        self, mock_create: AsyncMock, db, project_with_leader, mock_request,
+        self,
+        mock_create: AsyncMock,
+        db,
+        project_with_leader,
+        mock_request,
     ) -> None:
         from atc.api.routers.leader import spawn_aces
 
@@ -171,7 +186,11 @@ class TestSpawnAcesEndpoint:
         mock_request.app.state.tower_controller.get_progress.assert_awaited()
 
     async def test_spawn_with_no_ready_tasks(
-        self, mock_create: AsyncMock, db, project_with_leader, mock_request,
+        self,
+        mock_create: AsyncMock,
+        db,
+        project_with_leader,
+        mock_request,
     ) -> None:
         from atc.api.routers.leader import spawn_aces
 
@@ -197,7 +216,10 @@ class TestSpawnAcesEndpoint:
 @pytest.mark.asyncio
 class TestProgressEndpoint:
     async def test_progress_returns_summary(
-        self, db, project_with_leader, mock_request,
+        self,
+        db,
+        project_with_leader,
+        mock_request,
     ) -> None:
         from atc.api.routers.leader import get_progress
 
@@ -227,8 +249,12 @@ class TestProgressEndpoint:
 @pytest.mark.asyncio
 class TestTaskLifecycleEndpoints:
     async def test_task_done(
-        self, mock_create: AsyncMock, mock_destroy: AsyncMock,
-        db, project_with_leader, mock_request,
+        self,
+        mock_create: AsyncMock,
+        mock_destroy: AsyncMock,
+        db,
+        project_with_leader,
+        mock_request,
     ) -> None:
         from atc.api.routers.leader import TaskDoneRequest, spawn_aces, task_done
 
@@ -245,8 +271,12 @@ class TestTaskLifecycleEndpoints:
         mock_request.app.state.tower_controller.get_progress.assert_awaited()
 
     async def test_task_failed(
-        self, mock_create: AsyncMock, mock_destroy: AsyncMock,
-        db, project_with_leader, mock_request,
+        self,
+        mock_create: AsyncMock,
+        mock_destroy: AsyncMock,
+        db,
+        project_with_leader,
+        mock_request,
     ) -> None:
         from atc.api.routers.leader import TaskFailedRequest, spawn_aces, task_failed
 
@@ -272,7 +302,11 @@ class TestTaskLifecycleEndpoints:
 @pytest.mark.asyncio
 class TestCleanupEndpoint:
     async def test_cleanup_removes_orchestrator(
-        self, mock_destroy: AsyncMock, db, project_with_leader, mock_request,
+        self,
+        mock_destroy: AsyncMock,
+        db,
+        project_with_leader,
+        mock_request,
     ) -> None:
         from atc.api.routers.leader import cleanup
 
@@ -286,10 +320,12 @@ class TestCleanupEndpoint:
 
 @pytest.mark.asyncio
 async def test_instruct_returns_delivery_state_and_marks_assignment_working(
-    db, project_with_leader, mock_request,
+    db,
+    project_with_leader,
+    mock_request,
 ) -> None:
     from atc.api.routers.leader import InstructRequest, instruct_ace
-    from atc.runtime.models import RoleKind, RuntimeDeliveryResult
+    from atc.runtime.models import DeliveryState, RoleKind, RuntimeDeliveryResult, RuntimeState
     from atc.state.db import assign_task, create_session, create_task_graph, get_task_assignment
 
     project, leader = project_with_leader
@@ -325,6 +361,8 @@ async def test_instruct_returns_delivery_state_and_marks_assignment_working(
         verdict="confirmed",
         trace_id="trace-phase7",
         message="instruction delivered",
+        runtime_state=RuntimeState.ACTIVE,
+        delivery_state=DeliveryState.ACCEPTED_ACTIVE,
     )
 
     with patch("atc.leader.orchestrator.start_ace", new=AsyncMock(return_value=delivery)):

--- a/tests/unit/test_leader_orchestrator.py
+++ b/tests/unit/test_leader_orchestrator.py
@@ -9,6 +9,7 @@ import pytest
 
 from atc.core.events import EventBus
 from atc.leader.orchestrator import AceAssignment, LeaderOrchestrator
+from atc.runtime.models import DeliveryState, RoleKind, RuntimeDeliveryResult, RuntimeState
 from atc.state.db import (
     _SCHEMA_SQL,
     create_leader,
@@ -241,7 +242,7 @@ class TestSpawnAces:
         assert len(assignments) == 1
         mock_create.assert_called_once()
 
-    async def test_marks_task_in_progress(
+    async def test_spawn_marks_task_assigned_not_in_progress(
         self,
         mock_create: AsyncMock,
         db,
@@ -253,7 +254,7 @@ class TestSpawnAces:
 
         updated = await get_task_graph(db, tg.id)
         assert updated is not None
-        assert updated.status == "in_progress"
+        assert updated.status == "assigned"
 
     async def test_assigns_ace_to_task_graph(
         self,
@@ -413,6 +414,15 @@ class TestSendInstruction:
             task_title="Task A",
         )
 
+        mock_start.return_value = RuntimeDeliveryResult(
+            session_id=session.id,
+            provider_name="codex",
+            role=RoleKind.ACE,
+            status="confirmed",
+            runtime_state=RuntimeState.ACTIVE,
+            delivery_state=DeliveryState.ACCEPTED_ACTIVE,
+        )
+
         await orchestrator.send_instruction_to_ace(tg.id, "Build the login page")
 
         mock_start.assert_called_once_with(
@@ -422,6 +432,54 @@ class TestSendInstruction:
             event_bus=orchestrator.event_bus,
         )
         assert orchestrator.assignments[tg.id].status == "working"
+        updated = await get_task_graph(db, tg.id)
+        assert updated is not None
+        assert updated.status == "in_progress"
+
+    async def test_unverified_dispatch_does_not_mark_working(
+        self,
+        mock_start: AsyncMock,
+        db,
+        orchestrator: LeaderOrchestrator,
+    ) -> None:
+        tg = await create_task_graph(db, orchestrator.project_id, "Task B")
+        from atc.state import db as db_ops
+
+        session = await db_ops.create_session(
+            db,
+            orchestrator.project_id,
+            "ace",
+            "ace-task-b",
+        )
+        db_assignment, _ = await db_ops.assign_task(
+            db, tg.id, session.id, f"{orchestrator.leader_id}:{tg.id}"
+        )
+        orchestrator.assignments[tg.id] = AceAssignment(
+            ace_session_id=session.id,
+            task_graph_id=tg.id,
+            task_title="Task B",
+            assignment_id=db_assignment.assignment_id,
+        )
+        mock_start.return_value = RuntimeDeliveryResult(
+            session_id=session.id,
+            provider_name="codex",
+            role=RoleKind.ACE,
+            status="accepted",
+            runtime_state=RuntimeState.READY,
+            delivery_state=DeliveryState.SUBMITTED_PENDING_ACCEPTANCE,
+        )
+
+        await orchestrator.send_instruction_to_ace(tg.id, "Build the settings page")
+
+        assert orchestrator.assignments[tg.id].status == "assigned"
+        assert orchestrator.assignments[tg.id].dispatch_verified is False
+        updated = await get_task_graph(db, tg.id)
+        assert updated is not None
+        assert updated.status == "assigned"
+        persisted = await db_ops.get_task_assignment(db, db_assignment.assignment_id)
+        assert persisted is not None
+        assert persisted.dispatch_verified is False
+        assert persisted.dispatch_delivery_state == "submitted_pending_acceptance"
 
     async def test_instruction_to_unknown_task_raises(
         self,
@@ -469,7 +527,7 @@ class TestSpawnRetryAssignmentReuse:
         assert assignment is not None
         refreshed = await db_ops.get_task_graph(db, tg.id)
         assert refreshed is not None
-        assert refreshed.status == "in_progress"
+        assert refreshed.status == "assigned"
         assert refreshed.assigned_ace_id == "ace-new"
 
 


### PR DESCRIPTION
## Summary
- add provider-neutral Ace dispatch verification helpers and assignment-level dispatch truth fields
- persist dispatch_delivery_state, dispatch_verified, last_activity_at, assigned_task_id, and blocker_reason on task assignments
- keep task graphs assigned until Ace dispatch is accepted/active; expose dispatch truth in Leader progress

## Validation
- ruff check src/atc/leader/dispatch.py src/atc/leader/orchestrator.py src/atc/state/db.py src/atc/state/models.py src/atc/api/routers/leader.py tests/unit/test_ace_dispatch.py tests/unit/test_leader_orchestrator.py tests/unit/test_leader_api.py
- pytest tests/unit/test_ace_dispatch.py tests/unit/test_leader_orchestrator.py tests/unit/test_leader_api.py tests/unit/test_db_migrations.py tests/unit/test_lifecycle_transitions.py tests/unit/test_delivery_api.py -q — 55 passed, 1 existing FastAPI/Starlette deprecation warning
- frontend npm run build
- local health checks: http://127.0.0.1:8420/api/health 200; http://127.0.0.1:5173/dashboard 200
- Playwright smoke: 13/13 passed; report /private/tmp/atc-work/screenshots/playwright-atc-2026-06-12T12-22-39-703Z/report.json

## Encapsulation
Ace dispatch consumes provider-neutral RuntimeDeliveryResult truth only; no provider-specific prompt strings or Codex logic were added to Leader/Tower/API.