### PR TITLE
Surface leader health guidance

### DIFF
--- a/frontend/src/components/leader/LeaderConsole.css
+++ b/frontend/src/components/leader/LeaderConsole.css
@@ -40,6 +40,47 @@
   flex-shrink: 0;
 }
 
+.leader-console__health {
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  padding: var(--space-2) var(--space-3);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  font-size: var(--text-sm);
+  background: var(--color-surface-muted, rgba(255, 255, 255, 0.03));
+}
+
+.leader-console__health--warning {
+  border-color: var(--color-status-amber);
+}
+
+.leader-console__health--blocked {
+  border-color: var(--color-danger, #f85149);
+}
+
+.leader-console__health-topline {
+  color: var(--color-text);
+}
+
+.leader-console__health-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: var(--space-1) var(--space-2);
+  color: var(--color-text-muted);
+}
+
+.leader-console__health-blocker,
+.leader-console__health-action {
+  color: var(--color-text-secondary);
+}
+
+.leader-console__health-controls {
+  display: flex;
+  gap: var(--space-2);
+  flex-wrap: wrap;
+}
+
 .leader-console__goal {
   font-size: var(--text-sm);
   color: var(--color-text-secondary);

--- a/frontend/src/components/leader/LeaderConsole.tsx
+++ b/frontend/src/components/leader/LeaderConsole.tsx
@@ -6,7 +6,7 @@ import StatusBadge from "../common/StatusBadge";
 import ConfirmPopover from "../common/ConfirmPopover";
 import GitHubPanel from "../dashboard/GitHubPanel";
 import BudgetPanel from "./BudgetPanel";
-import type { DeliveryStatusResponse, Leader, Project } from "../../types";
+import type { DeliveryStatusResponse, Leader, LeaderRuntimeHealth, Project } from "../../types";
 import "./LeaderConsole.css";
 
 interface LeaderConsoleProps {
@@ -34,6 +34,8 @@ export default function LeaderConsole({
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [deliveryStatus, setDeliveryStatus] = useState<DeliveryStatusResponse | null>(null);
+  const [health, setHealth] = useState<LeaderRuntimeHealth | null>(null);
+  const [healthLoading, setHealthLoading] = useState(false);
   const [activeTab, setActiveTab] = useState<Tab>("github");
   const autoStarted = useRef(false);
   const userStopped = useRef(false);
@@ -70,6 +72,48 @@ export default function LeaderConsole({
       void handleStart();
     }
   }, [isTerminalProvider, isIdle, loading, projectId]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  useEffect(() => {
+    if (!leader?.session_id && !isRunning) {
+      setHealth(null);
+      return;
+    }
+    void refreshHealth();
+    const timer = window.setInterval(() => {
+      void refreshHealth();
+    }, 10_000);
+    return () => window.clearInterval(timer);
+  }, [leader?.session_id, isRunning, projectId]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  async function refreshHealth() {
+    setHealthLoading(true);
+    try {
+      const res = await api.get<LeaderRuntimeHealth>(`/projects/${projectId}/leader/health`);
+      setHealth(res);
+    } catch (err) {
+      console.error("Failed to load leader health:", err);
+    } finally {
+      setHealthLoading(false);
+    }
+  }
+
+  async function handleRecoveryDryRun() {
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await api.post<DeliveryStatusResponse>(
+        `/projects/${projectId}/leader/recover`,
+        { dry_run: true, policy: "inspect_first" },
+      );
+      setDeliveryStatus(res);
+      await refreshHealth();
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : "Failed to inspect recovery";
+      setError(msg);
+    } finally {
+      setLoading(false);
+    }
+  }
 
   async function handleStart() {
     userStopped.current = false;
@@ -178,6 +222,42 @@ export default function LeaderConsole({
           Delivery state: <strong>{deliveryStatus.delivery_state}</strong>
           {deliveryStatus.message ? ` — ${deliveryStatus.message}` : ""}
           {deliveryStatus.recovery ? ` Recovery: ${deliveryStatus.recovery}` : ""}
+        </div>
+      )}
+
+      {health && (
+        <div
+          className={`leader-console__health leader-console__health--${health.operator_guidance.severity}`}
+          data-testid="leader-health-guidance"
+        >
+          <div className="leader-console__health-topline">
+            <strong>Leader health:</strong> {health.operator_guidance.summary}
+          </div>
+          <div className="leader-console__health-grid">
+            <span>Runtime: {health.runtime_state}</span>
+            <span>Delivery: {health.delivery_state}</span>
+            <span>State: {health.kickoff_state.kickoff_state ?? "unknown"}</span>
+            <span>Tasks: {health.task_graph_state.total ?? 0}</span>
+          </div>
+          {health.current_blocker && (
+            <div className="leader-console__health-blocker">Blocker: {health.current_blocker}</div>
+          )}
+          {health.operator_guidance.recommended_action !== "none" && (
+            <div className="leader-console__health-action">
+              Recommended: {health.operator_guidance.recommended_action}
+              {health.operator_guidance.command ? ` — ${health.operator_guidance.command}` : ""}
+            </div>
+          )}
+          <div className="leader-console__health-controls">
+            <button className="btn btn-secondary btn-sm" onClick={refreshHealth} disabled={healthLoading}>
+              {healthLoading ? "Refreshing..." : "Refresh health"}
+            </button>
+            {health.operator_guidance.severity === "blocked" && (
+              <button className="btn btn-secondary btn-sm" onClick={handleRecoveryDryRun} disabled={loading}>
+                Inspect recovery
+              </button>
+            )}
+          </div>
         </div>
       )}
 

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -261,6 +261,41 @@ export interface DeliveryStatusResponse {
   };
 }
 
+export interface RuntimeOperatorGuidance {
+  severity: "ok" | "warning" | "blocked" | string;
+  summary: string;
+  recommended_action: string;
+  command: string;
+  details: string;
+}
+
+export interface LeaderRuntimeHealth {
+  runtime_state: string;
+  delivery_state: string;
+  current_blocker: string | null;
+  kickoff_state: {
+    kickoff_state?: string;
+    goal_acceptance_state?: string;
+    kickoff_verified?: boolean;
+    pending_prompt_observed?: boolean;
+    pending_prompt_matches_persisted_payload?: boolean;
+  };
+  task_graph_state: {
+    total?: number;
+    todo?: number;
+    assigned?: number;
+    in_progress?: number;
+    done?: number;
+    failed?: number;
+  };
+  ace_dispatch: {
+    verified?: number;
+    blocked?: number;
+    unverified?: number;
+  };
+  operator_guidance: RuntimeOperatorGuidance;
+}
+
 export interface AppState {
   projects: Project[];
   leaders: Record<string, Leader>;

--- a/src/atc/cli/leader.py
+++ b/src/atc/cli/leader.py
@@ -45,6 +45,11 @@ def register(subparsers: argparse._SubParsersAction) -> None:  # type: ignore[ty
     # atc leader health --project-id <id>
     health_parser = leader_sub.add_parser("health", help="Inspect leader runtime health")
     health_parser.add_argument("--project-id", required=True, help="Project UUID")
+    health_parser.add_argument(
+        "--summary",
+        action="store_true",
+        help="Print concise operator guidance instead of raw JSON",
+    )
     health_parser.add_argument("--api", default=_DEFAULT_API, help="ATC API base URL")
     health_parser.set_defaults(handler=_handle_health)
 
@@ -102,21 +107,54 @@ def _post_json(url: str, payload: dict) -> int:
         return 1
 
 
-def _get_json(url: str) -> int:
+def _get_json(url: str) -> tuple[int, dict | None]:
     """GET JSON from a URL and print the response."""
     req = urllib.request.Request(url, method="GET")
     try:
         with urllib.request.urlopen(req, timeout=30) as resp:
             body = json.loads(resp.read().decode())
-            print(json.dumps(body, indent=2))
-            return 0
+            return 0, body
     except urllib.error.HTTPError as exc:
         detail = exc.read().decode() if exc.fp else str(exc)
         print(f"Error: {exc.code} — {detail}", file=sys.stderr)
-        return 1
+        return 1, None
     except urllib.error.URLError as exc:
         print(f"Error: cannot reach ATC API — {exc.reason}", file=sys.stderr)
-        return 1
+        return 1, None
+
+
+def _print_health_summary(body: dict) -> None:
+    guidance = body.get("operator_guidance") or {}
+    kickoff = body.get("kickoff_state") or {}
+    tasks = body.get("task_graph_state") or {}
+    dispatch = body.get("ace_dispatch") or {}
+    print(f"Leader health: {guidance.get('severity', 'unknown')}")
+    print(f"Summary: {guidance.get('summary', 'No guidance available.')}")
+    print(f"Runtime: {body.get('runtime_state')} / delivery: {body.get('delivery_state')}")
+    print(
+        "Leader state: "
+        f"{kickoff.get('kickoff_state')} / acceptance: {kickoff.get('goal_acceptance_state')}"
+    )
+    print(
+        "Tasks: "
+        f"total={tasks.get('total', 0)} todo={tasks.get('todo', 0)} "
+        f"active={tasks.get('assigned', 0) + tasks.get('in_progress', 0)} "
+        f"done={tasks.get('done', 0)}"
+    )
+    print(
+        "Ace dispatch: "
+        f"verified={dispatch.get('verified', 0)} "
+        f"blocked={dispatch.get('blocked', 0)} "
+        f"unverified={dispatch.get('unverified', 0)}"
+    )
+    if body.get("current_blocker"):
+        print(f"Blocker: {body['current_blocker']}")
+    if guidance.get("recommended_action"):
+        print(f"Recommended action: {guidance['recommended_action']}")
+    if guidance.get("command"):
+        print(f"Command: {guidance['command']}")
+    if guidance.get("details"):
+        print(f"Details: {guidance['details']}")
 
 
 def _handle_start(args: argparse.Namespace) -> int:
@@ -138,7 +176,14 @@ def _handle_message(args: argparse.Namespace) -> int:
 
 
 def _handle_health(args: argparse.Namespace) -> int:
-    return _get_json(f"{args.api}/api/projects/{args.project_id}/leader/health")
+    rc, body = _get_json(f"{args.api}/api/projects/{args.project_id}/leader/health")
+    if rc != 0 or body is None:
+        return rc
+    if args.summary:
+        _print_health_summary(body)
+    else:
+        print(json.dumps(body, indent=2))
+    return 0
 
 
 def _handle_recover(args: argparse.Namespace) -> int:

--- a/src/atc/runtime/health.py
+++ b/src/atc/runtime/health.py
@@ -52,6 +52,7 @@ class RuntimeHealth:
     ace_count: int = 0
     current_blocker: str | None = None
     recovery_recommendation: dict[str, Any] | None = None
+    operator_guidance: dict[str, Any] = field(default_factory=dict)
     provider_diagnostics: dict[str, Any] = field(default_factory=dict)
 
     def as_dict(self) -> dict[str, Any]:
@@ -219,6 +220,97 @@ def _recovery_for(
     ).as_dict()
 
 
+def _operator_guidance_for(
+    *,
+    role: RuntimeRole,
+    project_id: str,
+    session_id: str | None,
+    runtime_state: str,
+    delivery_state: str,
+    current_blocker: str | None,
+    kickoff_state: dict[str, Any] | None = None,
+    ace_dispatch: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Return concise, provider-neutral operator-facing health guidance."""
+
+    kickoff = kickoff_state or {}
+    dispatch = ace_dispatch or {}
+    leader_state = kickoff.get("kickoff_state")
+    command = (
+        f"atc leader recover --project-id {project_id} --dry-run"
+        if role == "leader"
+        else (
+            f"atc ace recover --project-id {project_id} "
+            f"--ace-id {session_id or '<ace-id>'} --dry-run"
+        )
+    )
+    health_command = (
+        f"atc leader health --project-id {project_id} --summary"
+        if role == "leader"
+        else f"atc ace health --project-id {project_id} --ace-id {session_id or '<ace-id>'}"
+    )
+
+    if current_blocker:
+        if current_blocker == BlockerReason.PROMPT_NOT_SUBMITTED.value:
+            return {
+                "severity": "blocked",
+                "summary": "Kickoff prompt was not submitted to the provider.",
+                "recommended_action": "run_inspect_first_recovery",
+                "command": command,
+                "details": (
+                    "Use dry-run first; apply only if persisted payload/prompt "
+                    "evidence matches."
+                ),
+            }
+        if current_blocker == BlockerReason.PANE_MISSING.value:
+            return {
+                "severity": "blocked",
+                "summary": "Runtime pane/session is missing.",
+                "recommended_action": "restart_runtime",
+                "command": command,
+                "details": "Inspect runtime state before restarting managed work.",
+            }
+        return {
+            "severity": "blocked",
+            "summary": f"Runtime is blocked: {current_blocker}.",
+            "recommended_action": "inspect_runtime_blocker",
+            "command": command,
+            "details": "Provider-specific prompt text is intentionally kept in diagnostics.",
+        }
+
+    if role == "leader" and leader_state == "kickoff_unverified":
+        return {
+            "severity": "warning",
+            "summary": "Leader session exists but goal acceptance is not verified yet.",
+            "recommended_action": "wait_or_check_health",
+            "command": health_command,
+            "details": "Normal monitoring should wait for active report or actionable progress.",
+        }
+    if role == "leader" and leader_state == "task_graph_empty":
+        return {
+            "severity": "warning",
+            "summary": "Leader accepted the goal but no task graph/actionable step is visible.",
+            "recommended_action": "bootstrap_or_wait_for_task_graph",
+            "command": f"atc leader bootstrap-tasks --project-id {project_id}",
+            "details": "A task graph is required before Ace dispatch truth can be verified.",
+        }
+    if int(dispatch.get("blocked") or 0) > 0 or int(dispatch.get("unverified") or 0) > 0:
+        return {
+            "severity": "warning",
+            "summary": "Some Ace dispatches are blocked or unverified.",
+            "recommended_action": "inspect_dispatch_health",
+            "command": health_command,
+            "details": "Check dispatch evidence before treating assigned tasks as executing.",
+        }
+    return {
+        "severity": "ok",
+        "summary": f"{role.title()} runtime is {runtime_state}; delivery is {delivery_state}.",
+        "recommended_action": "none",
+        "command": health_command,
+        "details": "No recovery is currently required.",
+    }
+
+
 async def _inspect_session(
     session: Any | None,
     runtime_service: RuntimeService,
@@ -383,6 +475,7 @@ async def leader_health(
     current_blocker = blocker or next(
         (a.blocker_reason for a in project_assignments if a.blocker_reason), None
     )
+    delivery_state = _delivery_state_for_runtime(runtime_state, has_payload=bool(kickoff_payload))
     return RuntimeHealth(
         role="leader",
         project_id=project_id,
@@ -391,9 +484,7 @@ async def leader_health(
         pane_attached=bool(getattr(session, "tmux_pane", None)),
         provider=getattr(session, "provider", None),
         runtime_state=runtime_state,
-        delivery_state=_delivery_state_for_runtime(
-            runtime_state, has_payload=bool(kickoff_payload)
-        ),
+        delivery_state=delivery_state,
         blocker_reason=blocker,
         last_activity_at=latest_activity,
         task_graph_state=task_summary,
@@ -403,6 +494,16 @@ async def leader_health(
         current_blocker=current_blocker,
         recovery_recommendation=_recovery_for(
             "leader", project_id, current_blocker, session.id if session else None
+        ),
+        operator_guidance=_operator_guidance_for(
+            role="leader",
+            project_id=project_id,
+            session_id=session.id if session else None,
+            runtime_state=runtime_state,
+            delivery_state=delivery_state,
+            current_blocker=current_blocker,
+            kickoff_state=kickoff_state,
+            ace_dispatch=dispatch_summary,
         ),
         provider_diagnostics=diagnostics,
     )
@@ -436,6 +537,14 @@ async def ace_health(
             ace_count=0,
             current_blocker=blocker,
             recovery_recommendation=_recovery_for("ace", project_id, blocker, ace_id),
+            operator_guidance=_operator_guidance_for(
+                role="ace",
+                project_id=project_id,
+                session_id=ace_id,
+                runtime_state=runtime_state,
+                delivery_state=DeliveryState.NOT_STARTED.value,
+                current_blocker=blocker,
+            ),
             provider_diagnostics=diagnostics,
         )
     runtime_state, blocker, diagnostics = await _inspect_session(session, service)
@@ -489,6 +598,15 @@ async def ace_health(
         ace_count=1 if session is not None else 0,
         current_blocker=current_blocker,
         recovery_recommendation=_recovery_for("ace", project_id, current_blocker, ace_id),
+        operator_guidance=_operator_guidance_for(
+            role="ace",
+            project_id=project_id,
+            session_id=ace_id,
+            runtime_state=runtime_state,
+            delivery_state=delivery_state,
+            current_blocker=current_blocker,
+            ace_dispatch=ace_dispatch,
+        ),
         provider_diagnostics=diagnostics,
     )
 

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -322,6 +322,55 @@ class TestLeaderStart:
             cli(["leader", "start"])
 
 
+class TestLeaderHealth:
+    def test_health_summary_prints_operator_guidance(
+        self, api_stub: str, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        _StubHandler.response_body = {
+            "runtime_state": "blocked",
+            "delivery_state": "blocked",
+            "current_blocker": "prompt_not_submitted",
+            "kickoff_state": {
+                "kickoff_state": "blocked_on_provider_prompt",
+                "goal_acceptance_state": "unverified",
+            },
+            "task_graph_state": {
+                "total": 0,
+                "todo": 0,
+                "assigned": 0,
+                "in_progress": 0,
+                "done": 0,
+            },
+            "ace_dispatch": {"verified": 0, "blocked": 0, "unverified": 0},
+            "operator_guidance": {
+                "severity": "blocked",
+                "summary": "Kickoff prompt was not submitted to the provider.",
+                "recommended_action": "run_inspect_first_recovery",
+                "command": "atc leader recover --project-id proj-1 --dry-run",
+                "details": "Use dry-run first.",
+            },
+        }
+
+        rc = cli([
+            "leader",
+            "health",
+            "--project-id",
+            "proj-1",
+            "--summary",
+            "--api",
+            api_stub,
+        ])
+
+        assert rc == 0
+        req = _StubHandler.requests[0]
+        assert req["method"] == "GET"
+        assert req["path"] == "/api/projects/proj-1/leader/health"
+        output = capsys.readouterr().out
+        assert "Leader health: blocked" in output
+        assert "Recommended action: run_inspect_first_recovery" in output
+        assert "atc leader recover --project-id proj-1 --dry-run" in output
+
+
 class TestLeaderBootstrapTasks:
     def test_bootstrap_tasks_posts_decompose_specs(self, api_stub: str) -> None:
         rc = cli([

--- a/tests/unit/test_runtime_health.py
+++ b/tests/unit/test_runtime_health.py
@@ -140,6 +140,8 @@ async def test_leader_health_reports_runtime_and_task_summary(db) -> None:
     assert data["task_graph_state"]["total"] == 1
     assert data["ace_dispatch"]["verified"] == 1
     assert data["ace_count"] == 1
+    assert data["operator_guidance"]["severity"] == "ok"
+    assert data["operator_guidance"]["recommended_action"] == "none"
 
 
 @pytest.mark.asyncio
@@ -234,6 +236,8 @@ async def test_leader_health_surfaces_ace_blocker_without_tower_ace_inspection(d
     assert health.current_blocker == "ace_dispatch_failed"
     assert health.recovery_recommendation is not None
     assert health.recovery_recommendation["command"].startswith("atc leader recover")
+    assert health.operator_guidance["severity"] == "blocked"
+    assert health.operator_guidance["recommended_action"] == "inspect_runtime_blocker"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- add provider-neutral `operator_guidance` to Leader/Ace runtime health payloads so Tower/UI can show the actual health problem, blocker, and safe recovery command
- add `atc leader health --summary` for concise operator output instead of raw JSON
- surface Leader health guidance on the Project page with refresh and blocked-state recovery dry-run controls

## Provider separation
- health guidance is derived from provider-neutral runtime/kickoff/task/dispatch state
- provider-specific prompt text remains in diagnostics only
- recovery still goes through the existing provider/runtime recovery planner

## Evidence
- API/CLI evidence: `screenshots/loops-phase7-health-evidence.json`
- UI evidence: `screenshots/loops-phase7-2026-06-20T02-13-49-069Z/01-leader-health-guidance.png`
- Baseline smoke screenshots:
  - `screenshots/loops-phase7-2026-06-20T02-13-49-069Z/02-dashboard-baseline.png`
  - `screenshots/loops-phase7-2026-06-20T02-13-49-069Z/03-usage-baseline.png`

## Validation
- `./.venv/bin/python -m ruff check src/atc/runtime/health.py src/atc/cli/leader.py tests/unit/test_runtime_health.py tests/unit/test_cli.py`
- `./.venv/bin/python -m pytest tests/unit/test_runtime_health.py tests/unit/test_cli.py` → 50 passed, 1 warning
- `./.venv/bin/python -m pytest tests/unit/test_runtime_health.py tests/unit/test_cli.py tests/e2e/test_phase8_scenarios.py` → 59 passed, 1 warning
- `cd frontend && npm run build`
- `cd frontend && npx playwright test tests/e2e/dashboard-views.spec.ts tests/e2e/atc-qa.spec.ts --project=chromium --reporter=line` → 15 passed
