### PR TITLE
Phase 11: Ace startup readiness and artifact routing parity

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -113,6 +113,7 @@ GET    /api/projects/{id}/aces                → list ace sessions
 POST   /api/projects/{id}/aces                → spawn new ace
 GET    /api/projects/{id}/aces/{ace_id}/health → provider-neutral Ace runtime/assignment health
 POST   /api/projects/{id}/aces/{ace_id}/report-active → Ace reports assignment acceptance
+POST   /api/projects/{id}/aces/{ace_id}/report-artifact → Ace reports canonical artifact/worktree path
 POST   /api/projects/{id}/aces/{ace_id}/recover → inspect-first Ace recovery dry-run/apply
 POST   /api/aces/{id}/start                   → start session
 POST   /api/aces/{id}/stop                    → stop session
@@ -120,7 +121,7 @@ POST   /api/aces/{id}/message                 → send message to ace
 DELETE /api/aces/{id}                         → delete session
 ```
 
-Leader → Ace handoff uses a separate assignment-acceptance truth contract so Leaders do not confuse session/assignment existence with active Ace work. `ace_dispatch.assignment_acceptance_state` distinguishes `queued_unverified`, `session_created`, `payload_written`, `submitted_pending_acceptance`, `awaiting_ace_active_report`, `assignment_accepted`, `accepted_active`, `blocked`, and `failed`.
+Leader → Ace handoff uses a separate startup-readiness, assignment-acceptance, and artifact-routing truth contract so Leaders do not confuse session/assignment existence with active Ace work. `ace_dispatch.startup_readiness_state` distinguishes `startup_handshake_pending`, `awaiting_startup_confirmation`, `blocked_on_provider_startup_prompt`, `input_ready`, `runtime_missing`, and `startup_handshake_failed`. `ace_dispatch.assignment_acceptance_state` distinguishes `queued_unverified`, `session_created`, `payload_written`, `submitted_pending_acceptance`, `awaiting_ace_active_report`, `assignment_accepted`, `accepted_active`, `blocked`, and `failed`.
 
 `POST /api/projects/{id}/aces/{ace_id}/report-active` records Ace-side acceptance evidence:
 
@@ -134,11 +135,25 @@ Leader → Ace handoff uses a separate assignment-acceptance truth contract so L
 
 The response includes `ace_reported_active`, `assignment_accepted`, `assignment_accepted_at`, `acceptance_message`, and the resulting `ace_dispatch` block. Leaders should treat `dispatch_verified=true` plus `assignment_accepted=true` as stronger evidence than delivery alone; delivery alone may remain `awaiting_ace_active_report`.
 
+`POST /api/projects/{id}/aces/{ace_id}/report-artifact` records canonical artifact routing evidence so verification Aces do not search isolated sibling worktrees:
+
+```json
+{
+  "assignment_id": "optional-assignment-id",
+  "artifact_path": "/absolute/worktree-or-build-output",
+  "artifact_kind": "worktree",
+  "ready": true
+}
+```
+
+Leader progress and Ace health expose `artifact_ready`, `artifact_path`, `artifact_kind`, `artifact_reported_at`, `last_provider_activity_at`, and `last_ace_report_at` separately from task lifecycle status.
+
 CLI helpers:
 
 ```bash
 atc ace health --project-id <project-id> --ace-id <ace-id>
 atc ace report-active --project-id <project-id> --ace-id <ace-id> --message "accepted task"
+atc ace report-artifact --project-id <project-id> --ace-id <ace-id> --path /absolute/output --kind worktree
 atc ace recover --project-id <project-id> --ace-id <ace-id> --dry-run
 ```
 

--- a/docs/agents/ACE.md
+++ b/docs/agents/ACE.md
@@ -39,19 +39,24 @@ Ace should understand that assignment is not the same as verified execution. A t
 
 Ace reports should include enough evidence for Leader to update these provider-neutral fields:
 
+- `startup_readiness_state`
 - `runtime_state`
 - `delivery_state`
 - `dispatch_verified`
 - `assignment_acceptance_state`
 - `ace_reported_active`
 - `assignment_accepted`
+- `artifact_ready`
+- `artifact_path`
 - `blocker_reason`
-- task-specific verification output
+- task-specific verification notes
+
 
 At the start of an assignment, Ace should explicitly report acceptance with:
 
 ```bash
 atc ace report-active --project-id <project-id> --ace-id <ace-id> --message "accepted task"
+atc ace report-artifact --project-id <project-id> --ace-id <ace-id> --path /absolute/output --kind worktree
 ```
 
 This creates Ace-side evidence that the assignment was accepted. Without `assignment_accepted=true`, Leader should treat delivered prompts as `awaiting_ace_active_report` rather than verified active work.

--- a/docs/agents/LEADER.md
+++ b/docs/agents/LEADER.md
@@ -47,12 +47,13 @@ atc tasks assign --project-id <project-id> --task-id <task-id>
 atc leader bootstrap-tasks --project-id <project-id> --goal "..." --task "..."
 ```
 
-When assigning work to Aces, Leader must distinguish `dispatch_verified` delivery from Ace-side assignment acceptance. Delivery alone means the provider received or started the prompt; it is not proof the Ace accepted task ownership. Leader should monitor `ace_dispatch.assignment_acceptance_state` from `atc ace health --project-id <project-id> --ace-id <ace-id>` and wait for `assignment_accepted` or `accepted_active` before treating the Ace as actively working.
+When assigning work to Aces, Leader must distinguish startup readiness, delivery, Ace-side assignment acceptance, and artifact routing. Delivery alone means the provider received or started the prompt; it is not proof the Ace accepted task ownership. Leader should monitor `ace_dispatch.startup_readiness_state` from `atc ace health --project-id <project-id> --ace-id <ace-id>` and wait for `input_ready` before relying on assignment delivery. Startup blockers such as `awaiting_startup_confirmation` and `blocked_on_provider_startup_prompt` are provider-neutral states; Codex/Claude prompt text and key sequences stay inside provider adapters. Leader should then monitor `ace_dispatch.assignment_acceptance_state` and wait for `assignment_accepted` or `accepted_active` before treating the Ace as actively working.
 
 Ace-managed workspaces should call:
 
 ```bash
 atc ace report-active --project-id <project-id> --ace-id <ace-id> --message "accepted task"
+atc ace report-artifact --project-id <project-id> --ace-id <ace-id> --path /absolute/output --kind worktree
 ```
 
 Leader should recover unaccepted assignments through `atc ace recover --project-id <project-id> --ace-id <ace-id> --dry-run` rather than assuming the Ace is working because a session row or assignment row exists.

--- a/src/atc/agents/deploy.py
+++ b/src/atc/agents/deploy.py
@@ -458,6 +458,8 @@ def _build_ace_instructions_md(spec: AceDeploySpec) -> str:
             "```bash",
             f'atc ace report-active --project-id "{spec.project_id or '<project-id>'}" '
             f'--ace-id "{spec.session_id}" --message "accepted task"',
+            f'atc ace report-artifact --project-id "{spec.project_id or '<project-id>'}" '
+            f'--ace-id "{spec.session_id}" --path "$PWD" --kind worktree  # when output path ready',
             f'atc ace status "{spec.session_id}" working   # when actively working',
             f'atc ace status "{spec.session_id}" waiting   # when idle/waiting',
             f'atc ace done "{spec.session_id}"              # when task is complete',

--- a/src/atc/api/routers/aces.py
+++ b/src/atc/api/routers/aces.py
@@ -70,6 +70,13 @@ class AceActiveReportRequest(BaseModel):
     message: str | None = None
 
 
+class AceArtifactReportRequest(BaseModel):
+    assignment_id: str | None = None
+    artifact_path: str
+    artifact_kind: str = "build_output"
+    ready: bool = True
+
+
 async def _require_project_ace(db, project_id: str, session_id: str):
     session = await db_ops.get_session(db, session_id)
     if session is None or session.project_id != project_id or session.session_type != "ace":
@@ -242,6 +249,51 @@ async def report_ace_active(
         "assignment_accepted_at": report.assignment_accepted_at,
         "assignment_acceptance_state": dispatch.get("assignment_acceptance_state"),
         "ace_dispatch": dispatch,
+    }
+
+
+@router.post("/projects/{project_id}/aces/{session_id}/report-artifact")
+async def report_ace_artifact(
+    project_id: str,
+    session_id: str,
+    body: AceArtifactReportRequest,
+    request: Request,
+) -> dict[str, object]:
+    """Record a canonical artifact path produced by an Ace assignment."""
+    db = await _get_db(request)
+    project = await db_ops.get_project(db, project_id)
+    if project is None:
+        raise HTTPException(status_code=404, detail="Project not found")
+    await _require_project_ace(db, project_id, session_id)
+    assignments = await db_ops.list_task_assignments(db, ace_session_id=session_id)
+    if body.assignment_id:
+        assignment = next((a for a in assignments if a.assignment_id == body.assignment_id), None)
+    else:
+        assignment = next(
+            (a for a in assignments if a.status in {"assigned", "working", "done"}),
+            None,
+        )
+    if assignment is None:
+        raise HTTPException(status_code=404, detail="Ace assignment not found")
+    report = await db_ops.report_task_assignment_artifact(
+        db,
+        assignment.assignment_id,
+        artifact_path=body.artifact_path,
+        artifact_kind=body.artifact_kind,
+        ready=body.ready,
+    )
+    if report is None:
+        raise HTTPException(status_code=404, detail="Ace assignment not found")
+    return {
+        "status": "artifact_ready" if report.artifact_ready else "artifact_reported",
+        "project_id": project_id,
+        "ace_id": session_id,
+        "assignment_id": report.assignment_id,
+        "task_graph_id": report.task_graph_id,
+        "artifact_path": report.artifact_path,
+        "artifact_kind": report.artifact_kind,
+        "artifact_ready": report.artifact_ready,
+        "artifact_reported_at": report.artifact_reported_at,
     }
 
 

--- a/src/atc/cli/ace.py
+++ b/src/atc/cli/ace.py
@@ -24,6 +24,7 @@ _DEFAULT_API = "http://127.0.0.1:8420"
 def register(subparsers: argparse._SubParsersAction) -> None:  # type: ignore[type-arg]
     """Register the ``ace`` command group."""
     ace_parser = subparsers.add_parser("ace", help="Ace session commands")
+    ace_parser.set_defaults(handler=lambda _: ace_parser.print_help() or 1)
     ace_sub = ace_parser.add_subparsers(dest="ace_command")
 
     # atc ace status <session_id> <status>
@@ -119,6 +120,26 @@ def register(subparsers: argparse._SubParsersAction) -> None:  # type: ignore[ty
     )
     report_parser.set_defaults(handler=_handle_report_active)
 
+    artifact_parser = ace_sub.add_parser(
+        "report-artifact", help="Report canonical artifact path for an assignment"
+    )
+    artifact_parser.add_argument("--project-id", required=True, help="Project UUID")
+    artifact_parser.add_argument("--ace-id", required=True, help="Ace session UUID")
+    artifact_parser.add_argument("--assignment-id", default=None, help="Assignment idempotency key")
+    artifact_parser.add_argument("--path", required=True, help="Canonical artifact path")
+    artifact_parser.add_argument("--kind", default="build_output", help="Artifact kind")
+    artifact_parser.add_argument(
+        "--not-ready",
+        action="store_true",
+        help="Report artifact path without marking it ready",
+    )
+    artifact_parser.add_argument(
+        "--api",
+        default=_DEFAULT_API,
+        help="ATC API base URL",
+    )
+    artifact_parser.set_defaults(handler=_handle_report_artifact)
+
     # atc ace health --project-id <id> --ace-id <id>
     health_parser = ace_sub.add_parser("health", help="Inspect Ace runtime/dispatch health")
     health_parser.add_argument("--project-id", required=True, help="Project UUID")
@@ -179,8 +200,6 @@ def register(subparsers: argparse._SubParsersAction) -> None:  # type: ignore[ty
     mem_get_parser.set_defaults(handler=_handle_memory_get)
 
     memory_parser.set_defaults(handler=lambda _: memory_parser.print_help() or 1)
-
-    ace_parser.set_defaults(handler=lambda _: ace_parser.print_help() or 1)
 
 
 def _api_get_json(url: str) -> int:
@@ -401,6 +420,20 @@ def _handle_report_active(args: argparse.Namespace) -> int:
         payload["assignment_id"] = args.assignment_id
     return _api_post_json(
         f"{args.api}/api/projects/{args.project_id}/aces/{args.ace_id}/report-active",
+        payload,
+    )
+
+
+def _handle_report_artifact(args: argparse.Namespace) -> int:
+    payload = {
+        "artifact_path": args.path,
+        "artifact_kind": args.kind,
+        "ready": not args.not_ready,
+    }
+    if args.assignment_id:
+        payload["assignment_id"] = args.assignment_id
+    return _api_post_json(
+        f"{args.api}/api/projects/{args.project_id}/aces/{args.ace_id}/report-artifact",
         payload,
     )
 

--- a/src/atc/leader/orchestrator.py
+++ b/src/atc/leader/orchestrator.py
@@ -64,8 +64,16 @@ class AceAssignment:
     task_title: str
     assignment_id: str = ""  # idempotency key for assign_task
     status: str = "assigned"  # assigned|working|done|failed
+    startup_readiness_state: str = "startup_handshake_pending"
     dispatch_delivery_state: str = "queued_unverified"
     dispatch_verified: bool = False
+    ace_reported_active: bool = False
+    assignment_accepted: bool = False
+    assignment_accepted_at: str | None = None
+    artifact_ready: bool = False
+    artifact_path: str | None = None
+    artifact_kind: str | None = None
+    artifact_reported_at: str | None = None
     blocker_reason: str | None = None
     last_activity_at: str | None = None
     deployed_root: Path | None = None  # staging dir for cleanup
@@ -372,6 +380,36 @@ class LeaderOrchestrator:
 
         return assignment
 
+    async def _artifact_context_for_task(self, task_graph_id: str) -> str:
+        """Return dependency artifact paths that should be routed to this task."""
+
+        task = await db_ops.get_task_graph(self.conn, task_graph_id)
+        dependencies = getattr(task, "dependencies", None) if task is not None else None
+        if not dependencies:
+            return ""
+        assignments = await db_ops.list_task_assignments(self.conn)
+        dependency_artifacts = [
+            a
+            for a in assignments
+            if a.task_graph_id in dependencies and a.artifact_ready and a.artifact_path
+        ]
+        if not dependency_artifacts:
+            return ""
+        lines = [
+            "Dependency artifact routing:",
+            (
+                "Use these canonical paths from completed dependency tasks instead "
+                "of searching sibling worktrees."
+            ),
+        ]
+        for artifact in dependency_artifacts:
+            lines.append(
+                f"- task_graph_id={artifact.task_graph_id} "
+                f"kind={artifact.artifact_kind or 'artifact'} "
+                f"path={artifact.artifact_path}"
+            )
+        return "\n".join(lines)
+
     async def send_instruction_to_ace(
         self,
         task_graph_id: str,
@@ -382,6 +420,10 @@ class LeaderOrchestrator:
         if assignment is None:
             raise ValueError(f"No Ace assigned to task graph {task_graph_id}")
 
+        artifact_context = await self._artifact_context_for_task(task_graph_id)
+        if artifact_context:
+            instruction = f"{instruction}\n\n{artifact_context}"
+
         result = await start_ace(
             self.conn,
             assignment.ace_session_id,
@@ -391,9 +433,21 @@ class LeaderOrchestrator:
         verification = verify_ace_dispatch_delivery(result, task_graph_id=task_graph_id)
         assignment.dispatch_delivery_state = verification.dispatch_delivery_state
         assignment.dispatch_verified = verification.dispatch_verified
+        assignment.startup_readiness_state = str(
+            result.details.get("startup_readiness_state")
+            or result.details.get("startup_state")
+            or getattr(assignment, "startup_readiness_state", "startup_handshake_pending")
+        )
         assignment.blocker_reason = verification.blocker_reason
 
         if assignment.assignment_id:
+            await db_ops.update_task_assignment_startup_readiness(
+                self.conn,
+                assignment.assignment_id,
+                startup_readiness_state=assignment.startup_readiness_state,
+                blocker_reason=verification.blocker_reason,
+                last_activity=False,
+            )
             persisted_assignment = await db_ops.update_task_assignment_dispatch(
                 self.conn,
                 assignment.assignment_id,
@@ -669,24 +723,59 @@ class LeaderOrchestrator:
         )
 
         status = get_completion_status(task_graphs)
+        persisted_assignments = await db_ops.list_task_assignments(self.conn)
+        assignment_rows = persisted_assignments or list(self.assignments.values())
         status["assignments"] = [
             {
                 "task_graph_id": a.task_graph_id,
                 "ace_session_id": a.ace_session_id,
-                "task_title": a.task_title,
+                "task_title": getattr(a, "task_title", None),
                 "status": a.status,
+                "startup_readiness_state": getattr(
+                    a, "startup_readiness_state", "startup_handshake_pending"
+                ),
                 "dispatch_delivery_state": a.dispatch_delivery_state,
                 "dispatch_verified": a.dispatch_verified,
+                "assignment_acceptance_state": self._assignment_acceptance_state(a),
+                "ace_reported_active": getattr(a, "ace_reported_active", False),
+                "assignment_accepted": getattr(a, "assignment_accepted", False),
+                "assignment_accepted_at": getattr(a, "assignment_accepted_at", None),
+                "artifact_ready": getattr(a, "artifact_ready", False),
+                "artifact_path": getattr(a, "artifact_path", None),
+                "artifact_kind": getattr(a, "artifact_kind", None),
+                "artifact_reported_at": getattr(a, "artifact_reported_at", None),
                 "blocker_reason": a.blocker_reason,
                 "last_activity_at": a.last_activity_at,
+                "last_provider_activity_at": a.last_activity_at,
+                "last_ace_report_at": getattr(a, "assignment_accepted_at", None),
             }
-            for a in self.assignments.values()
+            for a in assignment_rows
         ]
         status["leader_id"] = self.leader_id
         status["project_id"] = self.project_id
         status["blocked_transition_errors"] = list(self.blocked_transition_errors)
 
         return status
+
+    @staticmethod
+    def _assignment_acceptance_state(assignment: Any) -> str:
+        if getattr(assignment, "assignment_accepted", False):
+            return "assignment_accepted"
+        if getattr(assignment, "ace_reported_active", False):
+            return "ace_reported_active"
+        if getattr(assignment, "blocker_reason", None):
+            return "blocked"
+        dispatch_state = getattr(assignment, "dispatch_delivery_state", "queued_unverified")
+        if dispatch_state == "accepted_active":
+            return "awaiting_ace_active_report"
+        if dispatch_state == "submitted_pending_acceptance":
+            return "submitted_pending_acceptance"
+        startup_state = getattr(
+            assignment, "startup_readiness_state", "startup_handshake_pending"
+        )
+        if startup_state != "input_ready":
+            return startup_state
+        return dispatch_state
 
     async def monitor_ace_assignments(self, *, detailed: bool = False) -> list[dict[str, Any]]:
         """Leader-owned Ace monitoring summary.

--- a/src/atc/runtime/health.py
+++ b/src/atc/runtime/health.py
@@ -629,6 +629,9 @@ async def ace_health(
         "assignment_id": active_assignment.assignment_id if active_assignment else None,
         "task_graph_id": active_assignment.task_graph_id if active_assignment else None,
         "assignment_status": active_assignment.status if active_assignment else None,
+        "startup_readiness_state": (
+            active_assignment.startup_readiness_state if active_assignment else None
+        ),
         "dispatch_delivery_state": dispatch_delivery_state,
         "dispatch_verified": active_assignment.dispatch_verified if active_assignment else False,
         "assignment_acceptance_state": assignment_acceptance_state,
@@ -642,6 +645,12 @@ async def ace_health(
             active_assignment.assignment_accepted_at if active_assignment else None
         ),
         "acceptance_message": active_assignment.acceptance_message if active_assignment else None,
+        "artifact_ready": active_assignment.artifact_ready if active_assignment else False,
+        "artifact_path": active_assignment.artifact_path if active_assignment else None,
+        "artifact_kind": active_assignment.artifact_kind if active_assignment else None,
+        "artifact_reported_at": (
+            active_assignment.artifact_reported_at if active_assignment else None
+        ),
         "first_work_observed_at": active_assignment.last_activity_at if active_assignment else None,
         "assigned_task_id": active_assignment.assigned_task_id if active_assignment else None,
         "blocker_reason": assignment_blocker,

--- a/src/atc/runtime/service.py
+++ b/src/atc/runtime/service.py
@@ -292,6 +292,22 @@ class RuntimeService:
             ),
         )
         provider = self.get_provider(handle.provider_name)
+        readiness = await provider.inspect_session(handle)
+        request.metadata["ace_startup_readiness_state"] = self._startup_readiness_state(readiness)
+        self._append_assignment_readiness_event(handle, request, trace_id, readiness)
+        if readiness.readiness is not ReadinessState.READY:
+            request.metadata["runtime_truth"] = self._runtime_truth_from_inspection(
+                readiness
+            )
+            return self._result_from_metadata(
+                handle,
+                request.metadata,
+                status="blocked",
+                message=(
+                    "Ace assignment was not submitted because the provider runtime "
+                    "is not input-ready"
+                ),
+            )
         try:
             await provider.assign_task(handle, request)
         except Exception as exc:
@@ -554,6 +570,115 @@ class RuntimeService:
             raise
 
     @staticmethod
+    def _runtime_truth_from_inspection(inspection: RuntimeInspection) -> dict[str, object]:
+        if inspection.readiness is ReadinessState.READY:
+            runtime_state = RuntimeState.READY
+            delivery_state = DeliveryState.RUNTIME_CREATED
+            blocker = None
+        elif inspection.readiness is ReadinessState.BLOCKED:
+            runtime_state = RuntimeState.BLOCKED
+            delivery_state = DeliveryState.BLOCKED
+            if inspection.block_reason is RuntimeBlockReason.TRUST:
+                blocker = BlockerReason.RUNTIME_TRUST_REQUIRED
+            elif inspection.block_reason in {RuntimeBlockReason.AUTH, RuntimeBlockReason.LOGIN}:
+                blocker = BlockerReason.RUNTIME_AUTH_REQUIRED
+            elif inspection.block_reason is RuntimeBlockReason.PERMISSION:
+                blocker = BlockerReason.RUNTIME_PERMISSION_REQUIRED
+            else:
+                blocker = BlockerReason.UNKNOWN_PROMPT_BLOCKER
+        elif inspection.readiness is ReadinessState.STOPPED:
+            runtime_state = RuntimeState.MISSING
+            delivery_state = DeliveryState.FAILED
+            blocker = BlockerReason.PANE_MISSING
+        elif inspection.readiness is ReadinessState.ERROR:
+            runtime_state = RuntimeState.FAILED
+            delivery_state = DeliveryState.FAILED
+            blocker = BlockerReason.PROVIDER_ERROR
+        else:
+            runtime_state = RuntimeState.STARTING
+            delivery_state = DeliveryState.RUNTIME_CREATED
+            blocker = BlockerReason.DELIVERY_UNVERIFIED
+        return {
+            "runtime_state": runtime_state.value,
+            "delivery_state": delivery_state.value,
+            "blocker_reason": blocker.value if blocker is not None else None,
+            "provider": inspection.provider_name,
+            "provider_diagnostics": inspection.details,
+        }
+
+    @staticmethod
+    def _startup_readiness_state(inspection: RuntimeInspection) -> str:
+        """Map provider inspection to a provider-neutral startup/input readiness gate."""
+
+        if inspection.readiness is ReadinessState.READY:
+            return "input_ready"
+        if inspection.readiness is ReadinessState.STARTING:
+            return "startup_handshake_pending"
+        if inspection.readiness is ReadinessState.BLOCKED:
+            if inspection.block_reason is RuntimeBlockReason.TRUST:
+                return "awaiting_startup_confirmation"
+            return "blocked_on_provider_startup_prompt"
+        if inspection.readiness is ReadinessState.STOPPED:
+            return "runtime_missing"
+        if inspection.readiness is ReadinessState.ERROR:
+            return "startup_handshake_failed"
+        return "startup_handshake_pending"
+
+    @staticmethod
+    def _append_assignment_readiness_event(
+        handle: RuntimeSessionHandle,
+        request: TaskAssignmentRequest,
+        trace_id: str,
+        inspection: RuntimeInspection,
+    ) -> None:
+        ready = inspection.readiness is ReadinessState.READY
+        if ready:
+            verdict = DeliveryVerdict.ACCEPTED
+            reason = DeliveryReasonCode.SESSION_RUNNING
+            stage = DeliveryStage.CONFIRMED_RUNNING
+        else:
+            verdict = DeliveryVerdict.BLOCKED
+            stage = DeliveryStage.BLOCKED
+            if inspection.block_reason is RuntimeBlockReason.TRUST:
+                reason = DeliveryReasonCode.TRUST_REQUIRED
+            elif inspection.block_reason in {RuntimeBlockReason.AUTH, RuntimeBlockReason.LOGIN}:
+                reason = DeliveryReasonCode.AUTH_REQUIRED
+            elif inspection.block_reason is RuntimeBlockReason.PERMISSION:
+                reason = DeliveryReasonCode.PERMISSION_REQUIRED
+            elif inspection.readiness is ReadinessState.STOPPED:
+                reason = DeliveryReasonCode.PANE_MISSING
+            elif inspection.readiness is ReadinessState.ERROR:
+                reason = DeliveryReasonCode.PROVIDER_ERROR
+            else:
+                reason = DeliveryReasonCode.UNKNOWN_PROMPT_BLOCKER
+        append_trace_event(
+            request.metadata,
+            trace_event(
+                trace_id=trace_id,
+                session_id=handle.session_id,
+                role=handle.role.value,
+                provider=handle.provider_name,
+                pane_id=handle.tmux_pane,
+                action=DeliveryAction.TASK_ASSIGNMENT,
+                stage=stage,
+                verdict=verdict,
+                reason_code=reason,
+                prompt_state_after=inspection.readiness.value,
+                first_output_excerpt=inspection.last_output_excerpt,
+                details={
+                    "startup_readiness_state": RuntimeService._startup_readiness_state(inspection),
+                    "summary": inspection.summary,
+                    "task_id": request.task_id,
+                    "assignment_id": request.assignment_id,
+                    "block_reason": inspection.block_reason.value
+                    if inspection.block_reason is not None
+                    else None,
+                    **inspection.details,
+                },
+            ),
+        )
+
+    @staticmethod
     def _ensure_trace_id(metadata: dict[str, object]) -> str:
         existing = metadata.get("delivery_trace_id")
         if isinstance(existing, str) and existing:
@@ -619,7 +744,14 @@ class RuntimeService:
         if isinstance(events, list) and events:
             latest = events[-1]
             if isinstance(latest, dict) and latest.get("stage") != DeliveryStage.QUEUED.value:
-                return
+                details = latest.get("details")
+                readiness_gate_only = (
+                    action is DeliveryAction.TASK_ASSIGNMENT
+                    and isinstance(details, dict)
+                    and "startup_readiness_state" in details
+                )
+                if not readiness_gate_only:
+                    return
         append_trace_event(
             metadata,
             trace_event(
@@ -632,7 +764,10 @@ class RuntimeService:
                 stage=DeliveryStage.CONFIRMED_RUNNING,
                 verdict=DeliveryVerdict.ACCEPTED,
                 reason_code=DeliveryReasonCode.DELIVERY_UNVERIFIED,
-                details={"source": "provider_returned_without_detailed_trace"},
+                details={
+                    "source": "provider_returned_without_detailed_trace",
+                    "startup_readiness_state": metadata.get("ace_startup_readiness_state"),
+                },
             ),
         )
 

--- a/src/atc/state/db.py
+++ b/src/atc/state/db.py
@@ -472,12 +472,17 @@ CREATE TABLE IF NOT EXISTS task_assignments (
     ace_session_id          TEXT NOT NULL,
     assignment_id           TEXT NOT NULL UNIQUE,
     status                  TEXT NOT NULL DEFAULT 'assigned',
+    startup_readiness_state TEXT NOT NULL DEFAULT 'startup_handshake_pending',
     dispatch_delivery_state TEXT NOT NULL DEFAULT 'queued_unverified',
     dispatch_verified       INTEGER NOT NULL DEFAULT 0,
     ace_reported_active     INTEGER NOT NULL DEFAULT 0,
     assignment_accepted     INTEGER NOT NULL DEFAULT 0,
     assignment_accepted_at  TEXT,
     acceptance_message      TEXT,
+    artifact_path           TEXT,
+    artifact_kind           TEXT,
+    artifact_ready          INTEGER NOT NULL DEFAULT 0,
+    artifact_reported_at    TEXT,
     last_activity_at        TEXT,
     assigned_task_id        TEXT,
     blocker_reason          TEXT,
@@ -582,12 +587,17 @@ async def run_migrations(db_path: str) -> None:
 
         # --- task_assignments dispatch truth fields ---
         task_assignment_columns = {
+            "startup_readiness_state": "TEXT NOT NULL DEFAULT 'startup_handshake_pending'",
             "dispatch_delivery_state": "TEXT NOT NULL DEFAULT 'queued_unverified'",
             "dispatch_verified": "INTEGER NOT NULL DEFAULT 0",
             "ace_reported_active": "INTEGER NOT NULL DEFAULT 0",
             "assignment_accepted": "INTEGER NOT NULL DEFAULT 0",
             "assignment_accepted_at": "TEXT",
             "acceptance_message": "TEXT",
+            "artifact_path": "TEXT",
+            "artifact_kind": "TEXT",
+            "artifact_ready": "INTEGER NOT NULL DEFAULT 0",
+            "artifact_reported_at": "TEXT",
             "last_activity_at": "TEXT",
             "assigned_task_id": "TEXT",
             "blocker_reason": "TEXT",
@@ -671,6 +681,24 @@ async def _apply_file_migrations(db: aiosqlite.Connection) -> None:
             ]
             if all(
                 [await _has_column(db, "task_assignments", column) for column in acceptance_columns]
+            ):
+                logger.info("Migration skip: %s already applied structurally", path.name)
+                await db.execute(
+                    "INSERT INTO schema_migrations (version, applied_at) VALUES (?, ?)",
+                    (path.name, _now()),
+                )
+                await db.commit()
+                continue
+        if path.name == "018_ace_startup_artifact_parity.sql":
+            parity_columns = [
+                "startup_readiness_state",
+                "artifact_path",
+                "artifact_kind",
+                "artifact_ready",
+                "artifact_reported_at",
+            ]
+            if all(
+                [await _has_column(db, "task_assignments", column) for column in parity_columns]
             ):
                 logger.info("Migration skip: %s already applied structurally", path.name)
                 await db.execute(
@@ -1310,7 +1338,12 @@ _ASSIGNMENT_TRANSITIONS: dict[str, set[str]] = {
 
 def _row_to_task_assignment(row: aiosqlite.Row) -> TaskAssignment:
     d = dict(row)
-    for key in ("dispatch_verified", "ace_reported_active", "assignment_accepted"):
+    for key in (
+        "dispatch_verified",
+        "ace_reported_active",
+        "assignment_accepted",
+        "artifact_ready",
+    ):
         if key in d:
             d[key] = bool(d[key])
     return TaskAssignment(**d)
@@ -1380,6 +1413,7 @@ async def assign_task(
             ace_session_id=ace_session_id,
             assignment_id=existing.assignment_id,
             status="assigned",
+            startup_readiness_state="startup_handshake_pending",
             dispatch_delivery_state="queued_unverified",
             dispatch_verified=False,
             assigned_task_id=task_graph_id,
@@ -1388,15 +1422,17 @@ async def assign_task(
         )
         await db.execute(
             """UPDATE task_assignments
-               SET ace_session_id = ?, status = ?, dispatch_delivery_state = ?,
-                   dispatch_verified = 0, ace_reported_active = 0,
+               SET ace_session_id = ?, status = ?, startup_readiness_state = ?,
+                   dispatch_delivery_state = ?, dispatch_verified = 0, ace_reported_active = 0,
                    assignment_accepted = 0, assignment_accepted_at = NULL,
-                   acceptance_message = NULL, last_activity_at = NULL,
+                   acceptance_message = NULL, artifact_path = NULL, artifact_kind = NULL,
+                   artifact_ready = 0, artifact_reported_at = NULL, last_activity_at = NULL,
                    assigned_task_id = ?, blocker_reason = NULL, updated_at = ?
                WHERE assignment_id = ?""",
             (
                 ace_session_id,
                 assignment.status,
+                assignment.startup_readiness_state,
                 assignment.dispatch_delivery_state,
                 task_graph_id,
                 assignment.updated_at,
@@ -1410,6 +1446,7 @@ async def assign_task(
             ace_session_id=ace_session_id,
             assignment_id=assignment_id,
             status="assigned",
+            startup_readiness_state="startup_handshake_pending",
             dispatch_delivery_state="queued_unverified",
             dispatch_verified=False,
             assigned_task_id=task_graph_id,
@@ -1420,15 +1457,17 @@ async def assign_task(
         await db.execute(
             """INSERT INTO task_assignments
                (id, task_graph_id, ace_session_id, assignment_id, status,
-                dispatch_delivery_state, dispatch_verified, assigned_task_id,
+                startup_readiness_state, dispatch_delivery_state,
+                dispatch_verified, assigned_task_id,
                 created_at, updated_at)
-               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
             (
                 assignment.id,
                 assignment.task_graph_id,
                 assignment.ace_session_id,
                 assignment.assignment_id,
                 assignment.status,
+                assignment.startup_readiness_state,
                 assignment.dispatch_delivery_state,
                 1 if assignment.dispatch_verified else 0,
                 assignment.assigned_task_id,
@@ -1525,8 +1564,34 @@ async def update_task_assignment_status(
 
 
 # ---------------------------------------------------------------------------
-# Heartbeat CRUD
+# Task assignment runtime/artifact truth
 # ---------------------------------------------------------------------------
+
+
+async def update_task_assignment_startup_readiness(
+    db: aiosqlite.Connection,
+    assignment_id: str,
+    *,
+    startup_readiness_state: str,
+    blocker_reason: str | None = None,
+    last_activity: bool = False,
+) -> TaskAssignment | None:
+    """Persist provider-neutral Ace startup/input readiness before assignment delivery."""
+
+    existing = await get_task_assignment(db, assignment_id)
+    if existing is None:
+        return None
+    now = _now()
+    last_activity_at = now if last_activity else existing.last_activity_at
+    await db.execute(
+        """UPDATE task_assignments
+           SET startup_readiness_state = ?, blocker_reason = ?,
+               last_activity_at = ?, updated_at = ?
+           WHERE assignment_id = ?""",
+        (startup_readiness_state, blocker_reason, last_activity_at, now, assignment_id),
+    )
+    await db.commit()
+    return await get_task_assignment(db, assignment_id)
 
 
 async def update_task_assignment_dispatch(
@@ -1594,6 +1659,31 @@ async def report_ace_assignment_active(
             now,
             assignment_id,
         ),
+    )
+    await db.commit()
+    return await get_task_assignment(db, assignment_id)
+
+
+async def report_task_assignment_artifact(
+    db: aiosqlite.Connection,
+    assignment_id: str,
+    *,
+    artifact_path: str,
+    artifact_kind: str = "build_output",
+    ready: bool = True,
+) -> TaskAssignment | None:
+    """Record canonical artifact routing info produced by an Ace assignment."""
+
+    existing = await get_task_assignment(db, assignment_id)
+    if existing is None:
+        return None
+    now = _now()
+    await db.execute(
+        """UPDATE task_assignments
+           SET artifact_path = ?, artifact_kind = ?, artifact_ready = ?,
+               artifact_reported_at = ?, last_activity_at = ?, updated_at = ?
+           WHERE assignment_id = ?""",
+        (artifact_path, artifact_kind, 1 if ready else 0, now, now, now, assignment_id),
     )
     await db.commit()
     return await get_task_assignment(db, assignment_id)

--- a/src/atc/state/migrations/versions/018_ace_startup_artifact_parity.sql
+++ b/src/atc/state/migrations/versions/018_ace_startup_artifact_parity.sql
@@ -1,0 +1,6 @@
+-- Phase 11: Leader→Ace startup readiness and artifact routing parity.
+ALTER TABLE task_assignments ADD COLUMN startup_readiness_state TEXT NOT NULL DEFAULT 'startup_handshake_pending';
+ALTER TABLE task_assignments ADD COLUMN artifact_path TEXT;
+ALTER TABLE task_assignments ADD COLUMN artifact_kind TEXT;
+ALTER TABLE task_assignments ADD COLUMN artifact_ready INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE task_assignments ADD COLUMN artifact_reported_at TEXT;

--- a/src/atc/state/models.py
+++ b/src/atc/state/models.py
@@ -238,12 +238,17 @@ class TaskAssignment:
     ace_session_id: str
     assignment_id: str
     status: str = "assigned"  # assigned|working|done|failed
+    startup_readiness_state: str = "startup_handshake_pending"
     dispatch_delivery_state: str = "queued_unverified"
     dispatch_verified: bool = False
     ace_reported_active: bool = False
     assignment_accepted: bool = False
     assignment_accepted_at: str | None = None
     acceptance_message: str | None = None
+    artifact_path: str | None = None
+    artifact_kind: str | None = None
+    artifact_ready: bool = False
+    artifact_reported_at: str | None = None
     last_activity_at: str | None = None
     assigned_task_id: str | None = None
     blocker_reason: str | None = None

--- a/tests/unit/test_documentation_contracts.py
+++ b/tests/unit/test_documentation_contracts.py
@@ -35,8 +35,12 @@ def test_api_docs_cover_leader_health_recovery_and_task_cli_contracts() -> None:
             "atc leader bootstrap-tasks --project-id",
             "GET    /api/projects/{id}/aces/{ace_id}/health",
             "POST   /api/projects/{id}/aces/{ace_id}/report-active",
+            "POST   /api/projects/{id}/aces/{ace_id}/report-artifact",
+            "startup_readiness_state",
             "assignment_acceptance_state",
+            "artifact_ready",
             "atc ace report-active --project-id",
+            "atc ace report-artifact --project-id",
         ],
     )
 
@@ -66,7 +70,10 @@ def test_role_docs_encode_runtime_truth_and_provider_boundary() -> None:
             "local ATC API helper",
             "do not inspect OpenAPI as the first move",
             "assignment_acceptance_state",
+            "startup_readiness_state",
+            "input_ready",
             "atc ace report-active --project-id",
+            "atc ace report-artifact --project-id",
             "session row or assignment row exists",
         ],
     )
@@ -79,6 +86,9 @@ def test_role_docs_encode_runtime_truth_and_provider_boundary() -> None:
             "assignment_acceptance_state",
             "ace_reported_active",
             "assignment_accepted",
+            "startup_readiness_state",
+            "artifact_ready",
+            "artifact_path",
             "awaiting_ace_active_report",
             "Leader owns recovery decisions",
             "provider-neutral blocker",

--- a/tests/unit/test_runtime_service.py
+++ b/tests/unit/test_runtime_service.py
@@ -661,3 +661,38 @@ def test_runtime_service_inspect_session_record_uses_provider_boundary() -> None
     assert inspection.provider_name == "dummy_runtime_record_inspect"
     assert inspection.alive is True
     assert service.get_handle("sess-record-ace-1").role is RoleKind.ACE
+
+
+def test_runtime_service_assign_task_blocks_until_ace_input_ready() -> None:
+    class TrustBlockedProvider(DummyProviderRuntime):
+        async def inspect_session(self, handle: RuntimeSessionHandle) -> RuntimeInspection:
+            return RuntimeInspection(
+                session_id=handle.session_id,
+                provider_name=handle.provider_name,
+                alive=True,
+                readiness=ReadinessState.BLOCKED,
+                block_reason=RuntimeBlockReason.TRUST,
+                summary="Do you trust this directory?",
+            )
+
+    register_provider_runtime("dummy_runtime_ace_startup_blocked", TrustBlockedProvider)
+    service = RuntimeService()
+    request = StartRoleRequest(
+        session_id="sess-ace-startup-blocked-1",
+        provider_name="dummy_runtime_ace_startup_blocked",
+        role=RoleKind.ACE,
+    )
+    handle = asyncio.run(service.start_ace(request))
+    assignment = TaskAssignmentRequest(
+        session_id="sess-ace-startup-blocked-1",
+        task_id="task-1",
+        message="Do the work",
+        assignment_id="assign-startup-blocked-1",
+    )
+    result = asyncio.run(service.assign_task_to_ace(handle, assignment))
+
+    provider = service.get_provider("dummy_runtime_ace_startup_blocked")
+    assert provider.assignments == []
+    assert result.status == "blocked"
+    assert result.blocker_reason.value == "runtime_trust_required"
+    assert result.details["startup_readiness_state"] == "awaiting_startup_confirmation"


### PR DESCRIPTION
## Summary

Phase 11 makes Leader → Ace handoff use the same robustness class as Tower → Leader while keeping provider mechanics modulated behind the runtime/provider boundary.

- gate Ace task assignment on provider-neutral startup readiness before writing/submitting assignment payloads
- distinguish Ace startup readiness, dispatch delivery, assignment acceptance, runtime health, and artifact readiness in health/progress surfaces
- add Ace artifact reporting via REST/CLI so build Aces can publish canonical artifact/worktree paths and verifier Aces can receive dependency artifact context
- add migration/model persistence for Ace startup readiness and artifact fields
- update Ace deployment instructions and API/role docs
- fix Ace CLI parser default ordering so subcommand handlers are not overwritten by the parent `ace` fallback

Provider separation note: ATC core consumes neutral readiness/blocker fields only. Provider prompt text, trust semantics, key sequences, and approval mechanics stay in provider runtimes/classifiers.

## Validation

Backend/API/CLI/docs:

```text
./.venv/bin/python -m ruff check docs/API.md docs/agents/ACE.md docs/agents/LEADER.md src/atc/agents/deploy.py src/atc/api/routers/aces.py src/atc/cli/ace.py src/atc/leader/orchestrator.py src/atc/runtime/health.py src/atc/runtime/service.py src/atc/state/db.py src/atc/state/models.py tests/unit/test_documentation_contracts.py tests/unit/test_runtime_service.py tests/unit/test_cli.py
All checks passed!

./.venv/bin/python -m pytest tests/unit/test_runtime_service.py tests/unit/test_runtime_health.py tests/unit/test_ace_dispatch.py tests/unit/test_db_migrations.py tests/unit/test_cli.py tests/unit/test_documentation_contracts.py tests/unit/test_leader_orchestrator.py tests/unit/test_leader_api.py tests/e2e/test_task_graph_api.py tests/e2e/test_phase8_scenarios.py -q
168 passed, 1 warning
```

Frontend/UI:

```text
cd frontend && npm run build
✓ built

npx playwright test tests/e2e/dashboard-views.spec.ts tests/e2e/atc-qa.spec.ts --project=chromium --reporter=line
15 passed
```

Live API/CLI evidence:

- `screenshots/phase11-live-ace-startup-artifact-evidence.json`
- Shows `atc ace report-active` and `atc ace report-artifact` both returned `0`, with Ace health/progress exposing `startup_readiness_state=input_ready`, `assignment_accepted=true`, `artifact_ready=true`, canonical `artifact_path`, `last_provider_activity_at`, and `last_ace_report_at`.

UI screenshots captured locally under:

- `screenshots/phase11-ui-2026-06-20T05-42-08-891Z/`
