### PR TITLE
Expand Leader kickoff truth fields

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -30,6 +30,22 @@ POST   /api/projects/{id}/leader/stop         → stop Leader session
 POST   /api/projects/{id}/leader/message      → send message to Leader
 ```
 
+### Leader start kickoff truth
+
+`POST /api/projects/{id}/leader/start` returns additive kickoff truth fields when a goal is provided. Consumers must not treat `session_id`, `leader_session_id`, `status`, `delivery_state`, or `202`-style queued/submitted wording as proof that the Leader accepted the goal.
+
+Important fields:
+
+- `kickoff_state`: staged delivery/kickoff state such as `not_requested`, `queued_unverified`, `runtime_created`, `payload_written`, `submitted_pending_acceptance`, `accepted_active`, `blocked`, or `failed`.
+- `kickoff_verified`: `true` only when provider-neutral evidence shows the Leader accepted the kickoff and began work.
+- `startup_handshake_state`: provider-neutral startup readiness, e.g. `not_started`, `runtime_created`, `ready`, `blocked`, or `failed`.
+- `goal_acceptance_state`: whether the goal is `not_submitted`, `submitted_pending_acceptance`, `accepted_active`, `blocked`, or `failed`.
+- `delivery_trace_id`: trace id correlating startup, payload persistence, prompt delivery, submit, and later recovery events.
+- `kickoff_payload_persisted`: whether the original Leader kickoff payload was saved for recovery planning.
+- `kickoff_blocker_reason` / `kickoff_recovery_recommendation`: structured blocker and inspect-first recovery guidance when kickoff is blocked or unverified.
+
+`GET /api/projects/{id}/leader/health` exposes the same kickoff dimensions under `kickoff_state` alongside runtime, task graph, and recovery summaries.
+
 ## Tasks / Task Graphs
 
 ```

--- a/src/atc/api/routers/projects.py
+++ b/src/atc/api/routers/projects.py
@@ -28,6 +28,7 @@ from atc.leader.kickoff import (
 )
 from atc.runtime.health import apply_recovery_plan, build_recovery_plan, leader_health
 from atc.runtime.models import RuntimeDeliveryResult
+from atc.runtime.tracing import new_trace_id
 from atc.state import db as db_ops
 
 logger = logging.getLogger(__name__)
@@ -411,6 +412,7 @@ async def start_leader(
             github_repo=github_repo,
             api_style="explicit-api",
         )
+        kickoff_trace_id = new_trace_id()
         kickoff_payload = await persist_leader_kickoff_payload(
             db,
             project_id=project_id,
@@ -418,11 +420,19 @@ async def start_leader(
             message=kickoff_msg,
             source="leader-start-api",
             auto_kickoff=body.auto_kickoff,
+            trace_id=kickoff_trace_id,
         )
         if body.auto_kickoff:
             try:
                 kickoff_delivery = await _send_leader_msg(
-                    db, project_id, kickoff_msg, event_bus=event_bus
+                    db,
+                    project_id,
+                    kickoff_msg,
+                    event_bus=event_bus,
+                    metadata={
+                        "delivery_trace_id": kickoff_trace_id,
+                        "instruction_kind": "leader_kickoff",
+                    },
                 )
             except ValueError as exc:
                 raise HTTPException(status_code=409, detail=str(exc)) from None

--- a/src/atc/leader/kickoff.py
+++ b/src/atc/leader/kickoff.py
@@ -14,7 +14,15 @@ from typing import TYPE_CHECKING, Any
 if TYPE_CHECKING:
     import aiosqlite  # type: ignore[import-not-found]
 
-from atc.runtime.models import BlockerReason, DeliveryState, RuntimeDeliveryResult, RuntimeState
+from atc.runtime.models import (
+    BlockerReason,
+    DeliveryState,
+    RecoveryRecommendation,
+    RecoveryState,
+    RuntimeDeliveryResult,
+    RuntimeState,
+)
+from atc.runtime.tracing import new_trace_id
 from atc.state import db as db_ops
 
 
@@ -27,6 +35,7 @@ class LeaderKickoffPayload:
     message: str
     source: str
     auto_kickoff: bool = True
+    trace_id: str | None = None
 
     def as_dict(self) -> dict[str, Any]:
         return {
@@ -35,6 +44,7 @@ class LeaderKickoffPayload:
             "message": self.message,
             "source": self.source,
             "auto_kickoff": self.auto_kickoff,
+            "trace_id": self.trace_id,
         }
 
 
@@ -49,6 +59,13 @@ class LeaderKickoffVerification:
     submit_sent: bool
     provider_accepted: bool
     leader_began_work: bool
+    startup_handshake_state: str
+    goal_acceptance_state: str
+    first_actionable_step_observed_at: str | None = None
+    task_graph_created_at: str | None = None
+    kickoff_blocker_reason: str | None = None
+    kickoff_recovery_recommendation: dict[str, Any] | None = None
+    delivery_trace_id: str | None = None
     blocker_reason: str | None = None
     message: str | None = None
 
@@ -61,6 +78,13 @@ class LeaderKickoffVerification:
             "submit_sent": self.submit_sent,
             "provider_accepted": self.provider_accepted,
             "leader_began_work": self.leader_began_work,
+            "startup_handshake_state": self.startup_handshake_state,
+            "goal_acceptance_state": self.goal_acceptance_state,
+            "first_actionable_step_observed_at": self.first_actionable_step_observed_at,
+            "task_graph_created_at": self.task_graph_created_at,
+            "kickoff_blocker_reason": self.kickoff_blocker_reason,
+            "kickoff_recovery_recommendation": self.kickoff_recovery_recommendation,
+            "delivery_trace_id": self.delivery_trace_id,
         }
         if self.blocker_reason:
             data["blocker_reason"] = self.blocker_reason
@@ -111,8 +135,7 @@ def build_leader_kickoff_message(
             f"/api/projects/{project_id}/leader/decompose.",
             "2. Then spawn Aces for ready tasks via POST "
             f"/api/projects/{project_id}/leader/spawn-aces.",
-            "3. Then instruct spawned Aces via POST "
-            f"/api/projects/{project_id}/leader/instruct.",
+            f"3. Then instruct spawned Aces via POST /api/projects/{project_id}/leader/instruct.",
             f"4. Monitor progress via GET /api/projects/{project_id}/leader/progress.",
             "5. Drive the project to completion by delegating, not by coding directly.",
             "",
@@ -139,6 +162,7 @@ async def persist_leader_kickoff_payload(
     message: str,
     source: str,
     auto_kickoff: bool = True,
+    trace_id: str | None = None,
 ) -> LeaderKickoffPayload:
     """Persist original kickoff payload on the Leader context for deterministic recovery."""
 
@@ -162,6 +186,7 @@ async def persist_leader_kickoff_payload(
         message=message,
         source=source,
         auto_kickoff=auto_kickoff,
+        trace_id=trace_id or new_trace_id(),
     )
     context["leader_kickoff_payload"] = payload.as_dict()
     context["leader_original_goal"] = goal
@@ -171,6 +196,74 @@ async def persist_leader_kickoff_payload(
     )
     await conn.commit()
     return payload
+
+
+def _startup_handshake_state(
+    runtime_state: RuntimeState | None,
+    delivery_state: DeliveryState | None,
+    blocker: BlockerReason | None,
+) -> str:
+    """Return provider-neutral startup readiness for kickoff response fields."""
+
+    if blocker is not None or delivery_state is DeliveryState.BLOCKED:
+        return "blocked"
+    if runtime_state in {RuntimeState.FAILED, RuntimeState.MISSING, RuntimeState.STALE}:
+        return "failed"
+    if runtime_state in {
+        RuntimeState.READY,
+        RuntimeState.ACTIVE,
+        RuntimeState.IDLE,
+        RuntimeState.IDLE_AT_DEFAULT_PROMPT,
+    }:
+        return "ready"
+    if delivery_state in {
+        DeliveryState.RUNTIME_CREATED,
+        DeliveryState.PROMPT_VISIBLE,
+        DeliveryState.PAYLOAD_WRITTEN,
+        DeliveryState.SUBMIT_SENT,
+        DeliveryState.SUBMITTED_PENDING_ACCEPTANCE,
+        DeliveryState.ACCEPTED_ACTIVE,
+    }:
+        return "runtime_created"
+    return "not_started"
+
+
+def _goal_acceptance_state(
+    *,
+    provider_accepted: bool,
+    leader_began_work: bool,
+    submit_sent: bool,
+    blocker: BlockerReason | None,
+    failed: bool,
+) -> str:
+    """Return provider-neutral goal acceptance without optimistic wording."""
+
+    if blocker is not None:
+        return "blocked"
+    if failed:
+        return "failed"
+    if provider_accepted and leader_began_work:
+        return "accepted_active"
+    if provider_accepted:
+        return "accepted_unverified_activity"
+    if submit_sent:
+        return "submitted_pending_acceptance"
+    return "not_submitted"
+
+
+def _recovery_recommendation(
+    blocker: BlockerReason | None,
+) -> dict[str, Any] | None:
+    if blocker is None:
+        return None
+    return RecoveryRecommendation(
+        state=RecoveryState.BLOCKED,
+        command="atc leader recover --project-id <project-id> --dry-run",
+        safety="inspect_first",
+        message="Inspect Leader runtime health before resending the persisted kickoff payload.",
+        requires_operator=blocker
+        not in {BlockerReason.PROMPT_NOT_SUBMITTED, BlockerReason.DELIVERY_UNVERIFIED},
+    ).as_dict()
 
 
 def verify_leader_kickoff_delivery(
@@ -187,6 +280,8 @@ def verify_leader_kickoff_delivery(
             submit_sent=False,
             provider_accepted=False,
             leader_began_work=False,
+            startup_handshake_state="not_started",
+            goal_acceptance_state="not_submitted",
             message="Kickoff delivery was queued but not observed",
         )
 
@@ -224,10 +319,10 @@ def verify_leader_kickoff_delivery(
         "delivered",
     }
     leader_began_work = (
-        runtime_state is RuntimeState.ACTIVE
-        or delivery is DeliveryState.ACCEPTED_ACTIVE
+        runtime_state is RuntimeState.ACTIVE or delivery is DeliveryState.ACCEPTED_ACTIVE
     )
     kickoff_verified = bool(result.ok and provider_accepted and leader_began_work)
+    failed = result.status == "failed" or delivery is DeliveryState.FAILED
 
     if blocker is not None or result.status in {"blocked", "failed"}:
         state = "blocked" if result.status == "blocked" else "failed"
@@ -252,6 +347,22 @@ def verify_leader_kickoff_delivery(
         submit_sent=submit_sent,
         provider_accepted=provider_accepted,
         leader_began_work=leader_began_work,
+        startup_handshake_state=_startup_handshake_state(runtime_state, delivery, blocker),
+        goal_acceptance_state=_goal_acceptance_state(
+            provider_accepted=provider_accepted,
+            leader_began_work=leader_began_work,
+            submit_sent=submit_sent,
+            blocker=blocker,
+            failed=failed,
+        ),
+        first_actionable_step_observed_at=result.last_activity_at if leader_began_work else None,
+        kickoff_blocker_reason=blocker.value if isinstance(blocker, BlockerReason) else None,
+        kickoff_recovery_recommendation=(
+            result.recovery_recommendation.as_dict()
+            if result.recovery_recommendation
+            else _recovery_recommendation(blocker)
+        ),
+        delivery_trace_id=result.trace_id,
         blocker_reason=blocker.value if isinstance(blocker, BlockerReason) else None,
         message=result.message,
     )

--- a/src/atc/leader/leader.py
+++ b/src/atc/leader/leader.py
@@ -17,7 +17,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 from atc.agents.deploy import ManagerDeploySpec, deploy_manager_files
-from atc.runtime.models import InstructionRequest, StopRoleRequest
+from atc.runtime.models import InstructionRequest, RuntimeDeliveryResult, StopRoleRequest
 from atc.runtime.service import RuntimeService
 from atc.session.ace import _accept_trust_dialog as _accept_trust_dialog  # noqa: F401
 from atc.session.ace import _persist_delivery_trace_events, _spawn_provider_session
@@ -324,7 +324,8 @@ async def send_leader_message(
     message: str,
     *,
     event_bus: EventBus | None = None,
-):
+    metadata: dict[str, object] | None = None,
+) -> RuntimeDeliveryResult:
     """Send a message to the Leader through the runtime boundary."""
     leader = await db_ops.get_leader_by_project(conn, project_id)
     if leader is None or leader.session_id is None:
@@ -345,10 +346,13 @@ async def send_leader_message(
 
     runtime = RuntimeService()
     handle = runtime.handle_from_session_record(session)
+    request_metadata: dict[str, object] = {"source": "leader_message"}
+    if metadata:
+        request_metadata.update(metadata)
     request = InstructionRequest(
         session_id=session.id,
         message=message,
-        metadata={"source": "leader_message"},
+        metadata=request_metadata,
     )
     try:
         result = await runtime.assign_project_to_leader(handle, request)

--- a/src/atc/runtime/health.py
+++ b/src/atc/runtime/health.py
@@ -234,6 +234,9 @@ async def leader_health(
     )
     context = leader.context if leader and isinstance(leader.context, dict) else {}
     kickoff_payload = context.get("leader_kickoff_payload") if isinstance(context, dict) else None
+    kickoff_trace_id = (
+        kickoff_payload.get("trace_id") if isinstance(kickoff_payload, dict) else None
+    )
     kickoff_state = {
         "kickoff_payload_persisted": bool(kickoff_payload),
         "kickoff_state": (
@@ -241,6 +244,19 @@ async def leader_health(
             if runtime_state == RuntimeState.ACTIVE.value
             else _delivery_state_for_runtime(runtime_state, has_payload=bool(kickoff_payload))
         ),
+        "startup_handshake_state": "blocked"
+        if blocker
+        else (
+            "ready"
+            if runtime_state in {RuntimeState.READY.value, RuntimeState.ACTIVE.value}
+            else "unknown"
+        ),
+        "goal_acceptance_state": "accepted_active"
+        if runtime_state == RuntimeState.ACTIVE.value
+        else ("submitted_pending_acceptance" if kickoff_payload else "not_submitted"),
+        "kickoff_verified": runtime_state == RuntimeState.ACTIVE.value,
+        "delivery_trace_id": kickoff_trace_id,
+        "kickoff_blocker_reason": blocker,
         "original_goal_available": bool(
             context.get("leader_original_goal") or (leader.goal if leader else None)
         ),

--- a/tests/unit/test_leader_kickoff.py
+++ b/tests/unit/test_leader_kickoff.py
@@ -65,6 +65,8 @@ async def test_persist_leader_kickoff_payload_is_recoverable(db) -> None:
     assert context["leader_original_goal"] == "Build runtime truth"
     assert context["leader_kickoff_payload"]["message"] == message
     assert context["leader_kickoff_payload"]["source"] == "test"
+    assert context["leader_kickoff_payload"]["trace_id"]
+    assert payload.trace_id == context["leader_kickoff_payload"]["trace_id"]
     assert f"/api/projects/{project.id}/leader/decompose" in message
     assert "/api/projects/{project_id}" not in message
 
@@ -80,12 +82,18 @@ def test_verify_leader_kickoff_accepts_active_delivery() -> None:
         reason_code="agent_output",
         runtime_state=RuntimeState.ACTIVE,
         delivery_state=DeliveryState.ACCEPTED_ACTIVE,
+        trace_id="trace-active",
+        last_activity_at="2026-06-13T00:00:00+00:00",
     )
 
     verification = verify_leader_kickoff_delivery(result)
 
     assert verification.kickoff_verified is True
     assert verification.kickoff_state == "accepted_active"
+    assert verification.startup_handshake_state == "ready"
+    assert verification.goal_acceptance_state == "accepted_active"
+    assert verification.delivery_trace_id == "trace-active"
+    assert verification.first_actionable_step_observed_at == "2026-06-13T00:00:00+00:00"
     assert verification.runtime_created is True
     assert verification.payload_written is True
     assert verification.submit_sent is True
@@ -110,6 +118,8 @@ def test_verify_leader_kickoff_distinguishes_pending_submission() -> None:
 
     assert verification.kickoff_verified is False
     assert verification.kickoff_state == "submitted_pending_acceptance"
+    assert verification.startup_handshake_state == "ready"
+    assert verification.goal_acceptance_state == "submitted_pending_acceptance"
     assert verification.payload_written is True
     assert verification.submit_sent is True
     assert verification.provider_accepted is False
@@ -136,4 +146,8 @@ def test_verify_leader_kickoff_reports_blocker() -> None:
 
     assert verification.kickoff_verified is False
     assert verification.kickoff_state == "blocked"
+    assert verification.startup_handshake_state == "blocked"
+    assert verification.goal_acceptance_state == "blocked"
     assert verification.blocker_reason == "runtime_update_required"
+    assert verification.kickoff_blocker_reason == "runtime_update_required"
+    assert verification.kickoff_recovery_recommendation is not None

--- a/tests/unit/test_leader_start_api.py
+++ b/tests/unit/test_leader_start_api.py
@@ -64,6 +64,8 @@ async def test_leader_start_returns_verified_kickoff_and_persists_payload(
 
     assert response["kickoff_verified"] is True
     assert response["kickoff_state"] == "accepted_active"
+    assert response["startup_handshake_state"] == "ready"
+    assert response["goal_acceptance_state"] == "accepted_active"
     assert response["truth_delivery_state"] == "accepted_active"
     assert response["runtime_state"] == "active"
     assert response["kickoff_payload_persisted"] is True
@@ -73,6 +75,7 @@ async def test_leader_start_returns_verified_kickoff_and_persists_payload(
     context = json.loads(context_json)
     assert context["leader_original_goal"] == "Build kickoff verification"
     assert context["leader_kickoff_payload"]["message"].startswith("# Mission Brief")
+    assert context["leader_kickoff_payload"]["trace_id"]
 
 
 @pytest.mark.asyncio
@@ -98,3 +101,6 @@ async def test_leader_start_without_auto_kickoff_still_persists_goal_payload(
     assert response["kickoff_verified"] is False
     assert response["kickoff_state"] == "not_requested"
     assert response["kickoff_payload_persisted"] is True
+    cursor = await db.execute("SELECT context FROM leaders WHERE project_id = ?", (project.id,))
+    context_json = (await cursor.fetchone())[0]
+    assert json.loads(context_json)["leader_kickoff_payload"]["trace_id"]


### PR DESCRIPTION
## Summary
- expand Leader kickoff verification with explicit startup handshake and goal acceptance states
- persist and reuse a kickoff delivery trace id so payload persistence, delivery, and recovery evidence correlate under one trace
- expose expanded kickoff dimensions in Leader health and document the additive API fields

## Validation
- python3 -m ruff format src/atc/leader/kickoff.py src/atc/leader/leader.py src/atc/api/routers/projects.py src/atc/runtime/health.py tests/unit/test_leader_kickoff.py tests/unit/test_leader_start_api.py
- python3 -m ruff check src/atc/leader/kickoff.py src/atc/leader/leader.py src/atc/api/routers/projects.py src/atc/runtime/health.py tests/unit/test_leader_kickoff.py tests/unit/test_leader_start_api.py
- pytest -q tests/unit/test_leader_kickoff.py tests/unit/test_leader_start_api.py tests/unit/test_runtime_health.py tests/unit/test_tower_controller.py tests/unit/test_runtime_service.py tests/unit/test_tower_progress_truth.py
- pytest -q tests/unit *(observed existing unrelated failures in codex runtime expectations, context migration fixture, e2e wiring provider-command assertions, and session_limit mocked leader setup)*