### PR TITLE
Add Ace assignment acceptance reporting

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -111,10 +111,35 @@ These commands return stable task/session identifiers plus task/runtime/delivery
 ```
 GET    /api/projects/{id}/aces                → list ace sessions
 POST   /api/projects/{id}/aces                → spawn new ace
+GET    /api/projects/{id}/aces/{ace_id}/health → provider-neutral Ace runtime/assignment health
+POST   /api/projects/{id}/aces/{ace_id}/report-active → Ace reports assignment acceptance
+POST   /api/projects/{id}/aces/{ace_id}/recover → inspect-first Ace recovery dry-run/apply
 POST   /api/aces/{id}/start                   → start session
 POST   /api/aces/{id}/stop                    → stop session
 POST   /api/aces/{id}/message                 → send message to ace
 DELETE /api/aces/{id}                         → delete session
+```
+
+Leader → Ace handoff uses a separate assignment-acceptance truth contract so Leaders do not confuse session/assignment existence with active Ace work. `ace_dispatch.assignment_acceptance_state` distinguishes `queued_unverified`, `session_created`, `payload_written`, `submitted_pending_acceptance`, `awaiting_ace_active_report`, `assignment_accepted`, `accepted_active`, `blocked`, and `failed`.
+
+`POST /api/projects/{id}/aces/{ace_id}/report-active` records Ace-side acceptance evidence:
+
+```json
+{
+  "assignment_id": "optional-assignment-id",
+  "assignment_accepted": true,
+  "message": "accepted and working"
+}
+```
+
+The response includes `ace_reported_active`, `assignment_accepted`, `assignment_accepted_at`, `acceptance_message`, and the resulting `ace_dispatch` block. Leaders should treat `dispatch_verified=true` plus `assignment_accepted=true` as stronger evidence than delivery alone; delivery alone may remain `awaiting_ace_active_report`.
+
+CLI helpers:
+
+```bash
+atc ace health --project-id <project-id> --ace-id <ace-id>
+atc ace report-active --project-id <project-id> --ace-id <ace-id> --message "accepted task"
+atc ace recover --project-id <project-id> --ace-id <ace-id> --dry-run
 ```
 
 ## Tower

--- a/docs/agents/ACE.md
+++ b/docs/agents/ACE.md
@@ -42,8 +42,19 @@ Ace reports should include enough evidence for Leader to update these provider-n
 - `runtime_state`
 - `delivery_state`
 - `dispatch_verified`
+- `assignment_acceptance_state`
+- `ace_reported_active`
+- `assignment_accepted`
 - `blocker_reason`
 - task-specific verification output
+
+At the start of an assignment, Ace should explicitly report acceptance with:
+
+```bash
+atc ace report-active --project-id <project-id> --ace-id <ace-id> --message "accepted task"
+```
+
+This creates Ace-side evidence that the assignment was accepted. Without `assignment_accepted=true`, Leader should treat delivered prompts as `awaiting_ace_active_report` rather than verified active work.
 
 If blocked by auth, trust, permissions, missing tools, or an unclear prompt, Ace should report the provider-neutral blocker upward. Leader owns recovery decisions and should use ATC health/recovery surfaces rather than asking the Ace to improvise provider-specific prompt handling.
 

--- a/docs/agents/LEADER.md
+++ b/docs/agents/LEADER.md
@@ -47,6 +47,16 @@ atc tasks assign --project-id <project-id> --task-id <task-id>
 atc leader bootstrap-tasks --project-id <project-id> --goal "..." --task "..."
 ```
 
+When assigning work to Aces, Leader must distinguish `dispatch_verified` delivery from Ace-side assignment acceptance. Delivery alone means the provider received or started the prompt; it is not proof the Ace accepted task ownership. Leader should monitor `ace_dispatch.assignment_acceptance_state` from `atc ace health --project-id <project-id> --ace-id <ace-id>` and wait for `assignment_accepted` or `accepted_active` before treating the Ace as actively working.
+
+Ace-managed workspaces should call:
+
+```bash
+atc ace report-active --project-id <project-id> --ace-id <ace-id> --message "accepted task"
+```
+
+Leader should recover unaccepted assignments through `atc ace recover --project-id <project-id> --ace-id <ace-id> --dry-run` rather than assuming the Ace is working because a session row or assignment row exists.
+
 When the kickoff goal is accepted, Leader should call the canonical report-active path so Tower can distinguish goal acceptance from a mere session row:
 
 ```text

--- a/src/atc/agents/deploy.py
+++ b/src/atc/agents/deploy.py
@@ -456,6 +456,8 @@ def _build_ace_instructions_md(spec: AceDeploySpec) -> str:
             "Use the `atc` CLI to report status back to the ATC tower:",
             "",
             "```bash",
+            f'atc ace report-active --project-id "{spec.project_id or '<project-id>'}" '
+            f'--ace-id "{spec.session_id}" --message "accepted task"',
             f'atc ace status "{spec.session_id}" working   # when actively working',
             f'atc ace status "{spec.session_id}" waiting   # when idle/waiting',
             f'atc ace done "{spec.session_id}"              # when task is complete',

--- a/src/atc/api/routers/aces.py
+++ b/src/atc/api/routers/aces.py
@@ -64,6 +64,12 @@ class RecoveryRequest(BaseModel):
     policy: str = "inspect_first"
 
 
+class AceActiveReportRequest(BaseModel):
+    assignment_id: str | None = None
+    assignment_accepted: bool = True
+    message: str | None = None
+
+
 async def _require_project_ace(db, project_id: str, session_id: str):
     session = await db_ops.get_session(db, session_id)
     if session is None or session.project_id != project_id or session.session_type != "ace":
@@ -170,7 +176,6 @@ async def get_ace_health(
     request: Request,
 ) -> dict[str, object]:
     """Return provider-neutral Ace runtime/dispatch health."""
-
     db = await _get_db(request)
     project = await db_ops.get_project(db, project_id)
     if project is None:
@@ -178,6 +183,66 @@ async def get_ace_health(
     await _require_project_ace(db, project_id, session_id)
     health = await ace_health(db, project_id, session_id)
     return health.as_dict()
+
+
+@router.post("/projects/{project_id}/aces/{session_id}/report-active")
+async def report_ace_active(
+    project_id: str,
+    session_id: str,
+    body: AceActiveReportRequest,
+    request: Request,
+) -> dict[str, object]:
+    """Record Ace-side assignment acceptance before Leader treats work as active."""
+    db = await _get_db(request)
+    project = await db_ops.get_project(db, project_id)
+    if project is None:
+        raise HTTPException(status_code=404, detail="Project not found")
+    await _require_project_ace(db, project_id, session_id)
+    assignments = await db_ops.list_task_assignments(db, ace_session_id=session_id)
+    if body.assignment_id:
+        assignment = next((a for a in assignments if a.assignment_id == body.assignment_id), None)
+    else:
+        assignment = next((a for a in assignments if a.status in {"assigned", "working"}), None)
+    if assignment is None:
+        raise HTTPException(status_code=404, detail="Active Ace assignment not found")
+
+    report = await db_ops.report_ace_assignment_active(
+        db,
+        assignment.assignment_id,
+        accepted=body.assignment_accepted,
+        message=body.message,
+    )
+    if report is None:
+        raise HTTPException(status_code=404, detail="Ace assignment not found")
+    if body.assignment_accepted:
+        await db_ops.update_session_status(db, session_id, "working")
+    acceptance_state = "assignment_accepted" if report.assignment_accepted else "active_unaccepted"
+    dispatch = {
+        "assignment_id": report.assignment_id,
+        "task_graph_id": report.task_graph_id,
+        "assignment_status": report.status,
+        "dispatch_delivery_state": report.dispatch_delivery_state,
+        "dispatch_verified": report.dispatch_verified,
+        "assignment_acceptance_state": acceptance_state,
+        "ace_reported_active": report.ace_reported_active,
+        "assignment_accepted": report.assignment_accepted,
+        "assignment_accepted_at": report.assignment_accepted_at,
+        "acceptance_message": report.acceptance_message,
+        "first_work_observed_at": report.last_activity_at,
+        "assigned_task_id": report.assigned_task_id,
+        "blocker_reason": report.blocker_reason,
+    }
+    return {
+        "status": "accepted",
+        "project_id": project_id,
+        "ace_id": session_id,
+        "assignment_id": report.assignment_id,
+        "assignment_accepted": report.assignment_accepted,
+        "ace_reported_active": report.ace_reported_active,
+        "assignment_accepted_at": report.assignment_accepted_at,
+        "assignment_acceptance_state": dispatch.get("assignment_acceptance_state"),
+        "ace_dispatch": dispatch,
+    }
 
 
 @router.post("/projects/{project_id}/aces/{session_id}/recover")

--- a/src/atc/cli/ace.py
+++ b/src/atc/cli/ace.py
@@ -99,6 +99,26 @@ def register(subparsers: argparse._SubParsersAction) -> None:  # type: ignore[ty
     )
     list_parser.set_defaults(handler=_handle_list)
 
+    # atc ace report-active --project-id <id> --ace-id <id>
+    report_parser = ace_sub.add_parser(
+        "report-active", help="Report assignment acceptance / active work"
+    )
+    report_parser.add_argument("--project-id", required=True, help="Project UUID")
+    report_parser.add_argument("--ace-id", required=True, help="Ace session UUID")
+    report_parser.add_argument("--assignment-id", default=None, help="Assignment idempotency key")
+    report_parser.add_argument("--message", default=None, help="Acceptance/status message")
+    report_parser.add_argument(
+        "--not-accepted",
+        action="store_true",
+        help="Report active reachability but do not mark assignment accepted",
+    )
+    report_parser.add_argument(
+        "--api",
+        default=_DEFAULT_API,
+        help="ATC API base URL",
+    )
+    report_parser.set_defaults(handler=_handle_report_active)
+
     # atc ace health --project-id <id> --ace-id <id>
     health_parser = ace_sub.add_parser("health", help="Inspect Ace runtime/dispatch health")
     health_parser.add_argument("--project-id", required=True, help="Project UUID")
@@ -370,6 +390,19 @@ def _handle_memory_get(args: argparse.Namespace) -> int:
 
 def _handle_health(args: argparse.Namespace) -> int:
     return _api_get_json(f"{args.api}/api/projects/{args.project_id}/aces/{args.ace_id}/health")
+
+
+def _handle_report_active(args: argparse.Namespace) -> int:
+    payload = {
+        "assignment_accepted": not args.not_accepted,
+        "message": args.message,
+    }
+    if args.assignment_id:
+        payload["assignment_id"] = args.assignment_id
+    return _api_post_json(
+        f"{args.api}/api/projects/{args.project_id}/aces/{args.ace_id}/report-active",
+        payload,
+    )
 
 
 def _handle_recover(args: argparse.Namespace) -> int:

--- a/src/atc/runtime/health.py
+++ b/src/atc/runtime/health.py
@@ -161,6 +161,44 @@ def _leader_kickoff_health_state(
     return "working"
 
 
+def _ace_assignment_acceptance_state(
+    *,
+    has_assignment: bool,
+    dispatch_delivery_state: str,
+    dispatch_verified: bool,
+    ace_reported_active: bool,
+    assignment_accepted: bool,
+    blocker: str | None,
+    runtime_state: str,
+) -> str:
+    """Return provider-neutral Leader→Ace assignment acceptance state."""
+
+    if blocker:
+        return "blocked"
+    if not has_assignment:
+        return "not_assigned"
+    if runtime_state in {RuntimeState.MISSING.value, RuntimeState.STALE.value}:
+        return "runtime_missing"
+    if runtime_state == RuntimeState.FAILED.value:
+        return "failed"
+    if assignment_accepted and ace_reported_active and dispatch_verified:
+        return "accepted_active"
+    if assignment_accepted and ace_reported_active:
+        return "assignment_accepted"
+    if dispatch_delivery_state == DeliveryState.ACCEPTED_ACTIVE.value or dispatch_verified:
+        return "awaiting_ace_active_report"
+    if dispatch_delivery_state in {
+        DeliveryState.SUBMITTED_PENDING_ACCEPTANCE.value,
+        DeliveryState.SUBMIT_SENT.value,
+    }:
+        return "submitted_pending_acceptance"
+    if dispatch_delivery_state == DeliveryState.PAYLOAD_WRITTEN.value:
+        return "payload_written"
+    if dispatch_delivery_state == DeliveryState.RUNTIME_CREATED.value:
+        return "session_created"
+    return "queued_unverified"
+
+
 def _provider_details_from_diagnostics(diagnostics: dict[str, Any]) -> dict[str, Any]:
     details = diagnostics.get("details")
     return details if isinstance(details, dict) else {}
@@ -293,6 +331,22 @@ def _operator_guidance_for(
             "recommended_action": "bootstrap_or_wait_for_task_graph",
             "command": f"atc leader bootstrap-tasks --project-id {project_id}",
             "details": "A task graph is required before Ace dispatch truth can be verified.",
+        }
+    if role == "ace" and dispatch.get("assignment_acceptance_state") in {
+        "queued_unverified",
+        "payload_written",
+        "submitted_pending_acceptance",
+        "awaiting_ace_active_report",
+    }:
+        return {
+            "severity": "warning",
+            "summary": "Ace assignment is not yet accepted as active work.",
+            "recommended_action": "wait_for_ace_report_active_or_inspect_runtime",
+            "command": health_command,
+            "details": (
+                "Leader should not treat this Ace as working until assignment_accepted "
+                "or accepted_active evidence is visible."
+            ),
         }
     if int(dispatch.get("blocked") or 0) > 0 or int(dispatch.get("unverified") or 0) > 0:
         return {
@@ -557,14 +611,38 @@ async def ace_health(
     )
     assignment_blocker = active_assignment.blocker_reason if active_assignment else None
     current_blocker = blocker or assignment_blocker
+    dispatch_delivery_state = (
+        active_assignment.dispatch_delivery_state
+        if active_assignment
+        else DeliveryState.NOT_STARTED.value
+    )
+    assignment_acceptance_state = _ace_assignment_acceptance_state(
+        has_assignment=active_assignment is not None,
+        dispatch_delivery_state=dispatch_delivery_state,
+        dispatch_verified=active_assignment.dispatch_verified if active_assignment else False,
+        ace_reported_active=active_assignment.ace_reported_active if active_assignment else False,
+        assignment_accepted=active_assignment.assignment_accepted if active_assignment else False,
+        blocker=current_blocker,
+        runtime_state=runtime_state,
+    )
     ace_dispatch = {
         "assignment_id": active_assignment.assignment_id if active_assignment else None,
         "task_graph_id": active_assignment.task_graph_id if active_assignment else None,
         "assignment_status": active_assignment.status if active_assignment else None,
-        "dispatch_delivery_state": active_assignment.dispatch_delivery_state
-        if active_assignment
-        else DeliveryState.NOT_STARTED.value,
+        "dispatch_delivery_state": dispatch_delivery_state,
         "dispatch_verified": active_assignment.dispatch_verified if active_assignment else False,
+        "assignment_acceptance_state": assignment_acceptance_state,
+        "ace_reported_active": (
+            active_assignment.ace_reported_active if active_assignment else False
+        ),
+        "assignment_accepted": (
+            active_assignment.assignment_accepted if active_assignment else False
+        ),
+        "assignment_accepted_at": (
+            active_assignment.assignment_accepted_at if active_assignment else None
+        ),
+        "acceptance_message": active_assignment.acceptance_message if active_assignment else None,
+        "first_work_observed_at": active_assignment.last_activity_at if active_assignment else None,
         "assigned_task_id": active_assignment.assigned_task_id if active_assignment else None,
         "blocker_reason": assignment_blocker,
     }
@@ -574,7 +652,7 @@ async def ace_health(
         "assigned_ace_id": task.assigned_ace_id if task else None,
     }
     delivery_state = (
-        active_assignment.dispatch_delivery_state
+        dispatch_delivery_state
         if active_assignment is not None
         else _delivery_state_for_runtime(runtime_state)
     )

--- a/src/atc/state/db.py
+++ b/src/atc/state/db.py
@@ -474,6 +474,10 @@ CREATE TABLE IF NOT EXISTS task_assignments (
     status                  TEXT NOT NULL DEFAULT 'assigned',
     dispatch_delivery_state TEXT NOT NULL DEFAULT 'queued_unverified',
     dispatch_verified       INTEGER NOT NULL DEFAULT 0,
+    ace_reported_active     INTEGER NOT NULL DEFAULT 0,
+    assignment_accepted     INTEGER NOT NULL DEFAULT 0,
+    assignment_accepted_at  TEXT,
+    acceptance_message      TEXT,
     last_activity_at        TEXT,
     assigned_task_id        TEXT,
     blocker_reason          TEXT,
@@ -580,6 +584,10 @@ async def run_migrations(db_path: str) -> None:
         task_assignment_columns = {
             "dispatch_delivery_state": "TEXT NOT NULL DEFAULT 'queued_unverified'",
             "dispatch_verified": "INTEGER NOT NULL DEFAULT 0",
+            "ace_reported_active": "INTEGER NOT NULL DEFAULT 0",
+            "assignment_accepted": "INTEGER NOT NULL DEFAULT 0",
+            "assignment_accepted_at": "TEXT",
+            "acceptance_message": "TEXT",
             "last_activity_at": "TEXT",
             "assigned_task_id": "TEXT",
             "blocker_reason": "TEXT",
@@ -646,6 +654,23 @@ async def _apply_file_migrations(db: aiosqlite.Connection) -> None:
             ]
             if all(
                 [await _has_column(db, "task_assignments", column) for column in dispatch_columns]
+            ):
+                logger.info("Migration skip: %s already applied structurally", path.name)
+                await db.execute(
+                    "INSERT INTO schema_migrations (version, applied_at) VALUES (?, ?)",
+                    (path.name, _now()),
+                )
+                await db.commit()
+                continue
+        if path.name == "017_ace_assignment_acceptance.sql":
+            acceptance_columns = [
+                "ace_reported_active",
+                "assignment_accepted",
+                "assignment_accepted_at",
+                "acceptance_message",
+            ]
+            if all(
+                [await _has_column(db, "task_assignments", column) for column in acceptance_columns]
             ):
                 logger.info("Migration skip: %s already applied structurally", path.name)
                 await db.execute(
@@ -1285,8 +1310,9 @@ _ASSIGNMENT_TRANSITIONS: dict[str, set[str]] = {
 
 def _row_to_task_assignment(row: aiosqlite.Row) -> TaskAssignment:
     d = dict(row)
-    if "dispatch_verified" in d:
-        d["dispatch_verified"] = bool(d["dispatch_verified"])
+    for key in ("dispatch_verified", "ace_reported_active", "assignment_accepted"):
+        if key in d:
+            d[key] = bool(d[key])
     return TaskAssignment(**d)
 
 
@@ -1363,7 +1389,9 @@ async def assign_task(
         await db.execute(
             """UPDATE task_assignments
                SET ace_session_id = ?, status = ?, dispatch_delivery_state = ?,
-                   dispatch_verified = 0, last_activity_at = NULL,
+                   dispatch_verified = 0, ace_reported_active = 0,
+                   assignment_accepted = 0, assignment_accepted_at = NULL,
+                   acceptance_message = NULL, last_activity_at = NULL,
                    assigned_task_id = ?, blocker_reason = NULL, updated_at = ?
                WHERE assignment_id = ?""",
             (
@@ -1533,6 +1561,47 @@ async def update_task_assignment_dispatch(
     )
     await db.commit()
     return await get_task_assignment(db, assignment_id)
+
+
+async def report_ace_assignment_active(
+    db: aiosqlite.Connection,
+    assignment_id: str,
+    *,
+    accepted: bool = True,
+    message: str | None = None,
+    last_activity: bool = True,
+) -> TaskAssignment | None:
+    """Record provider-neutral Ace assignment acceptance reported by the Ace."""
+
+    existing = await get_task_assignment(db, assignment_id)
+    if existing is None:
+        return None
+    now = _now()
+    last_activity_at = now if last_activity else existing.last_activity_at
+    accepted_at = now if accepted else existing.assignment_accepted_at
+    await db.execute(
+        """UPDATE task_assignments
+           SET ace_reported_active = 1,
+               assignment_accepted = ?, assignment_accepted_at = ?,
+               acceptance_message = ?, last_activity_at = ?,
+               blocker_reason = NULL, updated_at = ?
+           WHERE assignment_id = ?""",
+        (
+            1 if accepted else 0,
+            accepted_at,
+            message,
+            last_activity_at,
+            now,
+            assignment_id,
+        ),
+    )
+    await db.commit()
+    return await get_task_assignment(db, assignment_id)
+
+
+# ---------------------------------------------------------------------------
+# Heartbeat CRUD
+# ---------------------------------------------------------------------------
 
 
 async def register_heartbeat(

--- a/src/atc/state/migrations/versions/017_ace_assignment_acceptance.sql
+++ b/src/atc/state/migrations/versions/017_ace_assignment_acceptance.sql
@@ -1,0 +1,16 @@
+-- Phase 10: Ace assignment acceptance truth.
+--
+-- Adds provider-neutral evidence reported by the Ace itself so Leader→Ace
+-- handoff can distinguish assignment/session existence from assignment acceptance.
+
+ALTER TABLE task_assignments
+    ADD COLUMN ace_reported_active INTEGER NOT NULL DEFAULT 0;
+
+ALTER TABLE task_assignments
+    ADD COLUMN assignment_accepted INTEGER NOT NULL DEFAULT 0;
+
+ALTER TABLE task_assignments
+    ADD COLUMN assignment_accepted_at TEXT;
+
+ALTER TABLE task_assignments
+    ADD COLUMN acceptance_message TEXT;

--- a/src/atc/state/models.py
+++ b/src/atc/state/models.py
@@ -240,6 +240,10 @@ class TaskAssignment:
     status: str = "assigned"  # assigned|working|done|failed
     dispatch_delivery_state: str = "queued_unverified"
     dispatch_verified: bool = False
+    ace_reported_active: bool = False
+    assignment_accepted: bool = False
+    assignment_accepted_at: str | None = None
+    acceptance_message: str | None = None
     last_activity_at: str | None = None
     assigned_task_id: str | None = None
     blocker_reason: str | None = None

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -494,3 +494,61 @@ class TestAceList:
         req = _StubHandler.requests[0]
         assert req["method"] == "GET"
         assert req["path"] == "/api/projects/proj-1/aces"
+
+
+# ---------------------------------------------------------------------------
+# atc ace report-active
+# ---------------------------------------------------------------------------
+
+
+class TestAceReportActive:
+    def test_reports_assignment_acceptance(self, api_stub: str) -> None:
+        _StubHandler.response_body = {
+            "status": "accepted",
+            "assignment_acceptance_state": "assignment_accepted",
+        }
+        rc = cli(
+            [
+                "ace",
+                "report-active",
+                "--project-id",
+                "proj-1",
+                "--ace-id",
+                "ace-1",
+                "--assignment-id",
+                "assign-1",
+                "--message",
+                "accepted task",
+                "--api",
+                api_stub,
+            ]
+        )
+        assert rc == 0
+        req = _StubHandler.requests[0]
+        assert req["method"] == "POST"
+        assert req["path"] == "/api/projects/proj-1/aces/ace-1/report-active"
+        assert req["body"] == {
+            "assignment_id": "assign-1",
+            "assignment_accepted": True,
+            "message": "accepted task",
+        }
+
+    def test_can_report_active_without_acceptance(self, api_stub: str) -> None:
+        rc = cli(
+            [
+                "ace",
+                "report-active",
+                "--project-id",
+                "proj-1",
+                "--ace-id",
+                "ace-1",
+                "--not-accepted",
+                "--api",
+                api_stub,
+            ]
+        )
+        assert rc == 0
+        assert _StubHandler.requests[0]["body"] == {
+            "assignment_accepted": False,
+            "message": None,
+        }

--- a/tests/unit/test_documentation_contracts.py
+++ b/tests/unit/test_documentation_contracts.py
@@ -33,6 +33,10 @@ def test_api_docs_cover_leader_health_recovery_and_task_cli_contracts() -> None:
             "atc tasks create --project-id",
             "atc tasks assign --project-id",
             "atc leader bootstrap-tasks --project-id",
+            "GET    /api/projects/{id}/aces/{ace_id}/health",
+            "POST   /api/projects/{id}/aces/{ace_id}/report-active",
+            "assignment_acceptance_state",
+            "atc ace report-active --project-id",
         ],
     )
 
@@ -61,6 +65,9 @@ def test_role_docs_encode_runtime_truth_and_provider_boundary() -> None:
             "report-active",
             "local ATC API helper",
             "do not inspect OpenAPI as the first move",
+            "assignment_acceptance_state",
+            "atc ace report-active --project-id",
+            "session row or assignment row exists",
         ],
     )
     assert_contains_all(
@@ -69,6 +76,10 @@ def test_role_docs_encode_runtime_truth_and_provider_boundary() -> None:
             "dispatch_verified",
             "runtime_state",
             "delivery_state",
+            "assignment_acceptance_state",
+            "ace_reported_active",
+            "assignment_accepted",
+            "awaiting_ace_active_report",
             "Leader owns recovery decisions",
             "provider-neutral blocker",
         ],

--- a/tests/unit/test_runtime_health.py
+++ b/tests/unit/test_runtime_health.py
@@ -8,8 +8,13 @@ from unittest.mock import MagicMock
 import pytest
 from fastapi import HTTPException
 
+from atc.api.routers.aces import (
+    AceActiveReportRequest,
+    get_ace_health,
+    recover_ace,
+    report_ace_active,
+)
 from atc.api.routers.aces import RecoveryRequest as AceRecoveryRequest
-from atc.api.routers.aces import get_ace_health, recover_ace
 from atc.api.routers.projects import RecoveryRequest as LeaderRecoveryRequest
 from atc.api.routers.projects import get_leader_health, recover_leader
 from atc.runtime.health import (
@@ -183,6 +188,103 @@ async def test_ace_health_reports_blocked_dispatch_separately(db) -> None:
     assert data["ace_dispatch"]["dispatch_delivery_state"] == "blocked"
     assert data["ace_dispatch"]["dispatch_verified"] is False
     assert data["current_blocker"] == "unknown_prompt_blocker"
+
+
+@pytest.mark.asyncio
+async def test_ace_report_active_records_assignment_acceptance_and_health(db) -> None:
+    project = await create_project(db, "ace-report-active-proj")
+    task = await create_task_graph(db, project.id, "Task one")
+    ace = await create_session(db, project.id, "ace", "ace-one", status="waiting", task_id=task.id)
+    await db.execute(
+        "UPDATE sessions SET tmux_pane = ?, tmux_session = ? WHERE id = ?",
+        ("%10", "atc", ace.id),
+    )
+    assignment, _ = await assign_task(db, task.id, ace.id, f"ace:{task.id}")
+    await update_task_assignment_dispatch(
+        db,
+        assignment.assignment_id,
+        dispatch_delivery_state="accepted_active",
+        dispatch_verified=True,
+        last_activity=True,
+    )
+
+    result = await report_ace_active(
+        project.id,
+        ace.id,
+        AceActiveReportRequest(
+            assignment_id=assignment.assignment_id,
+            message="accepted and working",
+        ),
+        _request(db),
+    )
+
+    assert result["assignment_accepted"] is True
+    assert result["ace_reported_active"] is True
+    assert result["assignment_acceptance_state"] == "assignment_accepted"
+    updated_session = await get_session(db, ace.id)
+    assert updated_session is not None
+    assert updated_session.status == "working"
+
+    health = await ace_health(
+        db,
+        project.id,
+        ace.id,
+        runtime_service=FakeRuntimeService(
+            RuntimeInspection(
+                session_id=ace.id,
+                provider_name="codex",
+                alive=True,
+                readiness=ReadinessState.BUSY,
+                summary="working",
+            )
+        ),
+    )
+    dispatch = health.as_dict()["ace_dispatch"]
+    assert dispatch["assignment_acceptance_state"] == "accepted_active"
+    assert dispatch["assignment_accepted"] is True
+    assert dispatch["ace_reported_active"] is True
+    assert dispatch["acceptance_message"] == "accepted and working"
+    assert health.operator_guidance["severity"] == "ok"
+
+
+@pytest.mark.asyncio
+async def test_ace_health_warns_when_delivery_active_but_ace_has_not_reported(db) -> None:
+    project = await create_project(db, "ace-waiting-report-proj")
+    task = await create_task_graph(db, project.id, "Task one")
+    ace = await create_session(db, project.id, "ace", "ace-one", status="working", task_id=task.id)
+    await db.execute(
+        "UPDATE sessions SET tmux_pane = ?, tmux_session = ? WHERE id = ?",
+        ("%11", "atc", ace.id),
+    )
+    assignment, _ = await assign_task(db, task.id, ace.id, f"ace:{task.id}")
+    await update_task_assignment_dispatch(
+        db,
+        assignment.assignment_id,
+        dispatch_delivery_state="accepted_active",
+        dispatch_verified=True,
+        last_activity=True,
+    )
+
+    health = await ace_health(
+        db,
+        project.id,
+        ace.id,
+        runtime_service=FakeRuntimeService(
+            RuntimeInspection(
+                session_id=ace.id,
+                provider_name="codex",
+                alive=True,
+                readiness=ReadinessState.BUSY,
+                summary="working",
+            )
+        ),
+    )
+
+    assert health.ace_dispatch["assignment_acceptance_state"] == "awaiting_ace_active_report"
+    assert health.operator_guidance["severity"] == "warning"
+    assert health.operator_guidance["recommended_action"] == (
+        "wait_for_ace_report_active_or_inspect_runtime"
+    )
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- add Ace-side `report-active` API/CLI contract so Leader→Ace handoff distinguishes assignment/session existence from assignment acceptance
- persist Ace assignment acceptance evidence (`ace_reported_active`, `assignment_accepted`, acceptance timestamp/message) and surface it through Ace health
- update Ace deployed instructions and role/API docs so Aces report acceptance and Leaders wait for `assignment_accepted`/`accepted_active` before treating work as active
- add regression coverage for the new API, CLI, health state, docs contracts, migrations, and existing task graph behavior

## Validation
- `./.venv/bin/python -m ruff check src/atc/state/models.py src/atc/state/db.py src/atc/runtime/health.py src/atc/api/routers/aces.py src/atc/cli/ace.py src/atc/agents/deploy.py tests/unit/test_runtime_health.py tests/unit/test_cli.py tests/unit/test_documentation_contracts.py`
- `./.venv/bin/python -m pytest tests/unit/test_runtime_health.py tests/unit/test_cli.py tests/unit/test_documentation_contracts.py tests/unit/test_deploy.py tests/unit/test_task_graphs.py` → `183 passed, 1 warning`
- `./.venv/bin/python -m pytest tests/e2e/test_task_graph_api.py tests/e2e/test_phase8_scenarios.py tests/unit/test_leader_orchestrator.py tests/unit/test_ace_dispatch.py` → `77 passed, 1 warning`
- Live API/CLI evidence captured in `screenshots/loops-phase10-ace-acceptance-evidence.json`
- `cd frontend && npm run build`
- `cd frontend && npx playwright test tests/e2e/dashboard-views.spec.ts tests/e2e/atc-qa.spec.ts --project=chromium --reporter=line` → `15 passed`

## Evidence
- API/CLI evidence: `screenshots/loops-phase10-ace-acceptance-evidence.json`
- UI baseline screenshots: `screenshots/loops-phase10-2026-06-20T04-19-35-592Z/`

## Provider boundary
- The new contract remains provider-neutral: Ace acceptance is recorded through ATC API/CLI and health surfaces; provider-specific runtime prompts remain in runtime diagnostics/recovery classifiers.
