### PR TITLE
Align phase 9 documentation contracts

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -28,6 +28,9 @@ GET    /api/projects/{id}/manager             → Leader detail + task graph
 POST   /api/projects/{id}/leader/start        → start Leader session
 POST   /api/projects/{id}/leader/stop         → stop Leader session
 POST   /api/projects/{id}/leader/message      → send message to Leader
+POST   /api/projects/{id}/leader/report-active → Leader reports kickoff goal acceptance
+GET    /api/projects/{id}/leader/health       → provider-neutral Leader runtime/kickoff health
+POST   /api/projects/{id}/leader/recover      → inspect-first Leader recovery dry-run/apply
 ```
 
 ### Leader start kickoff truth
@@ -45,6 +48,27 @@ Important fields:
 - `kickoff_blocker_reason` / `kickoff_recovery_recommendation`: structured blocker and inspect-first recovery guidance when kickoff is blocked or unverified.
 
 `GET /api/projects/{id}/leader/health` exposes the same kickoff dimensions under `kickoff_state` alongside runtime, task graph, and recovery summaries.
+
+### Leader health and recovery
+
+`GET /api/projects/{id}/leader/health` is the canonical operator/Tower view for a Leader's runtime truth. Important top-level fields include:
+
+- `leader_state`: normalized health state for the Leader, such as healthy, unverified, blocked, or missing.
+- `runtime_state`: provider-neutral runtime state; product layers branch on this, not raw terminal text.
+- `delivery_state`: provider-neutral kickoff delivery state.
+- `blocker_reason`: stable blocker reason such as `pane_missing`, `runtime_trust_required`, `runtime_permission_required`, or `prompt_not_submitted`.
+- `recovery_recommendation`: concise safe next action for tooling.
+- `operator_guidance`: user-facing summary with severity, recommended action, command, and details.
+- `provider_diagnostics`: redacted nested provider details for debugging only; orchestration must not branch on provider-specific prompt strings.
+
+`POST /api/projects/{id}/leader/recover` plans or applies inspect-first recovery. Use dry-run before mutation. A typical operator flow is:
+
+```bash
+atc leader health --project-id <project-id> --summary
+atc leader recover --project-id <project-id> --dry-run
+```
+
+Recovery apply policies must remain explicit; pressing Enter or resending a persisted kickoff is not success until health/kickoff verification changes.
 
 ## Tasks / Task Graphs
 
@@ -71,6 +95,16 @@ Task graph responses keep `status` as a legacy product task-state field, but als
 `GET /api/tower/progress` keeps the legacy `todo`/`in_progress`/`done` task counters and adds separate `task_states`, `runtime_states`, `delivery_states`, `blocked`, and `dispatch_unverified` summaries. The progress endpoint therefore reports product progress and runtime truth as separate dimensions instead of collapsing assignment intent into "working".
 
 A task in `assigned` state is ownership intent only. UI/API consumers must not treat it as active Ace work unless `delivery_state`/`runtime_state` provide that evidence.
+
+First-class CLI helpers are thin wrappers over these REST contracts and are preferred for managed agents:
+
+```bash
+atc tasks create --project-id <project-id> --title "..." --description "..."
+atc tasks assign --project-id <project-id> --task-id <task-id>
+atc leader bootstrap-tasks --project-id <project-id> --goal "..." --task "..."
+```
+
+These commands return stable task/session identifiers plus task/runtime/delivery truth so Leaders do not need to inspect OpenAPI before creating or assigning normal task graphs.
 
 ## Aces
 

--- a/docs/agents/ACE.md
+++ b/docs/agents/ACE.md
@@ -33,6 +33,20 @@ Ace is expected to:
 - leave the workspace in a reviewable state
 - distinguish verified facts from assumptions
 
+## Runtime truth and evidence
+
+Ace should understand that assignment is not the same as verified execution. A task may be owned by an Ace while `dispatch_verified=false` until ATC has evidence that the assignment was delivered, submitted, and accepted or blocked.
+
+Ace reports should include enough evidence for Leader to update these provider-neutral fields:
+
+- `runtime_state`
+- `delivery_state`
+- `dispatch_verified`
+- `blocker_reason`
+- task-specific verification output
+
+If blocked by auth, trust, permissions, missing tools, or an unclear prompt, Ace should report the provider-neutral blocker upward. Leader owns recovery decisions and should use ATC health/recovery surfaces rather than asking the Ace to improvise provider-specific prompt handling.
+
 ## Must not do
 
 Ace must not:

--- a/docs/agents/LEADER.md
+++ b/docs/agents/LEADER.md
@@ -35,6 +35,26 @@ Leader is expected to:
 - update project plans when facts change
 - escalate unclear requirements, blocked dependencies, or unsafe actions to Tower
 
+## Task graph and API ergonomics
+
+Leader should use first-class ATC helpers for normal task graph work instead of starting by reading OpenAPI. In managed ATC workspaces, do not inspect OpenAPI as the first move for basic task creation or assignment.
+
+Preferred commands:
+
+```bash
+atc tasks create --project-id <project-id> --title "..." --description "..."
+atc tasks assign --project-id <project-id> --task-id <task-id>
+atc leader bootstrap-tasks --project-id <project-id> --goal "..." --task "..."
+```
+
+When the kickoff goal is accepted, Leader should call the canonical report-active path so Tower can distinguish goal acceptance from a mere session row:
+
+```text
+POST /api/projects/{project_id}/leader/report-active
+```
+
+Leader may inspect the local ATC API helper/capability files generated into the managed workspace for approved local API access. The local ATC API helper is restricted to the configured localhost base URL and allowlisted paths; external network or secret-bearing approval decisions remain outside Leader control.
+
 ## Must not do
 
 Leader must not:

--- a/docs/agents/TOWER.md
+++ b/docs/agents/TOWER.md
@@ -35,6 +35,22 @@ Tower is expected to:
 - enforce system-level constraints before allowing more work to start
 - keep state durable and inspectable
 
+## Runtime truth and recovery behavior
+
+Tower must treat Leader startup as unverified until provider-neutral evidence proves goal acceptance and actionable progress. A Leader session row is not proof that the Leader accepted the goal; neither are `queued`, `submitted`, `sent`, or a visible pane by themselves.
+
+Tower should monitor and display these neutral fields before entering normal low-frequency monitoring:
+
+- `kickoff_verified`
+- `kickoff_state.goal_acceptance_state`
+- `kickoff_state.task_graph_created_at`
+- `runtime_state`
+- `delivery_state`
+- `blocker_reason`
+- `operator_guidance`
+
+When a Leader is blocked, Tower should surface `operator_guidance` and run inspect-first recovery paths such as `atc leader health --project-id <project-id> --summary` and `atc leader recover --project-id <project-id> --dry-run`. Tower must not paste provider-specific key sequences or branch on raw provider prompt text; provider adapters/classifiers own those details and expose only provider-neutral blockers and recovery recommendations.
+
 ## Must not do
 
 Tower must not:

--- a/docs/leader_kickoff_recovery_plan.md
+++ b/docs/leader_kickoff_recovery_plan.md
@@ -350,6 +350,29 @@ Tower should not enter normal low-frequency monitoring until the Leader reaches 
 - Mac Studio Playwright changed-behavior and baseline smoke evidence is captured.
 - Post-merge validation is rerun from `main`.
 
+## Phase 9 — Contract/documentation convergence
+
+**Goal:** Make the durable API docs, role contracts, and validation tests match the runtime truth behavior implemented through Phase 8 so future agents do not regress to session-row or provider-prompt assumptions.
+
+### Work
+
+1. Update API docs for Leader health, report-active, and inspect-first recovery endpoints.
+2. Update Tower/Leader/Ace role contracts with the runtime truth responsibilities each role must follow.
+3. Document first-class task helpers and local ATC API helper expectations in the Leader-facing contract.
+4. Add documentation contract tests that fail if critical runtime truth fields, recovery commands, or role boundaries disappear from the docs.
+
+### Acceptance criteria
+
+- Docs and role contracts encode the same runtime truth rules as the code: normal monitoring still requires kickoff/task-graph truth rather than a session row.
+- Documentation contract tests pass and cover API, Tower, Leader, Ace, and the recovery plan.
+- Provider boundaries remain explicit: product docs refer to provider-neutral blockers/guidance; exact prompt strings and key sequences stay in adapters/classifiers.
+
+### Validation
+
+- Documentation contract tests pass with the targeted runtime/API/CLI suites.
+- Baseline UI smoke still passes, with screenshots attached to the PR when PR evidence exists.
+- Post-merge validation is rerun from `main`.
+
 ## Documentation requirements for every phase
 
 Every implementation PR for this plan must check and update the relevant docs before merge:

--- a/tests/e2e/test_phase8_scenarios.py
+++ b/tests/e2e/test_phase8_scenarios.py
@@ -40,6 +40,34 @@ from atc.runtime.tracing import (
 from atc.session.reconcile import reconcile_runtime_state
 from atc.state import db as db_ops
 
+
+async def _fake_create_ace_session(
+    conn,
+    project_id: str,
+    ace_name: str,
+    *,
+    task_id: str | None = None,
+    **_: object,
+) -> str:
+    """Create a DB Ace session without launching a provider process.
+
+    Scenario tests validate orchestration/runtime truth contracts; spawning real tmux
+    provider panes would make the suite depend on local descriptor/process limits.
+    """
+
+    session = await db_ops.create_session(
+        conn,
+        project_id,
+        "ace",
+        ace_name,
+        task_id=task_id,
+        status="waiting",
+        provider="codex",
+    )
+    await conn.commit()
+    return session.id
+
+
 if TYPE_CHECKING:
     from pathlib import Path
 
@@ -503,6 +531,10 @@ def test_tower_driven_project_flow_manages_leader_and_ace(client: TestClient) ->
                 trace_id="phase8-confirmed",
             ),
         ),
+        patch(
+            "atc.leader.orchestrator.create_ace",
+            new=_fake_create_ace_session,
+        ),
     ):
         start = client.post(
             f"/api/projects/{project['id']}/leader/start",
@@ -565,6 +597,10 @@ def test_blocked_ace_instruction_preserves_assignment_for_operator_resolution(
                 reason_code="trust_required",
                 trace_id="phase8-blocked",
             ),
+        ),
+        patch(
+            "atc.leader.orchestrator.create_ace",
+            new=_fake_create_ace_session,
         ),
     ):
         start = client.post(

--- a/tests/unit/test_documentation_contracts.py
+++ b/tests/unit/test_documentation_contracts.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+DOCS = ROOT / "docs"
+
+
+def read_doc(relative_path: str) -> str:
+    return (DOCS / relative_path).read_text(encoding="utf-8")
+
+
+def assert_contains_all(text: str, required: list[str]) -> None:
+    missing = [item for item in required if item not in text]
+    assert missing == []
+
+
+def test_api_docs_cover_leader_health_recovery_and_task_cli_contracts() -> None:
+    api = read_doc("API.md")
+
+    assert_contains_all(
+        api,
+        [
+            "GET    /api/projects/{id}/leader/health",
+            "POST   /api/projects/{id}/leader/recover",
+            "POST   /api/projects/{id}/leader/report-active",
+            "operator_guidance",
+            "leader_state",
+            "recovery_recommendation",
+            "provider_diagnostics",
+            "atc leader health --project-id",
+            "atc leader recover --project-id",
+            "atc tasks create --project-id",
+            "atc tasks assign --project-id",
+            "atc leader bootstrap-tasks --project-id",
+        ],
+    )
+
+
+def test_role_docs_encode_runtime_truth_and_provider_boundary() -> None:
+    tower = read_doc("agents/TOWER.md")
+    leader = read_doc("agents/LEADER.md")
+    ace = read_doc("agents/ACE.md")
+
+    assert_contains_all(
+        tower,
+        [
+            "kickoff_verified",
+            "operator_guidance",
+            "Leader session row is not proof",
+            "provider-neutral",
+            "Tower must not paste provider-specific key sequences",
+        ],
+    )
+    assert_contains_all(
+        leader,
+        [
+            "atc tasks create --project-id",
+            "atc tasks assign --project-id",
+            "atc leader bootstrap-tasks --project-id",
+            "report-active",
+            "local ATC API helper",
+            "do not inspect OpenAPI as the first move",
+        ],
+    )
+    assert_contains_all(
+        ace,
+        [
+            "dispatch_verified",
+            "runtime_state",
+            "delivery_state",
+            "Leader owns recovery decisions",
+            "provider-neutral blocker",
+        ],
+    )
+
+
+def test_leader_recovery_plan_has_phase9_doc_contract_status() -> None:
+    plan = read_doc("leader_kickoff_recovery_plan.md")
+
+    assert_contains_all(
+        plan,
+        [
+            "## Phase 9 — Contract/documentation convergence",
+            "Docs and role contracts encode the same runtime truth rules",
+            "Documentation contract tests pass",
+            "normal monitoring still requires kickoff/task-graph truth",
+        ],
+    )


### PR DESCRIPTION
## Summary
- add documentation contract tests that lock the Leader health/recovery API docs, role-contract runtime truth language, and Phase 9 recovery-plan status
- update API docs for Leader health/report-active/recover, operator guidance, provider diagnostics, inspect-first recovery, and first-class task CLI helpers
- update Tower/Leader/Ace role contracts with provider-neutral runtime truth responsibilities and helper guidance
- harden Phase 8 scenario tests to use DB-backed fake Ace sessions instead of launching real provider panes during scenario validation

## Validation
- `./.venv/bin/python -m ruff check tests/unit/test_documentation_contracts.py tests/e2e/test_phase8_scenarios.py tests/unit/test_runtime_health.py tests/unit/test_deploy.py tests/unit/test_cli.py docs/API.md docs/agents/TOWER.md docs/agents/LEADER.md docs/agents/ACE.md docs/leader_kickoff_recovery_plan.md`
- `./.venv/bin/python -m pytest tests/unit/test_documentation_contracts.py tests/e2e/test_phase8_scenarios.py tests/unit/test_runtime_health.py tests/unit/test_deploy.py tests/unit/test_cli.py` → 144 passed, 1 warning
- Live API/CLI/doc evidence artifact: `screenshots/loops-phase9-doc-contract-evidence.json`
- `cd frontend && npm run build`
- `cd frontend && npx playwright test tests/e2e/dashboard-views.spec.ts tests/e2e/atc-qa.spec.ts --project=chromium --reporter=line` → 15 passed

## Evidence screenshots
- `screenshots/loops-phase9-2026-06-20T03-23-11-135Z/01-dashboard-baseline.png`
- `screenshots/loops-phase9-2026-06-20T03-23-11-135Z/02-usage-baseline.png`

## Note
During validation the local `atc` tmux session contained hundreds of stale Codex panes from prior scenario runs and hit the macOS file-descriptor limit. I cleared that stale `atc` tmux session and then changed the scenario tests to avoid real provider pane launches for DB/API truth checks.
