### PR TITLE
Recover prompt-not-submitted kickoff safely

### DIFF
--- a/src/atc/providers/base.py
+++ b/src/atc/providers/base.py
@@ -73,6 +73,19 @@ class ProviderRuntime(Protocol):
         blocked and return False.
         """
 
+    async def submit_pending_prompt(
+        self,
+        handle: RuntimeSessionHandle,
+        inspection: RuntimeInspection,
+    ) -> bool:
+        """Provider-owned submission of an already-visible pending prompt.
+
+        Callers must inspect first and only invoke this for neutral
+        ``prompt_not_submitted`` recovery when the visible prompt text is proven
+        to match the expected persisted payload. Provider adapters own the actual
+        key sequence and must refuse auth, trust, permission, or unknown prompts.
+        """
+
     async def restore_session(
         self,
         handle: RuntimeSessionHandle,

--- a/src/atc/providers/claude_code/runtime.py
+++ b/src/atc/providers/claude_code/runtime.py
@@ -31,6 +31,7 @@ from atc.runtime.tmux.substrate import (
     ensure_tmux_session,
     kill_pane,
     pane_exists,
+    run_tmux,
     spawn_window_pane,
 )
 from atc.runtime.tracing import (
@@ -389,6 +390,27 @@ class ClaudeCodeRuntime(ProviderRuntime):
             inspection
         )
         return inspection
+
+    async def submit_pending_prompt(
+        self,
+        handle: RuntimeSessionHandle,
+        inspection: RuntimeInspection,
+    ) -> bool:
+        """Submit a visible Claude prompt by sending Enter only.
+
+        Claude does not yet expose provider-owned pending-payload text extraction,
+        so callers should only reach this after neutral safety checks prove the
+        pending prompt matches the persisted payload.
+        """
+
+        if not handle.tmux_pane:
+            return False
+        if inspection.readiness is not ReadinessState.READY:
+            return False
+        if inspection.block_reason is not None:
+            return False
+        await run_tmux("send-keys", "-t", handle.tmux_pane, "Enter")
+        return True
 
     def _runtime_hint_for_inspection(self, inspection: RuntimeInspection) -> str:
         if inspection.readiness is ReadinessState.READY:

--- a/src/atc/providers/codex/classifier.py
+++ b/src/atc/providers/codex/classifier.py
@@ -169,7 +169,10 @@ class CodexRuntimeClassifier:
                 prompt_state="prompt_visible:not_submitted",
                 provider_observation="codex_prompt_not_submitted",
                 recovery_state=RecoveryState.NOT_NEEDED,
-                diagnostics={"codex_observation": "prompt_not_submitted"},
+                diagnostics={
+                    "codex_observation": "prompt_not_submitted",
+                    "pending_prompt_text": prompt_text.strip(),
+                },
             )
         if CODEX_PROMPT_RE.search(excerpt):
             return RuntimeClassification(

--- a/src/atc/providers/codex/runtime.py
+++ b/src/atc/providers/codex/runtime.py
@@ -217,6 +217,23 @@ class CodexRuntime(ProviderRuntime):
         await run_tmux("send-keys", "-t", handle.tmux_pane, "Enter")
         return True
 
+    async def submit_pending_prompt(
+        self,
+        handle: RuntimeSessionHandle,
+        inspection: RuntimeInspection,
+    ) -> bool:
+        """Submit a provider-classified visible Codex prompt by sending Enter only."""
+
+        if not handle.tmux_pane:
+            return False
+        if inspection.details.get("blocker_reason") != "prompt_not_submitted":
+            return False
+        diagnostics = inspection.details.get("provider_diagnostics")
+        if not isinstance(diagnostics, dict) or not diagnostics.get("pending_prompt_text"):
+            return False
+        await run_tmux("send-keys", "-t", handle.tmux_pane, "Enter")
+        return True
+
     def _runtime_hint_for_inspection(self, inspection: RuntimeInspection) -> str:
         if inspection.readiness is ReadinessState.READY:
             return "prompt_visible"

--- a/src/atc/runtime/health.py
+++ b/src/atc/runtime/health.py
@@ -160,6 +160,38 @@ def _leader_kickoff_health_state(
     return "working"
 
 
+def _provider_details_from_diagnostics(diagnostics: dict[str, Any]) -> dict[str, Any]:
+    details = diagnostics.get("details")
+    return details if isinstance(details, dict) else {}
+
+
+def _pending_prompt_text_from_diagnostics(diagnostics: dict[str, Any]) -> str | None:
+    details = _provider_details_from_diagnostics(diagnostics)
+    provider_diagnostics = details.get("provider_diagnostics")
+    if not isinstance(provider_diagnostics, dict):
+        return None
+    text = provider_diagnostics.get("pending_prompt_text")
+    return text if isinstance(text, str) and text.strip() else None
+
+
+def _pending_prompt_matches_payload(
+    pending_prompt_text: str | None,
+    persisted_payload: dict[str, Any] | None,
+) -> bool:
+    if not pending_prompt_text or not isinstance(persisted_payload, dict):
+        return False
+    message = persisted_payload.get("message")
+    if not isinstance(message, str) or not message.strip():
+        return False
+    pending = " ".join(pending_prompt_text.split())
+    expected = " ".join(message.split())
+    if not pending:
+        return False
+    if pending == expected:
+        return True
+    return len(pending) >= 12 and pending in expected
+
+
 def _recovery_for(
     role: RuntimeRole, project_id: str, blocker: str | None, session_id: str | None
 ) -> dict[str, Any]:
@@ -279,6 +311,11 @@ async def leader_health(
     kickoff_trace_id = (
         kickoff_payload.get("trace_id") if isinstance(kickoff_payload, dict) else None
     )
+    pending_prompt_text = _pending_prompt_text_from_diagnostics(diagnostics)
+    pending_payload_matches = _pending_prompt_matches_payload(
+        pending_prompt_text,
+        kickoff_payload if isinstance(kickoff_payload, dict) else None,
+    )
     kickoff_state = {
         "kickoff_payload_persisted": bool(kickoff_payload),
         "kickoff_state": _leader_kickoff_health_state(
@@ -323,6 +360,11 @@ async def leader_health(
         "original_goal_available": bool(
             context.get("leader_original_goal") or (leader.goal if leader else None)
         ),
+        "pending_prompt_observed": bool(pending_prompt_text),
+        "pending_prompt_matches_persisted_payload": pending_payload_matches,
+        "pending_prompt_match_basis": "provider_pending_text"
+        if pending_prompt_text
+        else None,
     }
     task_summary = {
         "total": len(tasks),
@@ -524,6 +566,10 @@ def build_recovery_plan(
         BlockerReason.STALE_AFTER_UPDATE.value,
     } or health.runtime_state in {RuntimeState.MISSING.value, RuntimeState.STALE.value}
     update_required = health.current_blocker == BlockerReason.RUNTIME_UPDATE_REQUIRED.value
+    pending_prompt = health.current_blocker == BlockerReason.PROMPT_NOT_SUBMITTED.value
+    pending_matches_payload = bool(
+        health.kickoff_state.get("pending_prompt_matches_persisted_payload")
+    )
     required_restart_policy = _restart_policy_required(health) if restartable else None
 
     if not health.current_blocker and health.runtime_state in {
@@ -531,6 +577,27 @@ def build_recovery_plan(
         RuntimeState.ACTIVE.value,
     }:
         actions.append({"action": "none", "reason": "runtime_healthy"})
+    elif pending_prompt:
+        actions.append(
+            {
+                "action": "submit_pending_prompt",
+                "safe": pending_matches_payload,
+                "policy_required": "submit_pending_prompt",
+                "uses_persisted_payload": pending_matches_payload,
+                "match_basis": health.kickoff_state.get("pending_prompt_match_basis"),
+            }
+        )
+        safe = pending_matches_payload
+        if pending_matches_payload:
+            message = (
+                "Pending provider prompt matches persisted kickoff payload; "
+                "Enter-only submit can be applied under explicit policy."
+            )
+        else:
+            message = (
+                "Prompt-not-submitted was detected, but the visible prompt did "
+                "not match persisted payload."
+            )
     elif update_required:
         can_accept = bool(capabilities.get("can_accept_update_prompt"))
         fresh_required = bool(capabilities.get("requires_fresh_session_after_update"))
@@ -574,6 +641,8 @@ def build_recovery_plan(
 
     if mode == "apply" and not safe:
         refused = "unsafe_or_unneeded_recovery"
+    elif mode == "apply" and pending_prompt and policy != "submit_pending_prompt":
+        refused = "apply_requires_submit_pending_prompt_policy"
     elif (
         mode == "apply" and update_required and not _recovery_policy_allows(policy, "accept_update")
     ):
@@ -621,6 +690,47 @@ async def apply_recovery_plan(
 
     plan = build_recovery_plan(health, mode="apply", policy=policy)
     if plan.refused_reason:
+        return plan
+
+    if health.current_blocker == BlockerReason.PROMPT_NOT_SUBMITTED.value and any(
+        action.get("action") == "submit_pending_prompt" for action in plan.actions
+    ):
+        service = RuntimeService()
+        session = await db_ops.get_session(conn, health.session_id) if health.session_id else None
+        if session is None:
+            plan.refused_reason = "runtime_session_missing"
+            plan.message = "Apply refused: runtime session is missing."
+            return plan
+        inspection = await service.inspect_session_record(session)
+        blocker = _blocker_from_inspection(inspection)
+        if blocker != BlockerReason.PROMPT_NOT_SUBMITTED.value:
+            plan.refused_reason = "runtime_state_changed"
+            plan.message = "Apply refused: runtime is no longer prompt_not_submitted."
+            plan.actions.append(
+                {
+                    "action": "reinspect_runtime",
+                    "status": "refused",
+                    "blocker_reason": blocker,
+                }
+            )
+            return plan
+        submitted = await service.submit_pending_prompt_for_session_record(session, inspection)
+        if not submitted:
+            plan.refused_reason = "provider_refused_pending_prompt_submit"
+            plan.message = (
+                "Apply refused: provider adapter did not confirm safe pending "
+                "prompt submission."
+            )
+            return plan
+        plan.actions.append(
+            {"action": "submit_pending_prompt", "status": "applied", "session_id": session.id}
+        )
+        plan.message = "Pending kickoff prompt submitted via provider adapter."
+        plan.health = (
+            await leader_health(conn, health.project_id)
+            if health.role == "leader"
+            else await ace_health(conn, health.project_id, session.id)
+        ).as_dict()
         return plan
 
     if health.current_blocker == BlockerReason.RUNTIME_UPDATE_REQUIRED.value:

--- a/src/atc/runtime/service.py
+++ b/src/atc/runtime/service.py
@@ -348,6 +348,27 @@ class RuntimeService:
 
         return await self.inspect_session(self.handle_from_session_record(session))
 
+    async def submit_pending_prompt(
+        self,
+        handle: RuntimeSessionHandle,
+        inspection: RuntimeInspection,
+    ) -> bool:
+        """Submit a provider-classified pending prompt through the provider adapter."""
+
+        provider = self.get_provider(handle.provider_name)
+        return await provider.submit_pending_prompt(handle, inspection)
+
+    async def submit_pending_prompt_for_session_record(
+        self,
+        session: object,
+        inspection: RuntimeInspection,
+    ) -> bool:
+        """Submit a pending prompt for a DB-backed session via provider boundary."""
+
+        return await self.submit_pending_prompt(
+            self.handle_from_session_record(session), inspection
+        )
+
     async def _start_role(self, request: StartRoleRequest) -> RuntimeSessionHandle:
         provider = self.get_provider(request.provider_name)
         await provider.prepare_workspace(request)

--- a/tests/unit/test_runtime_health.py
+++ b/tests/unit/test_runtime_health.py
@@ -52,11 +52,16 @@ async def db():
 class FakeRuntimeService:
     def __init__(self, inspection: RuntimeInspection | Exception) -> None:
         self.inspection = inspection
+        self.submitted = False
 
     async def inspect_session_record(self, _session):
         if isinstance(self.inspection, Exception):
             raise self.inspection
         return self.inspection
+
+    async def submit_pending_prompt_for_session_record(self, _session, _inspection):
+        self.submitted = True
+        return True
 
 
 def _request(db):
@@ -306,6 +311,142 @@ async def test_recovery_dry_run_and_apply_refusal(db) -> None:
     explicit_apply = build_recovery_plan(health, mode="apply", policy="restart_missing_pane")
     assert explicit_apply.safe_to_apply is True
     assert explicit_apply.refused_reason is None
+
+
+@pytest.mark.asyncio
+async def test_prompt_not_submitted_recovery_requires_persisted_payload_match(db) -> None:
+    project = await create_project(db, "pending-prompt-proj")
+    leader = await create_leader(db, project.id, goal="Recover pending prompt")
+    session = await create_session(
+        db,
+        project.id,
+        "manager",
+        "leader-pending",
+        status="working",
+        provider="codex",
+    )
+    message = "# Mission Brief\n\nRecover pending prompt"
+    await db.execute(
+        "UPDATE sessions SET tmux_pane = ?, tmux_session = ? WHERE id = ?",
+        ("%21", "atc", session.id),
+    )
+    await db.execute(
+        "UPDATE leaders SET session_id = ?, context = ? WHERE id = ?",
+        (
+            session.id,
+            json.dumps(
+                {
+                    "leader_kickoff_payload": {
+                        "project_id": project.id,
+                        "goal": "Recover pending prompt",
+                        "message": message,
+                        "source": "test",
+                    }
+                }
+            ),
+            leader.id,
+        ),
+    )
+    await db.commit()
+
+    health = await leader_health(
+        db,
+        project.id,
+        runtime_service=FakeRuntimeService(
+            RuntimeInspection(
+                session_id=session.id,
+                provider_name="codex",
+                alive=True,
+                readiness=ReadinessState.READY,
+                summary="Codex prompt contains visible unsubmitted text",
+                details={
+                    "blocker_reason": BlockerReason.PROMPT_NOT_SUBMITTED.value,
+                    "provider_diagnostics": {
+                        "pending_prompt_text": "Recover pending prompt"
+                    },
+                },
+            )
+        ),
+    )
+
+    assert health.current_blocker == BlockerReason.PROMPT_NOT_SUBMITTED.value
+    assert health.kickoff_state["pending_prompt_observed"] is True
+    assert health.kickoff_state["pending_prompt_matches_persisted_payload"] is True
+    dry_run = build_recovery_plan(health, mode="dry_run")
+    assert dry_run.safe_to_apply is True
+    assert dry_run.actions[1]["action"] == "submit_pending_prompt"
+    assert dry_run.actions[1]["policy_required"] == "submit_pending_prompt"
+    apply_without_policy = build_recovery_plan(health, mode="apply")
+    assert (
+        apply_without_policy.refused_reason
+        == "apply_requires_submit_pending_prompt_policy"
+    )
+
+
+@pytest.mark.asyncio
+async def test_prompt_not_submitted_apply_reinspects_and_submits_via_provider(
+    db, monkeypatch
+) -> None:
+    project = await create_project(db, "pending-prompt-apply-proj")
+    leader = await create_leader(db, project.id, goal="Apply pending prompt")
+    session = await create_session(
+        db,
+        project.id,
+        "manager",
+        "leader-pending-apply",
+        status="working",
+        provider="codex",
+    )
+    await db.execute(
+        "UPDATE sessions SET tmux_pane = ?, tmux_session = ? WHERE id = ?",
+        ("%22", "atc", session.id),
+    )
+    await db.execute(
+        "UPDATE leaders SET session_id = ?, context = ? WHERE id = ?",
+        (
+            session.id,
+            json.dumps(
+                {
+                    "leader_kickoff_payload": {
+                        "project_id": project.id,
+                        "goal": "Apply pending prompt",
+                        "message": "# Mission Brief\n\nApply pending prompt",
+                        "source": "test",
+                    }
+                }
+            ),
+            leader.id,
+        ),
+    )
+    await db.commit()
+    inspection = RuntimeInspection(
+        session_id=session.id,
+        provider_name="codex",
+        alive=True,
+        readiness=ReadinessState.READY,
+        summary="Codex prompt contains visible unsubmitted text",
+        details={
+            "blocker_reason": BlockerReason.PROMPT_NOT_SUBMITTED.value,
+            "provider_diagnostics": {"pending_prompt_text": "Apply pending prompt"},
+        },
+    )
+    fake_service = FakeRuntimeService(inspection)
+    health = await leader_health(db, project.id, runtime_service=fake_service)
+
+    import atc.runtime.health as health_module
+
+    async def fake_leader_health(conn, project_id, *, runtime_service=None):
+        return health
+
+    monkeypatch.setattr(health_module, "RuntimeService", lambda: fake_service)
+    monkeypatch.setattr(health_module, "leader_health", fake_leader_health)
+
+    plan = await apply_recovery_plan(db, health, policy="submit_pending_prompt")
+
+    assert plan.refused_reason is None
+    assert fake_service.submitted is True
+    assert plan.actions[-1]["action"] == "submit_pending_prompt"
+    assert plan.actions[-1]["status"] == "applied"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- add provider-owned `submit_pending_prompt` recovery capability for classified pending prompts
- make Codex expose provider diagnostics with the visible pending prompt text and submit with Enter only through its adapter
- keep separation intact: REST/health plan provider-neutral recovery, provider adapters own key mechanics
- require inspect-first persisted-payload matching and explicit `submit_pending_prompt` policy before mutating recovery applies
- add Leader recovery tests for dry-run safety gating and apply-time reinspection/provider submission

## Validation
- `./.venv/bin/python -m ruff check src/atc/providers/base.py src/atc/providers/codex/classifier.py src/atc/providers/codex/runtime.py src/atc/providers/claude_code/runtime.py src/atc/runtime/service.py src/atc/runtime/health.py tests/unit/test_runtime_health.py`
- `./.venv/bin/python -m pytest tests/unit/test_runtime_health.py tests/unit/test_provider_classifiers.py tests/unit/test_codex_runtime_classifier.py tests/unit/test_codex_runtime.py tests/unit/test_runtime_service.py`
- `./.venv/bin/python -m pytest tests/unit/test_runtime_health.py tests/unit/test_leader_kickoff.py tests/unit/test_leader_start_api.py tests/unit/test_provider_classifiers.py tests/unit/test_codex_runtime_classifier.py tests/unit/test_codex_runtime.py tests/unit/test_runtime_service.py tests/unit/test_tower_controller.py tests/unit/test_tower_progress_truth.py`
- `cd frontend && npm run build && npx playwright test tests/e2e/dashboard-views.spec.ts tests/e2e/atc-qa.spec.ts --project=chromium --reporter=line`

## API evidence
`/api/projects/{project_id}/leader/health` saw `current_blocker=prompt_not_submitted` and `pending_prompt_matches_persisted_payload=true` from a tmux-backed Codex-classified pane.

`POST /api/projects/{project_id}/leader/recover` dry-run returned safe action:
```json
{
  "action": "submit_pending_prompt",
  "safe": true,
  "policy_required": "submit_pending_prompt",
  "uses_persisted_payload": true,
  "match_basis": "provider_pending_text"
}
```

Apply with explicit policy returned `200` and appended:
```json
{"action": "submit_pending_prompt", "status": "applied"}
```

Evidence file: `screenshots/loops-phase4-api-evidence.json`
