### PR TITLE
feat: add provider recovery policy apply

### DIFF
--- a/docs/runtime_truth_recovery_plan.md
+++ b/docs/runtime_truth_recovery_plan.md
@@ -1,7 +1,7 @@
 # Runtime Truth and Recovery Plan
 
-**Status:** Phases 1-5 implemented; Phase 6 next  
-**Last updated:** 2026-06-12 13:22 UTC  
+**Status:** Phases 1-6 implemented; Phase 7 next
+**Last updated:** 2026-06-12 13:52 UTC
 **Scope:** Provider-neutral runtime truth, delivery verification, health, and recovery for ATC Tower → Leader → Ace orchestration  
 **Primary design constraint:** Provider-specific terminal behavior, including Codex update prompts and starter screens, must remain encapsulated inside provider adapters/classifiers. Tower, Leader, Ace, task graph, API, CLI, and UI layers may only depend on provider-neutral runtime truth.
 
@@ -374,6 +374,15 @@ runtime evidence. Full repair commands remain Phase 5/6 work.
 ## Phase 6 — Update/stale-session recovery implementation
 
 **Goal:** Implement provider-policy-driven recovery for runtime update prompts and stale post-update sessions while keeping mechanics provider-owned.
+
+**Implemented in PR #292:**
+
+- Added provider-capability-aware recovery planning for runtime update prompts.
+- Added explicit recovery policies (`inspect_first`, `restart_missing_pane`, `restart_stale_runtime`, `auto_accept_updates_and_restart`) instead of optimistic apply behavior.
+- Kept provider update mechanics encapsulated: update prompt acceptance is refused until a provider adapter exposes a safe mutating capability.
+- Added stale/missing Leader apply recovery that restarts from persisted Leader goal.
+- Kept Ace recovery Leader-owned: direct Ace apply is refused so dispatch/re-dispatch stays under Leader task ownership.
+- Added tests covering update prompt policy gating, provider capability checks, stale Leader goal reuse, and existing health/recovery regressions.
 
 ### Work
 

--- a/src/atc/api/routers/aces.py
+++ b/src/atc/api/routers/aces.py
@@ -21,7 +21,7 @@ from pydantic import BaseModel
 
 from atc.api.delivery import delivery_response
 from atc.core.errors import CreationFailedError, SessionNotFoundError, SessionStaleError
-from atc.runtime.health import ace_health, build_recovery_plan
+from atc.runtime.health import ace_health, apply_recovery_plan, build_recovery_plan
 from atc.session import ace as ace_ops
 from atc.session.state_machine import InvalidTransitionError
 from atc.state import db as db_ops
@@ -199,10 +199,10 @@ async def recover_ace(
         raise HTTPException(status_code=404, detail="Project not found")
     await _require_project_ace(db, project_id, session_id)
     health = await ace_health(db, project_id, session_id)
-    plan = build_recovery_plan(
-        health,
-        mode="dry_run" if body.dry_run else "apply",
-        policy=body.policy,
+    plan = (
+        build_recovery_plan(health, mode="dry_run", policy=body.policy)
+        if body.dry_run
+        else await apply_recovery_plan(db, health, policy=body.policy)
     )
     if plan.refused_reason:
         raise HTTPException(status_code=409, detail=plan.as_dict())

--- a/src/atc/api/routers/projects.py
+++ b/src/atc/api/routers/projects.py
@@ -25,7 +25,7 @@ from atc.leader.kickoff import (
     persist_leader_kickoff_payload,
     verify_leader_kickoff_delivery,
 )
-from atc.runtime.health import build_recovery_plan, leader_health
+from atc.runtime.health import apply_recovery_plan, build_recovery_plan, leader_health
 from atc.runtime.models import RuntimeDeliveryResult
 from atc.state import db as db_ops
 
@@ -513,10 +513,15 @@ async def recover_leader(
     if project is None:
         raise HTTPException(status_code=404, detail="Project not found")
     health = await leader_health(db, project_id)
-    plan = build_recovery_plan(
-        health,
-        mode="dry_run" if body.dry_run else "apply",
-        policy=body.policy,
+    plan = (
+        build_recovery_plan(health, mode="dry_run", policy=body.policy)
+        if body.dry_run
+        else await apply_recovery_plan(
+            db,
+            health,
+            policy=body.policy,
+            event_bus=await _get_event_bus(request),
+        )
     )
     if plan.refused_reason:
         raise HTTPException(status_code=409, detail=plan.as_dict())

--- a/src/atc/runtime/health.py
+++ b/src/atc/runtime/health.py
@@ -367,14 +367,36 @@ async def ace_health(
     )
 
 
+def _provider_capabilities(health: RuntimeHealth) -> dict[str, Any]:
+    details = health.provider_diagnostics.get("details")
+    if isinstance(details, dict):
+        capabilities = details.get("recovery_capabilities")
+        if isinstance(capabilities, dict):
+            return capabilities
+    return {}
+
+
+def _recovery_policy_allows(policy: str, action: str) -> bool:
+    if policy in {"block_only", "notify_operator", "inspect_first"}:
+        return False
+    if action == "restart" and policy in {
+        "restart_missing_pane",
+        "restart_stale_runtime",
+        "auto_accept_updates_and_restart",
+    }:
+        return True
+    return action == "accept_update" and policy == "auto_accept_updates_and_restart"
+
+
 def build_recovery_plan(
     health: RuntimeHealth,
     *,
     mode: RecoveryMode = "dry_run",
     policy: str = "inspect_first",
 ) -> RecoveryPlan:
-    """Return an inspect-first recovery plan without provider-specific mechanics."""
+    """Return provider-policy recovery plan without provider-specific mechanics."""
 
+    capabilities = _provider_capabilities(health)
     actions: list[dict[str, Any]] = [
         {
             "action": "inspect_runtime",
@@ -383,30 +405,68 @@ def build_recovery_plan(
             "blocker_reason": health.current_blocker,
         }
     ]
+    safe = False
+    refused = None
+    message = "Runtime appears healthy; no recovery action planned."
+
+    restartable = health.current_blocker in {
+        BlockerReason.PANE_MISSING.value,
+        BlockerReason.STALE_AFTER_UPDATE.value,
+    } or health.runtime_state in {RuntimeState.MISSING.value, RuntimeState.STALE.value}
+    update_required = health.current_blocker == BlockerReason.RUNTIME_UPDATE_REQUIRED.value
+
     if not health.current_blocker and health.runtime_state in {
         RuntimeState.READY.value,
         RuntimeState.ACTIVE.value,
     }:
         actions.append({"action": "none", "reason": "runtime_healthy"})
-        safe = False
-        message = "Runtime appears healthy; no recovery action planned."
-    elif health.current_blocker == BlockerReason.PANE_MISSING.value:
-        actions.append({"action": "restart_required", "safe": True})
-        safe = True
-        message = (
-            "Runtime pane is missing; restart/re-dispatch can be planned from persisted state."
+    elif update_required:
+        can_accept = bool(capabilities.get("can_accept_update_prompt"))
+        fresh_required = bool(capabilities.get("requires_fresh_session_after_update"))
+        actions.append(
+            {
+                "action": "provider_update_required",
+                "safe": can_accept,
+                "policy_required": "auto_accept_updates_and_restart",
+                "provider_can_accept_update_prompt": can_accept,
+                "requires_fresh_session_after_update": fresh_required,
+            }
         )
+        if can_accept:
+            actions.append({"action": "accept_provider_update", "safe": True})
+            if fresh_required:
+                actions.append({"action": "restart_required", "safe": True})
+            safe = True
+            message = "Provider update can be accepted under explicit update-and-restart policy."
+        else:
+            message = (
+                "Provider update prompt detected; provider does not advertise safe auto-accept."
+            )
+    elif restartable:
+        actions.append(
+            {
+                "action": "restart_required",
+                "safe": True,
+                "uses_persisted_payload": health.kickoff_state.get("original_goal_available")
+                if health.role == "leader"
+                else bool(health.ace_dispatch.get("assignment_id")),
+            }
+        )
+        safe = True
+        message = "Runtime is stale/missing; restart can be planned from persisted state."
     else:
         actions.append({"action": "operator_intervention_required", "safe": False})
-        safe = False
         message = (
             "Recovery requires operator/provider policy; apply refused by inspect-first contract."
         )
 
-    refused = None
     if mode == "apply" and not safe:
         refused = "unsafe_or_unneeded_recovery"
-    elif mode == "apply" and policy == "inspect_first":
+    elif (
+        mode == "apply" and update_required and not _recovery_policy_allows(policy, "accept_update")
+    ):
+        refused = "apply_requires_update_policy"
+    elif mode == "apply" and restartable and not _recovery_policy_allows(policy, "restart"):
         refused = "apply_requires_explicit_policy"
 
     if refused:
@@ -422,3 +482,74 @@ def build_recovery_plan(
         message=message,
         refused_reason=refused,
     )
+
+
+async def apply_recovery_plan(
+    conn: aiosqlite.Connection,
+    health: RuntimeHealth,
+    *,
+    policy: str,
+    event_bus: Any | None = None,
+) -> RecoveryPlan:
+    """Apply safe provider-neutral recovery actions.
+
+    Provider-specific update acceptance remains in provider adapters. This first
+    mutating slice restarts stale/missing Leader runtimes from persisted kickoff
+    state and refuses provider-update prompts unless the provider advertises safe
+    update acceptance.
+    """
+
+    plan = build_recovery_plan(health, mode="apply", policy=policy)
+    if plan.refused_reason:
+        return plan
+
+    if health.current_blocker == BlockerReason.RUNTIME_UPDATE_REQUIRED.value:
+        # Phase 6 wires policy/capability semantics. Actual keypress/update
+        # mechanics must be provider-owned, so refuse if no provider-owned
+        # capability/action has been integrated yet.
+        plan.refused_reason = "provider_update_apply_not_implemented"
+        plan.message = (
+            "Apply refused: provider update handling must be executed by a "
+            "provider adapter capability before ATC restarts the runtime."
+        )
+        return plan
+
+    if health.role == "leader" and any(
+        action.get("action") == "restart_required" for action in plan.actions
+    ):
+        from atc.leader import leader as leader_ops
+
+        leader = await db_ops.get_leader_by_project(conn, health.project_id)
+        context = leader.context if leader and isinstance(leader.context, dict) else {}
+        goal = context.get("leader_original_goal") or (leader.goal if leader else None) or ""
+        if not goal:
+            plan.refused_reason = "missing_persisted_goal"
+            plan.message = "Apply refused: persisted Leader goal is unavailable."
+            return plan
+        await leader_ops.stop_leader(conn, health.project_id, event_bus=event_bus)
+        session_id = await leader_ops.start_leader(
+            conn, health.project_id, goal=goal, event_bus=event_bus
+        )
+        plan.actions.append(
+            {
+                "action": "restart_leader",
+                "status": "applied",
+                "session_id": session_id,
+                "goal_restored": True,
+            }
+        )
+        plan.message = "Leader runtime restarted from persisted goal."
+        plan.health = (await leader_health(conn, health.project_id)).as_dict()
+        return plan
+
+    if health.role == "ace" and any(
+        action.get("action") == "restart_required" for action in plan.actions
+    ):
+        plan.refused_reason = "leader_owned_ace_recovery_required"
+        plan.message = (
+            "Apply refused: Ace restart/re-dispatch must be initiated by the "
+            "Leader-owned task assignment flow."
+        )
+        return plan
+
+    return plan

--- a/tests/unit/test_runtime_health.py
+++ b/tests/unit/test_runtime_health.py
@@ -12,8 +12,20 @@ from atc.api.routers.aces import RecoveryRequest as AceRecoveryRequest
 from atc.api.routers.aces import get_ace_health, recover_ace
 from atc.api.routers.projects import RecoveryRequest as LeaderRecoveryRequest
 from atc.api.routers.projects import get_leader_health, recover_leader
-from atc.runtime.health import ace_health, build_recovery_plan, leader_health
-from atc.runtime.models import ReadinessState, RuntimeBlockReason, RuntimeInspection
+from atc.runtime.health import (
+    RuntimeHealth,
+    ace_health,
+    apply_recovery_plan,
+    build_recovery_plan,
+    leader_health,
+)
+from atc.runtime.models import (
+    BlockerReason,
+    ReadinessState,
+    RuntimeBlockReason,
+    RuntimeInspection,
+    RuntimeState,
+)
 from atc.state.db import (
     _SCHEMA_SQL,
     assign_task,
@@ -171,6 +183,103 @@ async def test_recovery_dry_run_and_apply_refusal(db) -> None:
     explicit_apply = build_recovery_plan(health, mode="apply", policy="restart_missing_pane")
     assert explicit_apply.safe_to_apply is True
     assert explicit_apply.refused_reason is None
+
+
+@pytest.mark.asyncio
+async def test_update_prompt_recovery_is_capability_and_policy_gated(db) -> None:
+    project = await create_project(db, "update-policy-proj")
+    health = RuntimeHealth(
+        role="leader",
+        project_id=project.id,
+        runtime_exists=True,
+        pane_attached=True,
+        provider="codex",
+        session_id="leader-session",
+        runtime_state=RuntimeState.BLOCKED.value,
+        current_blocker=BlockerReason.RUNTIME_UPDATE_REQUIRED.value,
+        provider_diagnostics={
+            "details": {
+                "recovery_capabilities": {
+                    "can_detect_update_prompt": True,
+                    "can_accept_update_prompt": True,
+                    "requires_fresh_session_after_update": True,
+                }
+            }
+        },
+    )
+
+    dry_run = build_recovery_plan(health, mode="dry_run")
+    assert dry_run.safe_to_apply is True
+    assert [a["action"] for a in dry_run.actions] == [
+        "inspect_runtime",
+        "provider_update_required",
+        "accept_provider_update",
+        "restart_required",
+    ]
+
+    apply_without_policy = build_recovery_plan(health, mode="apply")
+    assert apply_without_policy.refused_reason == "apply_requires_update_policy"
+
+    apply_with_policy = await apply_recovery_plan(
+        db,
+        health,
+        policy="auto_accept_updates_and_restart",
+    )
+    assert apply_with_policy.refused_reason == "provider_update_apply_not_implemented"
+
+
+@pytest.mark.asyncio
+async def test_stale_leader_restart_apply_uses_persisted_goal(db, monkeypatch) -> None:
+    project = await create_project(db, "stale-restart-proj")
+    await create_leader(db, project.id, goal="Recover from stale runtime")
+    calls = {}
+
+    async def fake_stop(conn, project_id, *, event_bus=None):
+        calls["stopped"] = project_id
+
+    async def fake_start(conn, project_id, *, goal=None, event_bus=None, context_package=None):
+        calls["started"] = {"project_id": project_id, "goal": goal}
+        return "new-leader-session"
+
+    async def fake_health(conn, project_id, *, runtime_service=None):
+        return RuntimeHealth(
+            role="leader",
+            project_id=project_id,
+            runtime_exists=True,
+            pane_attached=True,
+            provider="codex",
+            session_id="new-leader-session",
+            runtime_state=RuntimeState.READY.value,
+        )
+
+    import atc.runtime.health as health_module
+    from atc.leader import leader as leader_ops
+
+    monkeypatch.setattr(leader_ops, "stop_leader", fake_stop)
+    monkeypatch.setattr(leader_ops, "start_leader", fake_start)
+    monkeypatch.setattr(health_module, "leader_health", fake_health)
+
+    plan = await apply_recovery_plan(
+        db,
+        RuntimeHealth(
+            role="leader",
+            project_id=project.id,
+            runtime_exists=False,
+            pane_attached=False,
+            provider="codex",
+            runtime_state=RuntimeState.MISSING.value,
+            current_blocker=BlockerReason.PANE_MISSING.value,
+            kickoff_state={"original_goal_available": True},
+        ),
+        policy="restart_missing_pane",
+    )
+
+    assert plan.refused_reason is None
+    assert calls == {
+        "stopped": project.id,
+        "started": {"project_id": project.id, "goal": "Recover from stale runtime"},
+    }
+    assert plan.actions[-1]["action"] == "restart_leader"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- add provider-capability-aware recovery planning for runtime update prompts without putting Codex prompt mechanics in core recovery
- add explicit recovery policies for inspect-first, stale/missing runtime restarts, and future provider-owned update acceptance
- wire mutating recover endpoints through a safe apply layer: Leader stale/missing recovery restarts from persisted goal, provider-update apply is refused until adapter-owned mechanics exist, and direct Ace recovery remains Leader-owned
- update runtime truth plan status for Phase 6

## Validation
- `ruff check src/atc/runtime/health.py src/atc/api/routers/projects.py src/atc/api/routers/aces.py tests/unit/test_runtime_health.py`
- `pytest tests/unit/test_runtime_health.py tests/unit/test_leader_api.py tests/unit/test_ace_dispatch.py -q` → 22 passed
- `npm run build` from `frontend/`
- API health: `GET /api/health` → 200
- Dashboard health: `/dashboard` → 200
- Playwright smoke via `node playwright-smoke-atc.mjs --base-url http://127.0.0.1:5173` → 13/13 passed

## Evidence
- Playwright report: `/private/tmp/atc-work/screenshots/playwright-atc-2026-06-12T13-53-52-428Z/report.json`
- Dashboard screenshot: `/private/tmp/atc-work/screenshots/playwright-atc-2026-06-12T13-53-52-428Z/01-dashboard-initial.png`
- Create modal screenshot: `/private/tmp/atc-work/screenshots/playwright-atc-2026-06-12T13-53-52-428Z/05-create-project-modal.png`
- Context screenshot: `/private/tmp/atc-work/screenshots/playwright-atc-2026-06-12T13-53-52-428Z/12-context.png`
