### PR TITLE
Document Phase 6 local API capability completion

### DIFF
--- a/docs/leader_kickoff_recovery_plan.md
+++ b/docs/leader_kickoff_recovery_plan.md
@@ -1,6 +1,6 @@
 # Leader Kickoff Verification and Startup Prompt Recovery Plan
 
-**Status:** In progress — Phases 0–5 implemented through PR #320 follow-ups; Phase 5 adds first-class task graph CLI helpers plus targeted Leader assignment over canonical REST/service contracts.
+**Status:** In progress — Phases 0–6 implemented through PR #320 follow-ups; Phase 6 deploys provider-neutral local ATC API capability metadata/helpers for managed workspaces without broad external-network approval.
 **Issue:** [#297](https://github.com/wowc8/atc/issues/297)
 **Last updated:** 2026-06-13
 **Scope:** Follow-up runtime/orchestration hardening for Leader startup, managed-workspace provider prompts, `prompt_not_submitted` recovery, task graph ergonomics, and local ATC API capability setup.
@@ -261,6 +261,14 @@ Tower should not enter normal low-frequency monitoring until the Leader reaches 
 ## Phase 6 — Local ATC API capability preauthorization for managed agents
 
 **Goal:** Managed Leader/Ace agents can inspect the local ATC API without interactive provider approval, while not gaining broad network approval.
+
+### Implemented contract
+
+- Managed Tower/Leader/Ace deployment writes `.atc/local_api_capability.json` for local ATC API inspection when the configured API base URL resolves to `127.0.0.1` or `localhost`.
+- The capability declares `external_network_allowed: false`, a local host allowlist, bounded methods, and ATC/OpenAPI path prefixes only.
+- `.atc/local_api.sh` validates method/path against the capability file before issuing a request; disallowed paths fail locally without network access.
+- Provider-neutral AGENTS/CLAUDE instructions tell managed agents to use the scoped helper or `atc` CLI for local API inspection and explicitly state that external network access is not authorized.
+- Provider adapters remain responsible for any provider-specific approval or trust mechanics; orchestration/deploy code only emits neutral capability metadata, helper files, and instructions.
 
 ### Work
 


### PR DESCRIPTION
## Summary

Phase 6 reconciliation/update for managed-workspace local ATC API capability preauthorization:

- Documents that Phase 6 is implemented through provider-neutral `.atc/local_api_capability.json` and `.atc/local_api.sh` deployment.
- Records the scoped capability contract: local host allowlist only, bounded ATC/OpenAPI path prefixes, `external_network_allowed: false`, and helper-side method/path validation before network access.
- Reiterates provider separation: deployment emits neutral metadata/helper/instructions; provider adapters remain responsible for provider-specific approval/trust mechanics.

The functional Phase 6 surfaces were already present on current `main`; this PR aligns the kickoff recovery plan with the implemented state and carries Phase 6 validation evidence.

## Validation

- `./.venv/bin/python -m ruff check docs/leader_kickoff_recovery_plan.md src/atc/agents/deploy.py tests/unit/test_deploy.py tests/e2e/test_phase8_scenarios.py tests/unit/test_codex_runtime_classifier.py tests/unit/test_runtime_service.py`
  - `All checks passed!`
- `./.venv/bin/python -m pytest tests/unit/test_deploy.py tests/e2e/test_phase8_scenarios.py tests/unit/test_codex_runtime_classifier.py tests/unit/test_runtime_service.py -q`
  - `117 passed, 1 warning`
- Live local helper smoke on `http://127.0.0.1:8420`:
  - deployed temp managed Leader workspace `/tmp/phase6-local-api-smoke/phase6-live-leader`
  - capability: `local_atc_api_inspection`, `base_url=http://127.0.0.1:8420`, host allowlist `['127.0.0.1', 'localhost']`, `external_network_allowed=False`
  - `bash .atc/local_api.sh GET /api/health` returned `status=ok`, `auth_mode=none`
  - `bash .atc/local_api.sh GET /openapi.json` returned OpenAPI `3.1.0` and included `/api/health`
  - `bash .atc/local_api.sh GET /not-allowed` failed locally with `path not allowed: /not-allowed`
- `cd frontend && PATH=/opt/homebrew/bin:$PATH npm run build`
  - passed; existing Vite chunk-size warning only
- Playwright baseline smoke:
  - `PATH=/opt/homebrew/bin:$PATH node frontend/playwright-smoke-atc.mjs`
  - `13/13` checks passed
  - report: `/Users/mcole_studio/AI_Stack/agents/skunkworks/workspace/screenshots/playwright-atc-2026-07-10T15-49-28-196Z/report.json`

## Evidence screenshots

- `/Users/mcole_studio/AI_Stack/agents/skunkworks/workspace/screenshots/playwright-atc-2026-07-10T15-49-28-196Z/01-dashboard-initial.png`
- `/Users/mcole_studio/AI_Stack/agents/skunkworks/workspace/screenshots/playwright-atc-2026-07-10T15-49-28-196Z/05-create-project-modal.png`
- `/Users/mcole_studio/AI_Stack/agents/skunkworks/workspace/screenshots/playwright-atc-2026-07-10T15-49-28-196Z/08-usage.png`
- `/Users/mcole_studio/AI_Stack/agents/skunkworks/workspace/screenshots/playwright-atc-2026-07-10T15-49-28-196Z/12-context.png`

## Cleanup

Backend/frontend validation servers were stopped and ports 8420/5173 were verified clear. Local tracked modifications are limited to the docs update; generated `screenshots/` evidence remains untracked.
