### PR TITLE
fix: preserve provider recovery blockers

### DIFF
--- a/src/atc/runtime/health.py
+++ b/src/atc/runtime/health.py
@@ -76,6 +76,11 @@ class RecoveryPlan:
 
 
 def _blocker_from_inspection(inspection: RuntimeInspection) -> str | None:
+    provider_blocker = inspection.details.get("blocker_reason")
+    if isinstance(provider_blocker, str):
+        valid_blockers = {reason.value for reason in BlockerReason}
+        if provider_blocker in valid_blockers:
+            return provider_blocker
     if inspection.readiness is ReadinessState.BLOCKED:
         reason = inspection.block_reason.value if inspection.block_reason else "runtime_blocked"
         mapping = {
@@ -376,16 +381,42 @@ def _provider_capabilities(health: RuntimeHealth) -> dict[str, Any]:
     return {}
 
 
-def _recovery_policy_allows(policy: str, action: str) -> bool:
+def _restart_policy_required(health: RuntimeHealth) -> str:
+    if health.current_blocker == BlockerReason.STALE_AFTER_UPDATE.value:
+        return "restart_stale_runtime"
+    if health.runtime_state == RuntimeState.STALE.value:
+        return "restart_stale_runtime"
+    return "restart_missing_pane"
+
+
+def _recovery_policy_allows(
+    policy: str,
+    action: str,
+    *,
+    required_policy: str | None = None,
+) -> bool:
     if policy in {"block_only", "notify_operator", "inspect_first"}:
         return False
-    if action == "restart" and policy in {
-        "restart_missing_pane",
-        "restart_stale_runtime",
-        "auto_accept_updates_and_restart",
-    }:
-        return True
+    if action == "restart":
+        return policy == required_policy or (
+            policy == "auto_accept_updates_and_restart"
+            and required_policy == "restart_stale_runtime"
+        )
     return action == "accept_update" and policy == "auto_accept_updates_and_restart"
+
+
+def _is_stale_runtime_stop_error(exc: Exception) -> bool:
+    text = str(exc).lower()
+    stale_markers = (
+        "no such pane",
+        "can't find pane",
+        "can't find window",
+        "can't find session",
+        "pane unavailable",
+        "session missing",
+        "session not found",
+    )
+    return isinstance(exc, RuntimeError) and any(marker in text for marker in stale_markers)
 
 
 def build_recovery_plan(
@@ -414,6 +445,7 @@ def build_recovery_plan(
         BlockerReason.STALE_AFTER_UPDATE.value,
     } or health.runtime_state in {RuntimeState.MISSING.value, RuntimeState.STALE.value}
     update_required = health.current_blocker == BlockerReason.RUNTIME_UPDATE_REQUIRED.value
+    required_restart_policy = _restart_policy_required(health) if restartable else None
 
     if not health.current_blocker and health.runtime_state in {
         RuntimeState.READY.value,
@@ -447,6 +479,7 @@ def build_recovery_plan(
             {
                 "action": "restart_required",
                 "safe": True,
+                "policy_required": required_restart_policy,
                 "uses_persisted_payload": health.kickoff_state.get("original_goal_available")
                 if health.role == "leader"
                 else bool(health.ace_dispatch.get("assignment_id")),
@@ -466,7 +499,15 @@ def build_recovery_plan(
         mode == "apply" and update_required and not _recovery_policy_allows(policy, "accept_update")
     ):
         refused = "apply_requires_update_policy"
-    elif mode == "apply" and restartable and not _recovery_policy_allows(policy, "restart"):
+    elif (
+        mode == "apply"
+        and restartable
+        and not _recovery_policy_allows(
+            policy,
+            "restart",
+            required_policy=required_restart_policy,
+        )
+    ):
         refused = "apply_requires_explicit_policy"
 
     if refused:
@@ -526,7 +567,43 @@ async def apply_recovery_plan(
             plan.refused_reason = "missing_persisted_goal"
             plan.message = "Apply refused: persisted Leader goal is unavailable."
             return plan
-        await leader_ops.stop_leader(conn, health.project_id, event_bus=event_bus)
+        try:
+            await leader_ops.stop_leader(conn, health.project_id, event_bus=event_bus)
+        except Exception as exc:
+            if not _is_stale_runtime_stop_error(exc):
+                plan.refused_reason = "stop_leader_failed"
+                plan.message = (
+                    "Apply refused: stopping the current Leader failed for a non-stale-pane reason."
+                )
+                plan.actions.append(
+                    {
+                        "action": "stop_leader",
+                        "status": "failed",
+                        "error_type": type(exc).__name__,
+                        "error": str(exc),
+                    }
+                )
+                return plan
+            plan.actions.append(
+                {
+                    "action": "stop_stale_leader",
+                    "status": "degraded",
+                    "error_type": type(exc).__name__,
+                    "error": str(exc),
+                }
+            )
+            if leader and leader.session_id:
+                await db_ops.update_session_status(
+                    conn,
+                    leader.session_id,
+                    "disconnected",
+                )
+                await conn.execute(
+                    "UPDATE leaders SET session_id = NULL, status = 'idle',"
+                    " updated_at = datetime('now') WHERE id = ?",
+                    (leader.id,),
+                )
+                await conn.commit()
         session_id = await leader_ops.start_leader(
             conn, health.project_id, goal=goal, event_bus=event_bus
         )

--- a/tests/unit/test_runtime_health.py
+++ b/tests/unit/test_runtime_health.py
@@ -34,6 +34,7 @@ from atc.state.db import (
     create_session,
     create_task_graph,
     get_connection,
+    get_session,
     run_migrations,
     update_task_assignment_dispatch,
 )
@@ -229,6 +230,103 @@ async def test_update_prompt_recovery_is_capability_and_policy_gated(db) -> None
 
 
 @pytest.mark.asyncio
+async def test_provider_blocker_reason_flows_from_inspection_to_recovery_plan(db) -> None:
+    project = await create_project(db, "provider-blocker-proj")
+    leader = await create_leader(db, project.id, goal="Recover update")
+    session = await create_session(
+        db,
+        project.id,
+        "manager",
+        "leader-update",
+        status="working",
+        provider="codex",
+    )
+    await db.execute(
+        "UPDATE sessions SET tmux_pane = ?, tmux_session = ? WHERE id = ?",
+        ("%12", "atc", session.id),
+    )
+    await db.execute("UPDATE leaders SET session_id = ? WHERE id = ?", (session.id, leader.id))
+    await db.commit()
+
+    health = await leader_health(
+        db,
+        project.id,
+        runtime_service=FakeRuntimeService(
+            RuntimeInspection(
+                session_id=session.id,
+                provider_name="codex",
+                alive=True,
+                readiness=ReadinessState.BLOCKED,
+                block_reason=RuntimeBlockReason.PROVIDER_PROMPT,
+                summary="Codex runtime update prompt visible",
+                details={
+                    "blocker_reason": BlockerReason.RUNTIME_UPDATE_REQUIRED.value,
+                    "recovery_capabilities": {
+                        "can_detect_update_prompt": True,
+                        "can_accept_update_prompt": False,
+                        "requires_fresh_session_after_update": True,
+                    },
+                },
+            )
+        ),
+    )
+
+    assert health.current_blocker == BlockerReason.RUNTIME_UPDATE_REQUIRED.value
+    plan = build_recovery_plan(health, mode="dry_run")
+    assert plan.actions[1]["action"] == "provider_update_required"
+    assert plan.safe_to_apply is False
+
+
+@pytest.mark.asyncio
+async def test_restart_policy_must_match_missing_vs_stale_reason(db) -> None:
+    project = await create_project(db, "restart-policy-proj")
+
+    missing = RuntimeHealth(
+        role="leader",
+        project_id=project.id,
+        runtime_exists=False,
+        pane_attached=False,
+        provider="codex",
+        runtime_state=RuntimeState.MISSING.value,
+        current_blocker=BlockerReason.PANE_MISSING.value,
+    )
+    stale = RuntimeHealth(
+        role="leader",
+        project_id=project.id,
+        runtime_exists=True,
+        pane_attached=True,
+        provider="codex",
+        runtime_state=RuntimeState.STALE.value,
+        current_blocker=BlockerReason.STALE_AFTER_UPDATE.value,
+    )
+
+    assert (
+        build_recovery_plan(missing, mode="apply", policy="restart_stale_runtime").refused_reason
+        == "apply_requires_explicit_policy"
+    )
+    assert (
+        build_recovery_plan(
+            missing,
+            mode="apply",
+            policy="auto_accept_updates_and_restart",
+        ).refused_reason
+        == "apply_requires_explicit_policy"
+    )
+    assert (
+        build_recovery_plan(stale, mode="apply", policy="restart_missing_pane").refused_reason
+        == "apply_requires_explicit_policy"
+    )
+    assert (
+        build_recovery_plan(missing, mode="apply", policy="restart_missing_pane").refused_reason
+        is None
+    )
+    assert (
+        build_recovery_plan(stale, mode="apply", policy="restart_stale_runtime").refused_reason
+        is None
+    )
+
+
+@pytest.mark.asyncio
 async def test_stale_leader_restart_apply_uses_persisted_goal(db, monkeypatch) -> None:
     project = await create_project(db, "stale-restart-proj")
     await create_leader(db, project.id, goal="Recover from stale runtime")
@@ -280,6 +378,109 @@ async def test_stale_leader_restart_apply_uses_persisted_goal(db, monkeypatch) -
         "started": {"project_id": project.id, "goal": "Recover from stale runtime"},
     }
     assert plan.actions[-1]["action"] == "restart_leader"
+
+
+@pytest.mark.asyncio
+async def test_stale_leader_restart_tolerates_missing_pane_stop_failure(db, monkeypatch) -> None:
+    project = await create_project(db, "stop-failure-proj")
+    leader = await create_leader(db, project.id, goal="Recover despite missing pane")
+    session = await create_session(
+        db,
+        project.id,
+        "manager",
+        "leader-stale",
+        status="working",
+        provider="codex",
+    )
+    await db.execute(
+        "UPDATE sessions SET tmux_pane = ?, tmux_session = ? WHERE id = ?",
+        ("%missing", "atc", session.id),
+    )
+    await db.execute("UPDATE leaders SET session_id = ? WHERE id = ?", (session.id, leader.id))
+    await db.commit()
+
+    async def fake_stop(conn, project_id, *, event_bus=None):
+        raise RuntimeError("no such pane: %missing")
+
+    async def fake_start(conn, project_id, *, goal=None, event_bus=None, context_package=None):
+        return "replacement-session"
+
+    async def fake_health(conn, project_id, *, runtime_service=None):
+        return RuntimeHealth(
+            role="leader",
+            project_id=project_id,
+            runtime_exists=True,
+            pane_attached=True,
+            provider="codex",
+            session_id="replacement-session",
+            runtime_state=RuntimeState.READY.value,
+        )
+
+    import atc.runtime.health as health_module
+    from atc.leader import leader as leader_ops
+
+    monkeypatch.setattr(leader_ops, "stop_leader", fake_stop)
+    monkeypatch.setattr(leader_ops, "start_leader", fake_start)
+    monkeypatch.setattr(health_module, "leader_health", fake_health)
+
+    plan = await apply_recovery_plan(
+        db,
+        RuntimeHealth(
+            role="leader",
+            project_id=project.id,
+            runtime_exists=True,
+            pane_attached=True,
+            provider="codex",
+            session_id=session.id,
+            runtime_state=RuntimeState.STALE.value,
+            current_blocker=BlockerReason.STALE_AFTER_UPDATE.value,
+        ),
+        policy="restart_stale_runtime",
+    )
+
+    stale_session = await get_session(db, session.id)
+    assert plan.refused_reason is None
+    assert any(action["action"] == "stop_stale_leader" for action in plan.actions)
+    assert stale_session is not None
+    assert stale_session.status == "disconnected"
+    assert plan.actions[-1]["session_id"] == "replacement-session"
+
+
+@pytest.mark.asyncio
+async def test_stale_leader_restart_refuses_non_stale_stop_failure(db, monkeypatch) -> None:
+    project = await create_project(db, "stop-db-failure-proj")
+    await create_leader(db, project.id, goal="Do not split brain")
+    calls = {"started": False}
+
+    async def fake_stop(conn, project_id, *, event_bus=None):
+        raise RuntimeError("database locked")
+
+    async def fake_start(conn, project_id, *, goal=None, event_bus=None, context_package=None):
+        calls["started"] = True
+        return "should-not-start"
+
+    from atc.leader import leader as leader_ops
+
+    monkeypatch.setattr(leader_ops, "stop_leader", fake_stop)
+    monkeypatch.setattr(leader_ops, "start_leader", fake_start)
+
+    plan = await apply_recovery_plan(
+        db,
+        RuntimeHealth(
+            role="leader",
+            project_id=project.id,
+            runtime_exists=True,
+            pane_attached=True,
+            provider="codex",
+            runtime_state=RuntimeState.STALE.value,
+            current_blocker=BlockerReason.STALE_AFTER_UPDATE.value,
+        ),
+        policy="restart_stale_runtime",
+    )
+
+    assert plan.refused_reason == "stop_leader_failed"
+    assert calls["started"] is False
+    assert plan.actions[-1]["action"] == "stop_leader"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- fix Phase 6 review blockers after PR #292: preserve provider-owned blocker reasons from runtime inspections so Codex update prompts reach the provider-policy recovery path
- enforce exact restart policy matching for missing-pane vs stale-after-update recovery reasons
- harden stale/missing Leader apply recovery so a failed stale-pane stop marks the old session disconnected, unlinks it, and still restarts from the persisted goal
- add regression coverage for the real provider inspection path, restart policy mismatch refusals, and stale-pane stop failure tolerance

## Validation
- `ruff check src/atc/runtime/health.py tests/unit/test_runtime_health.py`
- `pytest tests/unit/test_runtime_health.py tests/unit/test_leader_api.py tests/unit/test_ace_dispatch.py tests/unit/test_codex_runtime_classifier.py tests/unit/test_runtime_truth.py tests/unit/test_runtime_service.py -q` → 48 passed
- `git diff --check`

## Notes
This is a follow-up to the already-merged Phase 6 PR #292 because review completed after merge and found provider recovery blockers that needed to land on main.
