### PR TITLE
Document CLI provider onboarding contracts

### DIFF
--- a/CODE_STRUCTURE.md
+++ b/CODE_STRUCTURE.md
@@ -27,8 +27,10 @@ It may have a best-supported provider at a given moment, but the architecture sh
 - startup, readiness, prompt delivery, and status handling belong at the provider boundary when provider-specific
 - product logic should depend on stable internal interfaces, not tool-specific terminal behaviors
 
-Practical rule:
+Practical rules:
 - Tower / Leader / Ace flows should talk to provider abstractions, not raw tmux or provider-specific CLI details, unless that code is explicitly part of a provider implementation
+- New CLI providers must start from [`docs/provider_onboarding.md`](docs/provider_onboarding.md) and [`docs/provider_interface_contract.md`](docs/provider_interface_contract.md)
+- Provider-specific logic belongs under the provider module; shared interfaces should not change in provider onboarding PRs unless a separate design log justifies a generic ATC need
 
 ### 2. Product logic and runtime wiring should stay separate
 

--- a/README.md
+++ b/README.md
@@ -109,10 +109,18 @@ tests/          → Unit, integration, e2e tests
 - [CODE_STRUCTURE.md](CODE_STRUCTURE.md) — high-level code structure, provider-agnostic architecture, and hygiene rules
 - [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) — System architecture
 - [docs/runtime_truth_recovery_plan.md](docs/runtime_truth_recovery_plan.md) — phased plan for provider-neutral runtime truth, delivery verification, health, and recovery
+- [docs/provider_onboarding.md](docs/provider_onboarding.md) — checklist for adding a new CLI provider/platform
+- [docs/provider_interface_contract.md](docs/provider_interface_contract.md) — provider-neutral orchestration, terminal, token, and runtime contracts
+- [docs/provider_acceptance_checklist.md](docs/provider_acceptance_checklist.md) — PR acceptance checklist for new CLI providers
+- [docs/provider_implementation_map.md](docs/provider_implementation_map.md) — source map for provider integration points
 - [docs/FEATURES.md](docs/FEATURES.md) — Feature guide
 - [docs/API.md](docs/API.md) — REST API + WebSocket reference
 - [docs/PATTERNS.md](docs/PATTERNS.md) — Code patterns
 - [docs/CONTRIBUTING.md](docs/CONTRIBUTING.md) — How to contribute
+
+### Adding a New CLI Provider
+
+Start with [docs/provider_onboarding.md](docs/provider_onboarding.md). Every new CLI-backed provider must satisfy the provider boundary lock, provider-neutral interface contract, Tower/Leader/Ace orchestration contract, terminal contract, token usage contract, and acceptance checklist before being considered supported. Provider-specific logic belongs in the provider module; shared interfaces should not change inside a provider onboarding PR unless a separate design log justifies a generic ATC need.
 
 ## Upgrading
 

--- a/docs/provider_acceptance_checklist.md
+++ b/docs/provider_acceptance_checklist.md
@@ -1,0 +1,114 @@
+# Provider Acceptance Checklist
+
+Use this checklist in every PR that adds or materially changes a CLI-backed provider/platform.
+
+## Provider boundary lock
+
+- [ ] Provider-specific logic is contained under the provider module.
+- [ ] Shared orchestration/session/token/terminal interfaces were not changed for a single provider.
+- [ ] If a shared interface changed, a separate design log explains the generic need and compatibility tests were added.
+- [ ] Shared modules receive only normalized ATC facts/events/statuses/token increments.
+- [ ] Provider-specific filesystem paths, event names, prompt text, and JSON payload shapes do not leak into shared modules.
+- [ ] Boundary regression scan is included and documented.
+
+## CLI availability and config
+
+- [ ] Provider CLI command discovery is implemented.
+- [ ] Missing CLI error is operator-readable.
+- [ ] PATH/command override behavior is documented if supported.
+- [ ] Provider can be enabled/disabled by config.
+- [ ] Provider-specific telemetry paths/globs/intervals are configurable when applicable.
+- [ ] `config.local.yaml` can override local machine details.
+
+## Session lifecycle
+
+- [ ] ATC session row is created before terminal/provider process spawn.
+- [ ] External provider session ID maps to ATC session ID.
+- [ ] Start behavior is tested.
+- [ ] Stop/shutdown behavior is tested.
+- [ ] Reconnect/recovery behavior is tested or explicitly documented as unsupported.
+- [ ] Unknown/unmapped provider sessions are skipped or surfaced safely; they do not create orphan task/usage rows.
+
+## Tower / Leader / Ace orchestration
+
+- [ ] Tower can start or recover the provider-backed Leader path.
+- [ ] Leader can spawn provider-backed Ace sessions.
+- [ ] Leader can assign tasks to Aces.
+- [ ] Ace reports active/accepted state.
+- [ ] Ace completion/report path reaches Leader/Tower/operator-visible surfaces.
+- [ ] Acceptance evidence follows `Operator → Tower → Leader → Ace` rather than direct Ace-only execution.
+
+## Terminal and prompt handling
+
+- [ ] Provider launch uses existing terminal/session infrastructure or an approved documented exception.
+- [ ] Terminal output streams to the UI.
+- [ ] Resize behavior is preserved.
+- [ ] Manual scrollback remains usable while output streams.
+- [ ] Live-follow resumes only after scrolling back to bottom.
+- [ ] Prompt submission sends instruction text and Enter atomically.
+- [ ] Shared terminal code does not encode provider prompt/auth text.
+
+## Trust, auth, and blocked states
+
+- [ ] First-run trust/auth prompts are detected when applicable.
+- [ ] Secret prompts are never auto-filled.
+- [ ] Secret-like fixture/log/doc values are replaced with `[REDACTED]`.
+- [ ] Blocked state is visible to the operator.
+- [ ] Recovery guidance is available.
+- [ ] Tests cover blocked/trust/auth paths or document why the provider has none.
+
+## Token usage
+
+- [ ] Token telemetry source is identified.
+- [ ] Provider parser fixtures are added.
+- [ ] Provider-specific token parsing lives inside the provider module.
+- [ ] Provider emits normalized `TokenUsageIncrement` values.
+- [ ] Token classes are preserved when available: input, cached input, output, reasoning output, total.
+- [ ] Cumulative provider totals are converted to increments behind the provider boundary.
+- [ ] Restart/re-read/backfill does not double-count.
+- [ ] Unknown/unmapped telemetry is skipped or reported safely.
+- [ ] Token summaries/API/UI reflect provider usage when applicable.
+
+## Runtime truth and recovery
+
+- [ ] Provider status is available through API or runtime status surfaces.
+- [ ] Health/status includes unavailable/blocked/ready/running/failure states as applicable.
+- [ ] Structured failure logs/reason codes are used.
+- [ ] Recovery actions are deterministic and tested where possible.
+- [ ] DB/API/terminal/frontend/provider state can be reconciled.
+
+## Frontend / operator visibility
+
+- [ ] Provider-specific operator actions are visible when needed.
+- [ ] Provider blocked/misconfigured state is visible.
+- [ ] Token sync/status is visible when provider has token telemetry.
+- [ ] Manual sync/backfill controls are visible when supported.
+- [ ] Frontend unit tests cover changed UI.
+- [ ] Playwright evidence is attached when workflow/UI behavior changes.
+
+## Cost/dollar prohibition
+
+- [ ] No `cost_usd`.
+- [ ] No pricing registry.
+- [ ] No dollar budgets or billing limits.
+- [ ] No `/api/*/cost` endpoints.
+- [ ] No provider model cost rates.
+- [ ] Stale cost-term scan is included.
+
+## Documentation
+
+- [ ] Provider-specific design log was created from `docs/templates/provider_onboarding_template.md`.
+- [ ] `docs/provider_implementation_map.md` was updated if new files/patterns were introduced.
+- [ ] `docs/FEATURES.md` was updated for operator-visible behavior changes.
+- [ ] `docs/ARCHITECTURE.md` was updated for subsystem responsibility changes.
+- [ ] README was updated if a new top-level entrypoint was added.
+
+## Validation evidence
+
+- [ ] Backend unit tests.
+- [ ] Integration/runtime tests where lifecycle or orchestration changed.
+- [ ] Frontend tests where UI changed.
+- [ ] Playwright smoke where operator workflow changed.
+- [ ] Provider-boundary scan.
+- [ ] Stale cost-term scan.
+- [ ] Post-merge validation on `main`.

--- a/docs/provider_implementation_map.md
+++ b/docs/provider_implementation_map.md
@@ -1,0 +1,159 @@
+# Provider Implementation Map
+
+Use this map to locate the ATC subsystems a new CLI provider may need to integrate with. Provider onboarding should start from the docs in this directory, then use this map to find the implementation areas.
+
+## Main docs
+
+- [`provider_onboarding.md`](provider_onboarding.md) — main onboarding guide.
+- [`provider_interface_contract.md`](provider_interface_contract.md) — shared/provider boundary contract.
+- [`provider_acceptance_checklist.md`](provider_acceptance_checklist.md) — PR acceptance checklist.
+- [`templates/provider_onboarding_template.md`](templates/provider_onboarding_template.md) — provider-specific design log template.
+
+## Provider modules
+
+Provider-specific logic belongs under provider-owned modules, for example:
+
+```text
+src/atc/agents/<provider>/
+src/atc/agents/<provider>_usage.py
+src/atc/agents/providers/<provider>/
+```
+
+Current examples:
+
+- `src/atc/agents/codex_usage.py` — Codex-owned token JSONL parser/sync service.
+
+Provider modules should adapt provider-specific facts into provider-neutral ATC primitives before calling shared code.
+
+## Session lifecycle
+
+Relevant areas:
+
+```text
+src/atc/session/
+src/atc/state/
+src/atc/core/
+```
+
+Use these areas for DB-backed session creation, lifecycle state, reconnect/recovery, and event handling. Preserve the DB-first invariant: session rows must exist before terminal panes or provider sessions are spawned.
+
+## Terminal, PTY, tmux, and output
+
+Relevant areas:
+
+```text
+src/atc/terminal/
+frontend/src/components/terminal/
+```
+
+Shared terminal code manages PTY/tmux streaming, resizing, output delivery, and operator-console behavior. Provider prompt text, trust prompt text, token event parsing, and CLI quirks do not belong in shared terminal modules.
+
+## Tower, Leader, Ace orchestration
+
+Relevant areas:
+
+```text
+src/atc/tower/
+src/atc/leader/
+src/atc/session/
+src/atc/core/
+```
+
+The normal execution chain is:
+
+```text
+Operator → Tower → Leader → Ace
+```
+
+Provider integrations must not add shortcuts around this chain for normal orchestration. Tests may use direct lower-level calls for debugging, but acceptance must prove Tower-driven Leader/Ace work.
+
+## Token usage
+
+Relevant shared area:
+
+```text
+src/atc/tracking/tokens.py
+```
+
+Provider-specific token collectors/parsers belong under provider modules, not here.
+
+Shared token tracking handles:
+
+- normalized `TokenUsageIncrement` validation;
+- append-only usage event storage;
+- summaries/aggregation;
+- event/WebSocket fanout;
+- token limit enforcement.
+
+Provider modules handle:
+
+- token telemetry source discovery;
+- token event/file parsing;
+- cumulative total to increment conversion;
+- external provider session mapping;
+- provider-specific de-dupe/source-key semantics.
+
+## API surfaces
+
+Relevant areas:
+
+```text
+src/atc/api/app.py
+src/atc/api/routers/
+```
+
+Provider APIs should expose normalized status and actions. Provider-specific details may be surfaced deliberately through provider-specific endpoints/cards, but parsing and interpretation should remain provider-owned.
+
+## Frontend operator visibility
+
+Relevant areas:
+
+```text
+frontend/src/pages/
+frontend/src/components/
+frontend/src/context/
+```
+
+Provider changes need UI only when operator action or visibility changes. Examples:
+
+- provider unavailable/misconfigured;
+- trust/auth blocked;
+- token sync status;
+- manual sync/backfill trigger;
+- recovery guidance.
+
+When UI changes, add unit tests and Playwright smoke evidence.
+
+## Config
+
+Relevant files:
+
+```text
+config.yaml
+src/atc/config.py
+```
+
+Provider-specific config should be explicit, local-overridable, and read by provider-owned code whenever possible. Shared modules should not learn provider-specific settings unless the setting is part of a provider-neutral contract.
+
+## Tests
+
+Common locations:
+
+```text
+tests/unit/test_<provider>.py
+tests/unit/test_<provider>_usage.py
+tests/unit/test_<provider>_runtime.py
+frontend/src/**/__tests__/
+scripts/playwright/
+```
+
+Required classes of tests are listed in [`provider_acceptance_checklist.md`](provider_acceptance_checklist.md).
+
+## Do not put this here
+
+- Do not put provider file/event parsing in `src/atc/tracking/tokens.py`.
+- Do not put provider CLI output branching in shared Tower/Leader/Ace orchestration.
+- Do not put provider auth/trust prompt text in shared terminal code.
+- Do not put provider secrets in docs, tests, fixtures, screenshots, or logs.
+- Do not add cost/dollar/billing concepts to token usage surfaces.
+- Do not modify shared interfaces in a provider PR unless a separate design log justifies the generic need.

--- a/docs/provider_interface_contract.md
+++ b/docs/provider_interface_contract.md
@@ -1,0 +1,212 @@
+# Provider Interface Contract
+
+This document defines the provider-neutral contracts that CLI-backed providers must adapt into. It is intentionally stricter than an implementation guide: provider modules may vary internally, but shared ATC interfaces must stay stable and provider-neutral.
+
+## Contract rule: adapt providers, do not reshape ATC
+
+New providers must adapt provider-specific behavior into existing ATC interfaces. Do not modify shared orchestration, session, terminal, token, or API contracts inside a provider onboarding PR unless there is a separate architecture decision proving a generic need.
+
+A shared interface change requires:
+
+- a design log explaining why the existing interface is insufficient;
+- at least one non-current-provider use case or generic ATC benefit;
+- compatibility tests for existing providers;
+- updates to this contract;
+- explicit PR review focus on the shared change.
+
+## Provider-owned responsibilities
+
+Provider modules own all provider-specific behavior:
+
+| Responsibility | Provider-owned examples |
+| --- | --- |
+| CLI discovery | binary name, version command, PATH quirks, launch flags |
+| Auth/trust | first-run prompt text, login status, trust prompts, blocked-state parsing |
+| Session metadata | external session IDs, working directory conventions, provider run IDs |
+| Terminal interpretation | provider-specific readiness text, prompt boundaries, completion markers |
+| Token telemetry | file paths, event names, JSON shapes, cumulative total semantics |
+| Health/error classification | provider-specific retryable/fatal/blocked messages |
+
+Provider modules convert those details into normalized ATC facts.
+
+## Shared interface boundaries
+
+Shared code may depend only on provider-neutral values:
+
+| Shared layer | Allowed inputs | Forbidden provider-specific inputs |
+| --- | --- | --- |
+| Orchestration | ATC project/session/task IDs, role, state, events | provider CLI output strings, provider prompt text |
+| Session lifecycle | session ID, command/env, PTY handle, readiness state | provider-specific metadata parsing outside provider module |
+| Terminal | PTY bytes, resize events, scroll/follow state | provider trust prompt wording or token telemetry formats |
+| Token tracking | `TokenUsageIncrement`, provider name, source IDs | provider files, JSONL schemas, event names, pricing/cost data |
+| API/UI | normalized status, token summaries, health fields | hidden provider parsing logic in UI/shared routers |
+
+## Runtime/session interface
+
+Every provider must expose enough behavior for ATC to manage sessions through the existing lifecycle.
+
+Required normalized facts:
+
+- provider name;
+- executable command and environment;
+- ATC session ID;
+- optional external provider session ID;
+- working directory/project mapping;
+- role: Tower, Leader, Ace, or provider-neutral runtime role;
+- readiness state;
+- blocked reason, if blocked;
+- recovery guidance, if recoverable;
+- health timestamp and status.
+
+The provider module may use provider-specific classes internally, but the shared session lifecycle should receive stable, provider-neutral primitives.
+
+## Orchestration interface
+
+Providers must support ATC's command chain:
+
+```text
+Operator → Tower → Leader → Ace
+```
+
+Shared orchestration contracts:
+
+- Tower receives operator goals and coordinates Leaders.
+- Leader receives project context, plans work, spawns Aces, assigns tasks, and monitors completion.
+- Ace receives task-scoped instructions and reports execution state/artifacts.
+- Event bus and DB records are the source of truth for orchestration state.
+
+Provider modules must not add alternate paths that let a provider bypass the Tower/Leader/Ace chain for normal work.
+
+## Terminal interface
+
+The terminal layer is provider-neutral. It manages PTY/tmux streaming, resizing, and UI delivery.
+
+Provider modules may provide:
+
+- command argv/env;
+- launch cwd;
+- readiness detector;
+- blocked-state detector;
+- provider-specific parser callbacks if wired through a provider-owned boundary.
+
+Shared terminal code must not encode provider prompt strings, auth text, token event formats, or provider filesystem paths.
+
+## Prompt submission interface
+
+Prompt dispatch must preserve ATC's atomic-send invariant:
+
+- instruction text and Enter are sent without an await gap;
+- prompt dispatch is associated with an ATC session/task when applicable;
+- provider readiness/trust state is checked before dispatch when possible;
+- failures are structured and recoverable.
+
+Provider-specific prompt wrappers or slash commands belong under the provider module.
+
+## Token usage interface
+
+Shared token tracking accepts only normalized increments:
+
+```python
+TokenUsageIncrement(
+    session_id=str,
+    project_id=str | None,
+    provider=str,
+    model=str | None,
+    recorded_at=datetime,
+    input_tokens=int,
+    cached_input_tokens=int,
+    output_tokens=int,
+    reasoning_output_tokens=int,
+    total_tokens=int,
+    source=str,
+    external_session_id=str | None,
+    source_event_id=str | None,
+    raw_usage=dict | None,
+)
+```
+
+Provider modules own:
+
+- telemetry source discovery;
+- parser fixtures;
+- event-shape handling;
+- source key semantics;
+- high-water/de-dupe offsets where provider-specific;
+- cumulative total to increment conversion;
+- external session mapping.
+
+Shared token tracking owns:
+
+- validation of normalized increments;
+- append-only usage event persistence;
+- aggregation/summaries;
+- fanout to events/WebSockets;
+- token limit enforcement;
+- provider-neutral high-water primitives when useful.
+
+Shared token tracking must not know about provider-specific files, event names, or token payload shapes.
+
+## Runtime truth and recovery interface
+
+Providers must normalize their runtime truth into states ATC can display and act on:
+
+- `available` / `unavailable`;
+- `starting` / `ready` / `running` / `blocked` / `failed` / `completed` where applicable;
+- blocked reason code;
+- operator-readable recovery guidance;
+- last checked timestamp;
+- last sync timestamp for usage collectors;
+- structured failure log fields.
+
+If provider output, DB state, terminal state, or API state disagree, the provider integration must surface the mismatch rather than hiding it behind a healthy status.
+
+## Context, artifact, and report interface
+
+Provider modules must use ATC context and artifact channels:
+
+- Leaders own context packaging.
+- Aces receive assignment context through Leader-managed paths.
+- Aces report progress/artifacts through ATC report/event APIs.
+- Provider-specific artifact discovery may happen in provider code, but artifacts become normalized paths/events before reaching shared UI/API surfaces.
+
+## Boundary regression expectations
+
+Every provider PR must include a provider-boundary scan tailored to the provider. Examples:
+
+```text
+# Codex-specific examples that must not appear in shared token tracking
+.codex
+token_count
+rollout-
+codex_jsonl
+```
+
+General scan targets:
+
+- shared token tracking modules;
+- shared orchestration modules;
+- shared terminal modules;
+- shared API models;
+- frontend shared state/components.
+
+A provider term in a shared module is acceptable only when it is intentionally provider-neutral metadata, such as a provider name passed through a generic field, and the PR explains why.
+
+## Cost and billing prohibition
+
+ATC provider integrations are token-only. Do not add provider pricing, cost estimates, billing limits, dollar budgets, or cost endpoints as part of provider onboarding.
+
+Forbidden examples:
+
+```text
+cost_usd
+monthly_cost_limit
+today_cost
+month_cost
+/api/usage/cost
+/api/tower/cost
+CostModel
+cost_model
+input_cost_per_token
+output_cost_per_token
+CostTracker
+```

--- a/docs/provider_onboarding.md
+++ b/docs/provider_onboarding.md
@@ -1,0 +1,258 @@
+# CLI Provider Onboarding Guide
+
+This guide is the canonical checklist for adding a new CLI-backed platform or provider to ATC. Use it before implementing support for a provider such as Claude Code, Codex, Gemini CLI, OpenCode, or any other terminal-driven agent runtime.
+
+A provider is not considered supported until it satisfies the provider boundary lock, Tower/Leader/Ace orchestration contract, terminal contract, token usage contract, runtime-truth contract, and acceptance checklist in this guide.
+
+## Start here
+
+1. Read [`provider_interface_contract.md`](provider_interface_contract.md).
+2. Read [`provider_implementation_map.md`](provider_implementation_map.md).
+3. Copy [`templates/provider_onboarding_template.md`](templates/provider_onboarding_template.md) into a provider-specific design log under `docs/design_logs/`.
+4. Use [`provider_acceptance_checklist.md`](provider_acceptance_checklist.md) as the PR checklist.
+
+## Provider boundary lock
+
+New CLI providers must adapt to ATC's existing provider-neutral contracts. A provider onboarding PR must not modify shared orchestration, session, terminal, token, or API interfaces just to fit one provider.
+
+Hard rules:
+
+- Provider-specific logic stays under the provider module.
+- Shared ATC layers receive only normalized ATC facts, events, statuses, and token increments.
+- Shared interface changes require a separate architecture decision/design log and must prove generic benefit beyond one provider.
+- Provider onboarding PRs must include boundary regression tests or scans that prove provider-specific terms did not leak into shared modules.
+
+Provider-owned behavior includes:
+
+- CLI command discovery and provider-specific launch flags.
+- Auth, trust, first-run, and blocked-prompt detection.
+- Provider-specific terminal output parsing.
+- Provider-specific session metadata and external session ID mapping.
+- Token telemetry file/event discovery and parsing.
+- Cumulative token total to increment conversion.
+- Provider-specific health interpretation and error classification.
+
+Shared layers must not know about provider-specific filesystem paths, JSON payload shapes, event names, prompt wording, or CLI quirks.
+
+## Required provider module
+
+Add provider logic under a provider-owned location, for example:
+
+```text
+src/atc/agents/<provider>/
+src/atc/agents/<provider>_usage.py
+src/atc/agents/providers/<provider>/
+```
+
+The provider module owns adaptation from provider-specific behavior into ATC-normalized primitives.
+
+Minimum responsibilities:
+
+- Resolve whether the provider CLI is installed and executable.
+- Build the command/env needed to launch the CLI.
+- Start or attach to provider-backed ATC sessions through existing session/terminal infrastructure.
+- Detect readiness, trust/auth prompts, blocked states, and completion states.
+- Map external provider session identifiers to ATC session IDs.
+- Emit normalized token usage increments when the provider has token telemetry.
+- Expose provider-specific status through provider-owned code, then normalize it for API/UI use.
+
+## Session lifecycle contract
+
+Every provider must respect ATC's session lifecycle invariants:
+
+- DB session rows are created before terminal/tmux panes are spawned.
+- Session IDs are stable and used for all downstream events.
+- Provider external session IDs are mapped to ATC session IDs before usage/events are recorded.
+- Start, stop, reconnect, health, and recovery paths are deterministic and testable.
+- Unknown or unmapped provider sessions are skipped or surfaced as blocked; they must not create orphan ATC usage rows or task events.
+
+## Tower / Leader / Ace orchestration contract
+
+Normal provider validation must prove the full chain:
+
+```text
+Operator → Tower → Leader → Ace
+```
+
+Required behavior:
+
+- Tower receives operator instructions and governs project/goal execution.
+- Tower starts, monitors, and recovers Leaders.
+- Leaders plan work, manage context, spawn Aces, assign tasks, and keep Aces on task.
+- Aces execute assigned work in isolated sessions and report active/accepted/completed states.
+- Artifact and report paths flow Ace → Leader → Tower/operator-visible surfaces.
+- Direct Ace execution may be used for low-level debugging, but it does not satisfy orchestration acceptance.
+
+Provider support must not bypass Tower/Leader/Ace boundaries by adding provider-specific shortcuts in shared orchestration code.
+
+## Terminal / PTY / tmux contract
+
+CLI providers are terminal runtimes and must preserve operator-console behavior:
+
+- launch through the existing terminal/session infrastructure unless a separate architecture decision approves otherwise;
+- stream output to the UI without unmounting terminals;
+- preserve resize behavior across panel/column splits;
+- preserve manual scrollback while output streams;
+- resume live-follow only after the operator scrolls back to the bottom;
+- submit prompts atomically, with instruction text and Enter sent without an await gap;
+- avoid provider-specific prompt parsing in shared terminal code.
+
+## Prompt submission contract
+
+Provider prompt submission must be deterministic:
+
+- Build prompts in provider-owned or orchestration-owned code, not ad hoc UI handlers.
+- Submit text and Enter atomically.
+- Record dispatch/delivery events where the orchestration contract requires runtime truth.
+- Detect blocked trust/auth prompts before sending task prompts when possible.
+
+## Trust, auth, and first-run prompts
+
+Providers often block on first-run trust, login, permissions, model selection, or workspace prompts. Provider modules must detect and surface these states without leaking secrets.
+
+Requirements:
+
+- Never auto-fill secrets, API keys, credentials, or passwords.
+- Never persist secrets in docs, fixtures, logs, screenshots, or tests.
+- Surface blocked states with operator-readable reason codes.
+- Provide a recovery path or manual instruction for the operator.
+- Tests should use sanitized fixtures with `[REDACTED]` for any secret-like examples.
+
+## Runtime truth and health contract
+
+Provider state must be reconcilable across API, DB, terminal/tmux, frontend, and provider output.
+
+Required surfaces:
+
+- provider available/unavailable state;
+- session running/blocked/ready/completed state;
+- trust/auth blocked state;
+- last health check or sync state, when applicable;
+- recovery guidance;
+- structured failure logs and reason codes.
+
+If the provider is blocked, ATC should report `blocked` or equivalent guidance rather than presenting the session as healthy/running.
+
+## Token usage contract
+
+Token accounting is token-only. Do not add or reintroduce cost, dollar, pricing, or billing semantics.
+
+Forbidden concepts include:
+
+```text
+cost_usd
+monthly_cost_limit
+today_cost
+month_cost
+/api/usage/cost
+/api/tower/cost
+CostModel
+cost_model
+input_cost_per_token
+output_cost_per_token
+CostTracker
+```
+
+Provider-specific token discovery/parsing belongs inside the provider module. Shared token tracking receives normalized increments only.
+
+Provider modules must emit:
+
+```python
+TokenUsageIncrement(
+    session_id=...,
+    project_id=...,
+    provider=...,
+    model=...,
+    input_tokens=...,
+    cached_input_tokens=...,
+    output_tokens=...,
+    reasoning_output_tokens=...,
+    total_tokens=...,
+    source=...,
+    external_session_id=...,
+    source_event_id=...,
+)
+```
+
+Requirements:
+
+- Preserve token classes when the provider exposes them.
+- Convert cumulative provider totals to increments behind the provider boundary.
+- Use durable high-water/de-dupe state where provider sources can be re-read.
+- Restart, re-read, and backfill must not double-count.
+- Shared token tracking must not parse provider files, event names, paths, or JSON payloads.
+
+## Context, artifact, and report contract
+
+Provider sessions must participate in ATC's context and artifact flows:
+
+- Leaders own project context packages.
+- Aces receive task-scoped context through Leader-managed assignment paths.
+- Aces report progress and artifacts through ATC event/report paths.
+- Artifact locations must be explicit and operator-visible.
+- Provider modules should not create alternate hidden context/report channels.
+
+## Frontend / operator visibility contract
+
+Provider support must include operator visibility for any provider-specific state that affects orchestration:
+
+- CLI unavailable/misconfigured;
+- trust/auth blocked;
+- session starting/running/ready/failed;
+- token usage sync enabled/running/stale/failed;
+- last sync/check timestamps;
+- recoverable next action.
+
+When UI changes are made, include frontend unit tests and Playwright evidence.
+
+## Config contract
+
+Provider config should be explicit and local-overridable:
+
+- global defaults in `config.yaml`;
+- local operator overrides in `config.local.yaml`;
+- provider enable/disable switch;
+- CLI command/path override if needed;
+- polling/sync intervals if needed;
+- provider-owned glob/path settings for telemetry sources.
+
+Do not require shared modules to know provider-specific config keys unless those keys are part of a provider-neutral interface.
+
+## Required tests
+
+At minimum, provider onboarding requires tests for:
+
+- CLI command discovery and missing-command errors;
+- session lifecycle start/stop/recovery behavior;
+- Tower → Leader → Ace orchestration path;
+- trust/auth blocked detection and recovery guidance;
+- prompt submission atomicity when provider-specific logic is involved;
+- terminal output streaming/resize behavior when UI or terminal code changes;
+- token parser fixtures, if provider exposes token telemetry;
+- no double-counting after restart/re-read/backfill;
+- unknown/unmapped external sessions are skipped safely;
+- API/UI status surfaces;
+- provider-boundary scans preventing provider-specific terms in shared modules;
+- stale cost/dollar term scans.
+
+## Required documentation updates
+
+Every new provider PR must update:
+
+- provider-specific design log created from [`templates/provider_onboarding_template.md`](templates/provider_onboarding_template.md);
+- [`provider_implementation_map.md`](provider_implementation_map.md) if new files or patterns are introduced;
+- [`FEATURES.md`](FEATURES.md) if operator-visible behavior changes;
+- [`ARCHITECTURE.md`](ARCHITECTURE.md) if subsystem responsibilities change;
+- README links only if a new top-level provider entrypoint is added.
+
+## Acceptance
+
+A provider is accepted only when:
+
+- provider-specific logic is contained in the provider module;
+- shared interfaces remain unchanged, or a separate design log justifies generic shared changes;
+- Tower/Leader/Ace orchestration is proven through the normal chain;
+- terminal behavior remains operator-console compatible;
+- token telemetry records normalized token increments without cost semantics;
+- runtime truth is visible and recoverable;
+- tests, scans, and UI evidence are attached to the PR.

--- a/docs/templates/provider_onboarding_template.md
+++ b/docs/templates/provider_onboarding_template.md
@@ -1,0 +1,153 @@
+# Provider: <Name> Onboarding Plan
+
+Copy this template into `docs/design_logs/NNN-provider-<name>-onboarding.md` before implementing a new CLI-backed provider/platform.
+
+## Provider summary
+
+- Provider name:
+- CLI command:
+- Provider module path:
+- Token telemetry available: yes/no/unknown
+- Auth/trust model:
+- Supported roles: Tower / Leader / Ace / other
+
+## Goals
+
+State what ATC should be able to do with this provider.
+
+## Non-goals
+
+State what is intentionally out of scope for the first provider implementation.
+
+## Provider boundary plan
+
+Explain where provider-specific logic will live.
+
+Provider-owned logic:
+
+- CLI discovery and launch flags:
+- Auth/trust prompt detection:
+- Session metadata mapping:
+- Token telemetry parsing:
+- Health/error classification:
+
+Shared interface changes:
+
+- Expected shared interface changes: none / list proposed changes
+- If any shared interface change is proposed, link the separate design log:
+
+## CLI availability and config
+
+- Command discovery:
+- Version detection:
+- PATH/command override:
+- Provider enable/disable config:
+- Local override expectations:
+
+## Auth, trust, and blocked states
+
+- First-run prompts:
+- Login/auth requirements:
+- Trust/workspace prompts:
+- Blocked-state detection:
+- Recovery guidance:
+- Secret handling plan:
+
+## Session model
+
+- Provider external session ID source:
+- ATC session mapping strategy:
+- Working directory/project mapping:
+- Start behavior:
+- Stop behavior:
+- Reconnect/recovery behavior:
+
+## Tower / Leader / Ace orchestration
+
+Describe how this provider supports the normal chain:
+
+```text
+Operator → Tower → Leader → Ace
+```
+
+- Tower support:
+- Leader support:
+- Ace support:
+- Assignment/report flow:
+- Artifact flow:
+- Acceptance evidence path:
+
+## Terminal and prompt behavior
+
+- Launch mechanism:
+- PTY/tmux integration:
+- Readiness detection:
+- Prompt submission:
+- Resize/scrollback considerations:
+- Provider-specific output parsing:
+
+## Token telemetry
+
+- Telemetry source:
+- Parser module:
+- Token classes available:
+- Cumulative or incremental source:
+- De-dupe/high-water strategy:
+- External session mapping:
+- Unknown/unmapped session handling:
+- Manual sync/backfill support:
+
+## Runtime truth and recovery
+
+- Availability status:
+- Readiness status:
+- Blocked/failure status:
+- Health check:
+- Recovery path:
+- API/UI visibility:
+
+## Frontend / operator visibility
+
+- Required status card/panel changes:
+- Manual actions:
+- Error/recovery display:
+- Token usage display:
+- Screenshots/Playwright evidence plan:
+
+## Test plan
+
+Backend:
+
+- [ ] CLI discovery tests
+- [ ] session lifecycle tests
+- [ ] orchestration tests
+- [ ] token parser tests
+- [ ] token de-dupe tests
+- [ ] runtime status tests
+
+Frontend/UI:
+
+- [ ] unit tests
+- [ ] Playwright smoke
+
+Scans:
+
+- [ ] provider-boundary scan
+- [ ] stale cost-term scan
+
+## Acceptance criteria
+
+- [ ] Provider-specific logic is contained in provider module.
+- [ ] Shared interfaces are unchanged, or separate design log justifies generic shared change.
+- [ ] Tower/Leader/Ace chain is proven.
+- [ ] Terminal behavior remains operator-console compatible.
+- [ ] Token telemetry emits normalized increments without double-counting.
+- [ ] No cost/dollar semantics are introduced.
+- [ ] Runtime truth is visible and recoverable.
+- [ ] Tests/scans/PR evidence are complete.
+
+## Open questions
+
+- Question:
+- Owner:
+- Resolution needed before:


### PR DESCRIPTION
## Summary
- add canonical CLI provider onboarding documentation and reusable provider plan template
- formalize the provider boundary lock: provider logic stays provider-owned and shared interfaces do not change in provider onboarding PRs without a separate generic design decision
- add README and CODE_STRUCTURE entrypoints for future provider integrations

## Validation
- Markdown local link check: `MARKDOWN_LINK_MISSING []`
- whitespace check: `git diff --check`
- stale cost scan outside provider docs: `TRACKED_COST_HITS_OUTSIDE_PROVIDER_DOCS []`

## Notes
The provider docs intentionally name forbidden legacy cost/dollar terms so future provider PRs can scan against them. They do not reintroduce runtime cost behavior.