### PR TITLE
Add Codex token usage parser

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -52,7 +52,7 @@ Design rule:
 | `terminal/` | PTY streaming (tmux pipe-pane → FIFO → WS), output parser, monitor |
 | `tracking/` | Provider-neutral token usage recorder, provider usage trackers, system resources (psutil), GitHub PR/CI, budget enforcer |
 | `rws/` | Remote Ace Server daemon for remote hosts |
-| `agents/` | Agent deployment SOT — writes config files to /tmp |
+| `agents/` | Agent deployment SOT — writes config files to /tmp; provider-owned runtime helpers such as Codex token JSONL parsing live here |
 
 ### Data Layer (`src/atc/state/`)
 

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -60,7 +60,7 @@ Per-project budget limits with:
 
 ## Token Usage Telemetry
 
-**Status**: Foundation implemented
+**Status**: Foundation + Codex provider parser implemented
 
 Provider-neutral token usage infrastructure with:
 - Append-only `usage_events` token increment rows
@@ -69,6 +69,13 @@ Provider-neutral token usage infrastructure with:
 - Durable `usage_source_offsets` high-water state for provider collectors to avoid double-counting
 - Shared `TokenUsageRecorder` interface used by provider-specific collectors
 - Boundary rule: provider-specific parsing, filesystem paths, and event formats stay in provider modules; shared tracking only records normalized token increments
+
+Codex-specific collection lives in `src/atc/agents/codex_usage.py`:
+- Discovers/parses Codex session JSONL files under the Codex provider boundary
+- Extracts Codex `token_count` cumulative token snapshots
+- Maps Codex session metadata/cwd back to ATC sessions without creating orphan usage rows
+- Converts cumulative Codex totals into provider-neutral token increments
+- Reuses shared high-water state so restart/re-read sync passes do not double-count
 
 ## GitHub Integration
 

--- a/src/atc/agents/codex_usage.py
+++ b/src/atc/agents/codex_usage.py
@@ -1,0 +1,407 @@
+"""Codex provider token usage collection.
+
+This module is the Codex-owned boundary for Codex JSONL discovery, parsing,
+session mapping, and cumulative-counter delta conversion. Shared token tracking
+only receives provider-neutral ``TokenUsageIncrement`` values from here.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import glob
+import json
+import logging
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+from atc.state.db import get_session, get_usage_source_offset, upsert_usage_source_offset
+from atc.tracking.tokens import TokenUsageIncrement, TokenUsageRecorder
+
+if TYPE_CHECKING:
+    import aiosqlite
+
+    from atc.api.ws.hub import WsHub
+    from atc.core.events import EventBus
+    from atc.state.models import Session, UsageSourceOffset
+
+logger = logging.getLogger(__name__)
+
+CODEX_PROVIDER = "codex"
+CODEX_SOURCE = "codex_jsonl"
+DEFAULT_CODEX_SESSIONS_GLOB = "~/.codex/sessions/**/*.jsonl"
+_TOKEN_KEYS = (
+    "input_tokens",
+    "cached_input_tokens",
+    "output_tokens",
+    "reasoning_output_tokens",
+    "total_tokens",
+)
+
+
+@dataclass(frozen=True, slots=True)
+class CodexTokenSnapshot:
+    """Cumulative token snapshot parsed from a Codex session JSONL file."""
+
+    external_session_id: str | None
+    source_file: Path
+    source_offset: int
+    recorded_at: datetime
+    model: str | None
+    cwd: Path | None
+    input_tokens: int = 0
+    cached_input_tokens: int = 0
+    output_tokens: int = 0
+    reasoning_output_tokens: int = 0
+    total_tokens: int = 0
+    raw: dict[str, Any] | None = None
+
+    def source_key(self) -> str:
+        """Return Codex-owned durable source key for high-water state."""
+        return str(self.source_file)
+
+
+class CodexJsonlParser:
+    """Parse Codex JSONL and yield token-count snapshots.
+
+    The parser keeps Codex event-shape knowledge here, not in the shared token
+    recorder. Malformed lines and non-token events are skipped.
+    """
+
+    def parse_file(self, path: Path, *, start_offset: int = 0) -> list[CodexTokenSnapshot]:
+        snapshots: list[CodexTokenSnapshot] = []
+        external_session_id: str | None = None
+        model: str | None = None
+        cwd: Path | None = None
+        offset = 0
+
+        try:
+            with path.open("rb") as handle:
+                if start_offset > 0:
+                    handle.seek(start_offset)
+                    offset = start_offset
+                for raw_line in handle:
+                    offset += len(raw_line)
+                    line = raw_line.decode("utf-8", errors="replace")
+                    try:
+                        event = json.loads(line)
+                    except json.JSONDecodeError:
+                        logger.debug("Skipping malformed Codex JSONL line path=%s", path)
+                        continue
+
+                    external_session_id = self._external_session_id(
+                        event, fallback=external_session_id
+                    )
+                    model = self._model(event, fallback=model)
+                    cwd = self._cwd(event, fallback=cwd)
+
+                    snapshot = self._token_snapshot(
+                        event,
+                        path=path,
+                        source_offset=offset,
+                        external_session_id=external_session_id,
+                        model=model,
+                        cwd=cwd,
+                    )
+                    if snapshot is not None:
+                        snapshots.append(snapshot)
+        except FileNotFoundError:
+            logger.debug("Codex JSONL disappeared before parsing: %s", path)
+        except OSError as exc:
+            logger.warning("Failed to parse Codex JSONL %s: %s", path, exc)
+        return snapshots
+
+    def _token_snapshot(
+        self,
+        event: dict[str, Any],
+        *,
+        path: Path,
+        source_offset: int,
+        external_session_id: str | None,
+        model: str | None,
+        cwd: Path | None,
+    ) -> CodexTokenSnapshot | None:
+        if event.get("type") != "event_msg":
+            return None
+        payload = event.get("payload")
+        if not isinstance(payload, dict) or payload.get("type") != "token_count":
+            return None
+        info = payload.get("info")
+        if not isinstance(info, dict):
+            return None
+        usage = info.get("total_token_usage")
+        if not isinstance(usage, dict):
+            return None
+
+        recorded_at = self._recorded_at(event)
+        return CodexTokenSnapshot(
+            external_session_id=external_session_id,
+            source_file=path,
+            source_offset=source_offset,
+            recorded_at=recorded_at,
+            model=model,
+            cwd=cwd,
+            input_tokens=self._int_token(usage, "input_tokens"),
+            cached_input_tokens=self._int_token(usage, "cached_input_tokens"),
+            output_tokens=self._int_token(usage, "output_tokens"),
+            reasoning_output_tokens=self._int_token(usage, "reasoning_output_tokens"),
+            total_tokens=self._int_token(usage, "total_tokens"),
+            raw=payload,
+        )
+
+    def _external_session_id(self, event: dict[str, Any], *, fallback: str | None) -> str | None:
+        if event.get("type") != "session_meta":
+            return fallback
+        payload = event.get("payload")
+        if not isinstance(payload, dict):
+            return fallback
+        raw_id = payload.get("id")
+        return str(raw_id) if raw_id else fallback
+
+    def _model(self, event: dict[str, Any], *, fallback: str | None) -> str | None:
+        payload = event.get("payload")
+        if not isinstance(payload, dict):
+            return fallback
+        raw_model = payload.get("model")
+        return str(raw_model) if raw_model else fallback
+
+    def _cwd(self, event: dict[str, Any], *, fallback: Path | None) -> Path | None:
+        payload = event.get("payload")
+        if not isinstance(payload, dict):
+            return fallback
+        raw_cwd = payload.get("cwd")
+        if not raw_cwd:
+            return fallback
+        return Path(str(raw_cwd))
+
+    def _recorded_at(self, event: dict[str, Any]) -> datetime:
+        raw_timestamp = event.get("timestamp")
+        if isinstance(raw_timestamp, str):
+            with contextlib.suppress(ValueError):
+                return datetime.fromisoformat(raw_timestamp.replace("Z", "+00:00"))
+        return datetime.now(UTC)
+
+    def _int_token(self, usage: dict[str, Any], key: str) -> int:
+        value = usage.get(key, 0)
+        if value is None:
+            return 0
+        try:
+            return max(0, int(value))
+        except (TypeError, ValueError):
+            return 0
+
+
+class CodexUsageSyncService:
+    """Poll Codex JSONL files and emit provider-neutral token increments."""
+
+    def __init__(
+        self,
+        db: aiosqlite.Connection,
+        event_bus: EventBus,
+        *,
+        ws_hub: WsHub | None = None,
+        sessions_glob: str = DEFAULT_CODEX_SESSIONS_GLOB,
+        poll_interval: float = 5.0,
+        parser: CodexJsonlParser | None = None,
+        recorder: TokenUsageRecorder | None = None,
+    ) -> None:
+        self._db = db
+        self._sessions_glob = sessions_glob
+        self._poll_interval = poll_interval
+        self._parser = parser or CodexJsonlParser()
+        self._recorder = recorder or TokenUsageRecorder(db, event_bus, ws_hub=ws_hub)
+        self._task: asyncio.Task[None] | None = None
+
+    async def start(self) -> None:
+        """Start the Codex usage polling loop."""
+        if self._task is not None:
+            return
+        self._task = asyncio.create_task(self._poll_loop())
+        logger.info(
+            "CodexUsageSyncService started (interval=%.0fs, glob=%s)",
+            self._poll_interval,
+            self._sessions_glob,
+        )
+
+    async def stop(self) -> None:
+        """Stop the Codex usage polling loop."""
+        if self._task is None:
+            return
+        self._task.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await self._task
+        self._task = None
+        logger.info("CodexUsageSyncService stopped")
+
+    async def sync_once(self) -> int:
+        """Synchronize currently discoverable Codex JSONL files once.
+
+        Returns the number of usage-event rows inserted.
+        """
+        inserted = 0
+        for path in self._discover_files():
+            inserted += await self._sync_file(path)
+        return inserted
+
+    def _discover_files(self) -> list[Path]:
+        expanded = str(Path(self._sessions_glob).expanduser())
+        paths = [Path(p) for p in glob.glob(expanded, recursive=True)]
+        return sorted((p for p in paths if p.is_file()), key=lambda p: p.stat().st_mtime)
+
+    async def _poll_loop(self) -> None:
+        while True:
+            try:
+                await self.sync_once()
+            except Exception:
+                logger.exception("Codex usage sync failed")
+            await asyncio.sleep(self._poll_interval)
+
+    async def _sync_file(self, path: Path) -> int:
+        offset = await get_usage_source_offset(
+            self._db,
+            provider=CODEX_PROVIDER,
+            source_key=str(path),
+        )
+        start_offset = offset.byte_offset if offset is not None else 0
+        snapshots = self._parser.parse_file(path, start_offset=start_offset)
+        inserted = 0
+        for snapshot in snapshots:
+            row_id = await self._record_snapshot_delta(snapshot, offset)
+            if row_id is not None:
+                inserted += 1
+            offset = await get_usage_source_offset(
+                self._db,
+                provider=CODEX_PROVIDER,
+                source_key=snapshot.source_key(),
+            )
+        return inserted
+
+    async def _record_snapshot_delta(
+        self,
+        snapshot: CodexTokenSnapshot,
+        previous: UsageSourceOffset | None,
+    ) -> str | None:
+        session = await self._map_snapshot_to_session(snapshot)
+        if session is None:
+            logger.info(
+                "Skipping unmapped Codex token snapshot file=%s offset=%s "
+                "external_session=%s cwd=%s",
+                snapshot.source_file,
+                snapshot.source_offset,
+                snapshot.external_session_id,
+                snapshot.cwd,
+            )
+            await self._store_high_water(snapshot)
+            return None
+
+        deltas = self._compute_delta(snapshot, previous)
+        await self._store_high_water(snapshot)
+        if all(value == 0 for value in deltas.values()):
+            return None
+
+        increment = TokenUsageIncrement(
+            session_id=session.id,
+            project_id=session.project_id,
+            provider=CODEX_PROVIDER,
+            model=snapshot.model,
+            recorded_at=snapshot.recorded_at,
+            input_tokens=deltas["input_tokens"],
+            cached_input_tokens=deltas["cached_input_tokens"],
+            output_tokens=deltas["output_tokens"],
+            reasoning_output_tokens=deltas["reasoning_output_tokens"],
+            total_tokens=deltas["total_tokens"],
+            source=CODEX_SOURCE,
+            external_session_id=snapshot.external_session_id,
+            source_event_id=f"{snapshot.source_file}:{snapshot.source_offset}",
+            source_file=str(snapshot.source_file),
+            source_offset=snapshot.source_offset,
+            raw_usage=snapshot.raw,
+        )
+        return await self._recorder.record_increment(increment)
+
+    def _compute_delta(
+        self,
+        snapshot: CodexTokenSnapshot,
+        previous: UsageSourceOffset | None,
+    ) -> dict[str, int]:
+        if previous is None:
+            return {key: getattr(snapshot, key) for key in _TOKEN_KEYS}
+
+        raw_deltas = {
+            "input_tokens": snapshot.input_tokens - previous.last_input_tokens,
+            "cached_input_tokens": (
+                snapshot.cached_input_tokens - previous.last_cached_input_tokens
+            ),
+            "output_tokens": snapshot.output_tokens - previous.last_output_tokens,
+            "reasoning_output_tokens": (
+                snapshot.reasoning_output_tokens - previous.last_reasoning_output_tokens
+            ),
+            "total_tokens": snapshot.total_tokens - previous.last_total_tokens,
+        }
+        if any(value < 0 for value in raw_deltas.values()):
+            logger.warning(
+                "Codex token counter moved backwards file=%s offset=%s; not emitting delta",
+                snapshot.source_file,
+                snapshot.source_offset,
+            )
+            return dict.fromkeys(_TOKEN_KEYS, 0)
+        return raw_deltas
+
+    async def _store_high_water(self, snapshot: CodexTokenSnapshot) -> None:
+        await upsert_usage_source_offset(
+            self._db,
+            provider=CODEX_PROVIDER,
+            source_key=snapshot.source_key(),
+            external_session_id=snapshot.external_session_id,
+            byte_offset=snapshot.source_offset,
+            last_input_tokens=snapshot.input_tokens,
+            last_cached_input_tokens=snapshot.cached_input_tokens,
+            last_output_tokens=snapshot.output_tokens,
+            last_reasoning_output_tokens=snapshot.reasoning_output_tokens,
+            last_total_tokens=snapshot.total_tokens,
+        )
+
+    async def _map_snapshot_to_session(self, snapshot: CodexTokenSnapshot) -> Session | None:
+        """Map Codex metadata to an ATC session without creating orphan rows."""
+        candidate_ids = self._candidate_session_ids(snapshot)
+        for session_id in candidate_ids:
+            session = await get_session(self._db, session_id)
+            if session is not None and session.provider == CODEX_PROVIDER:
+                return session
+
+        previous_session_id = await self._previous_usage_session_id(snapshot)
+        if previous_session_id is not None:
+            session = await get_session(self._db, previous_session_id)
+            if session is not None and session.provider == CODEX_PROVIDER:
+                return session
+        return None
+
+    async def _previous_usage_session_id(self, snapshot: CodexTokenSnapshot) -> str | None:
+        """Reuse source-file mapping after appended lines omit session metadata."""
+        cursor = await self._db.execute(
+            """SELECT session_id FROM usage_events
+               WHERE provider = ? AND source = ? AND source_file = ?
+               ORDER BY COALESCE(source_offset, 0) DESC LIMIT 1""",
+            (CODEX_PROVIDER, CODEX_SOURCE, str(snapshot.source_file)),
+        )
+        row = await cursor.fetchone()
+        if row is None or row["session_id"] is None:
+            return None
+        return str(row["session_id"])
+
+    def _candidate_session_ids(self, snapshot: CodexTokenSnapshot) -> list[str]:
+        candidates: list[str] = []
+        if snapshot.cwd is not None:
+            candidates.append(snapshot.cwd.name)
+            parts = [part for part in snapshot.cwd.parts if part]
+            candidates.extend(parts)
+        if snapshot.external_session_id:
+            candidates.append(snapshot.external_session_id)
+
+        deduped: list[str] = []
+        for candidate in candidates:
+            if candidate and candidate not in deduped:
+                deduped.append(candidate)
+        return deduped

--- a/tests/unit/test_codex_usage.py
+++ b/tests/unit/test_codex_usage.py
@@ -1,0 +1,305 @@
+"""Unit tests for Codex provider token usage collection."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from atc.agents.codex_usage import (
+    CODEX_PROVIDER,
+    CODEX_SOURCE,
+    CodexJsonlParser,
+    CodexUsageSyncService,
+)
+from atc.core.events import EventBus
+from atc.state.db import create_project, create_session, get_connection, run_migrations
+
+
+@pytest.fixture
+async def migrated_db(tmp_path: Path):
+    db_path = tmp_path / "atc.db"
+    await run_migrations(str(db_path))
+    async with get_connection(str(db_path)) as conn:
+        yield conn
+
+
+def write_jsonl(path: Path, *events: dict[str, Any] | str) -> None:
+    lines: list[str] = []
+    for event in events:
+        if isinstance(event, str):
+            lines.append(event)
+        else:
+            lines.append(json.dumps(event))
+    path.write_text("\n".join(lines) + "\n")
+
+
+def session_meta(
+    *, external_id: str = "codex-external", cwd: str = "/tmp/atc-session"
+) -> dict[str, Any]:
+    return {
+        "timestamp": "2026-07-02T12:00:00.000Z",
+        "type": "session_meta",
+        "payload": {"id": external_id, "cwd": cwd},
+    }
+
+
+def turn_context(*, model: str = "gpt-5.5", cwd: str = "/tmp/atc-session") -> dict[str, Any]:
+    return {
+        "timestamp": "2026-07-02T12:00:01.000Z",
+        "type": "turn_context",
+        "payload": {"model": model, "cwd": cwd},
+    }
+
+
+def token_count(
+    *,
+    input_tokens: int = 100,
+    cached_input_tokens: int = 40,
+    output_tokens: int = 20,
+    reasoning_output_tokens: int = 5,
+    total_tokens: int = 125,
+    timestamp: str = "2026-07-02T12:00:02.000Z",
+) -> dict[str, Any]:
+    return {
+        "timestamp": timestamp,
+        "type": "event_msg",
+        "payload": {
+            "type": "token_count",
+            "info": {
+                "total_token_usage": {
+                    "input_tokens": input_tokens,
+                    "cached_input_tokens": cached_input_tokens,
+                    "output_tokens": output_tokens,
+                    "reasoning_output_tokens": reasoning_output_tokens,
+                    "total_tokens": total_tokens,
+                },
+                "last_token_usage": {
+                    "input_tokens": input_tokens,
+                    "cached_input_tokens": cached_input_tokens,
+                    "output_tokens": output_tokens,
+                    "reasoning_output_tokens": reasoning_output_tokens,
+                    "total_tokens": total_tokens,
+                },
+            },
+        },
+    }
+
+
+class TestCodexJsonlParser:
+    def test_parser_extracts_complete_token_count(self, tmp_path: Path) -> None:
+        path = tmp_path / "rollout-session.jsonl"
+        write_jsonl(path, session_meta(), turn_context(), token_count())
+
+        snapshots = CodexJsonlParser().parse_file(path)
+
+        assert len(snapshots) == 1
+        snapshot = snapshots[0]
+        assert snapshot.external_session_id == "codex-external"
+        assert snapshot.model == "gpt-5.5"
+        assert snapshot.cwd == Path("/tmp/atc-session")
+        assert snapshot.input_tokens == 100
+        assert snapshot.cached_input_tokens == 40
+        assert snapshot.output_tokens == 20
+        assert snapshot.reasoning_output_tokens == 5
+        assert snapshot.total_tokens == 125
+        assert snapshot.source_offset == path.stat().st_size
+        assert snapshot.raw is not None
+        assert snapshot.raw["type"] == "token_count"
+
+    def test_parser_ignores_malformed_json_and_non_token_events(self, tmp_path: Path) -> None:
+        path = tmp_path / "rollout-session.jsonl"
+        write_jsonl(
+            path,
+            "{malformed",
+            {
+                "timestamp": "2026-07-02T12:00:00Z",
+                "type": "event_msg",
+                "payload": {"type": "task_started"},
+            },
+            token_count(),
+        )
+
+        snapshots = CodexJsonlParser().parse_file(path)
+
+        assert len(snapshots) == 1
+        assert snapshots[0].total_tokens == 125
+
+    def test_parser_handles_missing_optional_token_fields(self, tmp_path: Path) -> None:
+        path = tmp_path / "rollout-session.jsonl"
+        event = token_count()
+        usage = event["payload"]["info"]["total_token_usage"]
+        del usage["cached_input_tokens"]
+        del usage["reasoning_output_tokens"]
+        write_jsonl(path, event)
+
+        snapshot = CodexJsonlParser().parse_file(path)[0]
+
+        assert snapshot.input_tokens == 100
+        assert snapshot.cached_input_tokens == 0
+        assert snapshot.reasoning_output_tokens == 0
+        assert snapshot.total_tokens == 125
+
+    def test_parser_respects_start_offset_for_appended_jsonl(self, tmp_path: Path) -> None:
+        path = tmp_path / "rollout-session.jsonl"
+        write_jsonl(path, token_count(total_tokens=10, input_tokens=8, output_tokens=2))
+        start_offset = path.stat().st_size
+        with path.open("a") as handle:
+            handle.write(
+                json.dumps(token_count(total_tokens=25, input_tokens=20, output_tokens=5)) + "\n"
+            )
+
+        snapshots = CodexJsonlParser().parse_file(path, start_offset=start_offset)
+
+        assert len(snapshots) == 1
+        assert snapshots[0].total_tokens == 25
+        assert snapshots[0].source_offset == path.stat().st_size
+
+
+@pytest.mark.asyncio
+class TestCodexUsageSyncService:
+    async def test_first_cumulative_snapshot_records_increment(
+        self, migrated_db, tmp_path: Path
+    ) -> None:
+        project = await create_project(migrated_db, "codex project", agent_provider=CODEX_PROVIDER)
+        session = await create_session(
+            migrated_db,
+            project.id,
+            "ace",
+            "ace",
+            provider=CODEX_PROVIDER,
+            status="working",
+        )
+        path = tmp_path / "rollout-session.jsonl"
+        cwd = f"/private/tmp/atc-agents/{session.id}"
+        write_jsonl(path, session_meta(cwd=cwd), turn_context(cwd=cwd), token_count())
+
+        service = CodexUsageSyncService(
+            migrated_db,
+            EventBus(),
+            sessions_glob=str(tmp_path / "*.jsonl"),
+        )
+        inserted = await service.sync_once()
+
+        assert inserted == 1
+        cursor = await migrated_db.execute("SELECT * FROM usage_events")
+        row = await cursor.fetchone()
+        assert row["provider"] == CODEX_PROVIDER
+        assert row["source"] == CODEX_SOURCE
+        assert row["session_id"] == session.id
+        assert row["project_id"] == project.id
+        assert row["input_tokens"] == 100
+        assert row["cached_input_tokens"] == 40
+        assert row["output_tokens"] == 20
+        assert row["reasoning_output_tokens"] == 5
+        assert row["total_tokens"] == 125
+        assert row["external_session_id"] == "codex-external"
+        assert row["source_file"] == str(path)
+
+    async def test_subsequent_cumulative_snapshot_records_only_delta(
+        self, migrated_db, tmp_path: Path
+    ) -> None:
+        project = await create_project(migrated_db, "codex project", agent_provider=CODEX_PROVIDER)
+        session = await create_session(
+            migrated_db, project.id, "ace", "ace", provider=CODEX_PROVIDER
+        )
+        path = tmp_path / "rollout-session.jsonl"
+        cwd = f"/private/tmp/atc-agents/{session.id}"
+        write_jsonl(path, session_meta(cwd=cwd), turn_context(cwd=cwd), token_count())
+
+        service = CodexUsageSyncService(migrated_db, EventBus(), sessions_glob=str(path))
+        assert await service.sync_once() == 1
+        with path.open("a") as handle:
+            handle.write(
+                json.dumps(
+                    token_count(
+                        input_tokens=130,
+                        cached_input_tokens=55,
+                        output_tokens=35,
+                        reasoning_output_tokens=8,
+                        total_tokens=173,
+                        timestamp="2026-07-02T12:01:00.000Z",
+                    )
+                )
+                + "\n"
+            )
+
+        assert await service.sync_once() == 1
+        cursor = await migrated_db.execute(
+            "SELECT input_tokens, cached_input_tokens, output_tokens, "
+            "reasoning_output_tokens, total_tokens "
+            "FROM usage_events ORDER BY recorded_at"
+        )
+        rows = await cursor.fetchall()
+        assert rows[1]["input_tokens"] == 30
+        assert rows[1]["cached_input_tokens"] == 15
+        assert rows[1]["output_tokens"] == 15
+        assert rows[1]["reasoning_output_tokens"] == 3
+        assert rows[1]["total_tokens"] == 48
+
+    async def test_reread_does_not_double_count(self, migrated_db, tmp_path: Path) -> None:
+        project = await create_project(migrated_db, "codex project", agent_provider=CODEX_PROVIDER)
+        session = await create_session(
+            migrated_db, project.id, "ace", "ace", provider=CODEX_PROVIDER
+        )
+        path = tmp_path / "rollout-session.jsonl"
+        cwd = f"/tmp/{session.id}"
+        write_jsonl(path, session_meta(cwd=cwd), turn_context(cwd=cwd), token_count())
+        service = CodexUsageSyncService(migrated_db, EventBus(), sessions_glob=str(path))
+
+        assert await service.sync_once() == 1
+        assert await service.sync_once() == 0
+
+        cursor = await migrated_db.execute("SELECT COUNT(*) FROM usage_events")
+        row = await cursor.fetchone()
+        assert row[0] == 1
+
+    async def test_unmapped_session_skips_without_orphan_usage_row(
+        self, migrated_db, tmp_path: Path
+    ) -> None:
+        path = tmp_path / "rollout-session.jsonl"
+        write_jsonl(path, session_meta(cwd="/tmp/not-an-atc-session"), token_count())
+        service = CodexUsageSyncService(migrated_db, EventBus(), sessions_glob=str(path))
+
+        assert await service.sync_once() == 0
+        cursor = await migrated_db.execute("SELECT COUNT(*) FROM usage_events")
+        row = await cursor.fetchone()
+        assert row[0] == 0
+
+    async def test_rolled_back_counter_does_not_emit_negative_increment(
+        self, migrated_db, tmp_path: Path
+    ) -> None:
+        project = await create_project(migrated_db, "codex project", agent_provider=CODEX_PROVIDER)
+        session = await create_session(
+            migrated_db, project.id, "ace", "ace", provider=CODEX_PROVIDER
+        )
+        path = tmp_path / "rollout-session.jsonl"
+        cwd = f"/tmp/{session.id}"
+        write_jsonl(
+            path,
+            session_meta(cwd=cwd),
+            token_count(total_tokens=100, input_tokens=80, output_tokens=20),
+        )
+        service = CodexUsageSyncService(migrated_db, EventBus(), sessions_glob=str(path))
+        assert await service.sync_once() == 1
+        with path.open("a") as handle:
+            handle.write(
+                json.dumps(token_count(total_tokens=90, input_tokens=70, output_tokens=20)) + "\n"
+            )
+
+        assert await service.sync_once() == 0
+        cursor = await migrated_db.execute("SELECT COUNT(*) FROM usage_events")
+        row = await cursor.fetchone()
+        assert row[0] == 1
+
+
+def test_codex_parsing_stays_inside_codex_module() -> None:
+    shared = Path("src/atc/tracking/tokens.py").read_text()
+    forbidden = [".codex", "token_count", "rollout-", "codex_jsonl"]
+    assert [term for term in forbidden if term in shared] == []
+
+    codex_module = Path("src/atc/agents/codex_usage.py").read_text()
+    assert "token_count" in codex_module
+    assert "~/.codex/sessions/**/*.jsonl" in codex_module


### PR DESCRIPTION
## Summary
- add Codex-owned JSONL token parser and sync service that emits provider-neutral token increments
- preserve cached-input/reasoning-output token classes and durable high-water de-dupe state
- add fixture-heavy parser/sync tests plus docs for the provider boundary

## Validation
- ruff check src/atc/agents/codex_usage.py tests/unit/test_codex_usage.py
- PYTHONPATH=src pytest tests/unit/test_codex_usage.py tests/unit/test_usage_recorder.py tests/unit/test_tokens.py tests/unit/test_budget_enforcer.py -q
- PYTHONPATH=src pytest tests/unit/test_codex_usage.py tests/unit/test_usage_recorder.py tests/unit/test_tokens.py tests/unit/test_budget_enforcer.py tests/unit/test_agent_provider.py tests/unit/test_usage_oauth.py tests/unit/test_models.py -q
- tracked stale cost-term scan: no hits
- shared token boundary scan: no Codex-specific parsing terms in src/atc/tracking/tokens.py