### PR TITLE
feat: add runtime health recovery commands

### DIFF
--- a/src/atc/api/routers/aces.py
+++ b/src/atc/api/routers/aces.py
@@ -21,6 +21,7 @@ from pydantic import BaseModel
 
 from atc.api.delivery import delivery_response
 from atc.core.errors import CreationFailedError, SessionNotFoundError, SessionStaleError
+from atc.runtime.health import ace_health, build_recovery_plan
 from atc.session import ace as ace_ops
 from atc.session.state_machine import InvalidTransitionError
 from atc.state import db as db_ops
@@ -56,6 +57,22 @@ class MessageRequest(BaseModel):
 
 class NotifyRequest(BaseModel):
     message: str
+
+
+class RecoveryRequest(BaseModel):
+    dry_run: bool = True
+    policy: str = "inspect_first"
+
+
+async def _require_project_ace(db, project_id: str, session_id: str):
+    session = await db_ops.get_session(db, session_id)
+    if (
+        session is None
+        or session.project_id != project_id
+        or session.session_type != "ace"
+    ):
+        raise HTTPException(status_code=404, detail="Ace session not found")
+    return session
 
 
 class SessionResponse(BaseModel):
@@ -148,6 +165,48 @@ async def create_ace(project_id: str, body: CreateAceRequest, request: Request) 
     if session is None:
         raise CreationFailedError(f"Session creation failed for project {project_id}")
     return _session_to_response(session)
+
+
+@router.get("/projects/{project_id}/aces/{session_id}/health")
+async def get_ace_health(
+    project_id: str,
+    session_id: str,
+    request: Request,
+) -> dict[str, object]:
+    """Return provider-neutral Ace runtime/dispatch health."""
+
+    db = await _get_db(request)
+    project = await db_ops.get_project(db, project_id)
+    if project is None:
+        raise HTTPException(status_code=404, detail="Project not found")
+    await _require_project_ace(db, project_id, session_id)
+    health = await ace_health(db, project_id, session_id)
+    return health.as_dict()
+
+
+@router.post("/projects/{project_id}/aces/{session_id}/recover")
+async def recover_ace(
+    project_id: str,
+    session_id: str,
+    body: RecoveryRequest,
+    request: Request,
+) -> dict[str, object]:
+    """Inspect-first Ace recovery plan; mutation is policy-gated."""
+
+    db = await _get_db(request)
+    project = await db_ops.get_project(db, project_id)
+    if project is None:
+        raise HTTPException(status_code=404, detail="Project not found")
+    await _require_project_ace(db, project_id, session_id)
+    health = await ace_health(db, project_id, session_id)
+    plan = build_recovery_plan(
+        health,
+        mode="dry_run" if body.dry_run else "apply",
+        policy=body.policy,
+    )
+    if plan.refused_reason:
+        raise HTTPException(status_code=409, detail=plan.as_dict())
+    return plan.as_dict()
 
 
 @router.post("/aces/{session_id}/start")

--- a/src/atc/api/routers/projects.py
+++ b/src/atc/api/routers/projects.py
@@ -25,6 +25,7 @@ from atc.leader.kickoff import (
     persist_leader_kickoff_payload,
     verify_leader_kickoff_delivery,
 )
+from atc.runtime.health import build_recovery_plan, leader_health
 from atc.runtime.models import RuntimeDeliveryResult
 from atc.state import db as db_ops
 
@@ -71,6 +72,11 @@ class LeaderStartRequest(BaseModel):
 
 class LeaderMessageRequest(BaseModel):
     message: str
+
+
+class RecoveryRequest(BaseModel):
+    dry_run: bool = True
+    policy: str = "inspect_first"
 
 
 async def _get_db(request: Request):  # noqa: ANN202
@@ -480,6 +486,41 @@ async def send_leader_message(
         project_id=project_id,
         recovery="inspect Leader runtime/session status for delivery confirmation",
     )
+
+
+@router.get("/{project_id}/leader/health")
+async def get_leader_health(project_id: str, request: Request) -> dict[str, object]:
+    """Return provider-neutral Leader runtime health for operator/Tower use."""
+
+    db = await _get_db(request)
+    project = await db_ops.get_project(db, project_id)
+    if project is None:
+        raise HTTPException(status_code=404, detail="Project not found")
+    health = await leader_health(db, project_id)
+    return health.as_dict()
+
+
+@router.post("/{project_id}/leader/recover")
+async def recover_leader(
+    project_id: str,
+    body: RecoveryRequest,
+    request: Request,
+) -> dict[str, object]:
+    """Inspect-first Leader recovery plan; mutation is policy-gated."""
+
+    db = await _get_db(request)
+    project = await db_ops.get_project(db, project_id)
+    if project is None:
+        raise HTTPException(status_code=404, detail="Project not found")
+    health = await leader_health(db, project_id)
+    plan = build_recovery_plan(
+        health,
+        mode="dry_run" if body.dry_run else "apply",
+        policy=body.policy,
+    )
+    if plan.refused_reason:
+        raise HTTPException(status_code=409, detail=plan.as_dict())
+    return plan.as_dict()
 
 
 # ---------------------------------------------------------------------------

--- a/src/atc/cli/ace.py
+++ b/src/atc/cli/ace.py
@@ -35,7 +35,9 @@ def register(subparsers: argparse._SubParsersAction) -> None:  # type: ignore[ty
         help="New status",
     )
     status_parser.add_argument(
-        "--api", default=_DEFAULT_API, help="ATC API base URL",
+        "--api",
+        default=_DEFAULT_API,
+        help="ATC API base URL",
     )
     status_parser.set_defaults(handler=_handle_status)
 
@@ -43,7 +45,9 @@ def register(subparsers: argparse._SubParsersAction) -> None:  # type: ignore[ty
     done_parser = ace_sub.add_parser("done", help="Mark session as done (idle)")
     done_parser.add_argument("session_id", help="Session UUID")
     done_parser.add_argument(
-        "--api", default=_DEFAULT_API, help="ATC API base URL",
+        "--api",
+        default=_DEFAULT_API,
+        help="ATC API base URL",
     )
     done_parser.set_defaults(handler=_handle_done)
 
@@ -51,10 +55,14 @@ def register(subparsers: argparse._SubParsersAction) -> None:  # type: ignore[ty
     blocked_parser = ace_sub.add_parser("blocked", help="Report session is blocked")
     blocked_parser.add_argument("session_id", help="Session UUID")
     blocked_parser.add_argument(
-        "--reason", default="", help="Reason for being blocked",
+        "--reason",
+        default="",
+        help="Reason for being blocked",
     )
     blocked_parser.add_argument(
-        "--api", default=_DEFAULT_API, help="ATC API base URL",
+        "--api",
+        default=_DEFAULT_API,
+        help="ATC API base URL",
     )
     blocked_parser.set_defaults(handler=_handle_blocked)
 
@@ -63,7 +71,9 @@ def register(subparsers: argparse._SubParsersAction) -> None:  # type: ignore[ty
     notify_parser.add_argument("session_id", help="Session UUID")
     notify_parser.add_argument("message", help="Notification message")
     notify_parser.add_argument(
-        "--api", default=_DEFAULT_API, help="ATC API base URL",
+        "--api",
+        default=_DEFAULT_API,
+        help="ATC API base URL",
     )
     notify_parser.set_defaults(handler=_handle_notify)
 
@@ -73,7 +83,9 @@ def register(subparsers: argparse._SubParsersAction) -> None:  # type: ignore[ty
     create_parser.add_argument("--name", required=True, help="Ace session name")
     create_parser.add_argument("--task-id", default=None, help="Task ID to assign")
     create_parser.add_argument(
-        "--api", default=_DEFAULT_API, help="ATC API base URL",
+        "--api",
+        default=_DEFAULT_API,
+        help="ATC API base URL",
     )
     create_parser.set_defaults(handler=_handle_create)
 
@@ -81,9 +93,39 @@ def register(subparsers: argparse._SubParsersAction) -> None:  # type: ignore[ty
     list_parser = ace_sub.add_parser("list", help="List ace sessions for a project")
     list_parser.add_argument("--project-id", required=True, help="Project UUID")
     list_parser.add_argument(
-        "--api", default=_DEFAULT_API, help="ATC API base URL",
+        "--api",
+        default=_DEFAULT_API,
+        help="ATC API base URL",
     )
     list_parser.set_defaults(handler=_handle_list)
+
+    # atc ace health --project-id <id> --ace-id <id>
+    health_parser = ace_sub.add_parser("health", help="Inspect Ace runtime/dispatch health")
+    health_parser.add_argument("--project-id", required=True, help="Project UUID")
+    health_parser.add_argument("--ace-id", required=True, help="Ace session UUID")
+    health_parser.add_argument(
+        "--api",
+        default=_DEFAULT_API,
+        help="ATC API base URL",
+    )
+    health_parser.set_defaults(handler=_handle_health)
+
+    # atc ace recover --project-id <id> --ace-id <id> [--dry-run|--apply]
+    recover_parser = ace_sub.add_parser("recover", help="Plan inspect-first Ace recovery")
+    recover_parser.add_argument("--project-id", required=True, help="Project UUID")
+    recover_parser.add_argument("--ace-id", required=True, help="Ace session UUID")
+    recover_parser.add_argument("--policy", default="inspect_first", help="Recovery policy")
+    recover_mode = recover_parser.add_mutually_exclusive_group()
+    recover_mode.add_argument(
+        "--dry-run", action="store_true", default=True, help="Inspect and plan only"
+    )
+    recover_mode.add_argument("--apply", action="store_true", help="Apply only if policy allows")
+    recover_parser.add_argument(
+        "--api",
+        default=_DEFAULT_API,
+        help="ATC API base URL",
+    )
+    recover_parser.set_defaults(handler=_handle_recover)
 
     # atc ace memory <subcommand>
     memory_parser = ace_sub.add_parser("memory", help="Ace short-term memory commands")
@@ -94,10 +136,15 @@ def register(subparsers: argparse._SubParsersAction) -> None:  # type: ignore[ty
     mem_write_parser.add_argument("session_id", help="Session UUID")
     mem_write_parser.add_argument("content", help="Progress snapshot content")
     mem_write_parser.add_argument(
-        "--tool-count", type=int, default=0, help="Current tool call count",
+        "--tool-count",
+        type=int,
+        default=0,
+        help="Current tool call count",
     )
     mem_write_parser.add_argument(
-        "--api", default=_DEFAULT_API, help="ATC API base URL",
+        "--api",
+        default=_DEFAULT_API,
+        help="ATC API base URL",
     )
     mem_write_parser.set_defaults(handler=_handle_memory_write)
 
@@ -105,7 +152,9 @@ def register(subparsers: argparse._SubParsersAction) -> None:  # type: ignore[ty
     mem_get_parser = memory_sub.add_parser("get", help="Get STM progress snapshot")
     mem_get_parser.add_argument("session_id", help="Session UUID")
     mem_get_parser.add_argument(
-        "--api", default=_DEFAULT_API, help="ATC API base URL",
+        "--api",
+        default=_DEFAULT_API,
+        help="ATC API base URL",
     )
     mem_get_parser.set_defaults(handler=_handle_memory_get)
 
@@ -114,12 +163,54 @@ def register(subparsers: argparse._SubParsersAction) -> None:  # type: ignore[ty
     ace_parser.set_defaults(handler=lambda _: ace_parser.print_help() or 1)
 
 
+def _api_get_json(url: str) -> int:
+    """GET a JSON endpoint and print the response."""
+    req = urllib.request.Request(url, method="GET")
+    try:
+        with urllib.request.urlopen(req, timeout=10) as resp:
+            body = json.loads(resp.read().decode())
+            print(json.dumps(body, indent=2))
+            return 0
+    except urllib.error.HTTPError as exc:
+        detail = exc.read().decode() if exc.fp else str(exc)
+        print(f"Error: {exc.code} — {detail}", file=sys.stderr)
+        return 1
+    except urllib.error.URLError as exc:
+        print(f"Error: cannot reach ATC API — {exc.reason}", file=sys.stderr)
+        return 1
+
+
+def _api_post_json(url: str, payload: dict) -> int:
+    """POST JSON to a URL and print the response."""
+    data = json.dumps(payload).encode()
+    req = urllib.request.Request(
+        url,
+        data=data,
+        method="POST",
+        headers={"Content-Type": "application/json"},
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=30) as resp:
+            body = json.loads(resp.read().decode())
+            print(json.dumps(body, indent=2))
+            return 0
+    except urllib.error.HTTPError as exc:
+        detail = exc.read().decode() if exc.fp else str(exc)
+        print(f"Error: {exc.code} — {detail}", file=sys.stderr)
+        return 1
+    except urllib.error.URLError as exc:
+        print(f"Error: cannot reach ATC API — {exc.reason}", file=sys.stderr)
+        return 1
+
+
 def _api_patch_status(api_base: str, session_id: str, status: str) -> int:
     """PATCH /api/aces/{session_id}/status with the given status."""
     url = f"{api_base}/api/aces/{session_id}/status"
     payload = json.dumps({"status": status}).encode()
     req = urllib.request.Request(
-        url, data=payload, method="PATCH",
+        url,
+        data=payload,
+        method="PATCH",
         headers={"Content-Type": "application/json"},
     )
     try:
@@ -141,7 +232,9 @@ def _api_post_notify(api_base: str, session_id: str, message: str) -> int:
     url = f"{api_base}/api/aces/{session_id}/notify"
     payload = json.dumps({"message": message}).encode()
     req = urllib.request.Request(
-        url, data=payload, method="POST",
+        url,
+        data=payload,
+        method="POST",
         headers={"Content-Type": "application/json"},
     )
     try:
@@ -189,7 +282,9 @@ def _handle_create(args: argparse.Namespace) -> int:
         payload["task_id"] = args.task_id
     data = json.dumps(payload).encode()
     req = urllib.request.Request(
-        url, data=data, method="POST",
+        url,
+        data=data,
+        method="POST",
         headers={"Content-Type": "application/json"},
     )
     try:
@@ -229,12 +324,16 @@ def _handle_memory_write(args: argparse.Namespace) -> int:
     # The memory write goes through the API so the server can persist it.
     # We encode it as a PATCH to the STM endpoint that the memory router exposes.
     url = f"{args.api}/api/memory/ace/{args.session_id}/write"
-    payload = json.dumps({
-        "content": args.content,
-        "tool_call_count": args.tool_count,
-    }).encode()
+    payload = json.dumps(
+        {
+            "content": args.content,
+            "tool_call_count": args.tool_count,
+        }
+    ).encode()
     req = urllib.request.Request(
-        url, data=payload, method="POST",
+        url,
+        data=payload,
+        method="POST",
         headers={"Content-Type": "application/json"},
     )
     try:
@@ -267,3 +366,14 @@ def _handle_memory_get(args: argparse.Namespace) -> int:
     except urllib.error.URLError as exc:
         print(f"Error: cannot reach ATC API at {args.api} — {exc.reason}", file=sys.stderr)
         return 1
+
+
+def _handle_health(args: argparse.Namespace) -> int:
+    return _api_get_json(f"{args.api}/api/projects/{args.project_id}/aces/{args.ace_id}/health")
+
+
+def _handle_recover(args: argparse.Namespace) -> int:
+    return _api_post_json(
+        f"{args.api}/api/projects/{args.project_id}/aces/{args.ace_id}/recover",
+        {"dry_run": not args.apply, "policy": args.policy},
+    )

--- a/src/atc/cli/leader.py
+++ b/src/atc/cli/leader.py
@@ -42,6 +42,24 @@ def register(subparsers: argparse._SubParsersAction) -> None:  # type: ignore[ty
     msg_parser.add_argument("--api", default=_DEFAULT_API, help="ATC API base URL")
     msg_parser.set_defaults(handler=_handle_message)
 
+    # atc leader health --project-id <id>
+    health_parser = leader_sub.add_parser("health", help="Inspect leader runtime health")
+    health_parser.add_argument("--project-id", required=True, help="Project UUID")
+    health_parser.add_argument("--api", default=_DEFAULT_API, help="ATC API base URL")
+    health_parser.set_defaults(handler=_handle_health)
+
+    # atc leader recover --project-id <id> [--dry-run|--apply]
+    recover_parser = leader_sub.add_parser("recover", help="Plan inspect-first leader recovery")
+    recover_parser.add_argument("--project-id", required=True, help="Project UUID")
+    recover_parser.add_argument("--policy", default="inspect_first", help="Recovery policy")
+    recover_mode = recover_parser.add_mutually_exclusive_group()
+    recover_mode.add_argument(
+        "--dry-run", action="store_true", default=True, help="Inspect and plan only"
+    )
+    recover_mode.add_argument("--apply", action="store_true", help="Apply only if policy allows")
+    recover_parser.add_argument("--api", default=_DEFAULT_API, help="ATC API base URL")
+    recover_parser.set_defaults(handler=_handle_recover)
+
     leader_parser.set_defaults(handler=lambda _: leader_parser.print_help() or 1)
 
 
@@ -49,9 +67,28 @@ def _post_json(url: str, payload: dict) -> int:
     """POST JSON to a URL and print the response."""
     data = json.dumps(payload).encode()
     req = urllib.request.Request(
-        url, data=data, method="POST",
+        url,
+        data=data,
+        method="POST",
         headers={"Content-Type": "application/json"},
     )
+    try:
+        with urllib.request.urlopen(req, timeout=30) as resp:
+            body = json.loads(resp.read().decode())
+            print(json.dumps(body, indent=2))
+            return 0
+    except urllib.error.HTTPError as exc:
+        detail = exc.read().decode() if exc.fp else str(exc)
+        print(f"Error: {exc.code} — {detail}", file=sys.stderr)
+        return 1
+    except urllib.error.URLError as exc:
+        print(f"Error: cannot reach ATC API — {exc.reason}", file=sys.stderr)
+        return 1
+
+
+def _get_json(url: str) -> int:
+    """GET JSON from a URL and print the response."""
+    req = urllib.request.Request(url, method="GET")
     try:
         with urllib.request.urlopen(req, timeout=30) as resp:
             body = json.loads(resp.read().decode())
@@ -81,4 +118,15 @@ def _handle_message(args: argparse.Namespace) -> int:
     return _post_json(
         f"{args.api}/api/projects/{args.project_id}/leader/message",
         {"message": args.message},
+    )
+
+
+def _handle_health(args: argparse.Namespace) -> int:
+    return _get_json(f"{args.api}/api/projects/{args.project_id}/leader/health")
+
+
+def _handle_recover(args: argparse.Namespace) -> int:
+    return _post_json(
+        f"{args.api}/api/projects/{args.project_id}/leader/recover",
+        {"dry_run": not args.apply, "policy": args.policy},
     )

--- a/src/atc/runtime/health.py
+++ b/src/atc/runtime/health.py
@@ -1,0 +1,424 @@
+"""Provider-neutral runtime health and inspect-first recovery planning."""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, field
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING, Any, Literal
+
+from atc.runtime.models import (
+    BlockerReason,
+    DeliveryState,
+    ReadinessState,
+    RecoveryRecommendation,
+    RecoveryState,
+    RuntimeInspection,
+    RuntimeState,
+)
+from atc.runtime.service import RuntimeService
+from atc.state import db as db_ops
+
+if TYPE_CHECKING:
+    import aiosqlite  # type: ignore[import-not-found]
+
+RecoveryMode = Literal["dry_run", "apply"]
+RuntimeRole = Literal["leader", "ace"]
+
+_ACTIVE_SESSION_STATUSES = {"connecting", "idle", "working", "waiting", "paused"}
+
+
+def _now() -> str:
+    return datetime.now(UTC).isoformat()
+
+
+@dataclass(slots=True)
+class RuntimeHealth:
+    """Provider-neutral health summary for a Leader or Ace runtime."""
+
+    role: RuntimeRole
+    project_id: str
+    runtime_exists: bool
+    pane_attached: bool
+    provider: str | None
+    session_id: str | None = None
+    runtime_state: str = RuntimeState.MISSING.value
+    delivery_state: str = DeliveryState.NOT_STARTED.value
+    blocker_reason: str | None = None
+    last_activity_at: str | None = None
+    last_inspected_at: str = field(default_factory=_now)
+    task_graph_state: dict[str, Any] = field(default_factory=dict)
+    kickoff_state: dict[str, Any] = field(default_factory=dict)
+    ace_dispatch: dict[str, Any] = field(default_factory=dict)
+    ace_count: int = 0
+    current_blocker: str | None = None
+    recovery_recommendation: dict[str, Any] | None = None
+    provider_diagnostics: dict[str, Any] = field(default_factory=dict)
+
+    def as_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(slots=True)
+class RecoveryPlan:
+    """Inspect-first recovery response. Mutating recovery is policy-gated later."""
+
+    role: RuntimeRole
+    project_id: str
+    mode: RecoveryMode
+    safe_to_apply: bool
+    actions: list[dict[str, Any]]
+    health: dict[str, Any]
+    message: str
+    refused_reason: str | None = None
+
+    def as_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+def _blocker_from_inspection(inspection: RuntimeInspection) -> str | None:
+    if inspection.readiness is ReadinessState.BLOCKED:
+        reason = inspection.block_reason.value if inspection.block_reason else "runtime_blocked"
+        mapping = {
+            "auth": BlockerReason.RUNTIME_AUTH_REQUIRED.value,
+            "login": BlockerReason.RUNTIME_AUTH_REQUIRED.value,
+            "trust": BlockerReason.RUNTIME_TRUST_REQUIRED.value,
+            "permission": BlockerReason.RUNTIME_PERMISSION_REQUIRED.value,
+            "provider_prompt": BlockerReason.UNKNOWN_PROMPT_BLOCKER.value,
+            "unknown": BlockerReason.UNKNOWN_PROMPT_BLOCKER.value,
+        }
+        return mapping.get(reason, reason)
+    if inspection.readiness is ReadinessState.ERROR:
+        return BlockerReason.PROVIDER_ERROR.value
+    if not inspection.alive:
+        return BlockerReason.PANE_MISSING.value
+    return None
+
+
+def _runtime_state_from_inspection(inspection: RuntimeInspection) -> str:
+    if not inspection.alive:
+        return RuntimeState.MISSING.value
+    if inspection.readiness is ReadinessState.BLOCKED:
+        return RuntimeState.BLOCKED.value
+    if inspection.readiness is ReadinessState.ERROR:
+        return RuntimeState.FAILED.value
+    if inspection.readiness is ReadinessState.BUSY:
+        return RuntimeState.ACTIVE.value
+    if inspection.readiness is ReadinessState.READY:
+        return RuntimeState.READY.value
+    if inspection.readiness is ReadinessState.STOPPED:
+        return RuntimeState.STALE.value
+    return RuntimeState.STARTING.value
+
+
+def _delivery_state_for_runtime(runtime_state: str, *, has_payload: bool = False) -> str:
+    if runtime_state == RuntimeState.ACTIVE.value:
+        return DeliveryState.ACCEPTED_ACTIVE.value
+    if runtime_state == RuntimeState.BLOCKED.value:
+        return DeliveryState.BLOCKED.value
+    if runtime_state in {
+        RuntimeState.MISSING.value,
+        RuntimeState.FAILED.value,
+        RuntimeState.STALE.value,
+    }:
+        return DeliveryState.FAILED.value
+    if has_payload:
+        return DeliveryState.SUBMITTED_PENDING_ACCEPTANCE.value
+    return DeliveryState.NOT_STARTED.value
+
+
+def _recovery_for(
+    role: RuntimeRole, project_id: str, blocker: str | None, session_id: str | None
+) -> dict[str, Any]:
+    if role == "leader":
+        command = f"atc leader recover --project-id {project_id} --dry-run"
+    else:
+        command = (
+            f"atc ace recover --project-id {project_id} "
+            f"--ace-id {session_id or '<ace-id>'} --dry-run"
+        )
+    state = RecoveryState.BLOCKED if blocker else RecoveryState.NOT_NEEDED
+    if blocker == BlockerReason.PANE_MISSING.value:
+        state = RecoveryState.RESTART_REQUIRED
+    return RecoveryRecommendation(
+        state=state,
+        command=command,
+        safety="inspect_first",
+        message=(
+            "Inspect runtime truth before attempting recovery. Apply mode is "
+            "limited to safe, classified states."
+            if blocker
+            else "No recovery is currently required."
+        ),
+        requires_operator=blocker not in {None, BlockerReason.PANE_MISSING.value},
+    ).as_dict()
+
+
+async def _inspect_session(
+    session: Any | None,
+    runtime_service: RuntimeService,
+) -> tuple[str, str | None, dict[str, Any]]:
+    if session is None:
+        return RuntimeState.MISSING.value, BlockerReason.PANE_MISSING.value, {}
+    if not getattr(session, "tmux_pane", None):
+        return (
+            RuntimeState.MISSING.value,
+            BlockerReason.PANE_MISSING.value,
+            {
+                "status": getattr(session, "status", None),
+                "reason": "no_tmux_pane",
+            },
+        )
+    try:
+        inspection = await runtime_service.inspect_session_record(session)
+    except Exception as exc:
+        return (
+            RuntimeState.FAILED.value,
+            BlockerReason.PROVIDER_ERROR.value,
+            {
+                "status": getattr(session, "status", None),
+                "error_type": type(exc).__name__,
+                "error": str(exc),
+            },
+        )
+    runtime_state = _runtime_state_from_inspection(inspection)
+    blocker = _blocker_from_inspection(inspection)
+    diagnostics = {
+        "status": getattr(session, "status", None),
+        "readiness": inspection.readiness.value,
+        "alive": inspection.alive,
+        "summary": inspection.summary,
+        "details": inspection.details,
+    }
+    if inspection.last_output_excerpt:
+        diagnostics["redacted_excerpt"] = inspection.last_output_excerpt
+    return runtime_state, blocker, diagnostics
+
+
+async def leader_health(
+    conn: aiosqlite.Connection,
+    project_id: str,
+    *,
+    runtime_service: RuntimeService | None = None,
+) -> RuntimeHealth:
+    """Build provider-neutral Leader health for a project."""
+
+    service = runtime_service or RuntimeService()
+    leader = await db_ops.get_leader_by_project(conn, project_id)
+    session = (
+        await db_ops.get_session(conn, leader.session_id) if leader and leader.session_id else None
+    )
+    runtime_state, blocker, diagnostics = await _inspect_session(session, service)
+    tasks = await db_ops.list_task_graphs(conn, project_id=project_id)
+    aces = await db_ops.list_sessions(conn, project_id=project_id, session_type="ace")
+    assignments = await db_ops.list_task_assignments(conn)
+    project_assignments = [
+        assignment
+        for assignment in assignments
+        if any(task.id == assignment.task_graph_id for task in tasks)
+    ]
+    latest_activity = max(
+        [
+            value
+            for value in [
+                getattr(session, "updated_at", None),
+                *(a.last_activity_at for a in project_assignments),
+            ]
+            if value
+        ],
+        default=None,
+    )
+    context = leader.context if leader and isinstance(leader.context, dict) else {}
+    kickoff_payload = context.get("leader_kickoff_payload") if isinstance(context, dict) else None
+    kickoff_state = {
+        "kickoff_payload_persisted": bool(kickoff_payload),
+        "kickoff_state": (
+            DeliveryState.ACCEPTED_ACTIVE.value
+            if runtime_state == RuntimeState.ACTIVE.value
+            else _delivery_state_for_runtime(runtime_state, has_payload=bool(kickoff_payload))
+        ),
+        "original_goal_available": bool(
+            context.get("leader_original_goal") or (leader.goal if leader else None)
+        ),
+    }
+    task_summary = {
+        "total": len(tasks),
+        "todo": sum(1 for task in tasks if task.status == "todo"),
+        "assigned": sum(1 for task in tasks if task.status == "assigned"),
+        "in_progress": sum(1 for task in tasks if task.status == "in_progress"),
+        "done": sum(1 for task in tasks if task.status == "done"),
+        "failed": sum(1 for task in tasks if task.status == "failed"),
+    }
+    dispatch_summary = {
+        "total": len(project_assignments),
+        "verified": sum(1 for a in project_assignments if a.dispatch_verified),
+        "blocked": sum(1 for a in project_assignments if a.blocker_reason),
+        "unverified": sum(1 for a in project_assignments if not a.dispatch_verified),
+    }
+    current_blocker = blocker or next(
+        (a.blocker_reason for a in project_assignments if a.blocker_reason), None
+    )
+    return RuntimeHealth(
+        role="leader",
+        project_id=project_id,
+        session_id=session.id if session else None,
+        runtime_exists=session is not None and session.status in _ACTIVE_SESSION_STATUSES,
+        pane_attached=bool(getattr(session, "tmux_pane", None)),
+        provider=getattr(session, "provider", None),
+        runtime_state=runtime_state,
+        delivery_state=_delivery_state_for_runtime(
+            runtime_state, has_payload=bool(kickoff_payload)
+        ),
+        blocker_reason=blocker,
+        last_activity_at=latest_activity,
+        task_graph_state=task_summary,
+        kickoff_state=kickoff_state,
+        ace_dispatch=dispatch_summary,
+        ace_count=len(aces),
+        current_blocker=current_blocker,
+        recovery_recommendation=_recovery_for(
+            "leader", project_id, current_blocker, session.id if session else None
+        ),
+        provider_diagnostics=diagnostics,
+    )
+
+
+async def ace_health(
+    conn: aiosqlite.Connection,
+    project_id: str,
+    ace_id: str,
+    *,
+    runtime_service: RuntimeService | None = None,
+) -> RuntimeHealth:
+    """Build provider-neutral Ace health for one Ace session."""
+
+    service = runtime_service or RuntimeService()
+    session = await db_ops.get_session(conn, ace_id)
+    if session is None or session.project_id != project_id or session.session_type != "ace":
+        runtime_state, blocker, diagnostics = await _inspect_session(None, service)
+        return RuntimeHealth(
+            role="ace",
+            project_id=project_id,
+            session_id=ace_id,
+            runtime_exists=False,
+            pane_attached=False,
+            provider=None,
+            runtime_state=runtime_state,
+            delivery_state=DeliveryState.NOT_STARTED.value,
+            blocker_reason=blocker,
+            task_graph_state={},
+            ace_dispatch={},
+            ace_count=0,
+            current_blocker=blocker,
+            recovery_recommendation=_recovery_for("ace", project_id, blocker, ace_id),
+            provider_diagnostics=diagnostics,
+        )
+    runtime_state, blocker, diagnostics = await _inspect_session(session, service)
+    assignments = await db_ops.list_task_assignments(conn, ace_session_id=ace_id)
+    active_assignment = assignments[0] if assignments else None
+    task = (
+        await db_ops.get_task_graph(conn, active_assignment.task_graph_id)
+        if active_assignment is not None
+        else None
+    )
+    assignment_blocker = active_assignment.blocker_reason if active_assignment else None
+    current_blocker = blocker or assignment_blocker
+    ace_dispatch = {
+        "assignment_id": active_assignment.assignment_id if active_assignment else None,
+        "task_graph_id": active_assignment.task_graph_id if active_assignment else None,
+        "assignment_status": active_assignment.status if active_assignment else None,
+        "dispatch_delivery_state": active_assignment.dispatch_delivery_state
+        if active_assignment
+        else DeliveryState.NOT_STARTED.value,
+        "dispatch_verified": active_assignment.dispatch_verified if active_assignment else False,
+        "assigned_task_id": active_assignment.assigned_task_id if active_assignment else None,
+        "blocker_reason": assignment_blocker,
+    }
+    task_state = {
+        "task_graph_id": task.id if task else None,
+        "status": task.status if task else None,
+        "assigned_ace_id": task.assigned_ace_id if task else None,
+    }
+    delivery_state = (
+        active_assignment.dispatch_delivery_state
+        if active_assignment is not None
+        else _delivery_state_for_runtime(runtime_state)
+    )
+    return RuntimeHealth(
+        role="ace",
+        project_id=project_id,
+        session_id=ace_id,
+        runtime_exists=session is not None and session.status in _ACTIVE_SESSION_STATUSES,
+        pane_attached=bool(getattr(session, "tmux_pane", None)),
+        provider=getattr(session, "provider", None),
+        runtime_state=runtime_state,
+        delivery_state=delivery_state,
+        blocker_reason=blocker,
+        last_activity_at=(
+            active_assignment.last_activity_at
+            if active_assignment
+            else getattr(session, "updated_at", None)
+        ),
+        task_graph_state=task_state,
+        ace_dispatch=ace_dispatch,
+        ace_count=1 if session is not None else 0,
+        current_blocker=current_blocker,
+        recovery_recommendation=_recovery_for("ace", project_id, current_blocker, ace_id),
+        provider_diagnostics=diagnostics,
+    )
+
+
+def build_recovery_plan(
+    health: RuntimeHealth,
+    *,
+    mode: RecoveryMode = "dry_run",
+    policy: str = "inspect_first",
+) -> RecoveryPlan:
+    """Return an inspect-first recovery plan without provider-specific mechanics."""
+
+    actions: list[dict[str, Any]] = [
+        {
+            "action": "inspect_runtime",
+            "status": "complete",
+            "runtime_state": health.runtime_state,
+            "blocker_reason": health.current_blocker,
+        }
+    ]
+    if not health.current_blocker and health.runtime_state in {
+        RuntimeState.READY.value,
+        RuntimeState.ACTIVE.value,
+    }:
+        actions.append({"action": "none", "reason": "runtime_healthy"})
+        safe = False
+        message = "Runtime appears healthy; no recovery action planned."
+    elif health.current_blocker == BlockerReason.PANE_MISSING.value:
+        actions.append({"action": "restart_required", "safe": True})
+        safe = True
+        message = (
+            "Runtime pane is missing; restart/re-dispatch can be planned from persisted state."
+        )
+    else:
+        actions.append({"action": "operator_intervention_required", "safe": False})
+        safe = False
+        message = (
+            "Recovery requires operator/provider policy; apply refused by inspect-first contract."
+        )
+
+    refused = None
+    if mode == "apply" and not safe:
+        refused = "unsafe_or_unneeded_recovery"
+    elif mode == "apply" and policy == "inspect_first":
+        refused = "apply_requires_explicit_policy"
+
+    if refused:
+        message = f"Apply refused: {refused}. Re-run as dry-run or choose an explicit safe policy."
+
+    return RecoveryPlan(
+        role=health.role,
+        project_id=health.project_id,
+        mode=mode,
+        safe_to_apply=safe,
+        actions=actions,
+        health=health.as_dict(),
+        message=message,
+        refused_reason=refused,
+    )

--- a/tests/unit/test_runtime_health.py
+++ b/tests/unit/test_runtime_health.py
@@ -1,0 +1,233 @@
+"""Tests for provider-neutral runtime health and recovery planning."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock
+
+import pytest
+from fastapi import HTTPException
+
+from atc.api.routers.aces import RecoveryRequest as AceRecoveryRequest
+from atc.api.routers.aces import get_ace_health, recover_ace
+from atc.api.routers.projects import RecoveryRequest as LeaderRecoveryRequest
+from atc.api.routers.projects import get_leader_health, recover_leader
+from atc.runtime.health import ace_health, build_recovery_plan, leader_health
+from atc.runtime.models import ReadinessState, RuntimeBlockReason, RuntimeInspection
+from atc.state.db import (
+    _SCHEMA_SQL,
+    assign_task,
+    create_leader,
+    create_project,
+    create_session,
+    create_task_graph,
+    get_connection,
+    run_migrations,
+    update_task_assignment_dispatch,
+)
+
+
+@pytest.fixture
+async def db():
+    await run_migrations(":memory:")
+    async with get_connection(":memory:") as conn:
+        await conn.executescript(_SCHEMA_SQL)
+        await conn.commit()
+        yield conn
+
+
+class FakeRuntimeService:
+    def __init__(self, inspection: RuntimeInspection | Exception) -> None:
+        self.inspection = inspection
+
+    async def inspect_session_record(self, _session):
+        if isinstance(self.inspection, Exception):
+            raise self.inspection
+        return self.inspection
+
+
+def _request(db):
+    request = MagicMock()
+    request.app.state.db = db
+    return request
+
+
+@pytest.mark.asyncio
+async def test_leader_health_reports_runtime_and_task_summary(db) -> None:
+    project = await create_project(db, "health-proj")
+    leader = await create_leader(db, project.id, goal="Ship health")
+    session = await create_session(
+        db,
+        project.id,
+        "manager",
+        "leader-health",
+        status="working",
+        provider="codex",
+    )
+    await db.execute(
+        "UPDATE sessions SET tmux_pane = ?, tmux_session = ? WHERE id = ?",
+        ("%7", "atc", session.id),
+    )
+    await db.execute(
+        "UPDATE leaders SET session_id = ?, context = ? WHERE id = ?",
+        (
+            session.id,
+            json.dumps(
+                {"leader_kickoff_payload": {"message": "go"}, "leader_original_goal": "Ship health"}
+            ),
+            leader.id,
+        ),
+    )
+    task = await create_task_graph(db, project.id, "Task one")
+    ace = await create_session(db, project.id, "ace", "ace-one", status="working", task_id=task.id)
+    assignment, _ = await assign_task(db, task.id, ace.id, f"{leader.id}:{task.id}")
+    await update_task_assignment_dispatch(
+        db,
+        assignment.assignment_id,
+        dispatch_delivery_state="accepted_active",
+        dispatch_verified=True,
+        last_activity=True,
+    )
+    await db.commit()
+
+    health = await leader_health(
+        db,
+        project.id,
+        runtime_service=FakeRuntimeService(
+            RuntimeInspection(
+                session_id=session.id,
+                provider_name="codex",
+                alive=True,
+                readiness=ReadinessState.BUSY,
+                summary="working",
+            )
+        ),
+    )
+
+    data = health.as_dict()
+    assert data["runtime_state"] == "active"
+    assert data["kickoff_state"]["kickoff_payload_persisted"] is True
+    assert data["task_graph_state"]["total"] == 1
+    assert data["ace_dispatch"]["verified"] == 1
+    assert data["ace_count"] == 1
+
+
+@pytest.mark.asyncio
+async def test_ace_health_reports_blocked_dispatch_separately(db) -> None:
+    project = await create_project(db, "ace-health-proj")
+    task = await create_task_graph(db, project.id, "Task one")
+    ace = await create_session(db, project.id, "ace", "ace-one", status="waiting", task_id=task.id)
+    await db.execute(
+        "UPDATE sessions SET tmux_pane = ?, tmux_session = ? WHERE id = ?",
+        ("%9", "atc", ace.id),
+    )
+    assignment, _ = await assign_task(db, task.id, ace.id, f"ace:{task.id}")
+    await update_task_assignment_dispatch(
+        db,
+        assignment.assignment_id,
+        dispatch_delivery_state="blocked",
+        dispatch_verified=False,
+        blocker_reason="default_prompt_visible",
+    )
+
+    health = await ace_health(
+        db,
+        project.id,
+        ace.id,
+        runtime_service=FakeRuntimeService(
+            RuntimeInspection(
+                session_id=ace.id,
+                provider_name="codex",
+                alive=True,
+                readiness=ReadinessState.BLOCKED,
+                block_reason=RuntimeBlockReason.PROVIDER_PROMPT,
+                summary="default prompt",
+            )
+        ),
+    )
+
+    data = health.as_dict()
+    assert data["runtime_state"] == "blocked"
+    assert data["ace_dispatch"]["dispatch_delivery_state"] == "blocked"
+    assert data["ace_dispatch"]["dispatch_verified"] is False
+    assert data["current_blocker"] == "unknown_prompt_blocker"
+
+
+@pytest.mark.asyncio
+async def test_recovery_dry_run_and_apply_refusal(db) -> None:
+    project = await create_project(db, "recover-proj")
+    await create_leader(db, project.id, goal="Recover")
+    health = await leader_health(
+        db, project.id, runtime_service=FakeRuntimeService(RuntimeError("boom"))
+    )
+
+    dry_run = build_recovery_plan(health, mode="dry_run")
+    assert dry_run.mode == "dry_run"
+    assert dry_run.actions[0]["action"] == "inspect_runtime"
+
+    apply = build_recovery_plan(health, mode="apply")
+    assert apply.refused_reason == "apply_requires_explicit_policy"
+
+    explicit_apply = build_recovery_plan(health, mode="apply", policy="restart_missing_pane")
+    assert explicit_apply.safe_to_apply is True
+    assert explicit_apply.refused_reason is None
+
+
+@pytest.mark.asyncio
+async def test_ace_health_does_not_leak_cross_project_assignment(db) -> None:
+    owner = await create_project(db, "owner-proj")
+    other = await create_project(db, "other-proj")
+    task = await create_task_graph(db, owner.id, "Secret task")
+    ace = await create_session(db, owner.id, "ace", "ace-one", status="waiting", task_id=task.id)
+    assignment, _ = await assign_task(db, task.id, ace.id, f"ace:{task.id}")
+    await update_task_assignment_dispatch(
+        db,
+        assignment.assignment_id,
+        dispatch_delivery_state="blocked",
+        dispatch_verified=False,
+        blocker_reason="secret_blocker",
+    )
+
+    health = await ace_health(db, other.id, ace.id)
+    data = health.as_dict()
+    assert data["runtime_exists"] is False
+    assert data["ace_dispatch"] == {}
+    assert data["task_graph_state"] == {}
+
+
+@pytest.mark.asyncio
+async def test_ace_health_api_404s_for_cross_project_session(db) -> None:
+    owner = await create_project(db, "owner-api-proj")
+    other = await create_project(db, "other-api-proj")
+    ace = await create_session(db, owner.id, "ace", "ace-one", status="idle")
+    request = _request(db)
+
+    with pytest.raises(HTTPException) as exc_info:
+        await get_ace_health(other.id, ace.id, request)
+    assert exc_info.value.status_code == 404
+
+    with pytest.raises(HTTPException) as recover_exc:
+        await recover_ace(other.id, ace.id, AceRecoveryRequest(dry_run=True), request)
+    assert recover_exc.value.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_health_and_recover_api_endpoints(db) -> None:
+    project = await create_project(db, "api-health-proj")
+    await create_leader(db, project.id, goal="API health")
+    request = _request(db)
+
+    leader = await get_leader_health(project.id, request)
+    assert leader["role"] == "leader"
+    assert leader["runtime_state"] == "missing"
+
+    plan = await recover_leader(project.id, LeaderRecoveryRequest(dry_run=True), request)
+    assert plan["mode"] == "dry_run"
+
+    ace = await create_session(db, project.id, "ace", "ace-one", status="idle")
+    ace_data = await get_ace_health(project.id, ace.id, request)
+    assert ace_data["role"] == "ace"
+
+    with pytest.raises(HTTPException) as exc_info:
+        await recover_ace(project.id, ace.id, AceRecoveryRequest(dry_run=False), request)
+    assert exc_info.value.status_code == 409


### PR DESCRIPTION
## Summary
- add provider-neutral Leader/Ace runtime health summaries for runtime, delivery, blocker, task graph, kickoff, dispatch, and recovery recommendation truth
- expose health/recover REST endpoints and `atc leader/ace health|recover` CLI wrappers
- add inspect-first recovery planning with dry-run shape and apply refusal for unsafe/default policy states

## Validation
- `ruff check src/atc/runtime/health.py src/atc/api/routers/projects.py src/atc/api/routers/aces.py src/atc/cli/leader.py src/atc/cli/ace.py tests/unit/test_runtime_health.py`
- `pytest tests/unit/test_runtime_health.py tests/unit/test_leader_api.py tests/unit/test_ace_dispatch.py -q` — 18 passed, 1 existing FastAPI/Starlette deprecation warning
- frontend `npm run build` from `frontend/`
- local health checks: `http://127.0.0.1:8420/api/health` 200; `http://127.0.0.1:5173/dashboard` 200
- changed behavior smoke: created disposable project and verified `/leader/health` plus `/leader/recover` response shape
- Playwright smoke: 13/13 passed; report `/private/tmp/atc-work/screenshots/playwright-atc-2026-06-12T13-08-14-192Z/report.json`

## Encapsulation
Health/recovery consumes provider-neutral `RuntimeInspection` / runtime delivery / task assignment truth only; provider-specific prompt strings and mechanics remain outside Tower/Leader/Ace/API/CLI.
