### PR TITLE
Add provider helper subagent contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ tests/          → Unit, integration, e2e tests
 - [docs/provider_interface_contract.md](docs/provider_interface_contract.md) — provider-neutral orchestration, terminal, token, and runtime contracts
 - [docs/provider_acceptance_checklist.md](docs/provider_acceptance_checklist.md) — PR acceptance checklist for new CLI providers
 - [docs/provider_implementation_map.md](docs/provider_implementation_map.md) — source map for provider integration points
+- [docs/provider_subagent_contract.md](docs/provider_subagent_contract.md) — provider-native helper subagent contract and audit model
 - [docs/design_logs/014-provider-runtime-consolidation-audit.md](docs/design_logs/014-provider-runtime-consolidation-audit.md) — current provider runtime path audit and cleanup plan
 - [docs/FEATURES.md](docs/FEATURES.md) — Feature guide
 - [docs/API.md](docs/API.md) — REST API + WebSocket reference

--- a/config.yaml
+++ b/config.yaml
@@ -29,6 +29,11 @@ token_tracker:
   codex_enabled: true
   codex_sessions_glob: ~/.codex/sessions/**/*.jsonl
 
+provider_helpers:
+  enabled: true
+  default_visibility: hidden
+  audit_enabled: true
+
 sentry:
   enabled: false
   dsn: ""

--- a/docs/API.md
+++ b/docs/API.md
@@ -236,6 +236,8 @@ POST   /api/projects/{id}/github/sync         → force immediate sync
 ```
 GET    /api/settings                          → all config key/values
 PUT    /api/settings                          → bulk update
+GET    /api/settings/provider-helpers         → provider helper subagent settings
+PUT    /api/settings/provider-helpers         → update enabled/default_visibility; audit remains on
 ```
 
 ## Failure Logs

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -52,7 +52,8 @@ Design rule:
 | `terminal/` | PTY streaming (tmux pipe-pane → FIFO → WS), output parser, monitor |
 | `tracking/` | Provider-neutral token usage recorder, provider usage trackers, system resources (psutil), GitHub PR/CI, budget enforcer |
 | `rws/` | Remote Ace Server daemon for remote hosts |
-| `agents/` | Agent deployment SOT — writes config files to /tmp; provider-owned runtime helpers such as Codex token JSONL parsing live here |
+| `agents/` | Shared agent deployment SOT — writes config files to /tmp |
+| `providers/` | Provider-owned runtime adapters, provider-specific helpers, token collectors, and provider-native helper subagent mechanics |
 
 ### Data Layer (`src/atc/state/`)
 
@@ -108,7 +109,8 @@ Single WebSocket endpoint at `/ws` with channel-based pub/sub.
 ## Database Schema
 
 Core tables: `projects`, `leaders`, `sessions`, `tasks`, `project_budgets`,
-`usage_events`, `github_prs`, `notifications`, `config`, `tower_memory`, `failure_logs`.
+`usage_events`, `provider_helper_runs`, `provider_helper_events`, `github_prs`,
+`notifications`, `config`, `tower_memory`, `failure_logs`.
 
 See `src/atc/state/migrations/versions/` for the canonical schema.
 

--- a/docs/START_HERE.md
+++ b/docs/START_HERE.md
@@ -23,6 +23,7 @@ Examples:
   - `docs/leader_kickoff_recovery_plan.md`
   - `docs/provider_runtime_refactor_plan.md`
   - `docs/provider_cli_wrapper_spec.md`
+  - `docs/provider_subagent_contract.md`
   - `docs/RUNTIME_PROVIDER_GUARDRAILS.md`
 - API or architecture work:
   - `docs/service_model.md`
@@ -77,6 +78,8 @@ These docs exist to:
   - current provider runtime path audit and Phase 2 cleanup plan
 - `docs/provider_cli_wrapper_spec.md`
   - `atc-provider` wrapper contract
+- `docs/provider_subagent_contract.md`
+  - provider-native helper subagent contract, durable audit model, and visibility semantics
 - `docs/RUNTIME_PROVIDER_GUARDRAILS.md`
   - runtime/provider boundary rules
 - `docs/runtime_orchestration_refactor_phases.md`

--- a/docs/provider_acceptance_checklist.md
+++ b/docs/provider_acceptance_checklist.md
@@ -88,11 +88,11 @@ Use this checklist in every PR that adds or materially changes a CLI-backed prov
 
 ## Cost/dollar prohibition
 
-- [ ] No `cost_usd`.
+- [ ] No legacy dollar-denominated accounting fields.
 - [ ] No pricing registry.
 - [ ] No dollar budgets or billing limits.
-- [ ] No `/api/*/cost` endpoints.
-- [ ] No provider model cost rates.
+- [ ] No cost-specific usage/Tower endpoints.
+- [ ] Token limits are enforced using token counts only.
 - [ ] Stale cost-term scan is included.
 
 ## Documentation

--- a/docs/provider_implementation_map.md
+++ b/docs/provider_implementation_map.md
@@ -6,6 +6,7 @@ Use this map to locate the ATC subsystems a new CLI provider may need to integra
 
 - [`provider_onboarding.md`](provider_onboarding.md) — main onboarding guide.
 - [`provider_interface_contract.md`](provider_interface_contract.md) — shared/provider boundary contract.
+- [`provider_subagent_contract.md`](provider_subagent_contract.md) — provider-native helper subagent contract and audit model.
 - [`provider_acceptance_checklist.md`](provider_acceptance_checklist.md) — PR acceptance checklist.
 - [`templates/provider_onboarding_template.md`](templates/provider_onboarding_template.md) — provider-specific design log template.
 
@@ -93,6 +94,21 @@ Provider modules handle:
 - cumulative total to increment conversion;
 - external provider session mapping;
 - provider-specific de-dupe/source-key semantics.
+
+## Provider helper subagents
+
+Relevant shared areas:
+
+```text
+src/atc/providers/helpers.py
+src/atc/state/
+docs/provider_subagent_contract.md
+```
+
+Provider-native helper subagents are private/background assistants to Tower,
+Leader, or Ace roles. They must use the shared request/result contract and
+durable `provider_helper_runs` / `provider_helper_events` audit tables. Helper
+visibility is global/display-only; audit records are always written.
 
 ## API surfaces
 

--- a/docs/provider_interface_contract.md
+++ b/docs/provider_interface_contract.md
@@ -195,18 +195,6 @@ A provider term in a shared module is acceptable only when it is intentionally p
 
 ATC provider integrations are token-only. Do not add provider pricing, cost estimates, billing limits, dollar budgets, or cost endpoints as part of provider onboarding.
 
-Forbidden examples:
-
-```text
-cost_usd
-monthly_cost_limit
-today_cost
-month_cost
-/api/usage/cost
-/api/tower/cost
-CostModel
-cost_model
-input_cost_per_token
-output_cost_per_token
-CostTracker
-```
+Forbidden examples include legacy dollar-denominated accounting fields,
+billing-limit settings, pricing registries, per-token price tables,
+cost-tracker classes, and cost-specific usage/Tower API endpoints.

--- a/docs/provider_onboarding.md
+++ b/docs/provider_onboarding.md
@@ -137,21 +137,9 @@ If the provider is blocked, ATC should report `blocked` or equivalent guidance r
 
 Token accounting is token-only. Do not add or reintroduce cost, dollar, pricing, or billing semantics.
 
-Forbidden concepts include:
-
-```text
-cost_usd
-monthly_cost_limit
-today_cost
-month_cost
-/api/usage/cost
-/api/tower/cost
-CostModel
-cost_model
-input_cost_per_token
-output_cost_per_token
-CostTracker
-```
+Forbidden concepts include legacy dollar-denominated accounting fields, billing-limit
+settings, pricing registries, per-token price tables, cost-tracker classes, and
+cost-specific usage/Tower API endpoints.
 
 Provider-specific token discovery/parsing belongs inside the provider module. Shared token tracking receives normalized increments only.
 

--- a/docs/provider_subagent_contract.md
+++ b/docs/provider_subagent_contract.md
@@ -1,0 +1,132 @@
+# Provider Helper Subagent Contract
+
+## Purpose
+
+Provider helper subagents are provider-native background workers that can assist
+Tower, Leader, or Ace sessions without becoming part of the ATC command chain.
+They are optional execution helpers only. Tower, Leader, and Ace remain the
+operator-visible roles and the authoritative owners of ATC state.
+
+## Hard boundaries
+
+- ATC owns truth, persistence, visibility policy, token attribution, and allowed
+  state mutation paths.
+- Provider modules own provider-native helper execution mechanics.
+- Shared ATC modules must not parse Codex/Claude helper syntax, prompts, event
+  formats, or filesystem details.
+- Helper output cannot directly mutate canonical ATC state. Any state change must
+  go through existing ATC API/DB/event paths and be attributable to the parent
+  Tower/Leader/Ace role.
+- Audit logging is always on. Visibility controls only what is displayed.
+- Token usage remains token-only. No cost/dollar semantics belong in helper
+  records or helper token attribution.
+
+## Global settings
+
+```yaml
+provider_helpers:
+  enabled: true
+  default_visibility: hidden  # hidden | summary | full
+  audit_enabled: true         # locked on by backend behavior
+```
+
+`enabled` controls whether providers may use helpers. `default_visibility`
+controls display behavior. `audit_enabled` is always treated as true so hidden
+helper work is still reviewable after the fact.
+
+Backend settings endpoints:
+
+- `GET /api/settings/provider-helpers`
+- `PUT /api/settings/provider-helpers`
+
+## Visibility modes
+
+| Mode | Meaning |
+|---|---|
+| `hidden` | Normal workflow UI does not show helper panels; audit rows/events are still recorded. |
+| `summary` | UI may show compact lifecycle/status/result records. |
+| `full` | UI may show prompt, output, events, actions, timings, token details, warnings, and errors. |
+
+Visibility is display-only. Changing it must not start, stop, cancel, or alter
+helper execution.
+
+## Provider-neutral request shape
+
+The shared contract is `atc.providers.helpers.ProviderHelperRequest`:
+
+```python
+ProviderHelperRequest(
+    provider="codex",
+    parent_session_id="session-id",
+    parent_role="tower",      # tower | leader | ace
+    purpose="project_status_check",
+    prompt="Summarize current blockers...",
+    project_id="project-id",
+    task_id=None,
+    helper_id=None,
+    visibility="hidden",      # hidden | summary | full
+    allowed_tools=("read",),
+    allowed_actions=(),
+    metadata={},
+)
+```
+
+Provider modules may translate this into provider-native helper mechanics, but
+providers should emit provider-neutral audit records and events back to ATC.
+
+## Durable audit model
+
+Phase 3 adds two durable tables:
+
+### `provider_helper_runs`
+
+One row per helper run, including:
+
+- `provider`
+- `helper_id`
+- `parent_session_id`
+- `parent_role`
+- `project_id`
+- `task_id`
+- `purpose`
+- `visibility`
+- `status`
+- timestamps
+- prompt/output/summary/error fields
+- provider-neutral metadata JSON
+
+### `provider_helper_events`
+
+Append-only event timeline per helper run:
+
+- `helper_run_id`
+- `event_type`
+- `timestamp`
+- `message`
+- `payload_json`
+
+Typical event names:
+
+- `helper_requested`
+- `helper_started`
+- `prompt_submitted`
+- `provider_output_received`
+- `action_requested`
+- `action_completed`
+- `token_usage_recorded`
+- `helper_completed`
+- `helper_failed`
+
+## Token attribution
+
+Provider helpers should attribute token usage to the parent session/project while
+preserving helper metadata such as `helper_run_id`, `helper_purpose`, provider,
+and external provider session IDs in token metadata/raw usage details. The usage
+path stays provider-neutral and token-only.
+
+## Phase 4+ UI expectations
+
+Phase 3 establishes backend contract and durable audit state. Phase 4 will add
+the global Settings control and helper visibility UI shell. Later Codex helper
+phases should use these tables/contracts rather than inventing provider-specific
+helper state.

--- a/src/atc/api/routers/settings.py
+++ b/src/atc/api/routers/settings.py
@@ -8,6 +8,8 @@ Routes:
   GET  /api/settings/agent-provider       → get current agent provider config
   PUT  /api/settings/agent-provider       → update agent provider config
   GET  /api/settings/providers            → list available providers
+  GET  /api/settings/provider-helpers     → get provider helper settings
+  PUT  /api/settings/provider-helpers     → update provider helper settings
   GET  /api/settings/sentry              → get sentry status
   POST /api/settings/sentry/send-report  → manually send an error report
 """
@@ -197,6 +199,21 @@ class ProviderInfo(BaseModel):
     model: str
 
 
+class ProviderHelpersResponse(BaseModel):
+    """Global provider helper subagent settings."""
+
+    enabled: bool
+    default_visibility: str
+    audit_enabled: bool
+
+
+class ProviderHelpersUpdateRequest(BaseModel):
+    """Update global provider helper subagent settings."""
+
+    enabled: bool | None = None
+    default_visibility: str | None = None
+
+
 @router.get("/agent-provider")
 async def get_agent_provider(request: Request) -> AgentProviderResponse:
     """Return the current agent provider configuration."""
@@ -256,16 +273,22 @@ async def update_agent_provider(
                 try:
                     await ace_ops.stop_ace(db, session.id, event_bus=event_bus)
                 except Exception:
-                    logger.exception("Failed to pause stale ace session %s during provider switch", session.id)
+                    logger.exception(
+                        "Failed to pause stale ace session %s during provider switch", session.id
+                    )
 
         for leader_info in handoff["leaders"]:
             project_id = leader_info["project_id"]
             try:
                 await leader_ops.stop_leader(db, project_id, event_bus=event_bus)
             except Exception:
-                logger.exception("Failed to stop leader for project %s during provider switch", project_id)
+                logger.exception(
+                    "Failed to stop leader for project %s during provider switch", project_id
+                )
 
-        tower_was_running = handoff["tower"]["session_id"] is not None and handoff["tower"]["state"] in ("managing", "planning", "idle")
+        tower_was_running = handoff["tower"]["session_id"] is not None and handoff["tower"][
+            "state"
+        ] in ("managing", "planning", "idle")
         if handoff["tower"]["session_id"]:
             try:
                 await tower.stop_session()
@@ -307,6 +330,45 @@ async def list_available_providers() -> list[ProviderInfo]:
         )
         for info in list_provider_runtime_infos()
     ]
+
+
+@router.get("/provider-helpers", response_model=ProviderHelpersResponse)
+async def get_provider_helpers(request: Request) -> ProviderHelpersResponse:
+    """Return global provider helper subagent settings."""
+    cfg = request.app.state.settings.provider_helpers
+    return ProviderHelpersResponse(
+        enabled=cfg.enabled,
+        default_visibility=cfg.default_visibility,
+        audit_enabled=cfg.audit_enabled,
+    )
+
+
+@router.put("/provider-helpers", response_model=ProviderHelpersResponse)
+async def update_provider_helpers(
+    body: ProviderHelpersUpdateRequest,
+    request: Request,
+) -> ProviderHelpersResponse:
+    """Update global provider helper settings.
+
+    Visibility controls display only. Audit logging remains locked on because
+    helper execution must be observable after the fact even when hidden in UI.
+    """
+    cfg = request.app.state.settings.provider_helpers
+    if body.enabled is not None:
+        cfg.enabled = body.enabled
+    if body.default_visibility is not None:
+        if body.default_visibility not in {"hidden", "summary", "full"}:
+            raise HTTPException(
+                status_code=422,
+                detail="default_visibility must be hidden, summary, or full",
+            )
+        cfg.default_visibility = body.default_visibility
+    cfg.audit_enabled = True
+    return ProviderHelpersResponse(
+        enabled=cfg.enabled,
+        default_visibility=cfg.default_visibility,
+        audit_enabled=cfg.audit_enabled,
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -375,6 +437,7 @@ async def send_sentry_report(
 # ---------------------------------------------------------------------------
 # Resource limits settings
 # ---------------------------------------------------------------------------
+
 
 class ResourceLimitsResponse(BaseModel):
     max_concurrent_aces: int

--- a/src/atc/config.py
+++ b/src/atc/config.py
@@ -56,6 +56,12 @@ class TokenTrackerConfig(BaseModel):
     codex_sessions_glob: str = "~/.codex/sessions/**/*.jsonl"
 
 
+class ProviderHelpersConfig(BaseModel):
+    enabled: bool = True
+    default_visibility: str = "hidden"
+    audit_enabled: bool = True
+
+
 class HeartbeatConfig(BaseModel):
     enabled: bool = True
     interval_seconds: int = 30
@@ -126,6 +132,7 @@ class Settings(BaseSettings):
     github: GitHubConfig = GitHubConfig()
     budget: BudgetConfig = BudgetConfig()
     token_tracker: TokenTrackerConfig = TokenTrackerConfig()
+    provider_helpers: ProviderHelpersConfig = ProviderHelpersConfig()
     heartbeat: HeartbeatConfig = HeartbeatConfig()
     logging: LoggingConfig = LoggingConfig()
     sentry: SentryConfig = SentryConfig()

--- a/src/atc/providers/helpers.py
+++ b/src/atc/providers/helpers.py
@@ -1,0 +1,109 @@
+"""Provider-native helper subagent contract.
+
+Provider helper subagents are private/background assistants used by Tower,
+Leader, or Ace sessions. They are not ATC command-chain roles; ATC remains the
+source of truth for state and audit records while providers own helper execution
+mechanics.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import StrEnum
+from typing import Any
+
+
+class ProviderHelperVisibility(StrEnum):
+    """Display level for provider helper activity."""
+
+    HIDDEN = "hidden"
+    SUMMARY = "summary"
+    FULL = "full"
+
+
+class ProviderHelperParentRole(StrEnum):
+    """ATC-visible role that requested a helper run."""
+
+    TOWER = "tower"
+    LEADER = "leader"
+    ACE = "ace"
+
+
+class ProviderHelperRunStatus(StrEnum):
+    """Lifecycle status for a provider helper run audit record."""
+
+    REQUESTED = "requested"
+    RUNNING = "running"
+    COMPLETED = "completed"
+    FAILED = "failed"
+    CANCELLED = "cancelled"
+
+
+class ProviderHelperEventType(StrEnum):
+    """Known helper event types.
+
+    Providers may persist additional event_type strings as long as they remain
+    provider-neutral audit events and do not mutate ATC state directly.
+    """
+
+    HELPER_REQUESTED = "helper_requested"
+    HELPER_STARTED = "helper_started"
+    PROMPT_SUBMITTED = "prompt_submitted"
+    PROVIDER_OUTPUT_RECEIVED = "provider_output_received"
+    ACTION_REQUESTED = "action_requested"
+    ACTION_COMPLETED = "action_completed"
+    TOKEN_USAGE_RECORDED = "token_usage_recorded"
+    HELPER_COMPLETED = "helper_completed"
+    HELPER_FAILED = "helper_failed"
+
+
+@dataclass(frozen=True)
+class ProviderHelperRequest:
+    """Provider-neutral request to start a helper subagent.
+
+    Provider modules may translate this request into provider-native helper
+    mechanics. The request itself intentionally contains no Codex/Claude-specific
+    syntax, event names, or subprocess details.
+    """
+
+    provider: str
+    parent_session_id: str
+    parent_role: ProviderHelperParentRole | str
+    purpose: str
+    prompt: str
+    project_id: str | None = None
+    task_id: str | None = None
+    helper_id: str | None = None
+    visibility: ProviderHelperVisibility | str = ProviderHelperVisibility.HIDDEN
+    allowed_tools: tuple[str, ...] = ()
+    allowed_actions: tuple[str, ...] = ()
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "parent_role", ProviderHelperParentRole(self.parent_role))
+        object.__setattr__(self, "visibility", ProviderHelperVisibility(self.visibility))
+        object.__setattr__(self, "allowed_tools", tuple(self.allowed_tools))
+        object.__setattr__(self, "allowed_actions", tuple(self.allowed_actions))
+        if not self.provider.strip():
+            raise ValueError("provider is required")
+        if not self.parent_session_id.strip():
+            raise ValueError("parent_session_id is required")
+        if not self.purpose.strip():
+            raise ValueError("purpose is required")
+        if not self.prompt.strip():
+            raise ValueError("prompt is required")
+
+
+@dataclass(frozen=True)
+class ProviderHelperResult:
+    """Provider-neutral completion result from a helper subagent."""
+
+    helper_run_id: str
+    status: ProviderHelperRunStatus | str
+    summary: str | None = None
+    output_text: str | None = None
+    error: str | None = None
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "status", ProviderHelperRunStatus(self.status))

--- a/src/atc/state/db.py
+++ b/src/atc/state/db.py
@@ -28,6 +28,8 @@ from atc.state.models import (
     OrchestrationOperation,
     Project,
     ProjectBudget,
+    ProviderHelperEvent,
+    ProviderHelperRun,
     QALoopRun,
     Session,
     SessionHeartbeat,
@@ -378,6 +380,49 @@ CREATE TABLE IF NOT EXISTS usage_source_offsets (
     updated_at                    TEXT NOT NULL,
     PRIMARY KEY (provider, source_key)
 );
+
+CREATE TABLE IF NOT EXISTS provider_helper_runs (
+    id                 TEXT PRIMARY KEY,
+    provider           TEXT NOT NULL,
+    helper_id          TEXT,
+    parent_session_id  TEXT NOT NULL REFERENCES sessions(id) ON DELETE CASCADE,
+    parent_role        TEXT NOT NULL CHECK(parent_role IN ('tower', 'leader', 'ace')),
+    project_id         TEXT REFERENCES projects(id),
+    task_id            TEXT,
+    purpose            TEXT NOT NULL,
+    visibility         TEXT NOT NULL DEFAULT 'hidden'
+                       CHECK(visibility IN ('hidden', 'summary', 'full')),
+    status             TEXT NOT NULL DEFAULT 'requested'
+                       CHECK(status IN (
+                           'requested', 'running', 'completed', 'failed', 'cancelled'
+                       )),
+    started_at         TEXT NOT NULL,
+    finished_at        TEXT,
+    summary            TEXT,
+    prompt_text        TEXT,
+    output_text        TEXT,
+    metadata_json      TEXT,
+    error              TEXT,
+    created_at         TEXT NOT NULL,
+    updated_at         TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS provider_helper_events (
+    id             TEXT PRIMARY KEY,
+    helper_run_id  TEXT NOT NULL REFERENCES provider_helper_runs(id) ON DELETE CASCADE,
+    event_type     TEXT NOT NULL,
+    timestamp      TEXT NOT NULL,
+    message        TEXT,
+    payload_json   TEXT,
+    created_at     TEXT NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_provider_helper_runs_parent
+    ON provider_helper_runs(parent_session_id, parent_role, status);
+CREATE INDEX IF NOT EXISTS idx_provider_helper_runs_project
+    ON provider_helper_runs(project_id, started_at);
+CREATE INDEX IF NOT EXISTS idx_provider_helper_events_run
+    ON provider_helper_events(helper_run_id, timestamp);
 
 CREATE TABLE IF NOT EXISTS notifications (
     id          TEXT PRIMARY KEY,
@@ -2512,8 +2557,6 @@ async def write_usage_event(
     return event
 
 
-
-
 async def get_usage_source_offset(
     db: aiosqlite.Connection,
     *,
@@ -2593,6 +2636,211 @@ async def upsert_usage_source_offset(
     )
     await db.commit()
     return offset
+
+
+# ---------------------------------------------------------------------------
+# Provider helper audit helpers
+# ---------------------------------------------------------------------------
+
+
+async def create_provider_helper_run(
+    db: aiosqlite.Connection,
+    *,
+    provider: str,
+    parent_session_id: str,
+    parent_role: str,
+    purpose: str,
+    visibility: str = "hidden",
+    helper_id: str | None = None,
+    project_id: str | None = None,
+    task_id: str | None = None,
+    prompt_text: str | None = None,
+    metadata: dict[str, Any] | None = None,
+    status: str = "requested",
+    started_at: str | None = None,
+) -> ProviderHelperRun:
+    """Create a provider helper audit record before provider-native execution."""
+    now = _now()
+    run = ProviderHelperRun(
+        id=_uuid(),
+        provider=provider,
+        helper_id=helper_id,
+        parent_session_id=parent_session_id,
+        parent_role=parent_role,
+        project_id=project_id,
+        task_id=task_id,
+        purpose=purpose,
+        visibility=visibility,
+        status=status,
+        started_at=started_at or now,
+        prompt_text=prompt_text,
+        metadata_json=json.dumps(metadata or {}, sort_keys=True),
+        created_at=now,
+        updated_at=now,
+    )
+    await db.execute(
+        """INSERT INTO provider_helper_runs
+           (id, provider, helper_id, parent_session_id, parent_role, project_id,
+            task_id, purpose, visibility, status, started_at, finished_at, summary,
+            prompt_text, output_text, metadata_json, error, created_at, updated_at)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+        (
+            run.id,
+            run.provider,
+            run.helper_id,
+            run.parent_session_id,
+            run.parent_role,
+            run.project_id,
+            run.task_id,
+            run.purpose,
+            run.visibility,
+            run.status,
+            run.started_at,
+            run.finished_at,
+            run.summary,
+            run.prompt_text,
+            run.output_text,
+            run.metadata_json,
+            run.error,
+            run.created_at,
+            run.updated_at,
+        ),
+    )
+    await db.commit()
+    return run
+
+
+async def get_provider_helper_run(
+    db: aiosqlite.Connection,
+    helper_run_id: str,
+) -> ProviderHelperRun | None:
+    cursor = await db.execute("SELECT * FROM provider_helper_runs WHERE id = ?", (helper_run_id,))
+    row = await cursor.fetchone()
+    if row is None:
+        return None
+    return ProviderHelperRun(**_filter_model_fields(ProviderHelperRun, dict(row)))
+
+
+async def list_provider_helper_runs(
+    db: aiosqlite.Connection,
+    *,
+    parent_session_id: str | None = None,
+    project_id: str | None = None,
+    visibility: str | None = None,
+    limit: int = 50,
+) -> list[ProviderHelperRun]:
+    conditions: list[str] = []
+    params: list[Any] = []
+    if parent_session_id is not None:
+        conditions.append("parent_session_id = ?")
+        params.append(parent_session_id)
+    if project_id is not None:
+        conditions.append("project_id = ?")
+        params.append(project_id)
+    if visibility is not None:
+        conditions.append("visibility = ?")
+        params.append(visibility)
+    where = f"WHERE {' AND '.join(conditions)}" if conditions else ""
+    params.append(limit)
+    cursor = await db.execute(
+        f"SELECT * FROM provider_helper_runs {where} ORDER BY started_at DESC LIMIT ?",  # noqa: S608
+        params,
+    )
+    rows = await cursor.fetchall()
+    return [ProviderHelperRun(**_filter_model_fields(ProviderHelperRun, dict(row))) for row in rows]
+
+
+async def update_provider_helper_run(
+    db: aiosqlite.Connection,
+    helper_run_id: str,
+    *,
+    status: str | None = None,
+    finished_at: str | None = None,
+    summary: str | None = None,
+    output_text: str | None = None,
+    error: str | None = None,
+    metadata: dict[str, Any] | None = None,
+) -> ProviderHelperRun | None:
+    existing = await get_provider_helper_run(db, helper_run_id)
+    if existing is None:
+        return None
+    now = _now()
+    metadata_json = existing.metadata_json
+    if metadata is not None:
+        metadata_json = json.dumps(metadata, sort_keys=True)
+    await db.execute(
+        """UPDATE provider_helper_runs
+           SET status = ?, finished_at = ?, summary = ?, output_text = ?,
+               error = ?, metadata_json = ?, updated_at = ?
+           WHERE id = ?""",
+        (
+            status or existing.status,
+            finished_at if finished_at is not None else existing.finished_at,
+            summary if summary is not None else existing.summary,
+            output_text if output_text is not None else existing.output_text,
+            error if error is not None else existing.error,
+            metadata_json,
+            now,
+            helper_run_id,
+        ),
+    )
+    await db.commit()
+    return await get_provider_helper_run(db, helper_run_id)
+
+
+async def append_provider_helper_event(
+    db: aiosqlite.Connection,
+    *,
+    helper_run_id: str,
+    event_type: str,
+    message: str | None = None,
+    payload: dict[str, Any] | None = None,
+    timestamp: str | None = None,
+) -> ProviderHelperEvent:
+    """Append a provider-neutral helper audit event."""
+    now = _now()
+    event = ProviderHelperEvent(
+        id=_uuid(),
+        helper_run_id=helper_run_id,
+        event_type=event_type,
+        timestamp=timestamp or now,
+        message=message,
+        payload_json=json.dumps(payload or {}, sort_keys=True),
+        created_at=now,
+    )
+    await db.execute(
+        """INSERT INTO provider_helper_events
+           (id, helper_run_id, event_type, timestamp, message, payload_json, created_at)
+           VALUES (?, ?, ?, ?, ?, ?, ?)""",
+        (
+            event.id,
+            event.helper_run_id,
+            event.event_type,
+            event.timestamp,
+            event.message,
+            event.payload_json,
+            event.created_at,
+        ),
+    )
+    await db.commit()
+    return event
+
+
+async def list_provider_helper_events(
+    db: aiosqlite.Connection,
+    helper_run_id: str,
+) -> list[ProviderHelperEvent]:
+    cursor = await db.execute(
+        """SELECT * FROM provider_helper_events
+           WHERE helper_run_id = ?
+           ORDER BY timestamp, created_at""",
+        (helper_run_id,),
+    )
+    rows = await cursor.fetchall()
+    return [
+        ProviderHelperEvent(**_filter_model_fields(ProviderHelperEvent, dict(row))) for row in rows
+    ]
+
 
 # ---------------------------------------------------------------------------
 # ProjectBudget helpers

--- a/src/atc/state/migrations/versions/020_provider_helper_subagents.sql
+++ b/src/atc/state/migrations/versions/020_provider_helper_subagents.sql
@@ -1,0 +1,41 @@
+-- Provider helper subagent audit records and event timeline.
+-- Helpers are provider-native workers subordinate to Tower/Leader/Ace; ATC stores
+-- provider-neutral audit state even when helper visibility is hidden.
+CREATE TABLE IF NOT EXISTS provider_helper_runs (
+    id                 TEXT PRIMARY KEY,
+    provider           TEXT NOT NULL,
+    helper_id          TEXT,
+    parent_session_id  TEXT NOT NULL REFERENCES sessions(id) ON DELETE CASCADE,
+    parent_role        TEXT NOT NULL CHECK(parent_role IN ('tower', 'leader', 'ace')),
+    project_id         TEXT REFERENCES projects(id),
+    task_id            TEXT,
+    purpose            TEXT NOT NULL,
+    visibility         TEXT NOT NULL DEFAULT 'hidden' CHECK(visibility IN ('hidden', 'summary', 'full')),
+    status             TEXT NOT NULL DEFAULT 'requested' CHECK(status IN ('requested', 'running', 'completed', 'failed', 'cancelled')),
+    started_at         TEXT NOT NULL,
+    finished_at        TEXT,
+    summary            TEXT,
+    prompt_text        TEXT,
+    output_text        TEXT,
+    metadata_json      TEXT,
+    error              TEXT,
+    created_at         TEXT NOT NULL,
+    updated_at         TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS provider_helper_events (
+    id             TEXT PRIMARY KEY,
+    helper_run_id  TEXT NOT NULL REFERENCES provider_helper_runs(id) ON DELETE CASCADE,
+    event_type     TEXT NOT NULL,
+    timestamp      TEXT NOT NULL,
+    message        TEXT,
+    payload_json   TEXT,
+    created_at     TEXT NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_provider_helper_runs_parent
+    ON provider_helper_runs(parent_session_id, parent_role, status);
+CREATE INDEX IF NOT EXISTS idx_provider_helper_runs_project
+    ON provider_helper_runs(project_id, started_at);
+CREATE INDEX IF NOT EXISTS idx_provider_helper_events_run
+    ON provider_helper_events(helper_run_id, timestamp);

--- a/src/atc/state/models.py
+++ b/src/atc/state/models.py
@@ -138,6 +138,46 @@ class UsageSourceOffset:
 
 
 @dataclass
+class ProviderHelperRun:
+    id: str
+    provider: str
+    helper_id: str | None
+    parent_session_id: str
+    parent_role: str  # tower|leader|ace
+    purpose: str
+    visibility: str  # hidden|summary|full
+    status: str  # requested|running|completed|failed|cancelled
+    started_at: str
+    project_id: str | None = None
+    task_id: str | None = None
+    finished_at: str | None = None
+    summary: str | None = None
+    prompt_text: str | None = None
+    output_text: str | None = None
+    metadata_json: str | None = None
+    error: str | None = None
+    created_at: str = ""
+    updated_at: str = ""
+
+    def metadata(self) -> dict[str, Any]:
+        return json.loads(self.metadata_json) if self.metadata_json else {}
+
+
+@dataclass
+class ProviderHelperEvent:
+    id: str
+    helper_run_id: str
+    event_type: str
+    timestamp: str
+    message: str | None = None
+    payload_json: str | None = None
+    created_at: str = ""
+
+    def payload(self) -> dict[str, Any]:
+        return json.loads(self.payload_json) if self.payload_json else {}
+
+
+@dataclass
 class GitHubPR:
     id: str  # "{owner}/{repo}#{number}"
     project_id: str | None

--- a/tests/unit/test_provider_helper_settings.py
+++ b/tests/unit/test_provider_helper_settings.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+from fastapi import HTTPException
+
+from atc.api.routers.settings import (
+    ProviderHelpersUpdateRequest,
+    get_provider_helpers,
+    update_provider_helpers,
+)
+from atc.config import Settings
+
+
+def fake_request(settings: Settings):
+    return SimpleNamespace(app=SimpleNamespace(state=SimpleNamespace(settings=settings)))
+
+
+@pytest.mark.asyncio
+async def test_provider_helper_settings_defaults_and_update() -> None:
+    settings = Settings()
+    request = fake_request(settings)
+
+    defaults = await get_provider_helpers(request)
+    assert defaults.enabled is True
+    assert defaults.default_visibility == "hidden"
+    assert defaults.audit_enabled is True
+
+    updated = await update_provider_helpers(
+        ProviderHelpersUpdateRequest(enabled=False, default_visibility="summary"),
+        request,
+    )
+
+    assert updated.enabled is False
+    assert updated.default_visibility == "summary"
+    assert updated.audit_enabled is True
+    assert settings.provider_helpers.enabled is False
+    assert settings.provider_helpers.default_visibility == "summary"
+    assert settings.provider_helpers.audit_enabled is True
+
+
+@pytest.mark.asyncio
+async def test_provider_helper_settings_reject_invalid_visibility() -> None:
+    settings = Settings()
+
+    with pytest.raises(HTTPException) as exc:
+        await update_provider_helpers(
+            ProviderHelpersUpdateRequest(default_visibility="operator-only"),
+            fake_request(settings),
+        )
+
+    assert exc.value.status_code == 422
+    assert settings.provider_helpers.default_visibility == "hidden"

--- a/tests/unit/test_provider_helper_state.py
+++ b/tests/unit/test_provider_helper_state.py
@@ -1,0 +1,109 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+from atc.state.db import (
+    append_provider_helper_event,
+    create_project,
+    create_provider_helper_run,
+    create_session,
+    get_connection,
+    get_provider_helper_run,
+    list_provider_helper_events,
+    list_provider_helper_runs,
+    run_migrations,
+    update_provider_helper_run,
+)
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+@pytest.fixture
+async def migrated_db(tmp_path: Path):
+    db_path = tmp_path / "atc.db"
+    await run_migrations(str(db_path))
+    async with get_connection(str(db_path)) as conn:
+        yield conn
+
+
+@pytest.mark.asyncio
+async def test_provider_helper_run_and_events_are_durable_audit_records(migrated_db) -> None:
+    project = await create_project(migrated_db, "Helper Project")
+    session = await create_session(
+        migrated_db,
+        project.id,
+        "leader",
+        "Leader",
+        provider="codex",
+        status="running",
+    )
+
+    run = await create_provider_helper_run(
+        migrated_db,
+        provider="codex",
+        helper_id="external-helper-1",
+        parent_session_id=session.id,
+        parent_role="leader",
+        project_id=project.id,
+        purpose="inspect_blockers",
+        visibility="hidden",
+        prompt_text="Find blockers",
+        metadata={"reason": "unit-test"},
+    )
+
+    assert run.status == "requested"
+    assert run.visibility == "hidden"
+    assert run.metadata() == {"reason": "unit-test"}
+
+    event = await append_provider_helper_event(
+        migrated_db,
+        helper_run_id=run.id,
+        event_type="helper_requested",
+        message="queued",
+        payload={"visibility": "hidden"},
+    )
+    assert event.payload() == {"visibility": "hidden"}
+
+    updated = await update_provider_helper_run(
+        migrated_db,
+        run.id,
+        status="completed",
+        finished_at="2026-07-09T18:00:00Z",
+        summary="No blockers",
+        output_text="All clear",
+    )
+    assert updated is not None
+    assert updated.status == "completed"
+    assert updated.summary == "No blockers"
+    assert updated.output_text == "All clear"
+    assert updated.metadata() == {"reason": "unit-test"}
+
+    fetched = await get_provider_helper_run(migrated_db, run.id)
+    assert fetched is not None
+    assert fetched.parent_session_id == session.id
+    assert fetched.parent_role == "leader"
+
+    runs = await list_provider_helper_runs(
+        migrated_db,
+        parent_session_id=session.id,
+        visibility="hidden",
+    )
+    assert [item.id for item in runs] == [run.id]
+
+    events = await list_provider_helper_events(migrated_db, run.id)
+    assert [item.event_type for item in events] == ["helper_requested"]
+    assert events[0].message == "queued"
+
+
+@pytest.mark.asyncio
+async def test_provider_helper_migration_creates_expected_tables(migrated_db) -> None:
+    cursor = await migrated_db.execute(
+        """SELECT name FROM sqlite_master
+           WHERE type = 'table' AND name IN ('provider_helper_runs', 'provider_helper_events')
+           ORDER BY name"""
+    )
+    rows = await cursor.fetchall()
+    assert [row["name"] for row in rows] == ["provider_helper_events", "provider_helper_runs"]

--- a/tests/unit/test_provider_helpers.py
+++ b/tests/unit/test_provider_helpers.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+import pytest
+
+from atc.providers.helpers import (
+    ProviderHelperEventType,
+    ProviderHelperParentRole,
+    ProviderHelperRequest,
+    ProviderHelperResult,
+    ProviderHelperRunStatus,
+    ProviderHelperVisibility,
+)
+
+
+def test_provider_helper_request_normalizes_enums_and_tuples() -> None:
+    request = ProviderHelperRequest(
+        provider="codex",
+        parent_session_id="session-1",
+        parent_role="leader",
+        purpose="inspect_blockers",
+        prompt="Inspect blockers",
+        visibility="summary",
+        allowed_tools=["read"],  # type: ignore[arg-type]
+        allowed_actions=["comment"],  # type: ignore[arg-type]
+    )
+
+    assert request.parent_role is ProviderHelperParentRole.LEADER
+    assert request.visibility is ProviderHelperVisibility.SUMMARY
+    assert request.allowed_tools == ("read",)
+    assert request.allowed_actions == ("comment",)
+
+
+@pytest.mark.parametrize(
+    ("field", "kwargs"),
+    [
+        ("provider", {"provider": ""}),
+        ("parent_session_id", {"parent_session_id": ""}),
+        ("purpose", {"purpose": ""}),
+        ("prompt", {"prompt": ""}),
+    ],
+)
+def test_provider_helper_request_requires_core_fields(field: str, kwargs: dict[str, str]) -> None:
+    base = dict(
+        provider="codex",
+        parent_session_id="session-1",
+        parent_role="ace",
+        purpose="purpose",
+        prompt="prompt",
+    )
+    base.update(kwargs)
+
+    with pytest.raises(ValueError, match=f"{field} is required"):
+        ProviderHelperRequest(**base)
+
+
+def test_provider_helper_result_normalizes_status() -> None:
+    result = ProviderHelperResult(
+        helper_run_id="run-1",
+        status="completed",
+        summary="done",
+    )
+
+    assert result.status is ProviderHelperRunStatus.COMPLETED
+    assert result.summary == "done"
+
+
+def test_known_event_types_are_provider_neutral() -> None:
+    assert ProviderHelperEventType.HELPER_REQUESTED == "helper_requested"
+    assert ProviderHelperEventType.TOKEN_USAGE_RECORDED == "token_usage_recorded"


### PR DESCRIPTION
Phase 3 provider helper subagent foundation.\n\nAdds:\n- provider-neutral helper request/result contract\n- provider helper config and settings API\n- durable provider_helper_runs/provider_helper_events audit tables\n- docs for provider-native helper subagent semantics\n- helper contract/state/settings tests\n\nValidation:\n- ruff format/check targeted files\n- PYTHONPATH=src pytest tests/unit/test_provider_helpers.py tests/unit/test_provider_helper_state.py tests/unit/test_provider_helper_settings.py tests/unit/test_provider_runtime_boundary.py tests/unit/test_provider_registry.py tests/unit/test_db.py tests/unit/test_usage_recorder.py -q => 68 passed, 1 warning\n- git diff --check\n- full stale cost-term scan over src/tests/docs => NO_BLOCKING_COST_TERMS