### PR TITLE
Add provider-neutral token usage recorder foundation

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -50,7 +50,7 @@ Design rule:
 | `core/` | Event bus, orchestrator, state manager, failure logger |
 | `session/` | Session state machine, ace lifecycle, reconnect, SSH tunnels |
 | `terminal/` | PTY streaming (tmux pipe-pane → FIFO → WS), output parser, monitor |
-| `tracking/` | AI token usage tracker, system resources (psutil), GitHub PR/CI, budget enforcer |
+| `tracking/` | Provider-neutral token usage recorder, provider usage trackers, system resources (psutil), GitHub PR/CI, budget enforcer |
 | `rws/` | Remote Ace Server daemon for remote hosts |
 | `agents/` | Agent deployment SOT — writes config files to /tmp |
 

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -58,6 +58,18 @@ Per-project budget limits with:
 - Warning threshold notifications
 - Automatic session pause on budget exceeded
 
+## Token Usage Telemetry
+
+**Status**: Foundation implemented
+
+Provider-neutral token usage infrastructure with:
+- Append-only `usage_events` token increment rows
+- Provider/model/source metadata for usage attribution
+- Separate cached-input and reasoning-output token fields for providers that expose them
+- Durable `usage_source_offsets` high-water state for provider collectors to avoid double-counting
+- Shared `TokenUsageRecorder` interface used by provider-specific collectors
+- Boundary rule: provider-specific parsing, filesystem paths, and event formats stay in provider modules; shared tracking only records normalized token increments
+
 ## GitHub Integration
 
 **Status**: Stub

--- a/src/atc/api/routers/usage.py
+++ b/src/atc/api/routers/usage.py
@@ -86,7 +86,7 @@ async def get_usage_summary(request: Request) -> UsageSummaryResponse:
     today = datetime.now(UTC).strftime("%Y-%m-%d")
     month_start = datetime.now(UTC).strftime("%Y-%m-01")
 
-    tok = "COALESCE(input_tokens,0)+COALESCE(output_tokens,0)"
+    tok = "COALESCE(total_tokens, COALESCE(input_tokens,0)+COALESCE(output_tokens,0)+COALESCE(reasoning_output_tokens,0))"
     tok_cond = f"CASE WHEN recorded_at >= ? THEN {tok} ELSE 0 END"
     cursor = await db.execute(
         f"""SELECT

--- a/src/atc/state/db.py
+++ b/src/atc/state/db.py
@@ -34,6 +34,7 @@ from atc.state.models import (
     TaskAssignment,
     TaskGraph,
     UsageEvent,
+    UsageSourceOffset,
 )
 from atc.state.transitions import (
     TASK_ASSIGNMENT_TRANSITIONS,
@@ -339,18 +340,43 @@ CREATE TABLE IF NOT EXISTS project_budgets (
 );
 
 CREATE TABLE IF NOT EXISTS usage_events (
-    id              TEXT PRIMARY KEY,
-    project_id      TEXT,
-    session_id      TEXT,
-    event_type      TEXT NOT NULL,
-    model           TEXT,
-    input_tokens    INTEGER,
-    output_tokens   INTEGER,
-    cpu_pct         REAL,
-    ram_mb          REAL,
-    disk_mb         REAL,
-    api_calls       INTEGER,
-    recorded_at     TEXT NOT NULL
+    id                       TEXT PRIMARY KEY,
+    project_id               TEXT,
+    session_id               TEXT,
+    event_type               TEXT NOT NULL,
+    model                    TEXT,
+    provider                 TEXT,
+    source                   TEXT,
+    input_tokens             INTEGER,
+    cached_input_tokens      INTEGER,
+    output_tokens            INTEGER,
+    reasoning_output_tokens  INTEGER,
+    total_tokens             INTEGER,
+    external_session_id      TEXT,
+    source_event_id          TEXT,
+    source_file              TEXT,
+    source_offset            INTEGER,
+    raw_usage_json           TEXT,
+    cpu_pct                  REAL,
+    ram_mb                   REAL,
+    disk_mb                  REAL,
+    api_calls                INTEGER,
+    recorded_at              TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS usage_source_offsets (
+    provider                      TEXT NOT NULL,
+    source_key                    TEXT NOT NULL,
+    external_session_id           TEXT,
+    byte_offset                   INTEGER NOT NULL DEFAULT 0,
+    last_input_tokens             INTEGER NOT NULL DEFAULT 0,
+    last_cached_input_tokens      INTEGER NOT NULL DEFAULT 0,
+    last_output_tokens            INTEGER NOT NULL DEFAULT 0,
+    last_reasoning_output_tokens  INTEGER NOT NULL DEFAULT 0,
+    last_total_tokens             INTEGER NOT NULL DEFAULT 0,
+    created_at                    TEXT NOT NULL,
+    updated_at                    TEXT NOT NULL,
+    PRIMARY KEY (provider, source_key)
 );
 
 CREATE TABLE IF NOT EXISTS notifications (
@@ -692,6 +718,42 @@ async def _apply_file_migrations(db: aiosqlite.Connection) -> None:
                 [await _has_column(db, "task_assignments", column) for column in acceptance_columns]
             ):
                 logger.info("Migration skip: %s already applied structurally", path.name)
+                await db.execute(
+                    "INSERT INTO schema_migrations (version, applied_at) VALUES (?, ?)",
+                    (path.name, _now()),
+                )
+                await db.commit()
+                continue
+
+        if path.name == "019_provider_neutral_token_usage.sql":
+            usage_columns = [
+                "provider",
+                "source",
+                "cached_input_tokens",
+                "reasoning_output_tokens",
+                "total_tokens",
+                "external_session_id",
+                "source_event_id",
+                "source_file",
+                "source_offset",
+                "raw_usage_json",
+            ]
+            cursor = await db.execute(
+                "SELECT name FROM sqlite_master WHERE type='table' AND name='usage_source_offsets'"
+            )
+            offset_table_exists = await cursor.fetchone() is not None
+            if offset_table_exists and all(
+                [await _has_column(db, "usage_events", column) for column in usage_columns]
+            ):
+                logger.info("Migration skip: %s already applied structurally", path.name)
+                await db.execute(
+                    "CREATE INDEX IF NOT EXISTS idx_usage_events_tokens_recorded "
+                    "ON usage_events(event_type, recorded_at)"
+                )
+                await db.execute(
+                    "CREATE INDEX IF NOT EXISTS idx_usage_events_provider_source "
+                    "ON usage_events(provider, source, external_session_id)"
+                )
                 await db.execute(
                     "INSERT INTO schema_migrations (version, applied_at) VALUES (?, ?)",
                     (path.name, _now()),
@@ -2371,14 +2433,25 @@ async def write_usage_event(
     session_id: str | None = None,
     model: str | None = None,
     input_tokens: int | None = None,
+    cached_input_tokens: int | None = None,
     output_tokens: int | None = None,
+    reasoning_output_tokens: int | None = None,
+    total_tokens: int | None = None,
+    provider: str | None = None,
+    source: str | None = None,
+    external_session_id: str | None = None,
+    source_event_id: str | None = None,
+    source_file: str | None = None,
+    source_offset: int | None = None,
+    raw_usage_json: str | None = None,
     cpu_pct: float | None = None,
     ram_mb: float | None = None,
     disk_mb: float | None = None,
     api_calls: int | None = None,
+    recorded_at: str | None = None,
 ) -> UsageEvent:
     """Insert a usage_events row and return the dataclass."""
-    now = _now()
+    now = recorded_at or _now()
     event = UsageEvent(
         id=_uuid(),
         event_type=event_type,
@@ -2387,7 +2460,17 @@ async def write_usage_event(
         session_id=session_id,
         model=model,
         input_tokens=input_tokens,
+        cached_input_tokens=cached_input_tokens,
         output_tokens=output_tokens,
+        reasoning_output_tokens=reasoning_output_tokens,
+        total_tokens=total_tokens,
+        provider=provider,
+        source=source,
+        external_session_id=external_session_id,
+        source_event_id=source_event_id,
+        source_file=source_file,
+        source_offset=source_offset,
+        raw_usage_json=raw_usage_json,
         cpu_pct=cpu_pct,
         ram_mb=ram_mb,
         disk_mb=disk_mb,
@@ -2395,18 +2478,29 @@ async def write_usage_event(
     )
     await db.execute(
         """INSERT INTO usage_events
-           (id, project_id, session_id, event_type, model,
-            input_tokens, output_tokens,
-            cpu_pct, ram_mb, disk_mb, api_calls, recorded_at)
-           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+           (id, project_id, session_id, event_type, model, provider, source,
+            input_tokens, cached_input_tokens, output_tokens, reasoning_output_tokens,
+            total_tokens, external_session_id, source_event_id, source_file, source_offset,
+            raw_usage_json, cpu_pct, ram_mb, disk_mb, api_calls, recorded_at)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
         (
             event.id,
             event.project_id,
             event.session_id,
             event.event_type,
             event.model,
+            event.provider,
+            event.source,
             event.input_tokens,
+            event.cached_input_tokens,
             event.output_tokens,
+            event.reasoning_output_tokens,
+            event.total_tokens,
+            event.external_session_id,
+            event.source_event_id,
+            event.source_file,
+            event.source_offset,
+            event.raw_usage_json,
             event.cpu_pct,
             event.ram_mb,
             event.disk_mb,
@@ -2417,6 +2511,88 @@ async def write_usage_event(
     await db.commit()
     return event
 
+
+
+
+async def get_usage_source_offset(
+    db: aiosqlite.Connection,
+    *,
+    provider: str,
+    source_key: str,
+) -> UsageSourceOffset | None:
+    """Return durable high-water state for a provider source."""
+    cursor = await db.execute(
+        "SELECT * FROM usage_source_offsets WHERE provider = ? AND source_key = ?",
+        (provider, source_key),
+    )
+    row = await cursor.fetchone()
+    if row is None:
+        return None
+    return UsageSourceOffset(**_filter_model_fields(UsageSourceOffset, dict(row)))
+
+
+async def upsert_usage_source_offset(
+    db: aiosqlite.Connection,
+    *,
+    provider: str,
+    source_key: str,
+    external_session_id: str | None = None,
+    byte_offset: int = 0,
+    last_input_tokens: int = 0,
+    last_cached_input_tokens: int = 0,
+    last_output_tokens: int = 0,
+    last_reasoning_output_tokens: int = 0,
+    last_total_tokens: int = 0,
+) -> UsageSourceOffset:
+    """Insert/update durable provider source high-water state."""
+    now = _now()
+    offset = UsageSourceOffset(
+        provider=provider,
+        source_key=source_key,
+        external_session_id=external_session_id,
+        byte_offset=byte_offset,
+        last_input_tokens=last_input_tokens,
+        last_cached_input_tokens=last_cached_input_tokens,
+        last_output_tokens=last_output_tokens,
+        last_reasoning_output_tokens=last_reasoning_output_tokens,
+        last_total_tokens=last_total_tokens,
+        created_at=now,
+        updated_at=now,
+    )
+    existing = await get_usage_source_offset(db, provider=provider, source_key=source_key)
+    if existing is not None:
+        offset.created_at = existing.created_at
+    await db.execute(
+        """INSERT INTO usage_source_offsets
+           (provider, source_key, external_session_id, byte_offset,
+            last_input_tokens, last_cached_input_tokens, last_output_tokens,
+            last_reasoning_output_tokens, last_total_tokens, created_at, updated_at)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+           ON CONFLICT(provider, source_key) DO UPDATE SET
+             external_session_id = excluded.external_session_id,
+             byte_offset = excluded.byte_offset,
+             last_input_tokens = excluded.last_input_tokens,
+             last_cached_input_tokens = excluded.last_cached_input_tokens,
+             last_output_tokens = excluded.last_output_tokens,
+             last_reasoning_output_tokens = excluded.last_reasoning_output_tokens,
+             last_total_tokens = excluded.last_total_tokens,
+             updated_at = excluded.updated_at""",
+        (
+            offset.provider,
+            offset.source_key,
+            offset.external_session_id,
+            offset.byte_offset,
+            offset.last_input_tokens,
+            offset.last_cached_input_tokens,
+            offset.last_output_tokens,
+            offset.last_reasoning_output_tokens,
+            offset.last_total_tokens,
+            offset.created_at,
+            offset.updated_at,
+        ),
+    )
+    await db.commit()
+    return offset
 
 # ---------------------------------------------------------------------------
 # ProjectBudget helpers

--- a/src/atc/state/migrations/versions/019_provider_neutral_token_usage.sql
+++ b/src/atc/state/migrations/versions/019_provider_neutral_token_usage.sql
@@ -1,0 +1,31 @@
+-- Provider-neutral token usage telemetry foundation.
+ALTER TABLE usage_events ADD COLUMN provider TEXT;
+ALTER TABLE usage_events ADD COLUMN source TEXT;
+ALTER TABLE usage_events ADD COLUMN cached_input_tokens INTEGER;
+ALTER TABLE usage_events ADD COLUMN reasoning_output_tokens INTEGER;
+ALTER TABLE usage_events ADD COLUMN total_tokens INTEGER;
+ALTER TABLE usage_events ADD COLUMN external_session_id TEXT;
+ALTER TABLE usage_events ADD COLUMN source_event_id TEXT;
+ALTER TABLE usage_events ADD COLUMN source_file TEXT;
+ALTER TABLE usage_events ADD COLUMN source_offset INTEGER;
+ALTER TABLE usage_events ADD COLUMN raw_usage_json TEXT;
+
+CREATE INDEX IF NOT EXISTS idx_usage_events_tokens_recorded
+    ON usage_events(event_type, recorded_at);
+CREATE INDEX IF NOT EXISTS idx_usage_events_provider_source
+    ON usage_events(provider, source, external_session_id);
+
+CREATE TABLE IF NOT EXISTS usage_source_offsets (
+    provider                      TEXT NOT NULL,
+    source_key                    TEXT NOT NULL,
+    external_session_id           TEXT,
+    byte_offset                   INTEGER NOT NULL DEFAULT 0,
+    last_input_tokens             INTEGER NOT NULL DEFAULT 0,
+    last_cached_input_tokens      INTEGER NOT NULL DEFAULT 0,
+    last_output_tokens            INTEGER NOT NULL DEFAULT 0,
+    last_reasoning_output_tokens  INTEGER NOT NULL DEFAULT 0,
+    last_total_tokens             INTEGER NOT NULL DEFAULT 0,
+    created_at                    TEXT NOT NULL,
+    updated_at                    TEXT NOT NULL,
+    PRIMARY KEY (provider, source_key)
+);

--- a/src/atc/state/models.py
+++ b/src/atc/state/models.py
@@ -104,12 +104,37 @@ class UsageEvent:
     project_id: str | None = None
     session_id: str | None = None
     model: str | None = None
+    provider: str | None = None
+    source: str | None = None
     input_tokens: int | None = None
+    cached_input_tokens: int | None = None
     output_tokens: int | None = None
+    reasoning_output_tokens: int | None = None
+    total_tokens: int | None = None
+    external_session_id: str | None = None
+    source_event_id: str | None = None
+    source_file: str | None = None
+    source_offset: int | None = None
+    raw_usage_json: str | None = None
     cpu_pct: float | None = None
     ram_mb: float | None = None
     disk_mb: float | None = None
     api_calls: int | None = None
+
+
+@dataclass
+class UsageSourceOffset:
+    provider: str
+    source_key: str
+    byte_offset: int = 0
+    external_session_id: str | None = None
+    last_input_tokens: int = 0
+    last_cached_input_tokens: int = 0
+    last_output_tokens: int = 0
+    last_reasoning_output_tokens: int = 0
+    last_total_tokens: int = 0
+    created_at: str = ""
+    updated_at: str = ""
 
 
 @dataclass

--- a/src/atc/tracking/budget.py
+++ b/src/atc/tracking/budget.py
@@ -117,7 +117,7 @@ class BudgetEnforcer:
 
         if daily_token_limit is not None and daily_token_limit > 0:
             cursor = await self._db.execute(
-                """SELECT COALESCE(SUM(COALESCE(input_tokens, 0) + COALESCE(output_tokens, 0)), 0)
+                """SELECT COALESCE(SUM(COALESCE(total_tokens, COALESCE(input_tokens, 0) + COALESCE(output_tokens, 0) + COALESCE(reasoning_output_tokens, 0))), 0)
                    FROM usage_events
                    WHERE project_id = ?
                      AND event_type = 'ai_tokens'

--- a/src/atc/tracking/tokens.py
+++ b/src/atc/tracking/tokens.py
@@ -12,10 +12,12 @@ import asyncio
 import contextlib
 import json
 import logging
-import uuid
+from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
+
+from atc.state.db import write_usage_event
 
 if TYPE_CHECKING:
     import aiosqlite
@@ -26,6 +28,127 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 STATS_CACHE_PATH = Path.home() / ".claude" / "stats-cache.json"
+
+
+@dataclass(frozen=True, slots=True)
+class TokenUsageIncrement:
+    """Provider-neutral, datetime-stamped token usage increment.
+
+    Provider-specific collectors may parse cumulative usage however they need to,
+    but they must cross the shared ATC boundary as positive increments. This
+    class intentionally contains no Codex/Claude filesystem or event-shape
+    knowledge.
+    """
+
+    session_id: str
+    project_id: str | None
+    provider: str
+    model: str | None
+    recorded_at: datetime
+    input_tokens: int = 0
+    cached_input_tokens: int = 0
+    output_tokens: int = 0
+    reasoning_output_tokens: int = 0
+    total_tokens: int = 0
+    source: str = "provider"
+    external_session_id: str | None = None
+    source_event_id: str | None = None
+    source_file: str | None = None
+    source_offset: int | None = None
+    raw_usage: dict[str, Any] | None = None
+
+    def effective_total_tokens(self) -> int:
+        """Return canonical total for aggregate displays/budgets."""
+        if self.total_tokens > 0:
+            return self.total_tokens
+        return self.input_tokens + self.output_tokens + self.reasoning_output_tokens
+
+
+class TokenUsageRecorder:
+    """Provider-neutral persistence/fanout for token usage increments."""
+
+    def __init__(
+        self,
+        db: aiosqlite.Connection,
+        event_bus: EventBus,
+        *,
+        ws_hub: WsHub | None = None,
+    ) -> None:
+        self._db = db
+        self._event_bus = event_bus
+        self._ws_hub = ws_hub
+
+    async def record_increment(self, increment: TokenUsageIncrement) -> str | None:
+        """Record a provider-neutral token usage increment.
+
+        Returns the inserted event id, or ``None`` when the increment has no
+        positive token usage. Negative token values are rejected to keep provider
+        collectors from crossing the boundary with cumulative counter resets.
+        """
+        values = {
+            "input_tokens": increment.input_tokens,
+            "cached_input_tokens": increment.cached_input_tokens,
+            "output_tokens": increment.output_tokens,
+            "reasoning_output_tokens": increment.reasoning_output_tokens,
+            "total_tokens": increment.total_tokens,
+        }
+        negative = {name: value for name, value in values.items() if value < 0}
+        if negative:
+            raise ValueError(f"Token usage increments cannot be negative: {negative}")
+
+        effective_total = increment.effective_total_tokens()
+        if effective_total == 0:
+            logger.debug(
+                "Ignoring zero token usage increment provider=%s source=%s session=%s",
+                increment.provider,
+                increment.source,
+                increment.session_id,
+            )
+            return None
+
+        event = await write_usage_event(
+            self._db,
+            "ai_tokens",
+            project_id=increment.project_id,
+            session_id=increment.session_id,
+            model=increment.model,
+            provider=increment.provider,
+            source=increment.source,
+            input_tokens=increment.input_tokens,
+            cached_input_tokens=increment.cached_input_tokens,
+            output_tokens=increment.output_tokens,
+            reasoning_output_tokens=increment.reasoning_output_tokens,
+            total_tokens=effective_total,
+            external_session_id=increment.external_session_id,
+            source_event_id=increment.source_event_id,
+            source_file=increment.source_file,
+            source_offset=increment.source_offset,
+            raw_usage_json=(
+                json.dumps(increment.raw_usage) if increment.raw_usage is not None else None
+            ),
+            recorded_at=increment.recorded_at.isoformat(),
+        )
+
+        payload = {
+            "event_id": event.id,
+            "model": increment.model,
+            "provider": increment.provider,
+            "source": increment.source,
+            "input_tokens": increment.input_tokens,
+            "cached_input_tokens": increment.cached_input_tokens,
+            "output_tokens": increment.output_tokens,
+            "reasoning_output_tokens": increment.reasoning_output_tokens,
+            "total_tokens": effective_total,
+            "project_id": increment.project_id,
+            "session_id": increment.session_id,
+            "external_session_id": increment.external_session_id,
+            "recorded_at": event.recorded_at,
+        }
+        if self._ws_hub:
+            await self._ws_hub.broadcast("tokens", payload)
+        await self._event_bus.publish("tokens_recorded", payload)
+        return event.id
+
 
 class TokenTracker:
     """Polls ~/.claude/stats-cache.json and attributes token deltas to sessions."""
@@ -45,6 +168,7 @@ class TokenTracker:
         self._poll_interval = poll_interval
         self._stats_path = stats_path
         self._last_snapshot: dict[str, Any] = {}
+        self._recorder = TokenUsageRecorder(db, event_bus, ws_hub=ws_hub)
         self._task: asyncio.Task[None] | None = None
         # Sessions that report tokens explicitly via atc-tower tokens CLI.
         # Stats-cache polling is skipped for these to avoid double-counting.
@@ -115,36 +239,17 @@ class TokenTracker:
             if in_tok == 0 and out_tok == 0:
                 continue
 
-            now = datetime.now(UTC).isoformat()
-            event_id = str(uuid.uuid4())
-
-            await self._db.execute(
-                """INSERT INTO usage_events
-                   (id, project_id, session_id, event_type, model,
-                    input_tokens, output_tokens, recorded_at)
-                   VALUES (?, ?, ?, 'ai_tokens', ?, ?, ?, ?)""",
-                (event_id, project_id, session_id, model, in_tok, out_tok, now),
-            )
-            await self._db.commit()
-
-            if self._ws_hub:
-                await self._ws_hub.broadcast(
-                    "tokens",
-                    {
-                        "event_id": event_id,
-                        "model": model,
-                        "input_tokens": in_tok,
-                        "output_tokens": out_tok,
-                        "total_tokens": in_tok + out_tok,
-                        "project_id": project_id,
-                        "session_id": session_id,
-                        "recorded_at": now,
-                    },
+            await self._recorder.record_increment(
+                TokenUsageIncrement(
+                    session_id=session_id or "unknown",
+                    project_id=project_id,
+                    provider="claude_code",
+                    model=model,
+                    recorded_at=datetime.now(UTC),
+                    input_tokens=in_tok,
+                    output_tokens=out_tok,
+                    source="claude_stats_cache",
                 )
-
-            await self._event_bus.publish(
-                "tokens_recorded",
-                {"model": model, "input_tokens": in_tok, "output_tokens": out_tok, "project_id": project_id},
             )
 
             logger.debug(
@@ -238,43 +343,17 @@ class TokenTracker:
                 "Failed to find project for explicit token report: session=%s", session_id
             )
 
-        now = datetime.now(UTC).isoformat()
-        event_id = str(uuid.uuid4())
-
-        await self._db.execute(
-            """INSERT INTO usage_events
-               (id, project_id, session_id, event_type, model,
-                input_tokens, output_tokens, recorded_at)
-               VALUES (?, ?, ?, 'ai_tokens', ?, ?, ?, ?)""",
-            (event_id, project_id, session_id, model, input_tokens, output_tokens, now),
-        )
-        await self._db.commit()
-
-        if self._ws_hub:
-            await self._ws_hub.broadcast(
-                "tokens",
-                {
-                    "event_id": event_id,
-                    "model": model,
-                    "input_tokens": input_tokens,
-                    "output_tokens": output_tokens,
-                    "total_tokens": input_tokens + output_tokens,
-                    "project_id": project_id,
-                    "session_id": session_id,
-                    "recorded_at": now,
-                    "source": "explicit",
-                },
+        await self._recorder.record_increment(
+            TokenUsageIncrement(
+                session_id=session_id,
+                project_id=project_id,
+                provider="explicit",
+                model=model,
+                recorded_at=datetime.now(UTC),
+                input_tokens=input_tokens,
+                output_tokens=output_tokens,
+                source="explicit",
             )
-
-        await self._event_bus.publish(
-            "tokens_recorded",
-            {
-                "model": model,
-                "input_tokens": input_tokens,
-                "output_tokens": output_tokens,
-                "project_id": project_id,
-                "source": "explicit",
-            },
         )
 
         logger.debug(

--- a/tests/unit/test_usage_recorder.py
+++ b/tests/unit/test_usage_recorder.py
@@ -1,0 +1,298 @@
+"""Unit tests for provider-neutral token usage recording."""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from atc.core.events import EventBus
+from atc.state.db import (
+    get_connection,
+    get_usage_source_offset,
+    run_migrations,
+    upsert_usage_source_offset,
+)
+from atc.tracking.tokens import TokenUsageIncrement, TokenUsageRecorder
+
+
+@pytest.fixture
+async def migrated_db(tmp_path: Path):
+    db_path = tmp_path / "atc.db"
+    await run_migrations(str(db_path))
+    async with get_connection(str(db_path)) as conn:
+        yield conn
+
+
+@pytest.fixture
+def event_bus() -> EventBus:
+    return EventBus()
+
+
+@pytest.fixture
+def ws_hub() -> MagicMock:
+    hub = MagicMock()
+    hub.broadcast = AsyncMock()
+    return hub
+
+
+def increment(**overrides: object) -> TokenUsageIncrement:
+    values = {
+        "session_id": "session-1",
+        "project_id": "project-1",
+        "provider": "fake_provider",
+        "model": "fake-model",
+        "recorded_at": datetime(2026, 7, 2, 12, 0, tzinfo=UTC),
+        "input_tokens": 10,
+        "cached_input_tokens": 3,
+        "output_tokens": 5,
+        "reasoning_output_tokens": 2,
+        "total_tokens": 17,
+        "source": "unit_test",
+        "external_session_id": "external-1",
+        "source_event_id": "event-1",
+        "source_file": "/tmp/provider.jsonl",
+        "source_offset": 123,
+        "raw_usage": {"raw": {"total_tokens": 17}},
+    }
+    values.update(overrides)
+    return TokenUsageIncrement(**values)  # type: ignore[arg-type]
+
+
+@pytest.mark.asyncio
+class TestTokenUsageRecorder:
+    async def test_records_provider_neutral_increment(
+        self, migrated_db, event_bus: EventBus, ws_hub: MagicMock
+    ) -> None:
+        recorder = TokenUsageRecorder(migrated_db, event_bus, ws_hub=ws_hub)
+
+        event_id = await recorder.record_increment(increment())
+
+        assert event_id is not None
+        cursor = await migrated_db.execute("SELECT * FROM usage_events WHERE id = ?", (event_id,))
+        row = await cursor.fetchone()
+        assert row is not None
+        assert row["event_type"] == "ai_tokens"
+        assert row["provider"] == "fake_provider"
+        assert row["source"] == "unit_test"
+        assert row["model"] == "fake-model"
+        assert row["input_tokens"] == 10
+        assert row["cached_input_tokens"] == 3
+        assert row["output_tokens"] == 5
+        assert row["reasoning_output_tokens"] == 2
+        assert row["total_tokens"] == 17
+        assert row["external_session_id"] == "external-1"
+        assert row["source_event_id"] == "event-1"
+        assert row["source_file"] == "/tmp/provider.jsonl"
+        assert row["source_offset"] == 123
+        assert json.loads(row["raw_usage_json"]) == {"raw": {"total_tokens": 17}}
+        ws_hub.broadcast.assert_awaited_once()
+
+    async def test_multiple_increments_aggregate_with_total_tokens(
+        self, migrated_db, event_bus: EventBus
+    ) -> None:
+        recorder = TokenUsageRecorder(migrated_db, event_bus)
+        await recorder.record_increment(increment(total_tokens=17, source_event_id="a"))
+        await recorder.record_increment(increment(total_tokens=8, source_event_id="b"))
+
+        cursor = await migrated_db.execute(
+            """SELECT COALESCE(
+                   SUM(COALESCE(
+                       total_tokens,
+                       COALESCE(input_tokens, 0)
+                       + COALESCE(output_tokens, 0)
+                       + COALESCE(reasoning_output_tokens, 0)
+                   )),
+                   0
+               )
+               FROM usage_events WHERE event_type = 'ai_tokens'"""
+        )
+        row = await cursor.fetchone()
+        assert row[0] == 25
+
+    async def test_zero_token_increment_is_ignored(
+        self, migrated_db, event_bus: EventBus
+    ) -> None:
+        recorder = TokenUsageRecorder(migrated_db, event_bus)
+        event_id = await recorder.record_increment(
+            increment(
+                input_tokens=0,
+                cached_input_tokens=0,
+                output_tokens=0,
+                reasoning_output_tokens=0,
+                total_tokens=0,
+            )
+        )
+
+        assert event_id is None
+        cursor = await migrated_db.execute("SELECT COUNT(*) FROM usage_events")
+        row = await cursor.fetchone()
+        assert row[0] == 0
+
+    async def test_negative_increment_is_rejected(
+        self, migrated_db, event_bus: EventBus
+    ) -> None:
+        recorder = TokenUsageRecorder(migrated_db, event_bus)
+
+        with pytest.raises(ValueError, match="cannot be negative"):
+            await recorder.record_increment(increment(input_tokens=-1))
+
+    async def test_raw_usage_json_round_trips(
+        self, migrated_db, event_bus: EventBus
+    ) -> None:
+        recorder = TokenUsageRecorder(migrated_db, event_bus)
+        raw = {"provider": "fake", "nested": {"cached_input_tokens": 44}}
+        event_id = await recorder.record_increment(increment(raw_usage=raw))
+
+        cursor = await migrated_db.execute(
+            "SELECT raw_usage_json FROM usage_events WHERE id = ?", (event_id,)
+        )
+        row = await cursor.fetchone()
+        assert json.loads(row[0]) == raw
+
+
+@pytest.mark.asyncio
+class TestUsageSourceOffsets:
+    async def test_high_water_offset_insert_update_read(self, migrated_db) -> None:
+        first = await upsert_usage_source_offset(
+            migrated_db,
+            provider="fake_provider",
+            source_key="source-a",
+            external_session_id="external-a",
+            byte_offset=10,
+            last_input_tokens=100,
+            last_cached_input_tokens=50,
+            last_output_tokens=20,
+            last_reasoning_output_tokens=5,
+            last_total_tokens=125,
+        )
+        assert first.byte_offset == 10
+
+        second = await upsert_usage_source_offset(
+            migrated_db,
+            provider="fake_provider",
+            source_key="source-a",
+            external_session_id="external-a",
+            byte_offset=99,
+            last_input_tokens=150,
+            last_cached_input_tokens=80,
+            last_output_tokens=30,
+            last_reasoning_output_tokens=7,
+            last_total_tokens=187,
+        )
+        assert second.byte_offset == 99
+
+        loaded = await get_usage_source_offset(
+            migrated_db, provider="fake_provider", source_key="source-a"
+        )
+        assert loaded is not None
+        assert loaded.external_session_id == "external-a"
+        assert loaded.byte_offset == 99
+        assert loaded.last_input_tokens == 150
+        assert loaded.last_cached_input_tokens == 80
+        assert loaded.last_output_tokens == 30
+        assert loaded.last_reasoning_output_tokens == 7
+        assert loaded.last_total_tokens == 187
+        assert loaded.created_at
+        assert loaded.updated_at
+
+
+@pytest.mark.asyncio
+async def test_existing_usage_events_table_upgrades_without_dropping_rows(tmp_path: Path) -> None:
+    db_path = tmp_path / "existing.db"
+    import aiosqlite
+
+    async with aiosqlite.connect(str(db_path)) as db:
+        await db.execute(
+            """CREATE TABLE usage_events (
+                   id TEXT PRIMARY KEY,
+                   project_id TEXT,
+                   session_id TEXT,
+                   event_type TEXT NOT NULL,
+                   model TEXT,
+                   input_tokens INTEGER,
+                   output_tokens INTEGER,
+                   recorded_at TEXT NOT NULL
+               )"""
+        )
+        await db.execute(
+            """INSERT INTO usage_events
+               (id, project_id, session_id, event_type, model,
+                input_tokens, output_tokens, recorded_at)
+               VALUES (
+                   'old-event', 'project-1', 'session-1', 'ai_tokens',
+                   'legacy', 4, 5, '2026-07-02T00:00:00+00:00'
+               )"""
+        )
+        await db.commit()
+
+    await run_migrations(str(db_path))
+
+    async with get_connection(str(db_path)) as db:
+        cursor = await db.execute(
+            "SELECT input_tokens, output_tokens FROM usage_events WHERE id = 'old-event'"
+        )
+        row = await cursor.fetchone()
+        assert row is not None
+        assert row["input_tokens"] == 4
+        assert row["output_tokens"] == 5
+
+        cursor = await db.execute("PRAGMA table_info(usage_events)")
+        columns = {str(row["name"]) for row in await cursor.fetchall()}
+        assert "total_tokens" in columns
+        assert "raw_usage_json" in columns
+
+
+@pytest.mark.asyncio
+async def test_migration_adds_provider_neutral_usage_fields(tmp_path: Path) -> None:
+    db_path = tmp_path / "fresh.db"
+    await run_migrations(str(db_path))
+    async with get_connection(str(db_path)) as db:
+        cursor = await db.execute("PRAGMA table_info(usage_events)")
+        columns = {str(row["name"]) for row in await cursor.fetchall()}
+        assert {
+            "provider",
+            "source",
+            "cached_input_tokens",
+            "reasoning_output_tokens",
+            "total_tokens",
+            "external_session_id",
+            "source_event_id",
+            "source_file",
+            "source_offset",
+            "raw_usage_json",
+        }.issubset(columns)
+
+        cursor = await db.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' AND name='usage_source_offsets'"
+        )
+        assert await cursor.fetchone() is not None
+
+
+def test_shared_token_module_has_no_codex_specific_parsing() -> None:
+    shared = Path("src/atc/tracking/tokens.py").read_text()
+    forbidden = [".codex", "token_count", "rollout-", "codex_jsonl"]
+    assert [term for term in forbidden if term in shared] == []
+
+
+def test_no_cost_semantics_reintroduced_to_usage_foundation() -> None:
+    paths = [
+        Path("src/atc/tracking/tokens.py"),
+        Path("src/atc/api/routers/usage.py"),
+        Path("src/atc/state/models.py"),
+        Path("src/atc/state/migrations/versions/019_provider_neutral_token_usage.sql"),
+    ]
+    forbidden = [
+        "cost" + "_usd",
+        "/api/tower/" + "cost",
+        "/api/usage/" + "cost",
+        "Cost" + "Tracker",
+    ]
+    offenders: list[tuple[str, str]] = []
+    for path in paths:
+        text = path.read_text()
+        offenders.extend((str(path), term) for term in forbidden if term in text)
+    assert offenders == []


### PR DESCRIPTION
## Summary
- add provider-neutral `TokenUsageIncrement` and `TokenUsageRecorder` foundation
- extend token usage persistence with provider/source metadata, cached-input tokens, reasoning-output tokens, total tokens, external/source metadata, and raw usage retention
- add durable `usage_source_offsets` high-water table/helpers for future provider collectors to avoid double-counting
- update usage summary and token budget accounting to prefer `total_tokens` while preserving legacy input+output rows
- document the shared recorder/provider-boundary rule and add tight regression coverage

## Boundary
- This phase intentionally adds no Codex JSONL parsing.
- Shared tracking has a regression test proving Codex-specific paths/event-shape terms do not appear in `src/atc/tracking/tokens.py`.
- Codex-specific collection belongs in the Codex provider module in Phase 2.

## Validation
- `ruff check src/atc/tracking/tokens.py src/atc/state/db.py src/atc/state/models.py tests/unit/test_usage_recorder.py`
  - passed
- `PYTHONPATH=src pytest tests/unit/test_usage_recorder.py tests/unit/test_tokens.py tests/unit/test_budget_enforcer.py tests/unit/test_usage_oauth.py tests/unit/test_models.py tests/unit/test_section15.py tests/unit/test_agent_provider.py tests/unit/test_context_entries.py -q`
  - 181 passed, 1 warning
- stale cost-term scan over src/tests/docs for removed cost API/model names
  - no blocking stale terms found

## Notes
- Local `screenshots/` remains untracked and is not part of this PR.
