### PR TITLE
Settle Ace runtime before assignment delivery

### DIFF
--- a/src/atc/runtime/service.py
+++ b/src/atc/runtime/service.py
@@ -40,6 +40,7 @@ from atc.state.db import get_connection_app_state
 _STARTUP_INITIAL_DELAY_SECONDS = 2.0
 _STARTUP_RESOLVE_DELAY_SECONDS = 1.0
 _STARTUP_FINAL_DELAY_SECONDS = 1.0
+_ASSIGNMENT_READY_SETTLE_DELAY_SECONDS = 1.0
 if TYPE_CHECKING:
     from atc.providers.base import ProviderRuntime
 
@@ -294,7 +295,9 @@ class RuntimeService:
         provider = self.get_provider(handle.provider_name)
         readiness = await provider.inspect_session(handle)
         request.metadata["ace_startup_readiness_state"] = self._startup_readiness_state(readiness)
-        self._append_assignment_readiness_event(handle, request, trace_id, readiness)
+        self._append_assignment_readiness_event(
+            handle, request, trace_id, readiness, phase="initial"
+        )
         if readiness.readiness is not ReadinessState.READY:
             request.metadata["runtime_truth"] = self._runtime_truth_from_inspection(
                 readiness
@@ -308,6 +311,28 @@ class RuntimeService:
                     "is not input-ready"
                 ),
             )
+        if _ASSIGNMENT_READY_SETTLE_DELAY_SECONDS > 0:
+            await asyncio.sleep(_ASSIGNMENT_READY_SETTLE_DELAY_SECONDS)
+            readiness = await provider.inspect_session(handle)
+            request.metadata["ace_startup_readiness_state"] = self._startup_readiness_state(
+                readiness
+            )
+            self._append_assignment_readiness_event(
+                handle, request, trace_id, readiness, phase="post_ready_settle"
+            )
+            if readiness.readiness is not ReadinessState.READY:
+                request.metadata["runtime_truth"] = self._runtime_truth_from_inspection(
+                    readiness
+                )
+                return self._result_from_metadata(
+                    handle,
+                    request.metadata,
+                    status="blocked",
+                    message=(
+                        "Ace assignment was not submitted because the provider runtime "
+                        "was no longer input-ready after startup settle"
+                    ),
+                )
         try:
             await provider.assign_task(handle, request)
         except Exception as exc:
@@ -630,6 +655,8 @@ class RuntimeService:
         request: TaskAssignmentRequest,
         trace_id: str,
         inspection: RuntimeInspection,
+        *,
+        phase: str = "initial",
     ) -> None:
         ready = inspection.readiness is ReadinessState.READY
         if ready:
@@ -668,6 +695,7 @@ class RuntimeService:
                 details={
                     "startup_readiness_state": RuntimeService._startup_readiness_state(inspection),
                     "summary": inspection.summary,
+                    "readiness_phase": phase,
                     "task_id": request.task_id,
                     "assignment_id": request.assignment_id,
                     "block_reason": inspection.block_reason.value

--- a/tests/unit/test_runtime_service.py
+++ b/tests/unit/test_runtime_service.py
@@ -24,6 +24,7 @@ from atc.state.db import clear_connection_app_state, set_connection_app_state
 runtime_service_module._STARTUP_INITIAL_DELAY_SECONDS = 0.0
 runtime_service_module._STARTUP_RESOLVE_DELAY_SECONDS = 0.0
 runtime_service_module._STARTUP_FINAL_DELAY_SECONDS = 0.0
+runtime_service_module._ASSIGNMENT_READY_SETTLE_DELAY_SECONDS = 0.0
 
 
 class DummyProviderRuntime:
@@ -696,3 +697,68 @@ def test_runtime_service_assign_task_blocks_until_ace_input_ready() -> None:
     assert result.status == "blocked"
     assert result.blocker_reason.value == "runtime_trust_required"
     assert result.details["startup_readiness_state"] == "awaiting_startup_confirmation"
+
+
+def test_runtime_service_assign_task_rechecks_after_ready_settle(monkeypatch) -> None:
+    class ReadyThenPromptBlockedProvider(DummyProviderRuntime):
+        def __init__(self) -> None:
+            super().__init__()
+            self.inspect_count = 0
+
+        async def inspect_session(self, handle: RuntimeSessionHandle) -> RuntimeInspection:
+            self.inspect_count += 1
+            if self.inspect_count <= 3:
+                return RuntimeInspection(
+                    session_id=handle.session_id,
+                    provider_name=handle.provider_name,
+                    alive=True,
+                    readiness=ReadinessState.READY,
+                    summary="Ready",
+                )
+            return RuntimeInspection(
+                session_id=handle.session_id,
+                provider_name=handle.provider_name,
+                alive=True,
+                readiness=ReadinessState.BLOCKED,
+                block_reason=RuntimeBlockReason.PERMISSION,
+                summary="Startup prompt still settling",
+            )
+
+    monkeypatch.setattr(
+        runtime_service_module, "_ASSIGNMENT_READY_SETTLE_DELAY_SECONDS", 0.01
+    )
+    register_provider_runtime(
+        "dummy_runtime_ace_ready_then_blocked", ReadyThenPromptBlockedProvider
+    )
+    service = RuntimeService()
+    handle = asyncio.run(
+        service.start_ace(
+            StartRoleRequest(
+                session_id="sess-ace-ready-then-blocked-1",
+                provider_name="dummy_runtime_ace_ready_then_blocked",
+                role=RoleKind.ACE,
+            )
+        )
+    )
+    assignment = TaskAssignmentRequest(
+        session_id=handle.session_id,
+        task_id="task-ready-then-blocked",
+        message="Do the work",
+        assignment_id="assign-ready-then-blocked",
+    )
+
+    result = asyncio.run(service.assign_task_to_ace(handle, assignment))
+
+    provider = service.get_provider("dummy_runtime_ace_ready_then_blocked")
+    assert provider.assignments == []
+    assert result.status == "blocked"
+    assert result.blocker_reason.value == "runtime_permission_required"
+    readiness_events = [
+        event
+        for event in assignment.metadata["delivery_trace_events"]
+        if event["action"] == "task_assignment" and "readiness_phase" in event["details"]
+    ]
+    assert [event["details"]["readiness_phase"] for event in readiness_events] == [
+        "initial",
+        "post_ready_settle",
+    ]


### PR DESCRIPTION
## Summary

Addresses Leader feedback that a newly spawned Ace could be sitting at an empty Codex prompt because the startup prompt consumed the earlier assignment delivery.

- adds a provider-neutral 1s post-ready settle delay before `assign_task_to_ace` writes the assignment payload
- re-inspects the provider after the settle window before submitting
- blocks assignment delivery if the runtime becomes non-ready during that settle window instead of pasting behind a prompt
- records both readiness observations in delivery trace metadata with `readiness_phase=initial` and `readiness_phase=post_ready_settle`

Provider separation is preserved: the core still gates on `ReadinessState`/neutral blocker fields; provider-specific prompt text and key handling stay in provider adapters/classifiers.

## Validation

```text
./.venv/bin/python -m ruff check src/atc/runtime/service.py tests/unit/test_runtime_service.py
All checks passed!

./.venv/bin/python -m pytest tests/unit/test_runtime_service.py -q
22 passed, 1 warning

./.venv/bin/python -m pytest tests/unit/test_runtime_service.py tests/e2e/test_task_graph_api.py -q
49 passed, 1 warning
```
