### PR TITLE
Add Codex token sync visibility

### DIFF
--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -78,6 +78,7 @@ Codex-specific collection lives in `src/atc/agents/codex_usage.py`:
 - Reuses shared high-water state so restart/re-read sync passes do not double-count
 - Starts with the backend when `token_tracker.codex_enabled` is true
 - Supports manual deterministic sync through `POST /api/usage/tokens/sync-codex` or `atc usage sync-codex`
+- Exposes operator visibility on the Usage page: running/enabled state, last sync, files seen, last inserted event count, source glob, and manual sync trigger
 
 ## GitHub Integration
 

--- a/frontend/src/pages/UsagePage.css
+++ b/frontend/src/pages/UsagePage.css
@@ -134,3 +134,72 @@
   text-align: right;
   text-transform: capitalize;
 }
+
+.usage-page__card-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-3);
+  margin-bottom: var(--space-4);
+}
+
+.usage-page__card-header h3 {
+  margin-bottom: 0;
+}
+
+.usage-page__action-btn {
+  background: var(--color-accent);
+  border: 1px solid var(--color-accent);
+  border-radius: var(--radius-sm);
+  color: #fff;
+  cursor: pointer;
+  font-size: var(--text-xs);
+  padding: var(--space-1) var(--space-3);
+}
+
+.usage-page__action-btn:disabled {
+  cursor: not-allowed;
+  opacity: 0.6;
+}
+
+.usage-page__sync-grid {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: var(--space-3);
+}
+
+.usage-page__sync-item {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+  min-width: 0;
+}
+
+.usage-page__sync-item--wide {
+  grid-column: 1 / -1;
+}
+
+.usage-page__sync-value {
+  color: var(--color-text-primary);
+  font-family: var(--font-mono);
+  font-size: var(--text-sm);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.usage-page__sync-value--path {
+  color: var(--color-text-muted);
+}
+
+.usage-page__sync-error {
+  color: var(--color-status-red);
+  font-size: var(--text-sm);
+  margin-top: var(--space-3);
+}
+
+.usage-page__sync-message {
+  color: var(--color-text-muted);
+  font-size: var(--text-sm);
+  margin-top: var(--space-3);
+}

--- a/frontend/src/pages/UsagePage.tsx
+++ b/frontend/src/pages/UsagePage.tsx
@@ -32,6 +32,23 @@ interface ResourceDataPoint {
   ram_mb: number;
 }
 
+interface CodexSyncStatus {
+  enabled: boolean;
+  running: boolean;
+  sessions_glob: string;
+  poll_interval_seconds: number;
+  last_started_at: string | null;
+  last_finished_at: string | null;
+  last_inserted_events: number;
+  last_discovered_files: number;
+  last_error: string | null;
+}
+
+interface CodexSyncResponse {
+  inserted_events: number;
+  enabled: boolean;
+}
+
 type Period = "7d" | "30d" | "90d";
 
 const PERIODS: Period[] = ["7d", "30d", "90d"];
@@ -85,6 +102,12 @@ export default function UsagePage() {
   const [resourceData, setResourceData] = useState<ResourceDataPoint[]>([]);
   const [resourceLoaded, setResourceLoaded] = useState(false);
 
+  // Codex sync status
+  const [codexStatus, setCodexStatus] = useState<CodexSyncStatus | null>(null);
+  const [codexStatusLoaded, setCodexStatusLoaded] = useState(false);
+  const [codexSyncing, setCodexSyncing] = useState(false);
+  const [codexSyncMessage, setCodexSyncMessage] = useState<string | null>(null);
+
   async function fetchTokens(p: Period) {
     try {
       const data = await api.get<TokenDataPoint[]>(`/usage/tokens?period=${p}`);
@@ -105,8 +128,44 @@ export default function UsagePage() {
     }
   }
 
+  async function fetchCodexStatus() {
+    try {
+      const status = await api.get<CodexSyncStatus>(
+        "/usage/tokens/sync-codex/status",
+      );
+      setCodexStatus(status);
+    } catch {
+      setCodexStatus(null);
+    } finally {
+      setCodexStatusLoaded(true);
+    }
+  }
+
+  async function handleCodexSync() {
+    setCodexSyncing(true);
+    setCodexSyncMessage(null);
+    try {
+      const result = await api.post<CodexSyncResponse>(
+        "/usage/tokens/sync-codex",
+        {},
+      );
+      const suffix = result.inserted_events === 1 ? "" : "s";
+      setCodexSyncMessage(
+        `Inserted ${result.inserted_events} token event${suffix}.`,
+      );
+      setTokenLoaded(false);
+      await fetchCodexStatus();
+    } catch {
+      setCodexSyncMessage("Codex sync failed. Check backend logs.");
+      await fetchCodexStatus();
+    } finally {
+      setCodexSyncing(false);
+    }
+  }
+
   if (!tokenLoaded) void fetchTokens(period);
   if (!resourceLoaded) void fetchResources();
+  if (!codexStatusLoaded) void fetchCodexStatus();
 
   function handlePeriodChange(p: Period) {
     setPeriod(p);
@@ -114,15 +173,16 @@ export default function UsagePage() {
   }
 
   // Pivot token data for grouped bar (one entry per date+model)
-  const tokenByDate = tokenData.reduce<Record<string, Record<string, string | number>>>(
-    (acc, d) => {
-      if (!acc[d.date]) acc[d.date] = { date: d.date };
-      acc[d.date]![`${d.model}_in`] = Number(acc[d.date]![`${d.model}_in`] ?? 0) + d.input_tokens;
-      acc[d.date]![`${d.model}_out`] = Number(acc[d.date]![`${d.model}_out`] ?? 0) + d.output_tokens;
-      return acc;
-    },
-    {},
-  );
+  const tokenByDate = tokenData.reduce<
+    Record<string, Record<string, string | number>>
+  >((acc, d) => {
+    if (!acc[d.date]) acc[d.date] = { date: d.date };
+    acc[d.date]![`${d.model}_in`] =
+      Number(acc[d.date]![`${d.model}_in`] ?? 0) + d.input_tokens;
+    acc[d.date]![`${d.model}_out`] =
+      Number(acc[d.date]![`${d.model}_out`] ?? 0) + d.output_tokens;
+    return acc;
+  }, {});
   const tokenChartData = Object.values(tokenByDate);
 
   const models = [...new Set(tokenData.map((d) => d.model))];
@@ -174,7 +234,10 @@ export default function UsagePage() {
                 data={tokenChartData}
                 margin={{ top: 4, right: 4, left: 0, bottom: 0 }}
               >
-                <CartesianGrid strokeDasharray="3 3" stroke="var(--color-border)" />
+                <CartesianGrid
+                  strokeDasharray="3 3"
+                  stroke="var(--color-border)"
+                />
                 <XAxis
                   dataKey="date"
                   tick={{ fontSize: 9, fill: "var(--color-text-muted)" }}
@@ -236,7 +299,10 @@ export default function UsagePage() {
                 data={resourceData}
                 margin={{ top: 4, right: 4, left: 0, bottom: 0 }}
               >
-                <CartesianGrid strokeDasharray="3 3" stroke="var(--color-border)" />
+                <CartesianGrid
+                  strokeDasharray="3 3"
+                  stroke="var(--color-border)"
+                />
                 <XAxis
                   dataKey="timestamp"
                   tickFormatter={fmtTime}
@@ -260,9 +326,7 @@ export default function UsagePage() {
                   tickLine={false}
                   axisLine={false}
                   tickFormatter={(v: number) =>
-                    v >= 1024
-                      ? `${(v / 1024).toFixed(1)}G`
-                      : `${v.toFixed(0)}M`
+                    v >= 1024 ? `${(v / 1024).toFixed(1)}G` : `${v.toFixed(0)}M`
                   }
                 />
                 <Tooltip
@@ -303,6 +367,66 @@ export default function UsagePage() {
               No resource data yet.
             </div>
           )}
+        </div>
+
+        {/* Codex provider sync */}
+        <div className="panel usage-page__card usage-page__card--full">
+          <div className="usage-page__card-header">
+            <h3>Codex Token Sync</h3>
+            <button
+              className="usage-page__action-btn"
+              onClick={() => void handleCodexSync()}
+              disabled={codexSyncing}
+            >
+              {codexSyncing ? "Syncing…" : "Sync now"}
+            </button>
+          </div>
+          {codexStatus ? (
+            <div className="usage-page__sync-grid">
+              <div className="usage-page__sync-item">
+                <span className="usage-page__stat-label">Status</span>
+                <span className="usage-page__sync-value">
+                  {codexStatus.enabled
+                    ? codexStatus.running
+                      ? "Running"
+                      : "Enabled"
+                    : "Disabled"}
+                </span>
+              </div>
+              <div className="usage-page__sync-item">
+                <span className="usage-page__stat-label">Last sync</span>
+                <span className="usage-page__sync-value">
+                  {formatDateTime(codexStatus.last_finished_at)}
+                </span>
+              </div>
+              <div className="usage-page__sync-item">
+                <span className="usage-page__stat-label">Last inserted</span>
+                <span className="usage-page__sync-value">
+                  {codexStatus.last_inserted_events}
+                </span>
+              </div>
+              <div className="usage-page__sync-item">
+                <span className="usage-page__stat-label">Files seen</span>
+                <span className="usage-page__sync-value">
+                  {codexStatus.last_discovered_files}
+                </span>
+              </div>
+              <div className="usage-page__sync-item usage-page__sync-item--wide">
+                <span className="usage-page__stat-label">Source glob</span>
+                <span className="usage-page__sync-value usage-page__sync-value--path">
+                  {codexStatus.sessions_glob}
+                </span>
+              </div>
+            </div>
+          ) : (
+            <p className="usage-page__muted">Codex sync status unavailable.</p>
+          )}
+          {codexStatus?.last_error ? (
+            <p className="usage-page__sync-error">{codexStatus.last_error}</p>
+          ) : null}
+          {codexSyncMessage ? (
+            <p className="usage-page__sync-message">{codexSyncMessage}</p>
+          ) : null}
         </div>
 
         {/* Budget utilization per project */}
@@ -348,6 +472,20 @@ export default function UsagePage() {
       </div>
     </div>
   );
+}
+
+function formatDateTime(value: string | null): string {
+  if (!value) return "Never";
+  try {
+    return new Date(value).toLocaleString([], {
+      month: "short",
+      day: "numeric",
+      hour: "2-digit",
+      minute: "2-digit",
+    });
+  } catch {
+    return value;
+  }
 }
 
 function formatTokens(n: number): string {

--- a/frontend/src/pages/__tests__/UsagePage.test.tsx
+++ b/frontend/src/pages/__tests__/UsagePage.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { screen } from "@testing-library/react";
+import { fireEvent, screen, waitFor } from "@testing-library/react";
 import UsagePage from "../UsagePage";
 import { renderWithProviders } from "../../test/helpers";
 
@@ -35,13 +35,62 @@ describe("UsagePage", () => {
     expect(screen.getByText("Budget Utilization")).toBeInTheDocument();
   });
 
+  it("shows Codex token sync status and can trigger manual sync", async () => {
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockImplementation((input) => {
+        const url = String(input);
+        if (url.includes("/usage/tokens/sync-codex/status")) {
+          return Promise.resolve(
+            new Response(
+              JSON.stringify({
+                enabled: true,
+                running: true,
+                sessions_glob: "~/.codex/sessions/**/*.jsonl",
+                poll_interval_seconds: 30,
+                last_started_at: null,
+                last_finished_at: null,
+                last_inserted_events: 0,
+                last_discovered_files: 4,
+                last_error: null,
+              }),
+              { status: 200 },
+            ),
+          );
+        }
+        if (url.includes("/usage/tokens/sync-codex")) {
+          return Promise.resolve(
+            new Response(
+              JSON.stringify({ inserted_events: 2, enabled: true }),
+              {
+                status: 200,
+              },
+            ),
+          );
+        }
+        return Promise.resolve(
+          new Response(JSON.stringify([]), { status: 200 }),
+        );
+      });
+
+    renderWithProviders(<UsagePage />);
+
+    expect(screen.getByText("Codex Token Sync")).toBeInTheDocument();
+    await screen.findByText("~/.codex/sessions/**/*.jsonl");
+    fireEvent.click(screen.getByRole("button", { name: "Sync now" }));
+
+    await waitFor(() => {
+      expect(screen.getByText("Inserted 2 token events.")).toBeInTheDocument();
+    });
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/api/usage/tokens/sync-codex",
+      expect.objectContaining({ method: "POST" }),
+    );
+  });
+
   it("shows chart placeholders", () => {
     renderWithProviders(<UsagePage />);
-    expect(
-      screen.getByText(/No token data/),
-    ).toBeInTheDocument();
-    expect(
-      screen.getByText(/No resource data yet/),
-    ).toBeInTheDocument();
+    expect(screen.getByText(/No token data/)).toBeInTheDocument();
+    expect(screen.getByText(/No resource data yet/)).toBeInTheDocument();
   });
 });

--- a/scripts/playwright/phase4-codex-token-visibility.mjs
+++ b/scripts/playwright/phase4-codex-token-visibility.mjs
@@ -1,0 +1,94 @@
+import { chromium } from '../../frontend/node_modules/@playwright/test/index.mjs';
+import fs from 'fs';
+import path from 'path';
+
+const stamp = new Date().toISOString().replace(/[:.]/g, '-');
+const outDir = path.resolve('test-results', `phase4-codex-token-visibility-${stamp}`);
+fs.mkdirSync(outDir, { recursive: true });
+const checks = [];
+const consoleMessages = [];
+const failedRequests = [];
+const pageErrors = [];
+
+function check(name, ok, detail = '') {
+  checks.push({ name, ok, detail });
+  if (!ok) console.error(`FAIL ${name}: ${detail}`);
+}
+
+const browser = await chromium.launch();
+const page = await browser.newPage({ viewport: { width: 1440, height: 1000 } });
+page.on('console', (msg) => {
+  if (['error', 'warning'].includes(msg.type())) {
+    consoleMessages.push({ type: msg.type(), text: msg.text() });
+  }
+});
+page.on('pageerror', (err) => pageErrors.push(err.message));
+page.on('requestfailed', (request) => {
+  failedRequests.push({ url: request.url(), failure: request.failure()?.errorText ?? 'unknown' });
+});
+
+const codexStatus = {
+  enabled: true,
+  running: true,
+  sessions_glob: '~/.codex/sessions/**/*.jsonl',
+  poll_interval_seconds: 30,
+  last_started_at: '2026-07-03T16:48:00Z',
+  last_finished_at: '2026-07-03T16:48:01Z',
+  last_inserted_events: 0,
+  last_discovered_files: 7,
+  last_error: null,
+};
+
+await page.route('**/api/**', async (route) => {
+  const url = route.request().url();
+  if (url.includes('/api/usage/tokens/sync-codex/status')) {
+    await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(codexStatus) });
+    return;
+  }
+  if (url.includes('/api/usage/tokens/sync-codex')) {
+    codexStatus.last_inserted_events = 2;
+    codexStatus.last_finished_at = '2026-07-03T16:49:01Z';
+    await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ inserted_events: 2, enabled: true }) });
+    return;
+  }
+  if (url.includes('/api/usage/summary')) {
+    await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ today_tokens: 43210, month_tokens: 987654 }) });
+    return;
+  }
+  if (url.includes('/api/usage/tokens')) {
+    await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify([{ date: '2026-07-03', input_tokens: 40000, output_tokens: 3210, model: 'gpt-5.5' }]) });
+    return;
+  }
+  if (url.includes('/api/usage/resources')) {
+    await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify([{ timestamp: '2026-07-03T16:48:00Z', cpu_pct: 12, ram_mb: 2048 }]) });
+    return;
+  }
+  await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify([]) });
+});
+
+try {
+  await page.goto('http://127.0.0.1:5173/usage', { waitUntil: 'networkidle' });
+  await page.getByRole('heading', { name: 'Usage', exact: true }).waitFor();
+  await page.getByRole('heading', { name: 'Codex Token Sync' }).waitFor();
+  await page.getByText('~/.codex/sessions/**/*.jsonl').waitFor();
+  await page.screenshot({ path: path.join(outDir, 'usage-codex-sync-status.png'), fullPage: true });
+
+  await page.getByRole('button', { name: 'Sync now' }).click();
+  await page.getByText('Inserted 2 token events.').waitFor();
+  await page.screenshot({ path: path.join(outDir, 'usage-codex-sync-after-manual.png'), fullPage: true });
+
+  check('Usage route loads', await page.getByTestId('usage-page').isVisible());
+  check('Codex sync card visible', await page.getByRole('heading', { name: 'Codex Token Sync' }).isVisible());
+  check('Codex source glob visible', await page.getByText('~/.codex/sessions/**/*.jsonl').isVisible());
+  check('Manual sync feedback visible', await page.getByText('Inserted 2 token events.').isVisible());
+} catch (err) {
+  check('Playwright script completed', false, err?.stack || err?.message || String(err));
+}
+
+await browser.close();
+const report = { outDir, checks, consoleMessages, failedRequests, pageErrors };
+fs.writeFileSync(path.join(outDir, 'report.json'), JSON.stringify(report, null, 2));
+const failed = checks.filter((c) => !c.ok);
+console.log(`REPORT ${path.join(outDir, 'report.json')}`);
+console.log(`${checks.length - failed.length}/${checks.length} checks passed`);
+if (failed.length || pageErrors.length) process.exit(1);

--- a/src/atc/agents/codex_usage.py
+++ b/src/atc/agents/codex_usage.py
@@ -63,6 +63,21 @@ class CodexTokenSnapshot:
         return str(self.source_file)
 
 
+@dataclass(frozen=True, slots=True)
+class CodexUsageSyncStatus:
+    """Operator-visible status for the Codex usage sync service."""
+
+    enabled: bool
+    running: bool
+    sessions_glob: str
+    poll_interval_seconds: float
+    last_started_at: datetime | None = None
+    last_finished_at: datetime | None = None
+    last_inserted_events: int = 0
+    last_discovered_files: int = 0
+    last_error: str | None = None
+
+
 class CodexJsonlParser:
     """Parse Codex JSONL and yield token-count snapshots.
 
@@ -213,6 +228,11 @@ class CodexUsageSyncService:
         self._parser = parser or CodexJsonlParser()
         self._recorder = recorder or TokenUsageRecorder(db, event_bus, ws_hub=ws_hub)
         self._task: asyncio.Task[None] | None = None
+        self._last_started_at: datetime | None = None
+        self._last_finished_at: datetime | None = None
+        self._last_inserted_events = 0
+        self._last_discovered_files = 0
+        self._last_error: str | None = None
 
     async def start(self) -> None:
         """Start the Codex usage polling loop."""
@@ -240,10 +260,35 @@ class CodexUsageSyncService:
 
         Returns the number of usage-event rows inserted.
         """
+        self._last_started_at = datetime.now(UTC)
+        self._last_error = None
         inserted = 0
-        for path in self._discover_files():
-            inserted += await self._sync_file(path)
+        paths = self._discover_files()
+        self._last_discovered_files = len(paths)
+        try:
+            for path in paths:
+                inserted += await self._sync_file(path)
+        except Exception as exc:
+            self._last_error = str(exc)
+            raise
+        finally:
+            self._last_inserted_events = inserted
+            self._last_finished_at = datetime.now(UTC)
         return inserted
+
+    def status(self, *, enabled: bool = True) -> CodexUsageSyncStatus:
+        """Return current service status without triggering a sync."""
+        return CodexUsageSyncStatus(
+            enabled=enabled,
+            running=self._task is not None and not self._task.done(),
+            sessions_glob=self._sessions_glob,
+            poll_interval_seconds=self._poll_interval,
+            last_started_at=self._last_started_at,
+            last_finished_at=self._last_finished_at,
+            last_inserted_events=self._last_inserted_events,
+            last_discovered_files=self._last_discovered_files,
+            last_error=self._last_error,
+        )
 
     def _discover_files(self) -> list[Path]:
         expanded = str(Path(self._sessions_glob).expanduser())

--- a/src/atc/api/routers/usage.py
+++ b/src/atc/api/routers/usage.py
@@ -10,6 +10,7 @@ Usage routes:
 from __future__ import annotations
 
 import logging
+from dataclasses import asdict
 from datetime import UTC, datetime, timedelta
 
 from fastapi import APIRouter, HTTPException, Request
@@ -72,6 +73,18 @@ class CodexSyncResponse(BaseModel):
     enabled: bool
 
 
+class CodexSyncStatusResponse(BaseModel):
+    enabled: bool
+    running: bool
+    sessions_glob: str
+    poll_interval_seconds: float
+    last_started_at: datetime | None = None
+    last_finished_at: datetime | None = None
+    last_inserted_events: int = 0
+    last_discovered_files: int = 0
+    last_error: str | None = None
+
+
 def _is_oauth_mode() -> bool:
     """Return True when not using a real API key (OAuth or no key configured)."""
     from atc.agents.auth import get_auth_mode
@@ -125,6 +138,17 @@ async def sync_codex_usage(request: Request) -> CodexSyncResponse:
         inserted_events=inserted,
         enabled=bool(settings.token_tracker.codex_enabled),
     )
+
+
+@router.get("/tokens/sync-codex/status", response_model=CodexSyncStatusResponse)
+async def get_codex_sync_status(request: Request) -> CodexSyncStatusResponse:
+    """Return operator-visible status for deterministic Codex token sync."""
+    settings = request.app.state.settings
+    service = getattr(request.app.state, "codex_usage_sync", None)
+    if service is None:
+        raise HTTPException(status_code=503, detail="Codex usage sync service is unavailable")
+    status = service.status(enabled=bool(settings.token_tracker.codex_enabled))
+    return CodexSyncStatusResponse(**asdict(status))
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_codex_usage.py
+++ b/tests/unit/test_codex_usage.py
@@ -197,6 +197,12 @@ class TestCodexUsageSyncService:
         assert row["total_tokens"] == 125
         assert row["external_session_id"] == "codex-external"
         assert row["source_file"] == str(path)
+        status = service.status(enabled=True)
+        assert status.last_inserted_events == 1
+        assert status.last_discovered_files == 1
+        assert status.last_started_at is not None
+        assert status.last_finished_at is not None
+        assert status.last_error is None
 
     async def test_subsequent_cumulative_snapshot_records_only_delta(
         self, migrated_db, tmp_path: Path

--- a/tests/unit/test_codex_usage_runtime.py
+++ b/tests/unit/test_codex_usage_runtime.py
@@ -9,6 +9,7 @@ from typing import TYPE_CHECKING, Any
 
 from fastapi.testclient import TestClient
 
+from atc.agents.codex_usage import CodexUsageSyncStatus
 from atc.api.app import create_app
 from atc.config import Settings
 from atc.state import db as db_ops
@@ -43,6 +44,16 @@ class FakeCodexUsageSyncService:
     async def sync_once(self) -> int:
         self.sync_count += 1
         return 3
+
+    def status(self, *, enabled: bool = True) -> CodexUsageSyncStatus:
+        return CodexUsageSyncStatus(
+            enabled=enabled,
+            running=self.started and not self.stopped,
+            sessions_glob=self.sessions_glob,
+            poll_interval_seconds=self.poll_interval,
+            last_inserted_events=3 if self.sync_count else 0,
+            last_discovered_files=2,
+        )
 
 
 def settings_for(
@@ -105,6 +116,24 @@ def test_sync_codex_api_runs_one_service_pass(tmp_path: Path, monkeypatch) -> No
         assert response.status_code == 200
         assert response.json() == {"inserted_events": 3, "enabled": True}
         assert FakeCodexUsageSyncService.instances[0].sync_count == 1
+
+
+def test_sync_codex_status_api_reports_service_state(tmp_path: Path, monkeypatch) -> None:
+    from atc.agents import codex_usage
+
+    FakeCodexUsageSyncService.instances = []
+    monkeypatch.setattr(codex_usage, "CodexUsageSyncService", FakeCodexUsageSyncService)
+
+    app = create_app(settings_for(tmp_path, glob_value=str(tmp_path / "*.jsonl")))
+    with TestClient(app) as client:
+        response = client.get("/api/usage/tokens/sync-codex/status")
+        assert response.status_code == 200
+        body = response.json()
+        assert body["enabled"] is True
+        assert body["running"] is True
+        assert body["sessions_glob"] == str(tmp_path / "*.jsonl")
+        assert body["poll_interval_seconds"] == 123
+        assert body["last_discovered_files"] == 2
 
 
 def write_jsonl(path: Path, *events: dict[str, Any]) -> None:


### PR DESCRIPTION
## Summary
- add Codex sync status telemetry from the provider-owned sync service
- expose `GET /api/usage/tokens/sync-codex/status` for operator visibility
- add Usage page Codex Token Sync card with running/enabled state, last sync, files seen, source glob, and manual sync trigger
- add committed Playwright smoke for Codex sync visibility

## Validation
- `ruff check src/atc/agents/codex_usage.py src/atc/api/routers/usage.py tests/unit/test_codex_usage.py tests/unit/test_codex_usage_runtime.py`
- `PYTHONPATH=src pytest tests/unit/test_codex_usage.py tests/unit/test_codex_usage_runtime.py tests/unit/test_usage_recorder.py tests/unit/test_tokens.py tests/unit/test_budget_enforcer.py tests/unit/test_agent_provider.py tests/unit/test_usage_oauth.py tests/unit/test_models.py tests/unit/test_cli.py -q` → 186 passed, 1 warning
- `npx vitest run src/pages/__tests__/UsagePage.test.tsx` → 7 passed
- `npm run build` → passed
- `node scripts/playwright/phase4-codex-token-visibility.mjs` → 4/4 checks passed
- stale cost scan: `TRACKED_COST_HITS []`
- provider-boundary scan: `SHARED_CODEX_HITS []`

## UI evidence
- report: `/Users/mcole_studio/Repository/atc/test-results/phase4-codex-token-visibility-2026-07-03T19-58-36-322Z/report.json`
- screenshot: `/Users/mcole_studio/Repository/atc/test-results/phase4-codex-token-visibility-2026-07-03T19-58-36-322Z/usage-codex-sync-status.png`
- screenshot: `/Users/mcole_studio/Repository/atc/test-results/phase4-codex-token-visibility-2026-07-03T19-58-36-322Z/usage-codex-sync-after-manual.png`

Note: Playwright report includes Vite dev-server WebSocket warnings only; no failed requests and no page errors.