### PR TITLE
Add provider helper visibility settings UI

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -78,7 +78,7 @@ QueryClientProvider → AppProvider (WebSocket state) → Router
 |---|---|---|
 | `/dashboard` | Dashboard | Token usage charts, resource charts, project cards |
 | `/projects/:id` | ProjectView | Leader console + ace terminals + task board |
-| `/settings` | SettingsPage | Configuration management |
+| `/settings` | SettingsPage | Configuration management, including provider helper visibility controls |
 | `/usage` | UsagePage | Full analytics charts |
 
 ### Layout (Option A)

--- a/docs/provider_subagent_contract.md
+++ b/docs/provider_subagent_contract.md
@@ -124,9 +124,10 @@ preserving helper metadata such as `helper_run_id`, `helper_purpose`, provider,
 and external provider session IDs in token metadata/raw usage details. The usage
 path stays provider-neutral and token-only.
 
-## Phase 4+ UI expectations
+## Settings UI shell
 
-Phase 3 establishes backend contract and durable audit state. Phase 4 will add
-the global Settings control and helper visibility UI shell. Later Codex helper
-phases should use these tables/contracts rather than inventing provider-specific
-helper state.
+The Settings pane includes a Provider Helper Subagents section for the global
+helper enablement and default visibility controls. The UI deliberately treats
+visibility as display policy only and labels audit logging as always on. Later
+provider-specific helper phases should use these tables/contracts rather than
+inventing provider-specific helper state.

--- a/frontend/src/components/tower/SettingsPane.css
+++ b/frontend/src/components/tower/SettingsPane.css
@@ -122,3 +122,14 @@
   border-radius: var(--radius-md);
   overflow: hidden;
 }
+
+.settings-pane__switch-row {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: var(--space-3);
+}
+
+.settings-pane__switch-row input[type="checkbox"] {
+  margin-top: var(--space-1);
+}

--- a/frontend/src/components/tower/SettingsPane.tsx
+++ b/frontend/src/components/tower/SettingsPane.tsx
@@ -1,7 +1,11 @@
 import { useEffect, useMemo, useState } from "react";
 import { useAppContext } from "../../context/AppContext";
 import { api } from "../../utils/api";
-import type { AgentProviderConfig, ProviderInfo } from "../../types";
+import type {
+  AgentProviderConfig,
+  ProviderHelperSettings,
+  ProviderInfo,
+} from "../../types";
 import { BackupPanel } from "../settings/BackupPanel";
 import { ResourceLimitsPanel } from "../settings/ResourceLimitsPanel";
 import "./SettingsPane.css";
@@ -20,30 +24,58 @@ const EMPTY_PROVIDER_CONFIG: AgentProviderConfig = {
   codex_command: "codex",
 };
 
+const EMPTY_HELPER_SETTINGS: ProviderHelperSettings = {
+  enabled: true,
+  default_visibility: "hidden",
+  audit_enabled: true,
+};
+
+const HELPER_VISIBILITY_LABELS: Record<
+  ProviderHelperSettings["default_visibility"],
+  string
+> = {
+  hidden: "Hidden — normal workflow UI stays quiet, audit stays on",
+  summary: "Summary — show lifecycle and result summaries",
+  full: "Full — show prompts, output, timings, tokens, and events",
+};
+
 export default function SettingsPane({ onClose }: Props) {
   const { state } = useAppContext();
   const [githubOrg, setGithubOrg] = useState(
     () => globalThis.localStorage?.getItem(GITHUB_ORG_KEY) ?? "",
   );
-  const [providerConfig, setProviderConfig] = useState<AgentProviderConfig>(EMPTY_PROVIDER_CONFIG);
+  const [providerConfig, setProviderConfig] = useState<AgentProviderConfig>(
+    EMPTY_PROVIDER_CONFIG,
+  );
   const [providers, setProviders] = useState<ProviderInfo[]>([]);
   const [savingProvider, setSavingProvider] = useState(false);
   const [providerMessage, setProviderMessage] = useState<string | null>(null);
+  const [helperSettings, setHelperSettings] = useState<ProviderHelperSettings>(
+    EMPTY_HELPER_SETTINGS,
+  );
+  const [savingHelpers, setSavingHelpers] = useState(false);
+  const [helperMessage, setHelperMessage] = useState<string | null>(null);
 
   useEffect(() => {
     let mounted = true;
     void (async () => {
       try {
-        const [cfg, providerList] = await Promise.all([
+        const [cfg, providerList, helpers] = await Promise.all([
           api.get<AgentProviderConfig>("/settings/agent-provider"),
           api.get<ProviderInfo[]>("/settings/providers"),
+          api.get<ProviderHelperSettings>("/settings/provider-helpers"),
         ]);
         if (!mounted) return;
         setProviderConfig(cfg);
         setProviders(providerList);
+        setHelperSettings(helpers);
       } catch (err) {
         if (!mounted) return;
-        setProviderMessage(err instanceof Error ? err.message : "Failed to load provider settings");
+        setProviderMessage(
+          err instanceof Error
+            ? err.message
+            : "Failed to load provider settings",
+        );
       }
     })();
     return () => {
@@ -57,7 +89,9 @@ export default function SettingsPane({ onClose }: Props) {
   );
 
   const activeTowerProject = state.towerDetail.current_project_id
-    ? state.projects.find((project) => project.id === state.towerDetail.current_project_id) ?? null
+    ? (state.projects.find(
+        (project) => project.id === state.towerDetail.current_project_id,
+      ) ?? null)
     : null;
   const terminalBackedProviders = new Set(["claude_code", "codex"]);
 
@@ -81,7 +115,10 @@ export default function SettingsPane({ onClose }: Props) {
       window.dispatchEvent(new CustomEvent("atc:provider-switching"));
     }
     try {
-      const saved = await api.put<AgentProviderConfig>("/settings/agent-provider", next);
+      const saved = await api.put<AgentProviderConfig>(
+        "/settings/agent-provider",
+        next,
+      );
       setProviderConfig(saved);
       setProviderMessage(
         providerChanged
@@ -92,12 +129,44 @@ export default function SettingsPane({ onClose }: Props) {
         window.dispatchEvent(new CustomEvent("atc:provider-switched"));
       }
     } catch (err) {
-      setProviderMessage(err instanceof Error ? err.message : "Failed to save provider settings");
+      setProviderMessage(
+        err instanceof Error ? err.message : "Failed to save provider settings",
+      );
       if (providerChanged) {
         window.dispatchEvent(new CustomEvent("atc:provider-switched"));
       }
     } finally {
       setSavingProvider(false);
+    }
+  }
+
+  async function saveHelperSettings(next: Partial<ProviderHelperSettings>) {
+    const optimistic: ProviderHelperSettings = {
+      ...helperSettings,
+      ...next,
+      audit_enabled: true,
+    };
+    setHelperSettings(optimistic);
+    setSavingHelpers(true);
+    setHelperMessage(null);
+    try {
+      const saved = await api.put<ProviderHelperSettings>(
+        "/settings/provider-helpers",
+        next,
+      );
+      setHelperSettings(saved);
+      setHelperMessage(
+        "Provider helper visibility saved. Audit logging remains enabled.",
+      );
+    } catch (err) {
+      setHelperMessage(
+        err instanceof Error
+          ? err.message
+          : "Failed to save provider helper settings",
+      );
+      setHelperSettings((prev) => ({ ...prev, audit_enabled: true }));
+    } finally {
+      setSavingHelpers(false);
     }
   }
 
@@ -139,7 +208,9 @@ export default function SettingsPane({ onClose }: Props) {
             <select
               id="provider-default"
               value={providerConfig.default}
-              onChange={(e) => void saveProviderConfig({ default: e.target.value })}
+              onChange={(e) =>
+                void saveProviderConfig({ default: e.target.value })
+              }
               disabled={savingProvider}
             >
               {providers.map((provider) => (
@@ -152,8 +223,10 @@ export default function SettingsPane({ onClose }: Props) {
               {terminalBackedProviders.has(providerConfig.default)
                 ? "This provider uses live tmux terminal panes in the app."
                 : "This provider may use a non-terminal control flow even if a visibility pane exists."}{" "}
-              Changing the global provider affects all new sessions immediately. Existing live Tower, Leader,
-              and Ace sessions will be restarted or recreated as needed so stale provider-bound sessions do not linger.
+              Changing the global provider affects all new sessions immediately.
+              Existing live Tower, Leader, and Ace sessions will be restarted or
+              recreated as needed so stale provider-bound sessions do not
+              linger.
             </span>
           </div>
 
@@ -163,8 +236,17 @@ export default function SettingsPane({ onClose }: Props) {
               id="provider-claude-command"
               type="text"
               value={providerConfig.claude_command}
-              onChange={(e) => setProviderConfig((prev) => ({ ...prev, claude_command: e.target.value }))}
-              onBlur={() => void saveProviderConfig({ claude_command: providerConfig.claude_command })}
+              onChange={(e) =>
+                setProviderConfig((prev) => ({
+                  ...prev,
+                  claude_command: e.target.value,
+                }))
+              }
+              onBlur={() =>
+                void saveProviderConfig({
+                  claude_command: providerConfig.claude_command,
+                })
+              }
             />
           </div>
 
@@ -174,8 +256,17 @@ export default function SettingsPane({ onClose }: Props) {
               id="provider-codex-command"
               type="text"
               value={providerConfig.codex_command}
-              onChange={(e) => setProviderConfig((prev) => ({ ...prev, codex_command: e.target.value }))}
-              onBlur={() => void saveProviderConfig({ codex_command: providerConfig.codex_command })}
+              onChange={(e) =>
+                setProviderConfig((prev) => ({
+                  ...prev,
+                  codex_command: e.target.value,
+                }))
+              }
+              onBlur={() =>
+                void saveProviderConfig({
+                  codex_command: providerConfig.codex_command,
+                })
+              }
             />
           </div>
 
@@ -185,8 +276,17 @@ export default function SettingsPane({ onClose }: Props) {
               id="provider-opencode-url"
               type="text"
               value={providerConfig.opencode_url}
-              onChange={(e) => setProviderConfig((prev) => ({ ...prev, opencode_url: e.target.value }))}
-              onBlur={() => void saveProviderConfig({ opencode_url: providerConfig.opencode_url })}
+              onChange={(e) =>
+                setProviderConfig((prev) => ({
+                  ...prev,
+                  opencode_url: e.target.value,
+                }))
+              }
+              onBlur={() =>
+                void saveProviderConfig({
+                  opencode_url: providerConfig.opencode_url,
+                })
+              }
             />
           </div>
 
@@ -196,19 +296,35 @@ export default function SettingsPane({ onClose }: Props) {
               id="provider-tmux-session"
               type="text"
               value={providerConfig.tmux_session}
-              onChange={(e) => setProviderConfig((prev) => ({ ...prev, tmux_session: e.target.value }))}
-              onBlur={() => void saveProviderConfig({ tmux_session: providerConfig.tmux_session })}
+              onChange={(e) =>
+                setProviderConfig((prev) => ({
+                  ...prev,
+                  tmux_session: e.target.value,
+                }))
+              }
+              onBlur={() =>
+                void saveProviderConfig({
+                  tmux_session: providerConfig.tmux_session,
+                })
+              }
             />
           </div>
 
-          <div className="settings-pane__provider-status" data-testid="provider-global-status">
+          <div
+            className="settings-pane__provider-status"
+            data-testid="provider-global-status"
+          >
             <div className="settings-pane__info-row">
               <span className="settings-pane__label">Global provider</span>
-              <span className="settings-pane__value">{providerConfig.default}</span>
+              <span className="settings-pane__value">
+                {providerConfig.default}
+              </span>
             </div>
             <div className="settings-pane__info-row">
               <span className="settings-pane__label">Active projects</span>
-              <span className="settings-pane__value">{activeProjects.length}</span>
+              <span className="settings-pane__value">
+                {activeProjects.length}
+              </span>
             </div>
             <div className="settings-pane__info-row">
               <span className="settings-pane__label">Live Tower session</span>
@@ -220,7 +336,92 @@ export default function SettingsPane({ onClose }: Props) {
             </div>
           </div>
 
-          {providerMessage && <div className="form-hint">{providerMessage}</div>}
+          {providerMessage && (
+            <div className="form-hint">{providerMessage}</div>
+          )}
+        </section>
+
+        <section
+          className="panel settings-pane__section"
+          data-testid="provider-helper-settings"
+        >
+          <h3>Provider Helper Subagents</h3>
+          <div className="form-group settings-pane__switch-row">
+            <div>
+              <label htmlFor="provider-helpers-enabled">
+                Allow provider helpers
+              </label>
+              <span className="form-hint">
+                Providers may use private/background helper subagents for Tower,
+                Leader, or Ace work. Helpers never become operator-visible ATC
+                roles.
+              </span>
+            </div>
+            <input
+              id="provider-helpers-enabled"
+              type="checkbox"
+              checked={helperSettings.enabled}
+              disabled={savingHelpers}
+              onChange={(e) =>
+                void saveHelperSettings({ enabled: e.target.checked })
+              }
+            />
+          </div>
+
+          <div className="form-group">
+            <label htmlFor="provider-helper-visibility">
+              Default Helper Visibility
+            </label>
+            <select
+              id="provider-helper-visibility"
+              value={helperSettings.default_visibility}
+              disabled={savingHelpers || !helperSettings.enabled}
+              onChange={(e) =>
+                void saveHelperSettings({
+                  default_visibility: e.target
+                    .value as ProviderHelperSettings["default_visibility"],
+                })
+              }
+            >
+              <option value="hidden">Hidden</option>
+              <option value="summary">Summary</option>
+              <option value="full">Full</option>
+            </select>
+            <span className="form-hint">
+              {HELPER_VISIBILITY_LABELS[helperSettings.default_visibility]}
+            </span>
+          </div>
+
+          <div
+            className="settings-pane__provider-status"
+            data-testid="provider-helper-status"
+          >
+            <div className="settings-pane__info-row">
+              <span className="settings-pane__label">Helpers</span>
+              <span className="settings-pane__value">
+                {helperSettings.enabled ? "Enabled" : "Disabled"}
+              </span>
+            </div>
+            <div className="settings-pane__info-row">
+              <span className="settings-pane__label">Visibility</span>
+              <span className="settings-pane__value">
+                {helperSettings.default_visibility}
+              </span>
+            </div>
+            <div className="settings-pane__info-row">
+              <span className="settings-pane__label">Audit logging</span>
+              <span className="settings-pane__value">
+                {helperSettings.audit_enabled ? "Always on" : "Unavailable"}
+              </span>
+            </div>
+          </div>
+
+          <span className="form-hint">
+            Visibility controls display only. Durable helper audit records are
+            still written even when helper work is hidden from normal workflow
+            panels.
+          </span>
+          {helperMessage && <div className="form-hint">{helperMessage}</div>}
         </section>
 
         <section className="panel settings-pane__section">

--- a/frontend/src/components/tower/__tests__/SettingsPane.test.tsx
+++ b/frontend/src/components/tower/__tests__/SettingsPane.test.tsx
@@ -33,6 +33,54 @@ function project(overrides: Partial<Project> = {}): Project {
   };
 }
 
+function providerConfigResponse(overrides: Record<string, unknown> = {}) {
+  return new Response(
+    JSON.stringify({
+      default: "codex",
+      opencode_url: "http://localhost:4096",
+      tmux_session: "atc",
+      claude_command: "claude",
+      codex_command: "codex",
+      ...overrides,
+    }),
+    { status: 200 },
+  );
+}
+
+function providersResponse() {
+  return new Response(
+    JSON.stringify([
+      {
+        name: "claude_code",
+        supports_streaming: true,
+        supports_tool_use: true,
+        context_window: 200000,
+        model: "claude",
+      },
+      {
+        name: "codex",
+        supports_streaming: true,
+        supports_tool_use: true,
+        context_window: 200000,
+        model: "codex",
+      },
+    ]),
+    { status: 200 },
+  );
+}
+
+function providerHelpersResponse(overrides: Record<string, unknown> = {}) {
+  return new Response(
+    JSON.stringify({
+      enabled: true,
+      default_visibility: "hidden",
+      audit_enabled: true,
+      ...overrides,
+    }),
+    { status: 200 },
+  );
+}
+
 function setMockState(overrides: Partial<AppState> = {}) {
   mockState = {
     projects: [],
@@ -50,7 +98,15 @@ function setMockState(overrides: Partial<AppState> = {}) {
       leader_session_id: null,
       leader_activity_preview: null,
     },
-    towerProgress: { project_id: null, done: 0, total: 0, in_progress: 0, todo: 0, progress_pct: 0, all_done: false },
+    towerProgress: {
+      project_id: null,
+      done: 0,
+      total: 0,
+      in_progress: 0,
+      todo: 0,
+      progress_pct: 0,
+      all_done: false,
+    },
     brainStatus: { status: "idle", message: "Idle", active_projects: 0 },
     failureLogs: [],
     usage: { today_tokens: 0, month_tokens: 0 },
@@ -72,75 +128,34 @@ describe("SettingsPane", () => {
     setMockState({ projects: [project()] });
     const fetchMock = vi.spyOn(globalThis, "fetch");
     fetchMock
-      .mockResolvedValueOnce(
-        new Response(
-          JSON.stringify({
-            default: "codex",
-            opencode_url: "http://localhost:4096",
-            tmux_session: "atc",
-            claude_command: "claude",
-            codex_command: "codex",
-          }),
-          { status: 200 },
-        ),
-      )
-      .mockResolvedValueOnce(
-        new Response(
-          JSON.stringify([
-            { name: "claude_code", supports_streaming: true, supports_tool_use: true, context_window: 200000, model: "claude" },
-            { name: "codex", supports_streaming: true, supports_tool_use: true, context_window: 200000, model: "codex" },
-          ]),
-          { status: 200 },
-        ),
-      );
+      .mockResolvedValueOnce(providerConfigResponse())
+      .mockResolvedValueOnce(providersResponse())
+      .mockResolvedValueOnce(providerHelpersResponse());
 
     render(<SettingsPane onClose={() => undefined} />);
 
     await waitFor(() => {
       expect(screen.getByTestId("provider-global-status")).toBeInTheDocument();
     });
-    expect(screen.queryByTestId("provider-action-project")).not.toBeInTheDocument();
-    expect(screen.queryByTestId("provider-apply-project")).not.toBeInTheDocument();
-    expect(screen.queryByTestId("provider-restart-tower")).not.toBeInTheDocument();
+    expect(
+      screen.queryByTestId("provider-action-project"),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByTestId("provider-apply-project"),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByTestId("provider-restart-tower"),
+    ).not.toBeInTheDocument();
   });
 
   it("saves the global provider and shows restart/replacement messaging", async () => {
     const user = userEvent.setup();
     const fetchMock = vi.spyOn(globalThis, "fetch");
     fetchMock
-      .mockResolvedValueOnce(
-        new Response(
-          JSON.stringify({
-            default: "claude_code",
-            opencode_url: "http://localhost:4096",
-            tmux_session: "atc",
-            claude_command: "claude",
-            codex_command: "codex",
-          }),
-          { status: 200 },
-        ),
-      )
-      .mockResolvedValueOnce(
-        new Response(
-          JSON.stringify([
-            { name: "claude_code", supports_streaming: true, supports_tool_use: true, context_window: 200000, model: "claude" },
-            { name: "codex", supports_streaming: true, supports_tool_use: true, context_window: 200000, model: "codex" },
-          ]),
-          { status: 200 },
-        ),
-      )
-      .mockResolvedValueOnce(
-        new Response(
-          JSON.stringify({
-            default: "codex",
-            opencode_url: "http://localhost:4096",
-            tmux_session: "atc",
-            claude_command: "claude",
-            codex_command: "codex",
-          }),
-          { status: 200 },
-        ),
-      );
+      .mockResolvedValueOnce(providerConfigResponse({ default: "claude_code" }))
+      .mockResolvedValueOnce(providersResponse())
+      .mockResolvedValueOnce(providerHelpersResponse())
+      .mockResolvedValueOnce(providerConfigResponse({ default: "codex" }));
 
     render(<SettingsPane onClose={() => undefined} />);
 
@@ -162,5 +177,47 @@ describe("SettingsPane", () => {
       "/api/settings/agent-provider",
       expect.objectContaining({ method: "PUT" }),
     );
+  });
+
+  it("loads and saves provider helper visibility settings", async () => {
+    const user = userEvent.setup();
+    const fetchMock = vi.spyOn(globalThis, "fetch");
+    fetchMock
+      .mockResolvedValueOnce(providerConfigResponse())
+      .mockResolvedValueOnce(providersResponse())
+      .mockResolvedValueOnce(
+        providerHelpersResponse({ default_visibility: "hidden" }),
+      )
+      .mockResolvedValueOnce(
+        providerHelpersResponse({ default_visibility: "summary" }),
+      );
+
+    render(<SettingsPane onClose={() => undefined} />);
+
+    await waitFor(() => {
+      expect(
+        screen.getByTestId("provider-helper-settings"),
+      ).toBeInTheDocument();
+    });
+    expect(screen.getByText("Always on")).toBeInTheDocument();
+
+    await user.selectOptions(
+      screen.getByLabelText("Default Helper Visibility"),
+      "summary",
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(
+          "Provider helper visibility saved. Audit logging remains enabled.",
+        ),
+      ).toBeInTheDocument();
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/api/settings/provider-helpers",
+      expect.objectContaining({ method: "PUT" }),
+    );
+    expect(screen.getByText("summary")).toBeInTheDocument();
   });
 });

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -29,6 +29,14 @@ export interface ProviderInfo {
   model: string;
 }
 
+export type ProviderHelperVisibility = "hidden" | "summary" | "full";
+
+export interface ProviderHelperSettings {
+  enabled: boolean;
+  default_visibility: ProviderHelperVisibility;
+  audit_enabled: boolean;
+}
+
 export interface Leader {
   id: string;
   project_id: string;
@@ -240,7 +248,15 @@ export interface FeatureFlag {
 
 export interface DeliveryStatusResponse {
   status: string;
-  delivery_state: "queued" | "submitted" | "started" | "delivered" | "confirmed" | "blocked" | "failed" | string;
+  delivery_state:
+    | "queued"
+    | "submitted"
+    | "started"
+    | "delivered"
+    | "confirmed"
+    | "blocked"
+    | "failed"
+    | string;
   message?: string;
   session_id?: string;
   project_id?: string;


### PR DESCRIPTION
Phase 4 provider helper visibility UI.

Adds:
- Provider helper settings types in frontend shared types.
- Settings pane controls for provider helper enablement and default visibility.
- Audit logging status shell labeled as always on/display-only.
- Settings pane tests for loading and saving helper visibility.
- Docs updated to mark Phase 4 settings UI shell as implemented.

Validation:
- SettingsPane Vitest: 3 passed.
- Frontend production build: passed.
- Backend provider-helper settings tests: 2 passed, 1 warning.
- Playwright UI smoke with mocked backend: provider helper settings section visible, audit always-on label visible, visibility changed to summary, report had no page errors/failed requests.
- git diff --check: passed.
- tracked stale cost-term scan: NO_BLOCKING_COST_TERMS.

Screenshot evidence generated locally:
- /Users/mcole_studio/Repository/atc/screenshots/phase4-provider-helper-ui/provider-helper-settings-hidden.png
- /Users/mcole_studio/Repository/atc/screenshots/phase4-provider-helper-ui/provider-helper-settings-summary.png
- /Users/mcole_studio/Repository/atc/screenshots/phase4-provider-helper-ui/report.json
