### PR TITLE
Harden provider-owned startup trust handling

### DIFF
--- a/src/atc/providers/base.py
+++ b/src/atc/providers/base.py
@@ -2,17 +2,18 @@
 
 from __future__ import annotations
 
-from typing import Protocol, runtime_checkable
+from typing import TYPE_CHECKING, Protocol, runtime_checkable
 
-from atc.runtime.models import (
-    InstructionRequest,
-    ReadinessResult,
-    RuntimeInspection,
-    RuntimeSessionHandle,
-    StartRoleRequest,
-    StopRoleRequest,
-    TaskAssignmentRequest,
-)
+if TYPE_CHECKING:
+    from atc.runtime.models import (
+        InstructionRequest,
+        ReadinessResult,
+        RuntimeInspection,
+        RuntimeSessionHandle,
+        StartRoleRequest,
+        StopRoleRequest,
+        TaskAssignmentRequest,
+    )
 
 
 @runtime_checkable
@@ -59,6 +60,18 @@ class ProviderRuntime(Protocol):
         handle: RuntimeSessionHandle,
     ) -> RuntimeInspection:
         """Inspect health/output/readiness for a provider session."""
+
+    async def resolve_startup_prompt(
+        self,
+        handle: RuntimeSessionHandle,
+        inspection: RuntimeInspection,
+    ) -> bool:
+        """Provider-owned safe startup prompt resolution.
+
+        Implementations must only resolve prompts their classifier marked safe
+        to auto-resolve. Auth, secret, permission, and unknown prompts must stay
+        blocked and return False.
+        """
 
     async def restore_session(
         self,

--- a/src/atc/providers/classifiers.py
+++ b/src/atc/providers/classifiers.py
@@ -32,6 +32,11 @@ class RecoveryCapabilities:
     can_detect_auth_prompt: bool = False
     can_detect_trust_prompt: bool = False
     can_detect_permission_prompt: bool = False
+    can_classify_trust_prompt: bool = False
+    can_auto_accept_managed_workspace_trust_prompt: bool = False
+    can_classify_local_api_approval_prompt: bool = False
+    can_preauthorize_local_atc_api_access: bool = False
+    can_distinguish_auth_secret_unknown_permission_prompts: bool = False
 
     def as_dict(self) -> dict[str, bool]:
         return {
@@ -43,6 +48,15 @@ class RecoveryCapabilities:
             "can_detect_auth_prompt": self.can_detect_auth_prompt,
             "can_detect_trust_prompt": self.can_detect_trust_prompt,
             "can_detect_permission_prompt": self.can_detect_permission_prompt,
+            "can_classify_trust_prompt": self.can_classify_trust_prompt,
+            "can_auto_accept_managed_workspace_trust_prompt": (
+                self.can_auto_accept_managed_workspace_trust_prompt
+            ),
+            "can_classify_local_api_approval_prompt": self.can_classify_local_api_approval_prompt,
+            "can_preauthorize_local_atc_api_access": self.can_preauthorize_local_atc_api_access,
+            "can_distinguish_auth_secret_unknown_permission_prompts": (
+                self.can_distinguish_auth_secret_unknown_permission_prompts
+            ),
         }
 
 

--- a/src/atc/providers/codex/classifier.py
+++ b/src/atc/providers/codex/classifier.py
@@ -73,6 +73,7 @@ _INTERRUPT_SPEC = RuntimeInterruptSpec(
     permission_triggers=_PERMISSION_TRIGGERS,
     login_triggers=_AUTH_TRIGGERS,
     provider_error_triggers=_PROVIDER_ERROR_TRIGGERS,
+    auto_resolvable_trust_triggers=("trust this folder", "do you trust"),
 )
 
 
@@ -215,6 +216,11 @@ class CodexRuntimeClassifier:
             can_detect_auth_prompt=True,
             can_detect_trust_prompt=True,
             can_detect_permission_prompt=True,
+            can_classify_trust_prompt=True,
+            can_auto_accept_managed_workspace_trust_prompt=True,
+            can_classify_local_api_approval_prompt=False,
+            can_preauthorize_local_atc_api_access=False,
+            can_distinguish_auth_secret_unknown_permission_prompts=True,
         )
 
     def detect_interrupt(self, excerpt: str):

--- a/src/atc/providers/codex/runtime.py
+++ b/src/atc/providers/codex/runtime.py
@@ -23,6 +23,7 @@ from atc.runtime.tmux.substrate import (
     ensure_tmux_session,
     kill_pane,
     pane_exists,
+    run_tmux,
     spawn_window_pane,
 )
 from atc.runtime.tracing import (
@@ -191,6 +192,30 @@ class CodexRuntime(ProviderRuntime):
             inspection
         )
         return inspection
+
+    async def resolve_startup_prompt(
+        self,
+        handle: RuntimeSessionHandle,
+        inspection: RuntimeInspection,
+    ) -> bool:
+        """Resolve only Codex startup prompts declared safe by provider classification."""
+
+        if not handle.tmux_pane:
+            return False
+        if inspection.block_reason is not RuntimeBlockReason.TRUST:
+            return False
+        diagnostics = inspection.details.get("provider_diagnostics")
+        if not isinstance(diagnostics, dict):
+            return False
+        if diagnostics.get("safe_to_auto_resolve") is not True:
+            return False
+        capabilities = inspection.details.get("recovery_capabilities")
+        if not isinstance(capabilities, dict) or not capabilities.get(
+            "can_auto_accept_managed_workspace_trust_prompt"
+        ):
+            return False
+        await run_tmux("send-keys", "-t", handle.tmux_pane, "Enter")
+        return True
 
     def _runtime_hint_for_inspection(self, inspection: RuntimeInspection) -> str:
         if inspection.readiness is ReadinessState.READY:

--- a/src/atc/runtime/service.py
+++ b/src/atc/runtime/service.py
@@ -40,8 +40,6 @@ from atc.state.db import get_connection_app_state
 _STARTUP_INITIAL_DELAY_SECONDS = 2.0
 _STARTUP_RESOLVE_DELAY_SECONDS = 1.0
 _STARTUP_FINAL_DELAY_SECONDS = 1.0
-_STARTUP_AUTO_RESOLVE_REASONS = {RuntimeBlockReason.TRUST}
-
 if TYPE_CHECKING:
     from atc.providers.base import ProviderRuntime
 
@@ -409,7 +407,7 @@ class RuntimeService:
             phase="initial",
         )
         if first.readiness is ReadinessState.BLOCKED:
-            resolved = await self._try_resolve_startup_prompt(handle, first)
+            resolved = await self._try_resolve_startup_prompt(provider, handle, first)
             if resolved:
                 await asyncio.sleep(_STARTUP_RESOLVE_DELAY_SECONDS)
                 second = await provider.inspect_session(handle)
@@ -440,19 +438,28 @@ class RuntimeService:
             phase="final",
         )
 
-    @staticmethod
     async def _try_resolve_startup_prompt(
+        self,
+        provider: ProviderRuntime,
         handle: RuntimeSessionHandle,
         inspection: RuntimeInspection,
     ) -> bool:
-        if inspection.block_reason not in _STARTUP_AUTO_RESOLVE_REASONS:
+        if inspection.block_reason is not RuntimeBlockReason.TRUST:
             return False
-        if not handle.tmux_pane:
+        diagnostics = inspection.details.get("provider_diagnostics")
+        if not isinstance(diagnostics, dict):
             return False
-        from atc.runtime.tmux.substrate import run_tmux
-
-        await run_tmux("send-keys", "-t", handle.tmux_pane, "Enter")
-        return True
+        if diagnostics.get("safe_to_auto_resolve") is not True:
+            return False
+        capabilities = inspection.details.get("recovery_capabilities")
+        if not isinstance(capabilities, dict) or not capabilities.get(
+            "can_auto_accept_managed_workspace_trust_prompt"
+        ):
+            return False
+        resolver = getattr(provider, "resolve_startup_prompt", None)
+        if resolver is None:
+            return False
+        return bool(await resolver(handle, inspection))
 
     @staticmethod
     def _append_startup_inspection_event(

--- a/tests/unit/test_codex_runtime.py
+++ b/tests/unit/test_codex_runtime.py
@@ -71,7 +71,7 @@ def test_codex_inspect_session_reports_ready_at_prompt() -> None:
 
     assert inspection.alive is True
     assert inspection.readiness is ReadinessState.READY
-    assert inspection.summary == "Prompt ready"
+    assert inspection.summary == "Codex prompt ready"
 
 
 def test_codex_inspect_session_reports_busy_when_not_at_prompt() -> None:
@@ -141,7 +141,7 @@ def test_codex_inspect_session_reports_blocked_on_permission_prompt() -> None:
 
     assert inspection.readiness is ReadinessState.BLOCKED
     assert inspection.summary == "Blocked on permission prompt"
-    assert inspection.details["runtime_interrupt"] == "permission_prompt"
+    assert inspection.details["provider_diagnostics"]["runtime_interrupt"] == "permission_prompt"
     assert inspection.details["provider_runtime_action"] == "resolve_permission"
 
 

--- a/tests/unit/test_codex_runtime_classifier.py
+++ b/tests/unit/test_codex_runtime_classifier.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import pytest
 
 from atc.providers.codex import runtime as codex_runtime
+from atc.providers.codex.classifier import CodexRuntimeClassifier
 from atc.providers.codex.runtime import CodexRuntime
 from atc.runtime.models import (
     BlockerReason,
@@ -68,3 +69,29 @@ async def test_codex_runtime_missing_pane_uses_neutral_missing_classification(
     assert inspection.readiness is ReadinessState.STOPPED
     assert inspection.details["runtime_state"] == RuntimeState.MISSING.value
     assert inspection.details["blocker_reason"] == BlockerReason.PANE_MISSING.value
+
+
+def test_codex_classifier_marks_managed_workspace_trust_as_safely_resolvable() -> None:
+    classifier = CodexRuntimeClassifier()
+
+    classification = classifier.classify_excerpt("Do you trust this folder?")
+
+    assert classification.readiness is ReadinessState.BLOCKED
+    assert classification.blocker_reason is BlockerReason.RUNTIME_TRUST_REQUIRED
+    assert classification.diagnostics["safe_to_auto_resolve"] is True
+    capabilities = classifier.recovery_capabilities().as_dict()
+    assert capabilities["can_classify_trust_prompt"] is True
+    assert capabilities["can_auto_accept_managed_workspace_trust_prompt"] is True
+    assert capabilities["can_distinguish_auth_secret_unknown_permission_prompts"] is True
+
+
+def test_codex_classifier_keeps_auth_and_permission_unsafe() -> None:
+    classifier = CodexRuntimeClassifier()
+
+    auth = classifier.classify_excerpt("Please sign in to continue")
+    permission = classifier.classify_excerpt("Allow command: rm -rf /tmp/example?")
+
+    assert auth.blocker_reason is BlockerReason.RUNTIME_AUTH_REQUIRED
+    assert auth.diagnostics["safe_to_auto_resolve"] is False
+    assert permission.blocker_reason is BlockerReason.RUNTIME_PERMISSION_REQUIRED
+    assert permission.diagnostics["safe_to_auto_resolve"] is False

--- a/tests/unit/test_runtime_service.py
+++ b/tests/unit/test_runtime_service.py
@@ -275,12 +275,8 @@ def test_runtime_service_startup_handshake_traces_blocked_auth_without_auto_answ
     assert events[-1]["details"]["startup_phase"] == "final"
 
 
-def test_runtime_service_startup_handshake_auto_resolves_trust(monkeypatch) -> None:
-    send_keys: list[tuple[str, ...]] = []
-
-    async def fake_run_tmux(*args: str) -> str:
-        send_keys.append(args)
-        return ""
+def test_runtime_service_startup_handshake_auto_resolves_provider_declared_safe_trust() -> None:
+    resolved: list[str] = []
 
     class TrustThenReadyProvider(DummyProviderRuntime):
         def __init__(self) -> None:
@@ -307,6 +303,12 @@ def test_runtime_service_startup_handshake_auto_resolves_trust(monkeypatch) -> N
                     readiness=ReadinessState.BLOCKED,
                     block_reason=RuntimeBlockReason.TRUST,
                     summary="Blocked on trust prompt",
+                    details={
+                        "provider_diagnostics": {"safe_to_auto_resolve": True},
+                        "recovery_capabilities": {
+                            "can_auto_accept_managed_workspace_trust_prompt": True
+                        },
+                    },
                 )
             return RuntimeInspection(
                 session_id=handle.session_id,
@@ -316,7 +318,14 @@ def test_runtime_service_startup_handshake_auto_resolves_trust(monkeypatch) -> N
                 summary="Ready",
             )
 
-    monkeypatch.setattr("atc.runtime.tmux.substrate.run_tmux", fake_run_tmux)
+        async def resolve_startup_prompt(
+            self,
+            handle: RuntimeSessionHandle,
+            inspection: RuntimeInspection,
+        ) -> bool:
+            resolved.append(handle.session_id)
+            return True
+
     register_provider_runtime("dummy_runtime_trust_then_ready", TrustThenReadyProvider)
     service = RuntimeService()
     request = StartRoleRequest(
@@ -326,8 +335,7 @@ def test_runtime_service_startup_handshake_auto_resolves_trust(monkeypatch) -> N
     )
 
     asyncio.run(service.spawn_existing_session(request))
-
-    assert send_keys == [("send-keys", "-t", "%42", "Enter")]
+    assert resolved == ["sess-trust-1"]
     phases = [
         event["details"].get("startup_phase")
         for event in request.metadata["delivery_trace_events"]
@@ -335,6 +343,159 @@ def test_runtime_service_startup_handshake_auto_resolves_trust(monkeypatch) -> N
     assert "initial" in phases
     assert "after_auto_resolve" in phases
     assert "final" in phases
+
+
+def test_runtime_service_startup_handshake_refuses_unsafe_trust() -> None:
+    resolved: list[str] = []
+
+    class UnsafeTrustProvider(DummyProviderRuntime):
+        async def spawn_existing_session(self, request: StartRoleRequest) -> RuntimeSessionHandle:
+            self.spawned_existing.append(request)
+            return RuntimeSessionHandle(
+                session_id=request.session_id,
+                provider_name=request.provider_name,
+                role=request.role,
+                transport=RuntimeTransport.TMUX,
+                tmux_pane="%43",
+            )
+
+        async def inspect_session(self, handle: RuntimeSessionHandle) -> RuntimeInspection:
+            return RuntimeInspection(
+                session_id=handle.session_id,
+                provider_name=handle.provider_name,
+                alive=True,
+                readiness=ReadinessState.BLOCKED,
+                block_reason=RuntimeBlockReason.TRUST,
+                summary="Blocked on unsafe trust prompt",
+                details={
+                    "provider_diagnostics": {"safe_to_auto_resolve": False},
+                    "recovery_capabilities": {
+                        "can_auto_accept_managed_workspace_trust_prompt": True
+                    },
+                },
+            )
+
+        async def resolve_startup_prompt(
+            self,
+            handle: RuntimeSessionHandle,
+            inspection: RuntimeInspection,
+        ) -> bool:
+            resolved.append(handle.session_id)
+            return True
+
+    register_provider_runtime("dummy_runtime_unsafe_trust", UnsafeTrustProvider)
+    service = RuntimeService()
+    request = StartRoleRequest(
+        session_id="sess-unsafe-trust-1",
+        provider_name="dummy_runtime_unsafe_trust",
+        role=RoleKind.ACE,
+    )
+
+    asyncio.run(service.spawn_existing_session(request))
+
+    assert resolved == []
+    events = request.metadata["delivery_trace_events"]
+    assert events[-1]["stage"] == "blocked"
+    assert events[-1]["reason_code"] == "trust_required"
+    phases = [event["details"].get("startup_phase") for event in events]
+    assert "after_auto_resolve" not in phases
+
+
+def test_runtime_service_startup_handshake_requires_provider_capability_for_trust() -> None:
+    resolved: list[str] = []
+
+    class NoCapabilityTrustProvider(DummyProviderRuntime):
+        async def inspect_session(self, handle: RuntimeSessionHandle) -> RuntimeInspection:
+            return RuntimeInspection(
+                session_id=handle.session_id,
+                provider_name=handle.provider_name,
+                alive=True,
+                readiness=ReadinessState.BLOCKED,
+                block_reason=RuntimeBlockReason.TRUST,
+                summary="Blocked on trust prompt",
+                details={"provider_diagnostics": {"safe_to_auto_resolve": True}},
+            )
+
+        async def resolve_startup_prompt(
+            self,
+            handle: RuntimeSessionHandle,
+            inspection: RuntimeInspection,
+        ) -> bool:
+            resolved.append(handle.session_id)
+            return True
+
+    register_provider_runtime("dummy_runtime_no_capability_trust", NoCapabilityTrustProvider)
+    service = RuntimeService()
+    request = StartRoleRequest(
+        session_id="sess-no-capability-trust-1",
+        provider_name="dummy_runtime_no_capability_trust",
+        role=RoleKind.LEADER,
+    )
+
+    asyncio.run(service.spawn_existing_session(request))
+
+    assert resolved == []
+    assert request.metadata["delivery_trace_events"][-1]["stage"] == "blocked"
+
+
+def test_runtime_service_startup_handshake_traces_ready_no_prompt_branch() -> None:
+    register_provider_runtime("dummy_runtime_ready_no_prompt", DummyProviderRuntime)
+    service = RuntimeService()
+    request = StartRoleRequest(
+        session_id="sess-ready-no-prompt-1",
+        provider_name="dummy_runtime_ready_no_prompt",
+        role=RoleKind.LEADER,
+    )
+
+    asyncio.run(service.spawn_existing_session(request))
+
+    events = request.metadata["delivery_trace_events"]
+    assert events[-1]["details"]["startup_phase"] == "final"
+    assert events[-1]["reason_code"] == "session_running"
+
+
+def test_runtime_service_startup_handshake_never_auto_resolves_permission() -> None:
+    resolved: list[str] = []
+
+    class PermissionBlockedProvider(DummyProviderRuntime):
+        async def inspect_session(self, handle: RuntimeSessionHandle) -> RuntimeInspection:
+            return RuntimeInspection(
+                session_id=handle.session_id,
+                provider_name=handle.provider_name,
+                alive=True,
+                readiness=ReadinessState.BLOCKED,
+                block_reason=RuntimeBlockReason.PERMISSION,
+                summary="Blocked on permission prompt",
+                details={
+                    "provider_diagnostics": {"safe_to_auto_resolve": True},
+                    "recovery_capabilities": {
+                        "can_auto_accept_managed_workspace_trust_prompt": True
+                    },
+                },
+            )
+
+        async def resolve_startup_prompt(
+            self,
+            handle: RuntimeSessionHandle,
+            inspection: RuntimeInspection,
+        ) -> bool:
+            resolved.append(handle.session_id)
+            return True
+
+    register_provider_runtime("dummy_runtime_permission_blocked", PermissionBlockedProvider)
+    service = RuntimeService()
+    request = StartRoleRequest(
+        session_id="sess-permission-blocked-1",
+        provider_name="dummy_runtime_permission_blocked",
+        role=RoleKind.LEADER,
+    )
+
+    asyncio.run(service.spawn_existing_session(request))
+
+    assert resolved == []
+    event = request.metadata["delivery_trace_events"][-1]
+    assert event["stage"] == "blocked"
+    assert event["reason_code"] == "permission_required"
 
 
 def test_runtime_service_send_instruction_adds_queued_trace_event() -> None:


### PR DESCRIPTION
## Summary
- add provider capability metadata for managed-workspace trust handling and local API authorization classification flags
- keep Codex trust prompt detection/resolution provider-owned via classifier diagnostics and `CodexRuntime.resolve_startup_prompt`
- harden `RuntimeService` startup handshake so only provider-declared safe trust prompts are auto-resolved; auth/permission/unsafe trust remain blockers
- add unit coverage for safe trust, unsafe trust, missing capability, ready/no-prompt, and permission-blocker startup branches

## Validation
- `./.venv/bin/python -m ruff check src/atc/providers/classifiers.py src/atc/providers/codex/classifier.py src/atc/providers/base.py src/atc/providers/codex/runtime.py src/atc/runtime/service.py tests/unit/test_runtime_service.py tests/unit/test_codex_runtime_classifier.py tests/unit/test_codex_runtime.py`
- `./.venv/bin/python -m pytest tests/unit/test_runtime_service.py tests/unit/test_codex_runtime_classifier.py tests/unit/test_codex_runtime.py tests/unit/test_provider_classifiers.py tests/unit/test_runtime_interrupts.py tests/unit/test_tmux_session_runner.py tests/unit/test_trust_dialog.py tests/unit/test_claude_code_runtime.py` — 79 passed
- `export PATH="/opt/homebrew/bin:$PATH"; cd frontend && npm run build && npx playwright test tests/e2e/dashboard-views.spec.ts tests/e2e/atc-qa.spec.ts --project=chromium --reporter=line` — 15 passed
- screenshot/API evidence: `screenshots/loops-phase2-2026-06-15T19-20-19-123Z/report.json` — 6/6 passed

## Notes
- A full `pytest tests/unit` attempt was run for investigation. After the Codex runtime expectation drift was patched, the remaining 6 failures are outside this Phase 2 surface: context router registration, context migration fixture, legacy e2e wiring launch-command expectations, and session-limit kickoff mock behavior.
