### PR TITLE
Surface Leader-owned Ace blocker escalation

### DIFF
--- a/docs/agents/TOWER.md
+++ b/docs/agents/TOWER.md
@@ -67,7 +67,13 @@ atc leader message --project-id <project-id> --message "Please read your goal, i
 
 That nudge is a prompt-submission recovery, not a replacement for the original goal. Tower must not paste the full goal/context again unless a recovery path explicitly reports the original payload was lost.
 
-After the Leader reports active/goal accepted and begins project work, Tower must stop checking normal task progress. The Leader is the busy session and owns task graph/Ace monitoring. Tower should wait for the event-driven completion hook:
+After the Leader reports active/goal accepted and begins project work, Tower must stop checking normal task progress. The Leader is the busy session and owns task graph/Ace monitoring. If Leader progress surfaces `ace_blockers`, Tower applies a three-cycle policy without directly managing Aces:
+
+1. first identical blocker cycle: wait and report that Leader owns the Ace recovery;
+2. second identical blocker cycle: send one Leader nudge/request for Leader-owned recovery;
+3. third identical blocker cycle: escalate to the operator with choices such as wait, ask Leader to recover, stop/restart Leader, or operator-approved break-glass.
+
+Tower should then wait for the event-driven completion hook:
 
 ```text
 POST /api/projects/{project_id}/leader/report-complete

--- a/src/atc/api/routers/leader.py
+++ b/src/atc/api/routers/leader.py
@@ -93,6 +93,16 @@ class ProgressResponse(BaseModel):
     all_done: bool
     progress_pct: int
     assignments: list[dict[str, Any]]
+    leader_state: str = "working"
+    handoff_verified: bool = False
+    ace_blockers: list[dict[str, Any]] = Field(default_factory=list)
+    tower_recommended_action: str = "wait_for_leader_or_completion_hook"
+    tower_allowed_actions: list[str] = Field(default_factory=list)
+    tower_must_not: list[str] = Field(default_factory=list)
+    blocker_cycle_count: int = 0
+    should_nudge_leader: bool = False
+    should_escalate_to_operator: bool = False
+    escalation_reason: str | None = None
     blocked_transition_errors: list[dict[str, Any]] = Field(default_factory=list)
 
 
@@ -437,6 +447,22 @@ async def get_progress(
     """Return a summary of the Leader's task graph progress."""
     orch = await _get_or_create_orchestrator(request, project_id)
     progress = await orch.get_progress()
+    tower = getattr(request.app.state, "tower_controller", None)
+    if tower is not None and hasattr(tower, "observe_leader_ace_blockers"):
+        policy = tower.observe_leader_ace_blockers(
+            project_id,
+            list(progress.get("ace_blockers") or []),
+        )
+        progress.update(
+            {
+                "tower_recommended_action": policy["tower_recommended_action"],
+                "tower_allowed_actions": policy["tower_allowed_actions"],
+                "blocker_cycle_count": policy["blocker_cycle_count"],
+                "should_nudge_leader": policy["should_nudge_leader"],
+                "should_escalate_to_operator": policy["should_escalate_to_operator"],
+                "escalation_reason": policy["reason"],
+            }
+        )
     return ProgressResponse(**progress)
 
 

--- a/src/atc/leader/orchestrator.py
+++ b/src/atc/leader/orchestrator.py
@@ -725,7 +725,7 @@ class LeaderOrchestrator:
         status = get_completion_status(task_graphs)
         persisted_assignments = await db_ops.list_task_assignments(self.conn)
         assignment_rows = persisted_assignments or list(self.assignments.values())
-        status["assignments"] = [
+        assignments = [
             {
                 "task_graph_id": a.task_graph_id,
                 "ace_session_id": a.ace_session_id,
@@ -751,11 +751,65 @@ class LeaderOrchestrator:
             }
             for a in assignment_rows
         ]
+        ace_blockers = self._build_ace_blocker_summaries(assignments)
+        status["assignments"] = assignments
         status["leader_id"] = self.leader_id
         status["project_id"] = self.project_id
+        status["leader_state"] = self._leader_state(status, ace_blockers)
+        status["handoff_verified"] = bool(status.get("total") or assignments)
+        status["ace_blockers"] = ace_blockers
+        status["tower_must_not"] = [
+            "inspect_ace_pane",
+            "recover_ace_directly",
+            "message_ace_directly",
+            "mark_ace_done_directly",
+        ]
+        status["tower_recommended_action"] = (
+            "nudge_leader_to_resolve_ace_blockers"
+            if ace_blockers
+            else "wait_for_leader_or_completion_hook"
+        )
         status["blocked_transition_errors"] = list(self.blocked_transition_errors)
 
         return status
+
+    @staticmethod
+    def _leader_state(status: dict[str, Any], ace_blockers: list[dict[str, Any]]) -> str:
+        if status.get("all_done"):
+            return "complete"
+        if ace_blockers:
+            return "ace_blocked"
+        if status.get("in_progress") or status.get("todo") or status.get("total"):
+            return "working"
+        return "waiting_for_task_graph"
+
+    @staticmethod
+    def _build_ace_blocker_summaries(assignments: list[dict[str, Any]]) -> list[dict[str, Any]]:
+        blockers: list[dict[str, Any]] = []
+        for assignment in assignments:
+            blocker_reason = assignment.get("blocker_reason")
+            acceptance_state = assignment.get("assignment_acceptance_state")
+            dispatch_verified = bool(assignment.get("dispatch_verified"))
+            is_blocked = bool(blocker_reason) or (
+                acceptance_state in {"blocked", "startup_blocked"}
+            )
+            if not is_blocked:
+                continue
+            blockers.append(
+                {
+                    "ace_id": assignment.get("ace_session_id"),
+                    "ace_session_id": assignment.get("ace_session_id"),
+                    "task_id": assignment.get("task_graph_id"),
+                    "task_graph_id": assignment.get("task_graph_id"),
+                    "blocker_reason": blocker_reason or acceptance_state or "ace_blocked",
+                    "dispatch_verified": dispatch_verified,
+                    "assignment_acceptance_state": acceptance_state,
+                    "owner": "leader",
+                    "leader_action": "inspect_or_recover_ace_assignment",
+                    "tower_allowed_action": "nudge_leader_only",
+                }
+            )
+        return blockers
 
     @staticmethod
     def _assignment_acceptance_state(assignment: Any) -> str:

--- a/src/atc/tower/controller.py
+++ b/src/atc/tower/controller.py
@@ -35,7 +35,10 @@ from atc.runtime.health import leader_health
 from atc.runtime.models import DeliveryState, RoleKind, RuntimeDeliveryResult, RuntimeState
 from atc.session.state_machine import SessionStatus
 from atc.state import db as db_ops
-from atc.tower.monitoring import decide_tower_monitoring_cadence
+from atc.tower.monitoring import (
+    decide_leader_blocker_escalation,
+    decide_tower_monitoring_cadence,
+)
 from atc.tower.session import send_tower_message, start_tower_session, stop_tower_session
 
 if TYPE_CHECKING:
@@ -101,6 +104,7 @@ class TowerController:
         # Track Leader output lines for monitoring
         self._leader_output_lines: list[str] = []
         self._max_output_lines = 200
+        self._leader_blocker_cycles: dict[str, dict[str, Any]] = {}
 
         # Budget constraint flag — set when budget_warning fires, cleared on budget_ok
         self._budget_constrained = False
@@ -139,6 +143,30 @@ class TowerController:
     @property
     def current_session_id(self) -> str | None:
         return self._current_session_id
+
+    def observe_leader_ace_blockers(
+        self,
+        project_id: str,
+        ace_blockers: list[dict[str, Any]],
+    ) -> dict[str, Any]:
+        """Track repeated Leader-owned Ace blockers and return Tower-safe policy.
+
+        Tower does not inspect or recover Aces here. It only tracks whether the
+        Leader is reporting the same blocker across cycles, then recommends
+        wait → nudge Leader once → escalate to operator.
+        """
+
+        previous = self._leader_blocker_cycles.get(project_id, {})
+        decision = decide_leader_blocker_escalation(
+            ace_blockers,
+            previous_signature=previous.get("signature"),
+            previous_cycle_count=int(previous.get("cycle_count") or 0),
+        )
+        self._leader_blocker_cycles[project_id] = {
+            "signature": decision.blocker_signature,
+            "cycle_count": decision.blocker_cycle_count,
+        }
+        return decision.as_dict()
 
     async def _transition(self, target: TowerState) -> None:
         """Validate and perform a tower state transition."""
@@ -247,6 +275,7 @@ class TowerController:
         self._current_project_id = None
         self._current_session_id = None
         self._leader_output_lines.clear()
+        self._leader_blocker_cycles.clear()
 
         await self._event_bus.publish(
             "tower_state_changed",
@@ -490,6 +519,7 @@ class TowerController:
         self._current_goal = None
         self._leader_session_id = None
         self._leader_output_lines.clear()
+        self._leader_blocker_cycles.pop(project_id, None)
 
         payload = {
             "type": "leader_project_completed",

--- a/src/atc/tower/monitoring.py
+++ b/src/atc/tower/monitoring.py
@@ -31,6 +31,106 @@ class MonitoringCadenceDecision:
     reason: str
 
 
+@dataclass(frozen=True, slots=True)
+class LeaderBlockerEscalationDecision:
+    """Three-cycle Tower policy for Leader-owned Ace blocker summaries."""
+
+    blocker_signature: str
+    blocker_cycle_count: int
+    tower_recommended_action: str
+    tower_allowed_actions: list[str]
+    should_nudge_leader: bool
+    should_escalate_to_operator: bool
+    reason: str
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "blocker_signature": self.blocker_signature,
+            "blocker_cycle_count": self.blocker_cycle_count,
+            "tower_recommended_action": self.tower_recommended_action,
+            "tower_allowed_actions": self.tower_allowed_actions,
+            "should_nudge_leader": self.should_nudge_leader,
+            "should_escalate_to_operator": self.should_escalate_to_operator,
+            "reason": self.reason,
+        }
+
+
+def _blocker_signature(ace_blockers: list[dict[str, Any]]) -> str:
+    parts = [
+        ":".join(
+            [
+                str(blocker.get("ace_id") or blocker.get("ace_session_id") or ""),
+                str(blocker.get("task_id") or blocker.get("task_graph_id") or ""),
+                str(blocker.get("blocker_reason") or ""),
+            ]
+        )
+        for blocker in ace_blockers
+    ]
+    return "|".join(sorted(parts))
+
+
+def decide_leader_blocker_escalation(
+    ace_blockers: list[dict[str, Any]],
+    *,
+    previous_signature: str | None = None,
+    previous_cycle_count: int = 0,
+) -> LeaderBlockerEscalationDecision:
+    """Apply Tower's three-cycle policy without making Tower manage Aces.
+
+    Cycle 1: wait/report that Leader owns resolution.
+    Cycle 2: Tower may nudge Leader once.
+    Cycle 3+: Tower escalates to the operator with break-glass/restart options.
+    """
+
+    if not ace_blockers:
+        return LeaderBlockerEscalationDecision(
+            blocker_signature="",
+            blocker_cycle_count=0,
+            tower_recommended_action="wait_for_leader_or_completion_hook",
+            tower_allowed_actions=["wait", "inspect_leader_health"],
+            should_nudge_leader=False,
+            should_escalate_to_operator=False,
+            reason="no_leader_reported_ace_blockers",
+        )
+
+    signature = _blocker_signature(ace_blockers)
+    cycle_count = previous_cycle_count + 1 if signature == previous_signature else 1
+    if cycle_count == 1:
+        return LeaderBlockerEscalationDecision(
+            blocker_signature=signature,
+            blocker_cycle_count=cycle_count,
+            tower_recommended_action="wait_for_leader_to_resolve_ace_blockers",
+            tower_allowed_actions=["wait", "inspect_leader_health"],
+            should_nudge_leader=False,
+            should_escalate_to_operator=False,
+            reason="leader_reported_ace_blocker_first_cycle",
+        )
+    if cycle_count == 2:
+        return LeaderBlockerEscalationDecision(
+            blocker_signature=signature,
+            blocker_cycle_count=cycle_count,
+            tower_recommended_action="nudge_leader_to_resolve_ace_blockers",
+            tower_allowed_actions=["nudge_leader_once", "inspect_leader_health"],
+            should_nudge_leader=True,
+            should_escalate_to_operator=False,
+            reason="leader_reported_same_ace_blocker_second_cycle",
+        )
+    return LeaderBlockerEscalationDecision(
+        blocker_signature=signature,
+        blocker_cycle_count=cycle_count,
+        tower_recommended_action="escalate_ace_blockers_to_operator",
+        tower_allowed_actions=[
+            "wait",
+            "ask_leader_to_recover",
+            "operator_approved_break_glass",
+            "stop_or_restart_leader",
+        ],
+        should_nudge_leader=False,
+        should_escalate_to_operator=True,
+        reason="leader_reported_same_ace_blocker_three_cycles",
+    )
+
+
 def _parse_timestamp(value: str | None) -> datetime | None:
     if not value:
         return None

--- a/tests/unit/test_leader_orchestrator.py
+++ b/tests/unit/test_leader_orchestrator.py
@@ -946,3 +946,37 @@ async def test_monitor_ace_assignments_is_leader_owned_and_publishes_blockers(
     ]
     assert orchestrator.assignments["task-1"].blocker_reason == "ace_dispatch_failed"
     assert events and events[0]["leader_owned"] is True
+
+
+@pytest.mark.asyncio
+async def test_progress_surfaces_leader_owned_ace_blockers(
+    db,
+    orchestrator: LeaderOrchestrator,
+) -> None:
+    tg = await create_task_graph(db, orchestrator.project_id, "Blocked task")
+    orchestrator.assignments[tg.id] = AceAssignment(
+        ace_session_id="ace-blocked-1",
+        task_graph_id=tg.id,
+        task_title="Blocked task",
+        blocker_reason="prompt_not_submitted",
+    )
+
+    progress = await orchestrator.get_progress()
+
+    assert progress["leader_state"] == "ace_blocked"
+    assert progress["tower_recommended_action"] == "nudge_leader_to_resolve_ace_blockers"
+    assert "recover_ace_directly" in progress["tower_must_not"]
+    assert progress["ace_blockers"] == [
+        {
+            "ace_id": "ace-blocked-1",
+            "ace_session_id": "ace-blocked-1",
+            "task_id": tg.id,
+            "task_graph_id": tg.id,
+            "blocker_reason": "prompt_not_submitted",
+            "dispatch_verified": False,
+            "assignment_acceptance_state": "blocked",
+            "owner": "leader",
+            "leader_action": "inspect_or_recover_ace_assignment",
+            "tower_allowed_action": "nudge_leader_only",
+        }
+    ]

--- a/tests/unit/test_tower_monitoring.py
+++ b/tests/unit/test_tower_monitoring.py
@@ -12,7 +12,10 @@ from atc.runtime.health import RuntimeHealth
 from atc.runtime.models import RuntimeState
 from atc.state.db import _SCHEMA_SQL, get_connection, run_migrations
 from atc.tower.controller import TowerController, TowerState
-from atc.tower.monitoring import decide_tower_monitoring_cadence
+from atc.tower.monitoring import (
+    decide_leader_blocker_escalation,
+    decide_tower_monitoring_cadence,
+)
 
 
 @pytest.fixture
@@ -130,3 +133,52 @@ async def test_tower_startup_verification_uses_leader_health_no_ace_inspection(
     health_mock.assert_awaited_once_with(db, project_id)
     nudge_mock.assert_not_called()
     assert tower.state == TowerState.MANAGING
+
+
+def _ace_blocker() -> dict[str, object]:
+    return {
+        "ace_id": "ace-1",
+        "task_id": "task-1",
+        "blocker_reason": "blocked_on_provider_startup_prompt",
+        "owner": "leader",
+        "tower_allowed_action": "nudge_leader_only",
+    }
+
+
+def test_leader_blocker_escalation_three_cycle_policy() -> None:
+    first = decide_leader_blocker_escalation([_ace_blocker()])
+    assert first.blocker_cycle_count == 1
+    assert first.tower_recommended_action == "wait_for_leader_to_resolve_ace_blockers"
+    assert first.should_nudge_leader is False
+    assert first.should_escalate_to_operator is False
+
+    second = decide_leader_blocker_escalation(
+        [_ace_blocker()],
+        previous_signature=first.blocker_signature,
+        previous_cycle_count=first.blocker_cycle_count,
+    )
+    assert second.blocker_cycle_count == 2
+    assert second.tower_recommended_action == "nudge_leader_to_resolve_ace_blockers"
+    assert second.should_nudge_leader is True
+
+    third = decide_leader_blocker_escalation(
+        [_ace_blocker()],
+        previous_signature=second.blocker_signature,
+        previous_cycle_count=second.blocker_cycle_count,
+    )
+    assert third.blocker_cycle_count == 3
+    assert third.tower_recommended_action == "escalate_ace_blockers_to_operator"
+    assert third.should_escalate_to_operator is True
+    assert "operator_approved_break_glass" in third.tower_allowed_actions
+
+
+@pytest.mark.asyncio
+async def test_tower_controller_tracks_repeated_leader_blocker_cycles(db, event_bus) -> None:
+    tower = TowerController(db, event_bus)
+    first = tower.observe_leader_ace_blockers("project-1", [_ace_blocker()])
+    second = tower.observe_leader_ace_blockers("project-1", [_ace_blocker()])
+    third = tower.observe_leader_ace_blockers("project-1", [_ace_blocker()])
+
+    assert first["blocker_cycle_count"] == 1
+    assert second["tower_recommended_action"] == "nudge_leader_to_resolve_ace_blockers"
+    assert third["should_escalate_to_operator"] is True


### PR DESCRIPTION
## Summary

Implements Phase 3 Leader-owned Ace blocker surfacing and Tower escalation policy while preserving provider/role separation:

- Leader progress now surfaces `leader_state`, `handoff_verified`, `ace_blockers`, Tower-safe recommendations, and explicit `tower_must_not` guardrails.
- Tower tracks repeated Leader-reported Ace blockers by signature and applies a three-cycle policy: wait → nudge Leader once → escalate to operator.
- Progress API includes escalation fields (`blocker_cycle_count`, `should_nudge_leader`, `should_escalate_to_operator`, `tower_allowed_actions`).
- Tower role contract documents that Ace recovery remains Leader-owned and direct Tower→Ace management requires audited break-glass.

## Validation

Backend/API/unit:

- `./.venv/bin/python -m ruff check src/atc/tower/monitoring.py src/atc/tower/controller.py src/atc/leader/orchestrator.py src/atc/api/routers/leader.py tests/unit/test_tower_monitoring.py tests/unit/test_leader_orchestrator.py`
- `./.venv/bin/python -m pytest tests/unit/test_tower_monitoring.py tests/unit/test_leader_orchestrator.py tests/e2e/test_task_graph_api.py tests/unit/test_leader_kickoff.py -q`
  - Result: `75 passed, 1 warning`

Frontend/baseline smoke:

- `cd frontend && PATH=/opt/homebrew/bin:$PATH npm run build`
- `PATH=/opt/homebrew/bin:$PATH node frontend/playwright-smoke-atc.mjs`
  - Result: `13/13 checks passed`
  - Report: `/Users/mcole_studio/AI_Stack/agents/skunkworks/workspace/screenshots/playwright-atc-2026-06-24T01-16-09-891Z/report.json`
  - Screenshots:
    - `/Users/mcole_studio/AI_Stack/agents/skunkworks/workspace/screenshots/playwright-atc-2026-06-24T01-16-09-891Z/01-dashboard-initial.png`
    - `/Users/mcole_studio/AI_Stack/agents/skunkworks/workspace/screenshots/playwright-atc-2026-06-24T01-16-09-891Z/05-create-project-modal.png`
    - `/Users/mcole_studio/AI_Stack/agents/skunkworks/workspace/screenshots/playwright-atc-2026-06-24T01-16-09-891Z/08-usage.png`
    - `/Users/mcole_studio/AI_Stack/agents/skunkworks/workspace/screenshots/playwright-atc-2026-06-24T01-16-09-891Z/12-context.png`

Caveat: Playwright report captured benign Vite/WebSocket-close warnings during browser navigation/cleanup; no failed requests and all assertions passed.
