### PR TITLE
Integrate Codex token usage sync runtime

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -26,6 +26,8 @@ budget:
 
 token_tracker:
   poll_interval_seconds: 30
+  codex_enabled: true
+  codex_sessions_glob: ~/.codex/sessions/**/*.jsonl
 
 sentry:
   enabled: false

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -122,6 +122,7 @@ See `src/atc/state/migrations/versions/` for the canonical schema.
 6. Start resource monitor
 7. Start GitHub tracker
 8. Start budget enforcer
-9. Reconnect active sessions from last shutdown
+9. Start provider usage sync services such as Codex JSONL token sync when enabled
+10. Reconnect active sessions from last shutdown
 
 Shutdown runs in reverse order, draining queues before closing DB.

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -60,7 +60,7 @@ Per-project budget limits with:
 
 ## Token Usage Telemetry
 
-**Status**: Foundation + Codex provider parser implemented
+**Status**: Foundation + Codex provider runtime sync implemented
 
 Provider-neutral token usage infrastructure with:
 - Append-only `usage_events` token increment rows
@@ -76,6 +76,8 @@ Codex-specific collection lives in `src/atc/agents/codex_usage.py`:
 - Maps Codex session metadata/cwd back to ATC sessions without creating orphan usage rows
 - Converts cumulative Codex totals into provider-neutral token increments
 - Reuses shared high-water state so restart/re-read sync passes do not double-count
+- Starts with the backend when `token_tracker.codex_enabled` is true
+- Supports manual deterministic sync through `POST /api/usage/tokens/sync-codex` or `atc usage sync-codex`
 
 ## GitHub Integration
 

--- a/src/atc/api/app.py
+++ b/src/atc/api/app.py
@@ -488,12 +488,33 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
     await resource_monitor.start()
     app.state.resource_monitor = resource_monitor
 
-    # 10. Start token tracker
+    # 10. Start token trackers
     from atc.tracking.tokens import TokenTracker
 
-    token_tracker = TokenTracker(db, event_bus, ws_hub=ws_hub)
+    token_cfg = settings.token_tracker
+    token_tracker = TokenTracker(
+        db,
+        event_bus,
+        ws_hub=ws_hub,
+        poll_interval=token_cfg.poll_interval_seconds,
+    )
     await token_tracker.start()
     app.state.token_tracker = token_tracker
+
+    from atc.agents.codex_usage import CodexUsageSyncService
+
+    codex_usage_sync = CodexUsageSyncService(
+        db,
+        event_bus,
+        ws_hub=ws_hub,
+        sessions_glob=token_cfg.codex_sessions_glob,
+        poll_interval=token_cfg.poll_interval_seconds,
+    )
+    if token_cfg.codex_enabled:
+        await codex_usage_sync.start()
+    else:
+        logger.info("Codex usage sync disabled by config")
+    app.state.codex_usage_sync = codex_usage_sync
 
     # 11. Start GitHub tracker
     from atc.tracking.github import GitHubTracker
@@ -550,7 +571,8 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
         if _key:
             logger.warning(
                 "Running in OAuth mode — API-key-only provider features are disabled, "
-                "concurrent sessions may conflict. Set ATC_ANTHROPIC_API_KEY for full functionality."
+                "concurrent sessions may conflict. Set ATC_ANTHROPIC_API_KEY "
+                "for full functionality."
             )
         else:
             # No env var — using Claude's own stored credentials (best case for local dev)
@@ -584,6 +606,7 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
     await memory_cron.stop()
     await budget_enforcer.stop()
     await github_tracker.stop()
+    await codex_usage_sync.stop()
     await token_tracker.stop()
     await resource_monitor.stop()
     await heartbeat_monitor.stop()

--- a/src/atc/api/routers/usage.py
+++ b/src/atc/api/routers/usage.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 import logging
 from datetime import UTC, datetime, timedelta
 
-from fastapi import APIRouter, Request
+from fastapi import APIRouter, HTTPException, Request
 from pydantic import BaseModel
 
 logger = logging.getLogger(__name__)
@@ -67,6 +67,11 @@ class UsageSummaryResponse(BaseModel):
     message: str | None = None
 
 
+class CodexSyncResponse(BaseModel):
+    inserted_events: int
+    enabled: bool
+
+
 def _is_oauth_mode() -> bool:
     """Return True when not using a real API key (OAuth or no key configured)."""
     from atc.agents.auth import get_auth_mode
@@ -86,7 +91,10 @@ async def get_usage_summary(request: Request) -> UsageSummaryResponse:
     today = datetime.now(UTC).strftime("%Y-%m-%d")
     month_start = datetime.now(UTC).strftime("%Y-%m-01")
 
-    tok = "COALESCE(total_tokens, COALESCE(input_tokens,0)+COALESCE(output_tokens,0)+COALESCE(reasoning_output_tokens,0))"
+    tok = (
+        "COALESCE(total_tokens, COALESCE(input_tokens,0)+COALESCE(output_tokens,0)"
+        "+COALESCE(reasoning_output_tokens,0))"
+    )
     tok_cond = f"CASE WHEN recorded_at >= ? THEN {tok} ELSE 0 END"
     cursor = await db.execute(
         f"""SELECT
@@ -102,6 +110,20 @@ async def get_usage_summary(request: Request) -> UsageSummaryResponse:
     return UsageSummaryResponse(
         today_tokens=int(row[0]),
         month_tokens=int(row[1]),
+    )
+
+
+@router.post("/tokens/sync-codex", response_model=CodexSyncResponse)
+async def sync_codex_usage(request: Request) -> CodexSyncResponse:
+    """Run one deterministic Codex JSONL usage sync pass."""
+    settings = request.app.state.settings
+    service = getattr(request.app.state, "codex_usage_sync", None)
+    if service is None:
+        raise HTTPException(status_code=503, detail="Codex usage sync service is unavailable")
+    inserted = await service.sync_once()
+    return CodexSyncResponse(
+        inserted_events=inserted,
+        enabled=bool(settings.token_tracker.codex_enabled),
     )
 
 

--- a/src/atc/cli/main.py
+++ b/src/atc/cli/main.py
@@ -14,6 +14,7 @@ Usage::
     atc projects create --name '...' --description '...'
     atc projects show <id>
     atc tower status
+    atc usage sync-codex
 """
 
 from __future__ import annotations
@@ -21,7 +22,7 @@ from __future__ import annotations
 import argparse
 import sys
 
-from atc.cli import ace, leader, projects, tasks, tower
+from atc.cli import ace, leader, projects, tasks, tower, usage
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -37,6 +38,7 @@ def build_parser() -> argparse.ArgumentParser:
     leader.register(subparsers)
     projects.register(subparsers)
     tower.register(subparsers)
+    usage.register(subparsers)
 
     return parser
 

--- a/src/atc/cli/usage.py
+++ b/src/atc/cli/usage.py
@@ -1,0 +1,59 @@
+"""``atc usage`` subcommands for deterministic usage sync/backfill."""
+
+from __future__ import annotations
+
+import json
+import sys
+import urllib.error
+import urllib.request
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import argparse
+
+_DEFAULT_API = "http://127.0.0.1:8420"
+
+
+def register(subparsers: argparse._SubParsersAction) -> None:  # type: ignore[type-arg]
+    """Register the ``usage`` command group."""
+    usage_parser = subparsers.add_parser("usage", help="Usage telemetry commands")
+    usage_sub = usage_parser.add_subparsers(dest="usage_command")
+
+    sync_codex = usage_sub.add_parser(
+        "sync-codex",
+        help="Run one deterministic Codex token JSONL sync pass",
+    )
+    sync_codex.add_argument(
+        "--api",
+        default=_DEFAULT_API,
+        help="ATC API base URL",
+    )
+    sync_codex.set_defaults(handler=_handle_sync_codex)
+
+    usage_parser.set_defaults(handler=lambda _: usage_parser.print_help() or 1)
+
+
+def _post_json(url: str, payload: dict) -> int:
+    data = json.dumps(payload).encode()
+    req = urllib.request.Request(
+        url,
+        data=data,
+        method="POST",
+        headers={"Content-Type": "application/json"},
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=30) as resp:
+            body = json.loads(resp.read().decode())
+            print(json.dumps(body, indent=2))
+            return 0
+    except urllib.error.HTTPError as exc:
+        detail = exc.read().decode() if exc.fp else str(exc)
+        print(f"Error: {exc.code} — {detail}", file=sys.stderr)
+        return 1
+    except urllib.error.URLError as exc:
+        print(f"Error: cannot reach ATC API — {exc.reason}", file=sys.stderr)
+        return 1
+
+
+def _handle_sync_codex(args: argparse.Namespace) -> int:
+    return _post_json(f"{args.api}/api/usage/tokens/sync-codex", {})

--- a/src/atc/config.py
+++ b/src/atc/config.py
@@ -52,6 +52,8 @@ class BudgetConfig(BaseModel):
 
 class TokenTrackerConfig(BaseModel):
     poll_interval_seconds: int = 30
+    codex_enabled: bool = True
+    codex_sessions_glob: str = "~/.codex/sessions/**/*.jsonl"
 
 
 class HeartbeatConfig(BaseModel):

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -227,6 +227,17 @@ class TestTowerMemory:
         assert req["path"] == "/api/tower/memory"
 
 
+class TestUsageSyncCodex:
+    def test_posts_sync_codex(self, api_stub: str) -> None:
+        _StubHandler.response_body = {"inserted_events": 2, "enabled": True}
+        rc = cli(["usage", "sync-codex", "--api", api_stub])
+        assert rc == 0
+        req = _StubHandler.requests[0]
+        assert req["method"] == "POST"
+        assert req["path"] == "/api/usage/tokens/sync-codex"
+        assert req["body"] == {}
+
+
 # ---------------------------------------------------------------------------
 # atc projects list
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_codex_usage_runtime.py
+++ b/tests/unit/test_codex_usage_runtime.py
@@ -1,0 +1,207 @@
+"""Runtime integration tests for Codex token usage sync."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING, Any
+
+from fastapi.testclient import TestClient
+
+from atc.api.app import create_app
+from atc.config import Settings
+from atc.state import db as db_ops
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+class FakeCodexUsageSyncService:
+    instances: list[FakeCodexUsageSyncService] = []
+
+    def __init__(
+        self,
+        *args: Any,
+        sessions_glob: str,
+        poll_interval: float,
+        **kwargs: Any,
+    ) -> None:
+        self.sessions_glob = sessions_glob
+        self.poll_interval = poll_interval
+        self.started = False
+        self.stopped = False
+        self.sync_count = 0
+        FakeCodexUsageSyncService.instances.append(self)
+
+    async def start(self) -> None:
+        self.started = True
+
+    async def stop(self) -> None:
+        self.stopped = True
+
+    async def sync_once(self) -> int:
+        self.sync_count += 1
+        return 3
+
+
+def settings_for(
+    tmp_path: Path,
+    *,
+    codex_enabled: bool = True,
+    glob_value: str = "*.jsonl",
+) -> Settings:
+    return Settings(
+        database={"path": str(tmp_path / "test.db")},
+        token_tracker={
+            "poll_interval_seconds": 123,
+            "codex_enabled": codex_enabled,
+            "codex_sessions_glob": glob_value,
+        },
+        backup={"auto_backup_enabled": False},
+    )
+
+
+def test_codex_usage_sync_starts_and_stops_with_app_lifecycle(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    from atc.agents import codex_usage
+
+    FakeCodexUsageSyncService.instances = []
+    monkeypatch.setattr(codex_usage, "CodexUsageSyncService", FakeCodexUsageSyncService)
+
+    app = create_app(settings_for(tmp_path, glob_value=str(tmp_path / "*.jsonl")))
+    with TestClient(app):
+        service = FakeCodexUsageSyncService.instances[0]
+        assert service.started is True
+        assert service.sessions_glob == str(tmp_path / "*.jsonl")
+        assert service.poll_interval == 123
+    assert service.stopped is True
+
+
+def test_codex_usage_sync_does_not_start_when_disabled(tmp_path: Path, monkeypatch) -> None:
+    from atc.agents import codex_usage
+
+    FakeCodexUsageSyncService.instances = []
+    monkeypatch.setattr(codex_usage, "CodexUsageSyncService", FakeCodexUsageSyncService)
+
+    app = create_app(settings_for(tmp_path, codex_enabled=False))
+    with TestClient(app):
+        service = FakeCodexUsageSyncService.instances[0]
+        assert service.started is False
+    assert service.stopped is True
+
+
+def test_sync_codex_api_runs_one_service_pass(tmp_path: Path, monkeypatch) -> None:
+    from atc.agents import codex_usage
+
+    FakeCodexUsageSyncService.instances = []
+    monkeypatch.setattr(codex_usage, "CodexUsageSyncService", FakeCodexUsageSyncService)
+
+    app = create_app(settings_for(tmp_path))
+    with TestClient(app) as client:
+        response = client.post("/api/usage/tokens/sync-codex")
+        assert response.status_code == 200
+        assert response.json() == {"inserted_events": 3, "enabled": True}
+        assert FakeCodexUsageSyncService.instances[0].sync_count == 1
+
+
+def write_jsonl(path: Path, *events: dict[str, Any]) -> None:
+    path.write_text("\n".join(json.dumps(event) for event in events) + "\n")
+
+
+def session_meta(session_id: str) -> dict[str, Any]:
+    return {
+        "timestamp": "2026-07-02T12:00:00.000Z",
+        "type": "session_meta",
+        "payload": {
+            "id": "codex-external-runtime",
+            "cwd": f"/private/tmp/atc-agents/{session_id}",
+        },
+    }
+
+
+def turn_context(session_id: str) -> dict[str, Any]:
+    return {
+        "timestamp": "2026-07-02T12:00:01.000Z",
+        "type": "turn_context",
+        "payload": {
+            "model": "gpt-5.5",
+            "cwd": f"/private/tmp/atc-agents/{session_id}",
+        },
+    }
+
+
+def token_count(total_tokens: int = 25) -> dict[str, Any]:
+    timestamp = datetime.now(UTC).isoformat().replace("+00:00", "Z")
+    return {
+        "timestamp": timestamp,
+        "type": "event_msg",
+        "payload": {
+            "type": "token_count",
+            "info": {
+                "total_token_usage": {
+                    "input_tokens": 20,
+                    "cached_input_tokens": 10,
+                    "output_tokens": 5,
+                    "reasoning_output_tokens": 2,
+                    "total_tokens": total_tokens,
+                }
+            },
+        },
+    }
+
+
+def test_codex_sync_endpoint_records_tokens_and_summary_once(tmp_path: Path) -> None:
+    db_path = tmp_path / "test.db"
+    codex_dir = tmp_path / "codex"
+    codex_dir.mkdir()
+    settings = Settings(
+        database={"path": str(db_path)},
+        token_tracker={
+            "poll_interval_seconds": 999,
+            "codex_enabled": False,
+            "codex_sessions_glob": str(codex_dir / "*.jsonl"),
+        },
+        backup={"auto_backup_enabled": False},
+    )
+    app = create_app(settings)
+
+    with TestClient(app) as client:
+        async def create_records() -> str:
+            project = await db_ops.create_project(
+                app.state.db,
+                "runtime-codex-project",
+                agent_provider="codex",
+            )
+            session = await db_ops.create_session(
+                app.state.db,
+                project.id,
+                "ace",
+                "ace",
+                provider="codex",
+                status="working",
+            )
+            return session.id
+
+        session_id = asyncio.run(create_records())
+        write_jsonl(
+            codex_dir / "rollout-runtime.jsonl",
+            session_meta(session_id),
+            turn_context(session_id),
+            token_count(),
+        )
+
+        first = client.post("/api/usage/tokens/sync-codex")
+        assert first.status_code == 200
+        assert first.json()["inserted_events"] == 1
+
+        second = client.post("/api/usage/tokens/sync-codex")
+        assert second.status_code == 200
+        assert second.json()["inserted_events"] == 0
+
+        summary = client.get("/api/usage/summary")
+        assert summary.status_code == 200
+        assert summary.json()["today_tokens"] >= 25
+        assert summary.json()["month_tokens"] >= 25


### PR DESCRIPTION
## Summary
- start/stop Codex token JSONL sync with backend lifecycle using token_tracker config
- add manual deterministic sync endpoint and CLI command: `atc usage sync-codex`
- add lifecycle/API/integration tests covering enabled/disabled startup, shutdown, manual sync, summary updates, and no duplicate rows
- document runtime sync behavior

## Validation
- `ruff check src/atc/api/app.py src/atc/api/routers/usage.py src/atc/cli/main.py src/atc/cli/usage.py src/atc/config.py tests/unit/test_codex_usage_runtime.py tests/unit/test_cli.py`
- `PYTHONPATH=src pytest tests/unit/test_codex_usage_runtime.py tests/unit/test_cli.py -q`
- `PYTHONPATH=src pytest tests/unit/test_codex_usage.py tests/unit/test_codex_usage_runtime.py tests/unit/test_usage_recorder.py tests/unit/test_tokens.py tests/unit/test_budget_enforcer.py tests/unit/test_agent_provider.py tests/unit/test_usage_oauth.py tests/unit/test_models.py tests/unit/test_cli.py -q`
- tracked stale cost-term scan: no hits
- shared token boundary scan: no Codex-specific parsing terms in `src/atc/tracking/tokens.py`
