### PR TITLE
Add managed agent handoff contract

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -40,6 +40,7 @@ Current responsibilities:
 Design rule:
 - Orchestration should wrap existing high-level flows where they already exist, not duplicate runtime behavior. For example, `spawn_leader` goes through Tower's submit-goal path, and `send_instruction` goes through the existing provider-owned delivery path.
 - Runtime truth and recovery work must follow the provider-neutral plan in [`docs/runtime_truth_recovery_plan.md`](runtime_truth_recovery_plan.md): product layers depend on `runtime_state`, `delivery_state`, `blocker_reason`, and recovery recommendations, while provider-specific prompt detection/recovery mechanics remain inside provider adapters/classifiers.
+- Managed agent handoffs use a shared provider-neutral lifecycle contract in `atc.orchestration.handoff`. Tower→Leader kickoff and Leader→Ace assignment must distinguish `session_created`, `startup_inspected`, `input_ready`, `payload_written`, `payload_submitted`, `child_reported_active`, `first_actionable_step_observed`, and `handoff_verified`; session rows, `202 Accepted`, `queued`, or `submitted` transport states are not execution proof.
 - Leader kickoff hardening must follow [`docs/leader_kickoff_recovery_plan.md`](leader_kickoff_recovery_plan.md): Tower may treat a Leader as running only after provider-neutral kickoff evidence proves goal acceptance and actionable progress or task graph creation. Session existence, visible prompt text, `queued`, `submitted`, `sent`, or `202 Accepted` responses are not execution proof.
 
 | Package | Responsibility |

--- a/src/atc/api/routers/task_graphs.py
+++ b/src/atc/api/routers/task_graphs.py
@@ -16,6 +16,7 @@ from typing import Any
 from fastapi import APIRouter, HTTPException, Request
 from pydantic import BaseModel, Field
 
+from atc.orchestration.handoff import handoff_from_assignment
 from atc.runtime.models import DeliveryState, RuntimeState
 from atc.state import db as db_ops
 from atc.state.transitions import LifecycleTransitionError
@@ -130,6 +131,11 @@ def _runtime_truth_for_task(tg: Any, assignment: Any | None = None) -> RuntimeTr
     else:
         runtime_state = RuntimeState.IDLE.value
 
+    handoff = handoff_from_assignment(
+        assignment,
+        project_id=tg.project_id,
+        task_id=tg.id,
+    )
     return RuntimeTruthSummary(
         task_state=task_state,
         runtime_state=runtime_state,
@@ -142,6 +148,7 @@ def _runtime_truth_for_task(tg: Any, assignment: Any | None = None) -> RuntimeTr
             "assignment_id": assignment.assignment_id if assignment is not None else None,
             "ace_session_id": assignment.ace_session_id if assignment is not None else None,
             "assigned_task_id": assignment.assigned_task_id if assignment is not None else None,
+            "managed_handoff": handoff.as_dict(),
         },
     )
 

--- a/src/atc/leader/kickoff.py
+++ b/src/atc/leader/kickoff.py
@@ -15,11 +15,16 @@ from typing import TYPE_CHECKING, Any
 if TYPE_CHECKING:
     import aiosqlite  # type: ignore[import-not-found]
 
+from atc.orchestration.handoff import (
+    HandoffPayloadKind,
+    handoff_from_delivery_result,
+)
 from atc.runtime.models import (
     BlockerReason,
     DeliveryState,
     RecoveryRecommendation,
     RecoveryState,
+    RoleKind,
     RuntimeDeliveryResult,
     RuntimeState,
 )
@@ -69,6 +74,7 @@ class LeaderKickoffVerification:
     kickoff_blocker_reason: str | None = None
     kickoff_recovery_recommendation: dict[str, Any] | None = None
     delivery_trace_id: str | None = None
+    managed_handoff: dict[str, Any] | None = None
     blocker_reason: str | None = None
     message: str | None = None
 
@@ -90,6 +96,7 @@ class LeaderKickoffVerification:
             "kickoff_blocker_reason": self.kickoff_blocker_reason,
             "kickoff_recovery_recommendation": self.kickoff_recovery_recommendation,
             "delivery_trace_id": self.delivery_trace_id,
+            "managed_handoff": self.managed_handoff,
         }
         if self.blocker_reason:
             data["blocker_reason"] = self.blocker_reason
@@ -208,6 +215,12 @@ async def report_leader_goal_accepted(
         "message": message,
     }
     context["leader_active_report"] = report
+    existing_handoff = context.get("managed_handoff")
+    if isinstance(existing_handoff, dict):
+        existing_handoff["child_reported_active"] = True
+        existing_handoff["lifecycle_state"] = "child_reported_active"
+        existing_handoff["handoff_verified"] = False
+        context["managed_handoff"] = existing_handoff
     await conn.execute(
         (
             "UPDATE leaders SET context = ?, status = 'managing', "
@@ -255,6 +268,17 @@ async def persist_leader_kickoff_payload(
     )
     context["leader_kickoff_payload"] = payload.as_dict()
     context["leader_original_goal"] = goal
+    context["managed_handoff"] = {
+        "parent_role": RoleKind.TOWER.value,
+        "child_role": RoleKind.LEADER.value,
+        "payload_kind": HandoffPayloadKind.LEADER_GOAL.value,
+        "lifecycle_state": "session_created",
+        "project_id": project_id,
+        "payload_hash": payload.trace_id,
+        "trace_id": payload.trace_id,
+        "handoff_verified": False,
+        "child_reported_active": False,
+    }
     await conn.execute(
         "UPDATE leaders SET context = ?, goal = ?, updated_at = datetime('now') WHERE id = ?",
         (json.dumps(context), goal, leader.id),
@@ -346,6 +370,12 @@ def verify_leader_kickoff_delivery(
     """Classify a kickoff delivery result into explicit startup guarantees."""
 
     if result is None:
+        handoff = handoff_from_delivery_result(
+            None,
+            parent_role=RoleKind.TOWER,
+            child_role=RoleKind.LEADER,
+            payload_kind=HandoffPayloadKind.LEADER_GOAL,
+        )
         return LeaderKickoffVerification(
             kickoff_verified=False,
             kickoff_state="queued_unverified",
@@ -358,6 +388,7 @@ def verify_leader_kickoff_delivery(
             leader_began_work=False,
             startup_handshake_state="not_started",
             goal_acceptance_state="not_submitted",
+            managed_handoff=handoff.as_dict(),
             message="Kickoff delivery was queued but not observed",
         )
 
@@ -415,6 +446,20 @@ def verify_leader_kickoff_delivery(
         state = "runtime_created"
     else:
         state = "queued_unverified"
+    handoff = handoff_from_delivery_result(
+        result,
+        parent_role=RoleKind.TOWER,
+        child_role=RoleKind.LEADER,
+        payload_kind=HandoffPayloadKind.LEADER_GOAL,
+        child_reported_active=bool(leader_reported_active and goal_accepted),
+        first_actionable_step_observed=canonical_work_observed,
+        verified_at=first_actionable_step_observed_at or task_graph_created_at,
+        recovery_recommendation=(
+            result.recovery_recommendation.as_dict()
+            if result.recovery_recommendation
+            else _recovery_recommendation(blocker)
+        ),
+    )
 
     return LeaderKickoffVerification(
         kickoff_verified=kickoff_verified,
@@ -445,6 +490,7 @@ def verify_leader_kickoff_delivery(
             else _recovery_recommendation(blocker)
         ),
         delivery_trace_id=result.trace_id,
+        managed_handoff=handoff.as_dict(),
         blocker_reason=blocker.value if isinstance(blocker, BlockerReason) else None,
         message=result.message,
     )

--- a/src/atc/orchestration/handoff.py
+++ b/src/atc/orchestration/handoff.py
@@ -1,0 +1,357 @@
+"""Provider-neutral managed-agent handoff contract.
+
+This module intentionally contains no provider prompt matching or tmux behavior.
+It normalizes what ATC can prove about parent→child handoffs such as
+Tower→Leader kickoff and Leader→Ace assignment.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import StrEnum
+from typing import Any
+
+from atc.runtime.models import (
+    BlockerReason,
+    DeliveryState,
+    RoleKind,
+    RuntimeDeliveryResult,
+    RuntimeState,
+)
+
+
+class HandoffPayloadKind(StrEnum):
+    """Canonical payload kinds sent between managed agents."""
+
+    LEADER_GOAL = "leader_goal"
+    ACE_ASSIGNMENT = "ace_assignment"
+
+
+class HandoffLifecycleState(StrEnum):
+    """Provider-neutral parent→child handoff lifecycle ladder."""
+
+    NOT_STARTED = "not_started"
+    SESSION_CREATED = "session_created"
+    STARTUP_INSPECTED = "startup_inspected"
+    INPUT_READY = "input_ready"
+    PAYLOAD_WRITTEN = "payload_written"
+    PAYLOAD_SUBMITTED = "payload_submitted"
+    CHILD_REPORTED_ACTIVE = "child_reported_active"
+    FIRST_ACTIONABLE_STEP_OBSERVED = "first_actionable_step_observed"
+    HANDOFF_VERIFIED = "handoff_verified"
+    BLOCKED = "blocked"
+    FAILED = "failed"
+
+
+@dataclass(slots=True)
+class ManagedAgentHandoffContext:
+    """Shared Tower→Leader and Leader→Ace handoff truth.
+
+    The context is additive: callers can include it in API responses or persist it
+    in existing context JSON without requiring a schema migration. It must only
+    contain provider-neutral states and reason codes.
+    """
+
+    parent_role: RoleKind
+    child_role: RoleKind
+    payload_kind: HandoffPayloadKind
+    lifecycle_state: HandoffLifecycleState
+    project_id: str | None = None
+    session_id: str | None = None
+    task_id: str | None = None
+    assignment_id: str | None = None
+    payload_hash: str | None = None
+    runtime_state: RuntimeState | None = None
+    delivery_state: DeliveryState | None = None
+    startup_readiness_state: str | None = None
+    blocker_reason: BlockerReason | str | None = None
+    child_reported_active: bool = False
+    payload_written: bool = False
+    payload_submitted: bool = False
+    first_actionable_step_observed: bool = False
+    handoff_verified: bool = False
+    trace_id: str | None = None
+    verified_at: str | None = None
+    last_activity_at: str | None = None
+    recovery_recommendation: dict[str, Any] | None = None
+    evidence: dict[str, Any] = field(default_factory=dict)
+
+    def as_dict(self) -> dict[str, Any]:
+        """Return API-safe provider-neutral handoff truth."""
+
+        blocker = (
+            self.blocker_reason.value
+            if isinstance(self.blocker_reason, StrEnum)
+            else self.blocker_reason
+        )
+        data: dict[str, Any] = {
+            "parent_role": self.parent_role.value,
+            "child_role": self.child_role.value,
+            "payload_kind": self.payload_kind.value,
+            "lifecycle_state": self.lifecycle_state.value,
+            "project_id": self.project_id,
+            "session_id": self.session_id,
+            "task_id": self.task_id,
+            "assignment_id": self.assignment_id,
+            "payload_hash": self.payload_hash,
+            "runtime_state": self.runtime_state.value if self.runtime_state else None,
+            "delivery_state": self.delivery_state.value if self.delivery_state else None,
+            "startup_readiness_state": self.startup_readiness_state,
+            "blocker_reason": blocker,
+            "child_reported_active": self.child_reported_active,
+            "payload_written": self.payload_written,
+            "payload_submitted": self.payload_submitted,
+            "first_actionable_step_observed": self.first_actionable_step_observed,
+            "handoff_verified": self.handoff_verified,
+            "trace_id": self.trace_id,
+            "verified_at": self.verified_at,
+            "last_activity_at": self.last_activity_at,
+            "recovery_recommendation": self.recovery_recommendation,
+            "evidence": self.evidence,
+        }
+        return {key: value for key, value in data.items() if value is not None and value != {}}
+
+
+def _runtime_created(
+    runtime_state: RuntimeState | None,
+    delivery_state: DeliveryState | None,
+) -> bool:
+    return delivery_state in {
+        DeliveryState.RUNTIME_CREATED,
+        DeliveryState.PROMPT_VISIBLE,
+        DeliveryState.PAYLOAD_WRITTEN,
+        DeliveryState.SUBMIT_SENT,
+        DeliveryState.SUBMITTED_PENDING_ACCEPTANCE,
+        DeliveryState.ACCEPTED_ACTIVE,
+        DeliveryState.BLOCKED,
+    } or runtime_state in {
+        RuntimeState.READY,
+        RuntimeState.ACTIVE,
+        RuntimeState.BLOCKED,
+        RuntimeState.IDLE,
+        RuntimeState.IDLE_AT_DEFAULT_PROMPT,
+    }
+
+
+def _payload_written(delivery_state: DeliveryState | None) -> bool:
+    return delivery_state in {
+        DeliveryState.PAYLOAD_WRITTEN,
+        DeliveryState.SUBMIT_SENT,
+        DeliveryState.SUBMITTED_PENDING_ACCEPTANCE,
+        DeliveryState.ACCEPTED_ACTIVE,
+    }
+
+
+def _payload_submitted(delivery_state: DeliveryState | None) -> bool:
+    return delivery_state in {
+        DeliveryState.SUBMIT_SENT,
+        DeliveryState.SUBMITTED_PENDING_ACCEPTANCE,
+        DeliveryState.ACCEPTED_ACTIVE,
+    }
+
+
+def _startup_readiness_state(
+    runtime_state: RuntimeState | None,
+    delivery_state: DeliveryState | None,
+    blocker: BlockerReason | None,
+) -> str:
+    if blocker is not None or delivery_state is DeliveryState.BLOCKED:
+        return "blocked"
+    if runtime_state in {RuntimeState.FAILED, RuntimeState.MISSING, RuntimeState.STALE}:
+        return "failed"
+    if runtime_state in {
+        RuntimeState.READY,
+        RuntimeState.ACTIVE,
+        RuntimeState.IDLE,
+        RuntimeState.IDLE_AT_DEFAULT_PROMPT,
+    }:
+        return "input_ready"
+    if _runtime_created(runtime_state, delivery_state):
+        return "startup_inspected"
+    return "not_started"
+
+
+def lifecycle_from_truth(
+    *,
+    runtime_state: RuntimeState | None,
+    delivery_state: DeliveryState | None,
+    blocker_reason: BlockerReason | None = None,
+    child_reported_active: bool = False,
+    first_actionable_step_observed: bool = False,
+    handoff_verified: bool = False,
+    failed: bool = False,
+) -> HandoffLifecycleState:
+    """Classify neutral runtime/delivery/report truth into the shared ladder."""
+
+    if blocker_reason is not None or delivery_state is DeliveryState.BLOCKED:
+        return HandoffLifecycleState.BLOCKED
+    if failed or runtime_state in {RuntimeState.FAILED, RuntimeState.MISSING, RuntimeState.STALE}:
+        return HandoffLifecycleState.FAILED
+    if handoff_verified:
+        return HandoffLifecycleState.HANDOFF_VERIFIED
+    if first_actionable_step_observed:
+        return HandoffLifecycleState.FIRST_ACTIONABLE_STEP_OBSERVED
+    if child_reported_active:
+        return HandoffLifecycleState.CHILD_REPORTED_ACTIVE
+    if _payload_submitted(delivery_state):
+        return HandoffLifecycleState.PAYLOAD_SUBMITTED
+    if _payload_written(delivery_state):
+        return HandoffLifecycleState.PAYLOAD_WRITTEN
+    if runtime_state in {
+        RuntimeState.READY,
+        RuntimeState.ACTIVE,
+        RuntimeState.IDLE,
+        RuntimeState.IDLE_AT_DEFAULT_PROMPT,
+    }:
+        return HandoffLifecycleState.INPUT_READY
+    if delivery_state is DeliveryState.PROMPT_VISIBLE:
+        return HandoffLifecycleState.STARTUP_INSPECTED
+    if _runtime_created(runtime_state, delivery_state):
+        return HandoffLifecycleState.SESSION_CREATED
+    return HandoffLifecycleState.NOT_STARTED
+
+
+def handoff_from_delivery_result(
+    result: RuntimeDeliveryResult | None,
+    *,
+    parent_role: RoleKind,
+    child_role: RoleKind,
+    payload_kind: HandoffPayloadKind,
+    project_id: str | None = None,
+    session_id: str | None = None,
+    task_id: str | None = None,
+    assignment_id: str | None = None,
+    payload_hash: str | None = None,
+    child_reported_active: bool = False,
+    first_actionable_step_observed: bool = False,
+    verified_at: str | None = None,
+    recovery_recommendation: dict[str, Any] | None = None,
+    evidence: dict[str, Any] | None = None,
+) -> ManagedAgentHandoffContext:
+    """Build a shared handoff context from runtime delivery truth."""
+
+    runtime_state = result.runtime_state if result else None
+    delivery_state = result.delivery_state if result else None
+    blocker = result.blocker_reason if result else None
+    failed = bool(result and result.status == "failed")
+    submitted = _payload_submitted(delivery_state)
+    handoff_verified = bool(
+        submitted
+        and child_reported_active
+        and first_actionable_step_observed
+        and not blocker
+        and not failed
+    )
+    lifecycle_state = lifecycle_from_truth(
+        runtime_state=runtime_state,
+        delivery_state=delivery_state,
+        blocker_reason=blocker,
+        child_reported_active=child_reported_active,
+        first_actionable_step_observed=first_actionable_step_observed,
+        handoff_verified=handoff_verified,
+        failed=failed,
+    )
+    return ManagedAgentHandoffContext(
+        parent_role=parent_role,
+        child_role=child_role,
+        payload_kind=payload_kind,
+        lifecycle_state=lifecycle_state,
+        project_id=project_id,
+        session_id=session_id or (result.session_id if result else None),
+        task_id=task_id,
+        assignment_id=assignment_id,
+        payload_hash=payload_hash,
+        runtime_state=runtime_state,
+        delivery_state=delivery_state,
+        startup_readiness_state=_startup_readiness_state(runtime_state, delivery_state, blocker),
+        blocker_reason=blocker,
+        child_reported_active=child_reported_active,
+        payload_written=_payload_written(delivery_state),
+        payload_submitted=submitted,
+        first_actionable_step_observed=first_actionable_step_observed,
+        handoff_verified=handoff_verified,
+        trace_id=result.trace_id if result else None,
+        verified_at=verified_at if handoff_verified else None,
+        last_activity_at=result.last_activity_at if result else None,
+        recovery_recommendation=recovery_recommendation,
+        evidence=evidence or {},
+    )
+
+
+def handoff_from_assignment(
+    assignment: Any | None,
+    *,
+    project_id: str | None = None,
+    task_id: str | None = None,
+) -> ManagedAgentHandoffContext:
+    """Build Leader→Ace handoff truth from a task assignment row/model."""
+
+    delivery_state: DeliveryState | None = None
+    blocker: str | None = None
+    if assignment is not None:
+        raw_delivery_state = getattr(assignment, "dispatch_delivery_state", None)
+        if raw_delivery_state:
+            try:
+                delivery_state = DeliveryState(raw_delivery_state)
+            except ValueError:
+                delivery_state = DeliveryState.FAILED
+        blocker = assignment.blocker_reason
+    child_reported_active = bool(assignment and assignment.ace_reported_active)
+    first_actionable = bool(assignment and assignment.assignment_accepted)
+    verified = bool(assignment and assignment.dispatch_verified and assignment.assignment_accepted)
+    lifecycle_state = lifecycle_from_truth(
+        runtime_state=None,
+        delivery_state=delivery_state,
+        blocker_reason=None,
+        child_reported_active=child_reported_active,
+        first_actionable_step_observed=first_actionable,
+        handoff_verified=verified,
+        failed=delivery_state is DeliveryState.FAILED,
+    )
+    if blocker:
+        lifecycle_state = HandoffLifecycleState.BLOCKED
+    return ManagedAgentHandoffContext(
+        parent_role=RoleKind.LEADER,
+        child_role=RoleKind.ACE,
+        payload_kind=HandoffPayloadKind.ACE_ASSIGNMENT,
+        lifecycle_state=lifecycle_state,
+        project_id=project_id,
+        session_id=assignment.ace_session_id if assignment is not None else None,
+        task_id=task_id or (assignment.task_graph_id if assignment is not None else None),
+        assignment_id=assignment.assignment_id if assignment is not None else None,
+        delivery_state=delivery_state,
+        startup_readiness_state=(
+            assignment.startup_readiness_state if assignment is not None else "not_started"
+        ),
+        blocker_reason=blocker,
+        child_reported_active=child_reported_active,
+        payload_written=delivery_state
+        in {
+            DeliveryState.PAYLOAD_WRITTEN,
+            DeliveryState.SUBMIT_SENT,
+            DeliveryState.SUBMITTED_PENDING_ACCEPTANCE,
+            DeliveryState.ACCEPTED_ACTIVE,
+        },
+        payload_submitted=delivery_state
+        in {
+            DeliveryState.SUBMIT_SENT,
+            DeliveryState.SUBMITTED_PENDING_ACCEPTANCE,
+            DeliveryState.ACCEPTED_ACTIVE,
+        },
+        first_actionable_step_observed=first_actionable,
+        handoff_verified=verified,
+        verified_at=(
+            assignment.assignment_accepted_at if verified and assignment is not None else None
+        ),
+        last_activity_at=assignment.last_activity_at if assignment is not None else None,
+        evidence={
+            "assignment_status": assignment.status if assignment is not None else None,
+            "dispatch_verified": assignment.dispatch_verified if assignment is not None else False,
+            "assignment_accepted": assignment.assignment_accepted
+            if assignment is not None
+            else False,
+            "artifact_ready": assignment.artifact_ready if assignment is not None else False,
+        }
+        if assignment is not None
+        else {},
+    )

--- a/tests/e2e/test_task_graph_api.py
+++ b/tests/e2e/test_task_graph_api.py
@@ -374,6 +374,28 @@ class TestIdempotentAssignment:
         assert len(data) == 1
         assert data[0]["assignment_id"] == "key-list"
 
+    def test_runtime_truth_includes_managed_handoff_context(self, client: TestClient) -> None:
+        project_id = _create_project(client)
+        create_resp = client.post(
+            f"/api/projects/{project_id}/task-graphs",
+            json={"title": "Runtime truth handoff"},
+        )
+        tg_id = create_resp.json()["id"]
+
+        client.post(
+            f"/api/task-graphs/{tg_id}/assign",
+            json={"ace_session_id": "ace-1", "assignment_id": "key-handoff"},
+        )
+
+        resp = client.get(f"/api/task-graphs/{tg_id}")
+        assert resp.status_code == 200
+        handoff = resp.json()["runtime_truth"]["evidence"]["managed_handoff"]
+        assert handoff["parent_role"] == "leader"
+        assert handoff["child_role"] == "ace"
+        assert handoff["payload_kind"] == "ace_assignment"
+        assert handoff["lifecycle_state"] == "not_started"
+        assert handoff["handoff_verified"] is False
+
     def test_assignment_status_transition(self, client: TestClient) -> None:
         project_id = _create_project(client)
         create_resp = client.post(

--- a/tests/unit/test_leader_kickoff.py
+++ b/tests/unit/test_leader_kickoff.py
@@ -67,6 +67,9 @@ async def test_persist_leader_kickoff_payload_is_recoverable(db) -> None:
     assert context["leader_kickoff_payload"]["message"] == message
     assert context["leader_kickoff_payload"]["source"] == "test"
     assert context["leader_kickoff_payload"]["trace_id"]
+    assert context["managed_handoff"]["payload_kind"] == "leader_goal"
+    assert context["managed_handoff"]["lifecycle_state"] == "session_created"
+    assert context["managed_handoff"]["handoff_verified"] is False
     assert payload.trace_id == context["leader_kickoff_payload"]["trace_id"]
     assert f"/api/projects/{project.id}/leader/report-active" in message
     assert f"/api/projects/{project.id}/leader/decompose" in message
@@ -109,6 +112,9 @@ def test_verify_leader_kickoff_accepts_active_delivery() -> None:
     assert verification.goal_accepted is True
     assert verification.leader_reported_active is True
     assert verification.leader_began_work is True
+    assert verification.managed_handoff is not None
+    assert verification.managed_handoff["lifecycle_state"] == "handoff_verified"
+    assert verification.managed_handoff["child_reported_active"] is True
 
 
 def test_verify_leader_kickoff_distinguishes_pending_submission() -> None:

--- a/tests/unit/test_managed_agent_handoff.py
+++ b/tests/unit/test_managed_agent_handoff.py
@@ -1,0 +1,113 @@
+"""Tests for shared managed-agent handoff contract."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from atc.orchestration.handoff import (
+    HandoffLifecycleState,
+    HandoffPayloadKind,
+    handoff_from_assignment,
+    handoff_from_delivery_result,
+)
+from atc.runtime.models import (
+    BlockerReason,
+    DeliveryState,
+    RoleKind,
+    RuntimeDeliveryResult,
+    RuntimeState,
+)
+
+
+def test_handoff_ladder_distinguishes_session_from_verified_leader_handoff() -> None:
+    result = RuntimeDeliveryResult(
+        session_id="leader-1",
+        provider_name="codex",
+        role=RoleKind.LEADER,
+        status="accepted",
+        runtime_state=RuntimeState.ACTIVE,
+        delivery_state=DeliveryState.SUBMIT_SENT,
+        trace_id="trace-1",
+    )
+
+    pending = handoff_from_delivery_result(
+        result,
+        parent_role=RoleKind.TOWER,
+        child_role=RoleKind.LEADER,
+        payload_kind=HandoffPayloadKind.LEADER_GOAL,
+        project_id="project-1",
+    )
+
+    assert pending.lifecycle_state is HandoffLifecycleState.PAYLOAD_SUBMITTED
+    assert pending.handoff_verified is False
+    assert pending.payload_submitted is True
+    assert pending.child_reported_active is False
+
+    verified = handoff_from_delivery_result(
+        result,
+        parent_role=RoleKind.TOWER,
+        child_role=RoleKind.LEADER,
+        payload_kind=HandoffPayloadKind.LEADER_GOAL,
+        project_id="project-1",
+        child_reported_active=True,
+        first_actionable_step_observed=True,
+        verified_at="2026-06-23T00:00:00+00:00",
+    )
+
+    assert verified.lifecycle_state is HandoffLifecycleState.HANDOFF_VERIFIED
+    assert verified.handoff_verified is True
+    assert verified.verified_at == "2026-06-23T00:00:00+00:00"
+    assert verified.as_dict()["payload_kind"] == "leader_goal"
+
+
+def test_handoff_ladder_surfaces_provider_neutral_blocker() -> None:
+    result = RuntimeDeliveryResult(
+        session_id="leader-1",
+        provider_name="codex",
+        role=RoleKind.LEADER,
+        status="blocked",
+        runtime_state=RuntimeState.BLOCKED,
+        delivery_state=DeliveryState.BLOCKED,
+        blocker_reason=BlockerReason.RUNTIME_TRUST_REQUIRED,
+    )
+
+    handoff = handoff_from_delivery_result(
+        result,
+        parent_role=RoleKind.TOWER,
+        child_role=RoleKind.LEADER,
+        payload_kind=HandoffPayloadKind.LEADER_GOAL,
+    )
+
+    assert handoff.lifecycle_state is HandoffLifecycleState.BLOCKED
+    assert handoff.startup_readiness_state == "blocked"
+    assert handoff.as_dict()["blocker_reason"] == "runtime_trust_required"
+
+
+def test_assignment_handoff_uses_same_lifecycle_contract() -> None:
+    assignment = SimpleNamespace(
+        ace_session_id="ace-1",
+        task_graph_id="task-1",
+        assignment_id="assignment-1",
+        status="working",
+        startup_readiness_state="input_ready",
+        dispatch_delivery_state="accepted_active",
+        dispatch_verified=True,
+        ace_reported_active=True,
+        assignment_accepted=True,
+        assignment_accepted_at="2026-06-23T00:05:00+00:00",
+        acceptance_message="accepted",
+        artifact_ready=False,
+        blocker_reason=None,
+        last_activity_at="2026-06-23T00:05:30+00:00",
+    )
+
+    handoff = handoff_from_assignment(assignment, project_id="project-1")
+
+    assert handoff.parent_role is RoleKind.LEADER
+    assert handoff.child_role is RoleKind.ACE
+    assert handoff.payload_kind is HandoffPayloadKind.ACE_ASSIGNMENT
+    assert handoff.lifecycle_state is HandoffLifecycleState.HANDOFF_VERIFIED
+    assert handoff.handoff_verified is True
+    assert handoff.child_reported_active is True
+    assert handoff.first_actionable_step_observed is True
+    assert handoff.as_dict()["assignment_id"] == "assignment-1"


### PR DESCRIPTION
## Summary

Phase 1 of the managed-agent handoff plan: adds a shared provider-neutral handoff contract and wires current Tower→Leader and Leader→Ace surfaces into it.

- Adds `atc.orchestration.handoff.ManagedAgentHandoffContext` plus lifecycle enums for:
  - `session_created`
  - `startup_inspected`
  - `input_ready`
  - `payload_written`
  - `payload_submitted`
  - `child_reported_active`
  - `first_actionable_step_observed`
  - `handoff_verified`
  - `blocked` / `failed`
- Adds conversion helpers for:
  - Tower→Leader kickoff delivery truth from `RuntimeDeliveryResult`
  - Leader→Ace assignment truth from task assignment state
- Persists initial Tower→Leader `managed_handoff` context when kickoff payload is saved.
- Includes managed handoff context in Leader kickoff verification responses.
- Includes Leader→Ace managed handoff context in task runtime truth evidence.
- Updates architecture docs to make this lifecycle contract canonical and provider-neutral.

## Validation

- `./.venv/bin/python -m ruff check src/atc/orchestration/handoff.py src/atc/leader/kickoff.py src/atc/api/routers/task_graphs.py tests/unit/test_managed_agent_handoff.py tests/unit/test_leader_kickoff.py tests/e2e/test_task_graph_api.py`
- `./.venv/bin/python -m pytest tests/unit/test_managed_agent_handoff.py tests/unit/test_leader_kickoff.py tests/unit/test_runtime_health.py tests/e2e/test_task_graph_api.py -q` → 57 passed, 1 warning
- `./.venv/bin/python -m pytest tests/e2e/test_smoke.py -q` → 24 passed, 1 warning

## Notes

No UI behavior changed, so no screenshot evidence is attached for this phase.
