### PR TITLE
Fix Playwright drift failure handling

### DIFF
--- a/frontend/src/components/tower/TowerBar.tsx
+++ b/frontend/src/components/tower/TowerBar.tsx
@@ -5,6 +5,10 @@ import LogViewer from "./LogViewer";
 import SettingsPane from "./SettingsPane";
 import "./TowerBar.css";
 
+function formatCost(cost: number | null | undefined): string {
+  return cost == null ? "unavailable" : `$${cost.toFixed(2)}`;
+}
+
 function StatusDot({ status }: { status: string }) {
   const colorMap: Record<string, string> = {
     idle: "var(--color-text-muted)",
@@ -86,7 +90,7 @@ export default function TowerBar() {
           )}
 
           <span className="tower-bar__metric" data-testid="cost-summary">
-            ${usage.today_cost.toFixed(2)} today
+            {formatCost(usage.today_cost)} today
           </span>
 
           <span className="tower-bar__metric" data-testid="token-summary">

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -13,6 +13,10 @@ type ViewMode = "grid" | "row" | "board";
 
 const VIEW_PREF_KEY = "atc_dashboard_view";
 
+function formatCost(cost: number | null | undefined): string {
+  return cost == null ? "unavailable" : `$${cost.toFixed(2)}`;
+}
+
 function loadViewPref(): ViewMode {
   const stored = localStorage.getItem(VIEW_PREF_KEY);
   if (stored === "grid" || stored === "row" || stored === "board") return stored;
@@ -86,13 +90,13 @@ export default function Dashboard() {
           <h3 className="dashboard__card-title">Cost</h3>
           <div className="dashboard__stat">
             <span className="dashboard__stat-value">
-              ${usage.today_cost.toFixed(2)}
+              {formatCost(usage.today_cost)}
             </span>
             <span className="dashboard__stat-label">today</span>
           </div>
           <div className="dashboard__stat">
             <span className="dashboard__stat-value">
-              ${usage.month_cost.toFixed(2)}
+              {formatCost(usage.month_cost)}
             </span>
             <span className="dashboard__stat-label">this month</span>
           </div>

--- a/frontend/src/pages/UsagePage.tsx
+++ b/frontend/src/pages/UsagePage.tsx
@@ -48,6 +48,10 @@ const PERIOD_LABELS: Record<Period, string> = {
   "90d": "90d",
 };
 
+function formatCost(cost: number | null | undefined): string {
+  return cost == null ? "unavailable" : `$${cost.toFixed(2)}`;
+}
+
 // ---------------------------------------------------------------------------
 // Period selector
 // ---------------------------------------------------------------------------
@@ -181,13 +185,13 @@ export default function UsagePage() {
           <div className="usage-page__stats">
             <div className="usage-page__stat">
               <span className="usage-page__stat-value">
-                ${usage.today_cost.toFixed(2)}
+                {formatCost(usage.today_cost)}
               </span>
               <span className="usage-page__stat-label">Today</span>
             </div>
             <div className="usage-page__stat">
               <span className="usage-page__stat-value">
-                ${usage.month_cost.toFixed(2)}
+                {formatCost(usage.month_cost)}
               </span>
               <span className="usage-page__stat-label">This Month</span>
             </div>

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -134,10 +134,12 @@ export interface Notification {
 }
 
 export interface UsageSummary {
-  today_cost: number;
-  month_cost: number;
+  today_cost: number | null;
+  month_cost: number | null;
   today_tokens: number;
   month_tokens: number;
+  oauth_mode?: boolean;
+  message?: string | null;
 }
 
 export interface GitHubSummary {

--- a/frontend/tests/e2e/atc-qa.spec.ts
+++ b/frontend/tests/e2e/atc-qa.spec.ts
@@ -211,9 +211,9 @@ test("Test 4: Budget API CRUD operations", async ({ page }) => {
 });
 
 // ============================================================================
-// Test 5: Project page tabs
+// Test 5: Project page sections and Leader tabs
 // ============================================================================
-test("Test 5: Project page tabs render correctly", async ({ page }) => {
+test("Test 5: Project page sections and Leader tabs render correctly", async ({ page }) => {
   const projectId = await getTestProjectId();
   const jsErrors: string[] = [];
   page.on("pageerror", (err) => jsErrors.push(err.message));
@@ -228,8 +228,9 @@ test("Test 5: Project page tabs render correctly", async ({ page }) => {
   // No JS errors
   expect(jsErrors).toHaveLength(0);
 
-  // Tabs are visible
-  await expect(page.locator(".leader-console__tab", { hasText: "Tasks" })).toBeVisible();
+  // Task management is now a first-class Project page section, while Leader keeps
+  // only its own GitHub/Budget tabs.
+  await expect(page.locator(".project-view__tasks")).toBeVisible();
   await expect(page.locator(".leader-console__tab", { hasText: "GitHub" })).toBeVisible();
   await expect(page.locator(".leader-console__tab", { hasText: "Budget" })).toBeVisible();
 
@@ -249,10 +250,7 @@ test("Test 5: Project page tabs render correctly", async ({ page }) => {
   const githubContent = await tabContent.textContent();
   expect(githubContent).not.toBe("");
 
-  // Click Tasks tab
-  await page.locator(".leader-console__tab", { hasText: "Tasks" }).click();
-  await page.waitForTimeout(500);
-  const tasksContent = await tabContent.textContent();
+  const tasksContent = await page.locator(".project-view__tasks").textContent();
   expect(tasksContent).not.toBe("");
 });
 
@@ -262,16 +260,19 @@ test("Test 5: Project page tabs render correctly", async ({ page }) => {
 test("Test 6: API endpoints return correct structure", async ({ page }) => {
   // GET /api/usage/summary
   const summary = (await apiGet("/api/usage/summary")) as {
-    today_cost: number;
-    month_cost: number;
+    today_cost: number | null;
+    month_cost: number | null;
     today_tokens: number;
     month_tokens: number;
+    oauth_mode?: boolean;
+    message?: string | null;
   };
   expect(summary).toHaveProperty("today_cost");
   expect(summary).toHaveProperty("month_cost");
   expect(summary).toHaveProperty("today_tokens");
   expect(summary).toHaveProperty("month_tokens");
-  expect(typeof summary.today_cost).toBe("number");
+  expect(summary.today_cost === null || typeof summary.today_cost === "number").toBe(true);
+  expect(summary.month_cost === null || typeof summary.month_cost === "number").toBe(true);
   expect(typeof summary.today_tokens).toBe("number");
 
   // GET /api/usage/cost?period=7d - should return array


### PR DESCRIPTION
## Summary
- update Project page e2e coverage for the current task-section plus Leader GitHub/Budget tabs layout
- align usage summary frontend/types/e2e expectations with nullable cost fields returned by the API
- render unavailable cost values safely instead of calling `toFixed` on `null`

## Investigation
- Reproduced the committed Playwright suite failures.
- Classified the old Leader `Tasks` tab assertion as test drift: task management is now a Project page section, while Leader keeps GitHub/Budget tabs.
- Classified nullable usage costs as a contract/product handling issue: the API can return `null` costs, so frontend consumers and tests now accept and render that state.

## Validation
- `cd frontend && npm run build`
- `cd frontend && npx playwright test tests/e2e/dashboard-views.spec.ts tests/e2e/atc-qa.spec.ts --project=chromium --reporter=line`
- Screenshot evidence report: `screenshots/playwright-drift-failures-2026-06-15T18-28-54-040Z/report.json`
