### PR TITLE
Audit prompt-not-submitted recovery

### DIFF
--- a/docs/leader_kickoff_recovery_plan.md
+++ b/docs/leader_kickoff_recovery_plan.md
@@ -1,6 +1,6 @@
 # Leader Kickoff Verification and Startup Prompt Recovery Plan
 
-**Status:** Planned
+**Status:** In progress — Phases 0–4 implemented through PR #320 follow-up; Phase 4 adds inspect-first `prompt_not_submitted` recovery with provider-owned submission and audit events.
 **Issue:** [#297](https://github.com/wowc8/atc/issues/297)
 **Last updated:** 2026-06-13
 **Scope:** Follow-up runtime/orchestration hardening for Leader startup, managed-workspace provider prompts, `prompt_not_submitted` recovery, task graph ergonomics, and local ATC API capability setup.

--- a/src/atc/runtime/health.py
+++ b/src/atc/runtime/health.py
@@ -914,6 +914,33 @@ def build_recovery_plan(
     )
 
 
+async def _publish_recovery_audit(
+    event_bus: Any | None,
+    health: RuntimeHealth,
+    *,
+    policy: str,
+    status: str,
+    action: str | None = None,
+    blocker_reason: str | None = None,
+    refused_reason: str | None = None,
+) -> None:
+    if event_bus is None:
+        return
+    payload = {
+        "role": health.role,
+        "project_id": health.project_id,
+        "session_id": health.session_id,
+        "blocker_reason": blocker_reason if blocker_reason is not None else health.current_blocker,
+        "policy": policy,
+        "status": status,
+    }
+    if action:
+        payload["action"] = action
+    if refused_reason:
+        payload["refused_reason"] = refused_reason
+    await event_bus.publish("runtime_recovery_audit", payload)
+
+
 async def apply_recovery_plan(
     conn: aiosqlite.Connection,
     health: RuntimeHealth,
@@ -931,6 +958,13 @@ async def apply_recovery_plan(
 
     plan = build_recovery_plan(health, mode="apply", policy=policy)
     if plan.refused_reason:
+        await _publish_recovery_audit(
+            event_bus,
+            health,
+            policy=policy,
+            status="refused",
+            refused_reason=plan.refused_reason,
+        )
         return plan
 
     if health.current_blocker == BlockerReason.PROMPT_NOT_SUBMITTED.value and any(
@@ -941,6 +975,13 @@ async def apply_recovery_plan(
         if session is None:
             plan.refused_reason = "runtime_session_missing"
             plan.message = "Apply refused: runtime session is missing."
+            await _publish_recovery_audit(
+                event_bus,
+                health,
+                policy=policy,
+                status="refused",
+                refused_reason=plan.refused_reason,
+            )
             return plan
         inspection = await service.inspect_session_record(session)
         blocker = _blocker_from_inspection(inspection)
@@ -954,6 +995,15 @@ async def apply_recovery_plan(
                     "blocker_reason": blocker,
                 }
             )
+            await _publish_recovery_audit(
+                event_bus,
+                health,
+                policy=policy,
+                status="refused",
+                action="reinspect_runtime",
+                blocker_reason=blocker,
+                refused_reason=plan.refused_reason,
+            )
             return plan
         submitted = await service.submit_pending_prompt_for_session_record(session, inspection)
         if not submitted:
@@ -961,6 +1011,14 @@ async def apply_recovery_plan(
             plan.message = (
                 "Apply refused: provider adapter did not confirm safe pending "
                 "prompt submission."
+            )
+            await _publish_recovery_audit(
+                event_bus,
+                health,
+                policy=policy,
+                status="refused",
+                action="submit_pending_prompt",
+                refused_reason=plan.refused_reason,
             )
             return plan
         plan.actions.append(
@@ -972,6 +1030,13 @@ async def apply_recovery_plan(
             if health.role == "leader"
             else await ace_health(conn, health.project_id, session.id)
         ).as_dict()
+        await _publish_recovery_audit(
+            event_bus,
+            health,
+            policy=policy,
+            status="applied",
+            action="submit_pending_prompt",
+        )
         return plan
 
     if health.current_blocker == BlockerReason.RUNTIME_UPDATE_REQUIRED.value:

--- a/tests/unit/test_runtime_health.py
+++ b/tests/unit/test_runtime_health.py
@@ -69,6 +69,14 @@ class FakeRuntimeService:
         return True
 
 
+class FakeEventBus:
+    def __init__(self) -> None:
+        self.events: list[tuple[str, dict]] = []
+
+    async def publish(self, event_type: str, payload: dict) -> None:
+        self.events.append((event_type, payload))
+
+
 def _request(db):
     request = MagicMock()
     request.app.state.db = db
@@ -687,13 +695,68 @@ async def test_prompt_not_submitted_apply_reinspects_and_submits_via_provider(
 
     monkeypatch.setattr(health_module, "RuntimeService", lambda: fake_service)
     monkeypatch.setattr(health_module, "leader_health", fake_leader_health)
+    event_bus = FakeEventBus()
 
-    plan = await apply_recovery_plan(db, health, policy="submit_pending_prompt")
+    plan = await apply_recovery_plan(
+        db,
+        health,
+        policy="submit_pending_prompt",
+        event_bus=event_bus,
+    )
 
     assert plan.refused_reason is None
     assert fake_service.submitted is True
     assert plan.actions[-1]["action"] == "submit_pending_prompt"
     assert plan.actions[-1]["status"] == "applied"
+    assert event_bus.events == [
+        (
+            "runtime_recovery_audit",
+            {
+                "role": "leader",
+                "project_id": project.id,
+                "session_id": session.id,
+                "blocker_reason": "prompt_not_submitted",
+                "policy": "submit_pending_prompt",
+                "status": "applied",
+                "action": "submit_pending_prompt",
+            },
+        )
+    ]
+
+
+@pytest.mark.asyncio
+async def test_prompt_not_submitted_apply_audits_policy_refusal(db) -> None:
+    project = await create_project(db, "pending-prompt-refuse-audit")
+    health = RuntimeHealth(
+        role="leader",
+        project_id=project.id,
+        runtime_exists=True,
+        pane_attached=True,
+        provider="codex",
+        session_id="leader-session",
+        runtime_state=RuntimeState.BLOCKED.value,
+        current_blocker=BlockerReason.PROMPT_NOT_SUBMITTED.value,
+        kickoff_state={"pending_prompt_matches_persisted_payload": True},
+    )
+    event_bus = FakeEventBus()
+
+    plan = await apply_recovery_plan(db, health, policy="inspect_first", event_bus=event_bus)
+
+    assert plan.refused_reason == "apply_requires_submit_pending_prompt_policy"
+    assert event_bus.events == [
+        (
+            "runtime_recovery_audit",
+            {
+                "role": "leader",
+                "project_id": project.id,
+                "session_id": "leader-session",
+                "blocker_reason": "prompt_not_submitted",
+                "policy": "inspect_first",
+                "status": "refused",
+                "refused_reason": "apply_requires_submit_pending_prompt_policy",
+            },
+        )
+    ]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Loops Phase 4 follow-up for inspect-first `prompt_not_submitted` recovery:

- Adds provider-neutral `runtime_recovery_audit` events for recovery apply outcomes.
- Audits policy refusals, missing sessions, changed runtime state after reinspection, provider refusal, and successful provider-owned pending-prompt submission.
- Keeps provider mechanics separated: health/recovery publishes neutral events; provider adapters still own prompt classification and the actual submit/Enter behavior.
- Updates the kickoff recovery plan status for Phases 0–4.

## Validation

- `./.venv/bin/python -m ruff check src/atc/runtime/health.py tests/unit/test_runtime_health.py`
- `./.venv/bin/python -m pytest tests/unit/test_runtime_health.py tests/unit/test_leader_kickoff.py tests/unit/test_provider_classifiers.py tests/unit/test_codex_runtime.py tests/unit/test_runtime_service.py -q`
  - `73 passed, 1 warning`
- `./.venv/bin/python -m pytest tests/e2e/test_smoke.py tests/e2e/test_phase8_scenarios.py -q`
  - `38 passed, 1 warning`
- `cd frontend && PATH=/opt/homebrew/bin:$PATH npm run build`
  - passed; existing Vite chunk-size warning only
- Playwright baseline smoke:
  - `PATH=/opt/homebrew/bin:$PATH node frontend/playwright-smoke-atc.mjs`
  - `13/13` checks passed
  - report: `/Users/mcole_studio/AI_Stack/agents/skunkworks/workspace/screenshots/playwright-atc-2026-06-24T01-43-54-973Z/report.json`

## Evidence screenshots

- `/Users/mcole_studio/AI_Stack/agents/skunkworks/workspace/screenshots/playwright-atc-2026-06-24T01-43-54-973Z/01-dashboard-initial.png`
- `/Users/mcole_studio/AI_Stack/agents/skunkworks/workspace/screenshots/playwright-atc-2026-06-24T01-43-54-973Z/05-create-project-modal.png`
- `/Users/mcole_studio/AI_Stack/agents/skunkworks/workspace/screenshots/playwright-atc-2026-06-24T01-43-54-973Z/08-usage.png`
- `/Users/mcole_studio/AI_Stack/agents/skunkworks/workspace/screenshots/playwright-atc-2026-06-24T01-43-54-973Z/12-context.png`
