### PR TITLE
Add first-class task graph CLI helpers

### DIFF
--- a/src/atc/agents/deploy.py
+++ b/src/atc/agents/deploy.py
@@ -502,23 +502,36 @@ def _build_manager_instructions_md(spec: ManagerDeploySpec) -> str:
         "",
         "#### Step 2 — Decompose the goal into tasks",
         "",
-        "Send a POST with `task_specs` array. Each spec needs `title` and `description`:",
+        "Use the first-class ATC task CLI instead of inspecting OpenAPI:",
         "```",
-        f"curl -s -X POST {spec.api_base_url}/api/projects/{spec.project_id}/leader/decompose \\",
-        '  -H "Content-Type: application/json" \\',
-        '  -d \'{"task_specs": [',
-        '    {"title": "Task 1 title", "description": "What to build and acceptance criteria"},',
-        '    {"title": "Task 2 title", "description": "..."}',
-        "  ]}'",
+        f"atc leader bootstrap-tasks --api {spec.api_base_url} --project-id {spec.project_id} \\",
+        '  --goal "Tower goal" \\',
+        '  --task "Task 1 title" \\',
+        '  --task "Task 2 title"',
         "```",
         "The response contains a `task_graphs` array with `id` fields — save these IDs.",
+        (
+            "For one-off additions, use `atc tasks create --project-id ... "
+            "--title ... --description ...`."
+        ),
         "",
         "#### Step 3 — Spawn Aces for ready tasks",
         "",
+        "Assign one ready task at a time:",
+        "```",
+        (
+            f"atc tasks assign --api {spec.api_base_url} "
+            f"--project-id {spec.project_id} --task-id <task_graph_id>"
+        ),
+        "```",
+        "Or spawn Aces for all ready tasks when concurrency is appropriate:",
         "```",
         f"curl -s -X POST {spec.api_base_url}/api/projects/{spec.project_id}/leader/spawn-aces",
         "```",
-        "Returns a `spawned` array with `ace_session_id` and `task_graph_id` for each Ace.",
+        (
+            "Returns `ace_session_id`, `task_graph_id`, `assignment_id`, "
+            "and `status` for each assignment."
+        ),
         "",
         "#### Step 4 — Send work instructions to each Ace",
         "",

--- a/src/atc/api/routers/leader.py
+++ b/src/atc/api/routers/leader.py
@@ -3,6 +3,7 @@
 Routes:
   POST   /api/projects/{project_id}/leader/decompose     → decompose goal into tasks
   POST   /api/projects/{project_id}/leader/spawn-aces     → spawn Aces for ready tasks
+  POST   /api/projects/{project_id}/leader/assign-task    → spawn one Ace for a task
   POST   /api/projects/{project_id}/leader/instruct       → send instruction to an Ace
   POST   /api/projects/{project_id}/leader/task-done      → mark a task as done
   POST   /api/projects/{project_id}/leader/task-failed    → mark a task as failed
@@ -50,6 +51,10 @@ class InstructRequest(BaseModel):
     instruction: str
 
 
+class AssignTaskRequest(BaseModel):
+    task_graph_id: str
+
+
 class TaskDoneRequest(BaseModel):
     task_graph_id: str
 
@@ -68,6 +73,11 @@ class DecomposeResponse(BaseModel):
 
 class SpawnAcesResponse(BaseModel):
     spawned: list[dict[str, Any]]
+
+
+class AssignTaskResponse(BaseModel):
+    assigned: dict[str, Any] | None = None
+    error: str | None = None
 
 
 class ProgressResponse(BaseModel):
@@ -265,9 +275,41 @@ async def spawn_aces(
                 "ace_session_id": a.ace_session_id,
                 "task_graph_id": a.task_graph_id,
                 "task_title": a.task_title,
+                "assignment_id": a.assignment_id,
+                "status": a.status,
             }
             for a in assignments
         ],
+    )
+
+
+@router.post(
+    "/projects/{project_id}/leader/assign-task",
+    response_model=AssignTaskResponse,
+)
+async def assign_task(
+    project_id: str,
+    body: AssignTaskRequest,
+    request: Request,
+) -> AssignTaskResponse:
+    """Spawn or reuse one Ace assignment for a specific ready task graph entry."""
+    orch = await _get_or_create_orchestrator(request, project_id)
+    try:
+        assignment = await orch.spawn_ace_for_task(body.task_graph_id)
+    except ValueError as exc:
+        raise HTTPException(status_code=409, detail=str(exc)) from None
+    await _broadcast_tower_progress(request)
+
+    if assignment is None:
+        return AssignTaskResponse(error="assignment_not_created")
+    return AssignTaskResponse(
+        assigned={
+            "ace_session_id": assignment.ace_session_id,
+            "task_graph_id": assignment.task_graph_id,
+            "task_title": assignment.task_title,
+            "assignment_id": assignment.assignment_id,
+            "status": assignment.status,
+        }
     )
 
 

--- a/src/atc/cli/leader.py
+++ b/src/atc/cli/leader.py
@@ -60,6 +60,22 @@ def register(subparsers: argparse._SubParsersAction) -> None:  # type: ignore[ty
     recover_parser.add_argument("--api", default=_DEFAULT_API, help="ATC API base URL")
     recover_parser.set_defaults(handler=_handle_recover)
 
+    # atc leader bootstrap-tasks --project-id <id> --goal '...' [--task '...']
+    bootstrap_parser = leader_sub.add_parser(
+        "bootstrap-tasks",
+        help="Create an initial task graph without inspecting OpenAPI",
+    )
+    bootstrap_parser.add_argument("--project-id", required=True, help="Project UUID")
+    bootstrap_parser.add_argument("--goal", default=None, help="Goal to bootstrap")
+    bootstrap_parser.add_argument(
+        "--task",
+        action="append",
+        default=[],
+        help="Task title to create; repeat for multiple tasks",
+    )
+    bootstrap_parser.add_argument("--api", default=_DEFAULT_API, help="ATC API base URL")
+    bootstrap_parser.set_defaults(handler=_handle_bootstrap_tasks)
+
     leader_parser.set_defaults(handler=lambda _: leader_parser.print_help() or 1)
 
 
@@ -129,4 +145,24 @@ def _handle_recover(args: argparse.Namespace) -> int:
     return _post_json(
         f"{args.api}/api/projects/{args.project_id}/leader/recover",
         {"dry_run": not args.apply, "policy": args.policy},
+    )
+
+
+def _handle_bootstrap_tasks(args: argparse.Namespace) -> int:
+    goal = args.goal or "Deliver the Tower goal"
+    task_titles = args.task or [
+        "Plan delivery and acceptance criteria",
+        "Execute the implementation work",
+        "Validate and report completion evidence",
+    ]
+    task_specs = [
+        {
+            "title": title,
+            "description": f"Bootstrap task for goal: {goal}",
+        }
+        for title in task_titles
+    ]
+    return _post_json(
+        f"{args.api}/api/projects/{args.project_id}/leader/decompose",
+        {"task_specs": task_specs},
     )

--- a/src/atc/cli/main.py
+++ b/src/atc/cli/main.py
@@ -6,6 +6,8 @@ Usage::
     atc ace done <session_id>
     atc ace create --project-id <id> --name '...'
     atc ace list --project-id <id>
+    atc tasks create --project-id <id> --title '...'
+    atc tasks assign --project-id <id> --task-id <task_graph_id>
     atc leader start --project-id <id>
     atc leader stop --project-id <id>
     atc projects list
@@ -19,7 +21,7 @@ from __future__ import annotations
 import argparse
 import sys
 
-from atc.cli import ace, leader, projects, tower
+from atc.cli import ace, leader, projects, tasks, tower
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -31,6 +33,7 @@ def build_parser() -> argparse.ArgumentParser:
     subparsers = parser.add_subparsers(dest="command")
 
     ace.register(subparsers)
+    tasks.register(subparsers)
     leader.register(subparsers)
     projects.register(subparsers)
     tower.register(subparsers)

--- a/src/atc/cli/tasks.py
+++ b/src/atc/cli/tasks.py
@@ -1,0 +1,102 @@
+"""``atc tasks`` subcommands — first-class task graph helpers for Leaders.
+
+These commands intentionally wrap the project task-graph and Leader assignment
+REST APIs so managed Leader agents do not need to inspect OpenAPI or hand-write
+curl payloads for common task graph operations.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+import urllib.error
+import urllib.request
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    import argparse
+
+_DEFAULT_API = "http://127.0.0.1:8420"
+
+
+def register(subparsers: argparse._SubParsersAction) -> None:  # type: ignore[type-arg]
+    """Register the ``tasks`` command group."""
+    tasks_parser = subparsers.add_parser("tasks", help="Task graph commands")
+    tasks_sub = tasks_parser.add_subparsers(dest="tasks_command")
+
+    list_parser = tasks_sub.add_parser("list", help="List project task graph entries")
+    list_parser.add_argument("--project-id", required=True, help="Project UUID")
+    list_parser.add_argument("--api", default=_DEFAULT_API, help="ATC API base URL")
+    list_parser.set_defaults(handler=_handle_list)
+
+    create_parser = tasks_sub.add_parser("create", help="Create a task graph entry")
+    create_parser.add_argument("--project-id", required=True, help="Project UUID")
+    create_parser.add_argument("--title", required=True, help="Task title")
+    create_parser.add_argument("--description", default=None, help="Task description")
+    create_parser.add_argument(
+        "--depends-on",
+        action="append",
+        default=[],
+        help="Dependency task_graph_id; repeat for multiple dependencies",
+    )
+    create_parser.add_argument("--api", default=_DEFAULT_API, help="ATC API base URL")
+    create_parser.set_defaults(handler=_handle_create)
+
+    assign_parser = tasks_sub.add_parser("assign", help="Assign/spawn an Ace for one ready task")
+    assign_parser.add_argument("--project-id", required=True, help="Project UUID")
+    assign_parser.add_argument("--task-id", required=True, help="Task graph UUID")
+    assign_parser.add_argument("--api", default=_DEFAULT_API, help="ATC API base URL")
+    assign_parser.set_defaults(handler=_handle_assign)
+
+    tasks_parser.set_defaults(handler=lambda _: tasks_parser.print_help() or 1)
+
+
+def _print_json(body: Any) -> None:
+    print(json.dumps(body, indent=2))
+
+
+def _read_response(resp: Any) -> Any:
+    raw = resp.read().decode()
+    return json.loads(raw) if raw else {}
+
+
+def _request_json(url: str, *, method: str = "GET", payload: dict[str, Any] | None = None) -> int:
+    data = json.dumps(payload).encode() if payload is not None else None
+    headers = {"Content-Type": "application/json"} if payload is not None else {}
+    req = urllib.request.Request(url, data=data, method=method, headers=headers)
+    try:
+        with urllib.request.urlopen(req, timeout=30) as resp:
+            _print_json(_read_response(resp))
+            return 0
+    except urllib.error.HTTPError as exc:
+        detail = exc.read().decode() if exc.fp else str(exc)
+        print(f"Error: {exc.code} — {detail}", file=sys.stderr)
+        return 1
+    except urllib.error.URLError as exc:
+        print(f"Error: cannot reach ATC API — {exc.reason}", file=sys.stderr)
+        return 1
+
+
+def _handle_list(args: argparse.Namespace) -> int:
+    return _request_json(f"{args.api}/api/projects/{args.project_id}/task-graphs")
+
+
+def _handle_create(args: argparse.Namespace) -> int:
+    payload: dict[str, Any] = {"title": args.title}
+    if args.description:
+        payload["description"] = args.description
+    if args.depends_on:
+        payload["dependencies"] = args.depends_on
+    return _request_json(
+        f"{args.api}/api/projects/{args.project_id}/task-graphs",
+        method="POST",
+        payload=payload,
+    )
+
+
+def _handle_assign(args: argparse.Namespace) -> int:
+    return _request_json(
+        f"{args.api}/api/projects/{args.project_id}/leader/assign-task",
+        method="POST",
+        payload={"task_graph_id": args.task_id},
+    )

--- a/src/atc/leader/orchestrator.py
+++ b/src/atc/leader/orchestrator.py
@@ -148,6 +148,67 @@ class LeaderOrchestrator:
 
         return new_assignments
 
+    async def spawn_ace_for_task(self, task_graph_id: str) -> AceAssignment | None:
+        """Spawn or reuse an Ace assignment for one ready task graph entry."""
+        task_graphs = await db_ops.list_task_graphs(
+            self.conn,
+            project_id=self.project_id,
+        )
+        task_by_id = {tg.id: tg for tg in task_graphs}
+        task = task_by_id.get(task_graph_id)
+        if task is None:
+            raise ValueError(f"TaskGraph {task_graph_id} not found")
+
+        active_aces_by_task = await self._active_ace_sessions_by_task()
+        if task_graph_id in active_aces_by_task:
+            existing = self.assignments.get(task_graph_id)
+            if existing is not None:
+                return existing
+            active_assignment = next(
+                (
+                    assignment
+                    for assignment in await db_ops.list_task_assignments(
+                        self.conn,
+                        task_graph_id=task_graph_id,
+                    )
+                    if assignment.status in {"assigned", "working"}
+                    and assignment.ace_session_id == active_aces_by_task[task_graph_id]
+                ),
+                None,
+            )
+            if active_assignment is not None:
+                restored = AceAssignment(
+                    ace_session_id=active_assignment.ace_session_id,
+                    task_graph_id=task_graph_id,
+                    task_title=task.title,
+                    assignment_id=active_assignment.assignment_id,
+                    status=active_assignment.status,
+                )
+                self.assignments[task_graph_id] = restored
+                return restored
+            raise ValueError(
+                f"Task {task_graph_id} already has an active Ace session "
+                f"{active_aces_by_task[task_graph_id]}"
+            )
+
+        ready_ids = {tg.id for tg in get_ready_tasks(task_graphs)}
+        if task_graph_id not in ready_ids:
+            raise ValueError(f"Task {task_graph_id} is not ready for assignment")
+
+        global _GLOBAL_ACTIVE_ACES
+        lock = await _get_global_lock()
+        reserved = False
+        async with lock:
+            if self._governor.available_ace_slots(_GLOBAL_ACTIVE_ACES) <= 0:
+                raise ValueError("No Ace slots available")
+            _GLOBAL_ACTIVE_ACES += 1
+            reserved = True
+
+        assignment = await self._spawn_ace_for_task(task.id, task.title, task.description)
+        if assignment is None and reserved:
+            _GLOBAL_ACTIVE_ACES = max(0, _GLOBAL_ACTIVE_ACES - 1)
+        return assignment
+
     async def _active_ace_sessions_by_task(self) -> dict[str, str]:
         """Return active Ace sessions keyed by task id to preserve 1:1 pairing."""
         terminal_statuses = {"completed", "cancelled", "error", "disconnected"}

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -322,6 +322,77 @@ class TestLeaderStart:
             cli(["leader", "start"])
 
 
+class TestLeaderBootstrapTasks:
+    def test_bootstrap_tasks_posts_decompose_specs(self, api_stub: str) -> None:
+        rc = cli([
+            "leader", "bootstrap-tasks",
+            "--project-id", "proj-1",
+            "--goal", "Ship phase 5",
+            "--task", "Create CLI",
+            "--task", "Validate CLI",
+            "--api", api_stub,
+        ])
+        assert rc == 0
+        req = _StubHandler.requests[0]
+        assert req["method"] == "POST"
+        assert req["path"] == "/api/projects/proj-1/leader/decompose"
+        assert [task["title"] for task in req["body"]["task_specs"]] == [
+            "Create CLI",
+            "Validate CLI",
+        ]
+        assert req["body"]["task_specs"][0]["description"] == (
+            "Bootstrap task for goal: Ship phase 5"
+        )
+
+    def test_bootstrap_tasks_defaults_to_three_tasks(self, api_stub: str) -> None:
+        rc = cli(["leader", "bootstrap-tasks", "--project-id", "proj-1", "--api", api_stub])
+        assert rc == 0
+        assert len(_StubHandler.requests[0]["body"]["task_specs"]) == 3
+
+
+class TestTaskGraphCommands:
+    def test_lists_task_graphs(self, api_stub: str) -> None:
+        _StubHandler.response_body = []  # type: ignore[assignment]
+        rc = cli(["tasks", "list", "--project-id", "proj-1", "--api", api_stub])
+        assert rc == 0
+        req = _StubHandler.requests[0]
+        assert req["method"] == "GET"
+        assert req["path"] == "/api/projects/proj-1/task-graphs"
+
+    def test_creates_task_graph(self, api_stub: str) -> None:
+        rc = cli([
+            "tasks", "create",
+            "--project-id", "proj-1",
+            "--title", "Build UI",
+            "--description", "Implement the UI",
+            "--depends-on", "task-a",
+            "--depends-on", "task-b",
+            "--api", api_stub,
+        ])
+        assert rc == 0
+        req = _StubHandler.requests[0]
+        assert req["method"] == "POST"
+        assert req["path"] == "/api/projects/proj-1/task-graphs"
+        assert req["body"] == {
+            "title": "Build UI",
+            "description": "Implement the UI",
+            "dependencies": ["task-a", "task-b"],
+        }
+
+    def test_assigns_task_graph(self, api_stub: str) -> None:
+        rc = cli([
+            "tasks", "assign",
+            "--project-id", "proj-1",
+            "--task-id", "tg-1",
+            "--api", api_stub,
+        ])
+        assert rc == 0
+        req = _StubHandler.requests[0]
+        assert req["method"] == "POST"
+        assert req["path"] == "/api/projects/proj-1/leader/assign-task"
+        assert req["body"] == {"task_graph_id": "tg-1"}
+
+
 # ---------------------------------------------------------------------------
 # atc leader stop
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_leader_api.py
+++ b/tests/unit/test_leader_api.py
@@ -207,6 +207,30 @@ class TestSpawnAcesEndpoint:
         # Blocker is already assigned, blocked is waiting
         assert len(result.spawned) == 0
 
+    async def test_assign_task_endpoint_returns_single_assignment(
+        self,
+        mock_create: AsyncMock,
+        db,
+        project_with_leader,
+        mock_request,
+    ) -> None:
+        from atc.api.routers.leader import AssignTaskRequest, assign_task
+
+        project, _ = project_with_leader
+        tg = await create_task_graph(db, project.id, "Ready Task")
+
+        result = await assign_task(
+            project.id,
+            AssignTaskRequest(task_graph_id=tg.id),
+            mock_request,
+        )
+
+        assert result.assigned is not None
+        assert result.assigned["task_graph_id"] == tg.id
+        assert result.assigned["assignment_id"].endswith(f":{tg.id}")
+        assert result.assigned["status"] == "assigned"
+        mock_request.app.state.tower_controller.get_progress.assert_awaited()
+
 
 # ---------------------------------------------------------------------------
 # progress endpoint


### PR DESCRIPTION
## Summary
- add first-class `atc tasks` CLI helpers for listing, creating, and assigning task graph entries
- add `atc leader bootstrap-tasks` so Leaders can create initial task graphs without inspecting OpenAPI
- add a provider-neutral Leader `assign-task` REST endpoint that spawns/reuses one Ace assignment for a selected ready task
- update deployed Leader instructions to prefer the task graph CLI path and keep REST/curl as lower-level fallback

## Validation
- `./.venv/bin/python -m ruff check src/atc/agents/deploy.py src/atc/api/routers/leader.py src/atc/cli/main.py src/atc/cli/leader.py src/atc/cli/tasks.py src/atc/leader/orchestrator.py tests/unit/test_cli.py tests/unit/test_leader_api.py`
- `./.venv/bin/python -m pytest tests/unit/test_cli.py tests/unit/test_leader_api.py tests/unit/test_task_graphs.py tests/unit/test_deploy.py` — 168 passed, 1 warning
- `./.venv/bin/python -m pytest tests/e2e/test_task_graph_api.py tests/e2e/test_phase8_scenarios.py` — 36 passed, 1 warning
- CLI/API evidence against local backend on 127.0.0.1:8421:
  - `atc tasks list`
  - `atc leader bootstrap-tasks`
  - `atc tasks create --depends-on ...`
  - `atc tasks assign`
  - OpenAPI contains `/api/projects/{project_id}/leader/assign-task`
  - Assignment points to a live Ace session and task runtime truth reports assignment evidence
- Frontend build and baseline Playwright smoke:
  - `cd frontend && npm run build`
  - `npx playwright test tests/e2e/dashboard-views.spec.ts tests/e2e/atc-qa.spec.ts --project=chromium --reporter=line` — 15 passed

## Evidence artifacts
- CLI/API evidence: `screenshots/loops-phase5-cli-api-evidence.json`
- UI screenshots:
  - `screenshots/loops-phase5-2026-06-20T00-34-16-009Z/01-dashboard-baseline.png`
  - `screenshots/loops-phase5-2026-06-20T00-34-16-009Z/02-projects-baseline.png`
  - `screenshots/loops-phase5-2026-06-20T00-34-16-009Z/03-usage-baseline.png`
