### PR TITLE
Surface Leader health guidance

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -53,11 +53,12 @@ Important fields:
 
 `GET /api/projects/{id}/leader/health` is the canonical operator/Tower view for a Leader's runtime truth. Important top-level fields include:
 
-- `leader_state`: normalized health state for the Leader, such as healthy, unverified, blocked, or missing.
+- `leader_state`: normalized health state for the Leader, such as `blocked_on_provider_prompt`, `kickoff_unverified`, `task_graph_empty`, `working`, or `runtime_missing`.
 - `runtime_state`: provider-neutral runtime state; product layers branch on this, not raw terminal text.
 - `delivery_state`: provider-neutral kickoff delivery state.
 - `blocker_reason`: stable blocker reason such as `pane_missing`, `runtime_trust_required`, `runtime_permission_required`, or `prompt_not_submitted`.
 - `recovery_recommendation`: concise safe next action for tooling.
+- `recommended_command`: top-level operator command mirroring the current guidance command for CLI/UI consumers.
 - `operator_guidance`: user-facing summary with severity, recommended action, command, and details.
 - `provider_diagnostics`: redacted nested provider details for debugging only; orchestration must not branch on provider-specific prompt strings.
 

--- a/docs/leader_kickoff_recovery_plan.md
+++ b/docs/leader_kickoff_recovery_plan.md
@@ -1,6 +1,6 @@
 # Leader Kickoff Verification and Startup Prompt Recovery Plan
 
-**Status:** In progress — Phases 0–6 implemented through PR #320 follow-ups; Phase 6 deploys provider-neutral local ATC API capability metadata/helpers for managed workspaces without broad external-network approval.
+**Status:** In progress — Phases 0–7 implemented through PR #320 follow-ups; Phase 7 surfaces Leader health/recovery guidance in API, CLI, and Project UI without provider prompt parsing outside adapters.
 **Issue:** [#297](https://github.com/wowc8/atc/issues/297)
 **Last updated:** 2026-06-13
 **Scope:** Follow-up runtime/orchestration hardening for Leader startup, managed-workspace provider prompts, `prompt_not_submitted` recovery, task graph ergonomics, and local ATC API capability setup.
@@ -297,6 +297,14 @@ Tower should not enter normal low-frequency monitoring until the Leader reaches 
 ## Phase 7 — UI/CLI health surfacing and operator recovery guidance
 
 **Goal:** Operators see the real Leader health state and an actionable recovery path instead of only zero progress/tasks.
+
+### Implemented contract
+
+- `GET /api/projects/{id}/leader/health` returns top-level `leader_state`, `runtime_state`, `delivery_state`, `blocker_reason`/`current_blocker`, `recovery_recommendation`, `recommended_command`, `operator_guidance`, and redacted `provider_diagnostics`.
+- `leader_state` is derived from provider-neutral kickoff/task evidence, not raw provider prompt strings: `blocked_on_provider_prompt`, `kickoff_unverified`, `task_graph_empty`, and `working` remain separate from task-count progress.
+- `atc leader health --summary` prints the normalized Leader state, task/dispatch truth, recommended action, and the exact recovery/health command operators should run next.
+- Project UI Leader health guidance displays the same normalized Leader state and recommended command so a blocked/unverified startup does not appear as only `0 tasks`.
+- Provider-specific prompt text/key handling remains inside runtime provider adapters/classifiers; API/CLI/UI surfaces consume only neutral health fields and redacted diagnostics.
 
 ### Work
 

--- a/frontend/src/components/leader/LeaderConsole.tsx
+++ b/frontend/src/components/leader/LeaderConsole.tsx
@@ -190,6 +190,8 @@ export default function LeaderConsole({
     recommended_action: "none" as const,
     command: null,
   };
+  const leaderHealthState = health?.leader_state ?? health?.kickoff_state.kickoff_state ?? "unknown";
+  const recommendedCommand = health?.recommended_command ?? healthGuidance.command;
 
   return (
     <div className="leader-console" data-testid="leader-console">
@@ -245,7 +247,7 @@ export default function LeaderConsole({
           <div className="leader-console__health-grid">
             <span>Runtime: {health.runtime_state}</span>
             <span>Delivery: {health.delivery_state}</span>
-            <span>State: {health.kickoff_state.kickoff_state ?? "unknown"}</span>
+            <span>Leader: {leaderHealthState}</span>
             <span>Tasks: {health.task_graph_state.total ?? 0}</span>
           </div>
           {health.current_blocker && (
@@ -254,7 +256,7 @@ export default function LeaderConsole({
           {healthGuidance.recommended_action !== "none" && (
             <div className="leader-console__health-action">
               Recommended: {healthGuidance.recommended_action}
-              {healthGuidance.command ? ` — ${healthGuidance.command}` : ""}
+              {recommendedCommand ? ` — ${recommendedCommand}` : ""}
             </div>
           )}
           <div className="leader-console__health-controls">

--- a/frontend/src/components/leader/__tests__/LeaderConsole.test.tsx
+++ b/frontend/src/components/leader/__tests__/LeaderConsole.test.tsx
@@ -195,6 +195,43 @@ describe("LeaderConsole", () => {
     resolvePost(new Response(JSON.stringify({ status: "started" }), { status: 200 }));
   });
 
+  it("surfaces Leader health state and recommended recovery command", async () => {
+    vi.spyOn(globalThis, "fetch").mockImplementation(() =>
+      Promise.resolve(
+        new Response(
+          JSON.stringify({
+            leader_state: "blocked_on_provider_prompt",
+            runtime_state: "blocked",
+            delivery_state: "blocked",
+            current_blocker: "prompt_not_submitted",
+            recommended_command: "atc leader recover --project-id proj-1 --dry-run",
+            kickoff_state: { kickoff_state: "fallback_should_not_render" },
+            task_graph_state: { total: 0 },
+            ace_dispatch: {},
+            operator_guidance: {
+              severity: "blocked",
+              summary: "Kickoff prompt was not submitted to the provider.",
+              recommended_action: "run_inspect_first_recovery",
+              command: "atc leader recover --project-id proj-1 --dry-run",
+              details: "Use dry-run first.",
+            },
+          }),
+          { status: 200 },
+        ),
+      ),
+    );
+
+    render(<LeaderConsole projectId="proj-1" leader={managingLeader} onRefresh={vi.fn()} />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("leader-health-guidance")).toBeInTheDocument();
+    });
+    expect(screen.getByText(/Leader: blocked_on_provider_prompt/)).toBeInTheDocument();
+    expect(screen.getByText(/Recommended: run_inspect_first_recovery/)).toHaveTextContent(
+      "atc leader recover --project-id proj-1 --dry-run",
+    );
+  });
+
   it("treats codex as a terminal-backed provider", () => {
     setMockState({ projects: [codexProject] });
     render(<LeaderConsole projectId="proj-1" leader={idleLeader} onRefresh={vi.fn()} project={codexProject} />);

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -283,9 +283,11 @@ export interface RuntimeOperatorGuidance {
 }
 
 export interface LeaderRuntimeHealth {
+  leader_state?: string | null;
   runtime_state: string;
   delivery_state: string;
   current_blocker: string | null;
+  recommended_command?: string | null;
   kickoff_state: {
     kickoff_state?: string;
     goal_acceptance_state?: string;

--- a/src/atc/cli/leader.py
+++ b/src/atc/cli/leader.py
@@ -144,12 +144,14 @@ def _print_health_summary(body: dict) -> None:
     kickoff = body.get("kickoff_state") or {}
     tasks = body.get("task_graph_state") or {}
     dispatch = body.get("ace_dispatch") or {}
+    leader_state = body.get("leader_state") or kickoff.get("kickoff_state")
+    recommended_command = body.get("recommended_command") or guidance.get("command")
     print(f"Leader health: {guidance.get('severity', 'unknown')}")
     print(f"Summary: {guidance.get('summary', 'No guidance available.')}")
     print(f"Runtime: {body.get('runtime_state')} / delivery: {body.get('delivery_state')}")
     print(
         "Leader state: "
-        f"{kickoff.get('kickoff_state')} / acceptance: {kickoff.get('goal_acceptance_state')}"
+        f"{leader_state} / acceptance: {kickoff.get('goal_acceptance_state')}"
     )
     print(
         "Tasks: "
@@ -167,8 +169,8 @@ def _print_health_summary(body: dict) -> None:
         print(f"Blocker: {body['current_blocker']}")
     if guidance.get("recommended_action"):
         print(f"Recommended action: {guidance['recommended_action']}")
-    if guidance.get("command"):
-        print(f"Command: {guidance['command']}")
+    if recommended_command:
+        print(f"Command: {recommended_command}")
     if guidance.get("details"):
         print(f"Details: {guidance['details']}")
 

--- a/src/atc/runtime/health.py
+++ b/src/atc/runtime/health.py
@@ -41,6 +41,7 @@ class RuntimeHealth:
     pane_attached: bool
     provider: str | None
     session_id: str | None = None
+    leader_state: str | None = None
     runtime_state: str = RuntimeState.MISSING.value
     delivery_state: str = DeliveryState.NOT_STARTED.value
     blocker_reason: str | None = None
@@ -51,6 +52,7 @@ class RuntimeHealth:
     ace_dispatch: dict[str, Any] = field(default_factory=dict)
     ace_count: int = 0
     current_blocker: str | None = None
+    recommended_command: str | None = None
     recovery_recommendation: dict[str, Any] | None = None
     operator_guidance: dict[str, Any] = field(default_factory=dict)
     provider_diagnostics: dict[str, Any] = field(default_factory=dict)
@@ -566,10 +568,21 @@ async def leader_health(
         (a.blocker_reason for a in project_assignments if a.blocker_reason), None
     )
     delivery_state = _delivery_state_for_runtime(runtime_state, has_payload=bool(kickoff_payload))
+    operator_guidance = _operator_guidance_for(
+        role="leader",
+        project_id=project_id,
+        session_id=session.id if session else None,
+        runtime_state=runtime_state,
+        delivery_state=delivery_state,
+        current_blocker=current_blocker,
+        kickoff_state=kickoff_state,
+        ace_dispatch=dispatch_summary,
+    )
     return RuntimeHealth(
         role="leader",
         project_id=project_id,
         session_id=session.id if session else None,
+        leader_state=kickoff_state["kickoff_state"],
         runtime_exists=session is not None and session.status in _ACTIVE_SESSION_STATUSES,
         pane_attached=bool(getattr(session, "tmux_pane", None)),
         provider=getattr(session, "provider", None),
@@ -582,19 +595,11 @@ async def leader_health(
         ace_dispatch=dispatch_summary,
         ace_count=len(aces),
         current_blocker=current_blocker,
+        recommended_command=operator_guidance.get("command"),
         recovery_recommendation=_recovery_for(
             "leader", project_id, current_blocker, session.id if session else None
         ),
-        operator_guidance=_operator_guidance_for(
-            role="leader",
-            project_id=project_id,
-            session_id=session.id if session else None,
-            runtime_state=runtime_state,
-            delivery_state=delivery_state,
-            current_blocker=current_blocker,
-            kickoff_state=kickoff_state,
-            ace_dispatch=dispatch_summary,
-        ),
+        operator_guidance=operator_guidance,
         provider_diagnostics=diagnostics,
     )
 

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -338,9 +338,11 @@ class TestLeaderHealth:
         self, api_stub: str, capsys: pytest.CaptureFixture[str]
     ) -> None:
         _StubHandler.response_body = {
+            "leader_state": "blocked_on_provider_prompt",
             "runtime_state": "blocked",
             "delivery_state": "blocked",
             "current_blocker": "prompt_not_submitted",
+            "recommended_command": "atc leader recover --project-id proj-1 --dry-run",
             "kickoff_state": {
                 "kickoff_state": "blocked_on_provider_prompt",
                 "goal_acceptance_state": "unverified",
@@ -378,6 +380,7 @@ class TestLeaderHealth:
         assert req["path"] == "/api/projects/proj-1/leader/health"
         output = capsys.readouterr().out
         assert "Leader health: blocked" in output
+        assert "Leader state: blocked_on_provider_prompt / acceptance: unverified" in output
         assert "Recommended action: run_inspect_first_recovery" in output
         assert "atc leader recover --project-id proj-1 --dry-run" in output
 

--- a/tests/unit/test_documentation_contracts.py
+++ b/tests/unit/test_documentation_contracts.py
@@ -27,6 +27,7 @@ def test_api_docs_cover_leader_health_recovery_and_task_cli_contracts() -> None:
             "operator_guidance",
             "leader_state",
             "recovery_recommendation",
+            "recommended_command",
             "provider_diagnostics",
             "atc leader health --project-id",
             "atc leader recover --project-id",

--- a/tests/unit/test_runtime_health.py
+++ b/tests/unit/test_runtime_health.py
@@ -150,6 +150,10 @@ async def test_leader_health_reports_runtime_and_task_summary(db) -> None:
     assert data["kickoff_state"]["goal_accepted"] is True
     assert data["kickoff_state"]["kickoff_verified"] is True
     assert data["kickoff_state"]["kickoff_state"] == "working"
+    assert data["leader_state"] == "working"
+    assert data["recommended_command"] == (
+        f"atc leader health --project-id {project.id} --summary"
+    )
     assert data["task_graph_state"]["total"] == 1
     assert data["ace_dispatch"]["verified"] == 1
     assert data["ace_count"] == 1
@@ -199,6 +203,7 @@ async def test_leader_health_treats_startup_trust_as_expected_pre_nudge_branch(d
     )
 
     assert health.runtime_state == "blocked"
+    assert health.leader_state == "blocked_on_provider_prompt"
     assert health.current_blocker == "runtime_trust_required"
     assert health.kickoff_state["kickoff_state"] == "blocked_on_provider_prompt"
     assert health.operator_guidance["recommended_action"] == (
@@ -247,6 +252,7 @@ async def test_leader_health_unverified_startup_checks_trust_before_progress_nud
         ),
     )
 
+    assert health.leader_state == "kickoff_unverified"
     assert health.kickoff_state["kickoff_state"] == "kickoff_unverified"
     assert health.operator_guidance["recommended_action"] == (
         "check_startup_trust_prompt_before_nudge"


### PR DESCRIPTION
## Summary
- expose provider-neutral `leader_state` and `recommended_command` at the Leader health boundary
- teach `atc leader health --summary` and the Project Leader panel to display the normalized Leader health state and actionable recovery command
- document the Phase 7 health-guidance contract while preserving provider separation: prompt classification/submit behavior stays in provider adapters, API/CLI/UI consume neutral health fields only

## Validation
- `./.venv/bin/python -m ruff check src/atc/runtime/health.py src/atc/cli/leader.py tests/unit/test_runtime_health.py tests/unit/test_cli.py tests/unit/test_documentation_contracts.py`
- `PYTHONPATH=src ./.venv/bin/python -m pytest tests/unit/test_runtime_health.py tests/unit/test_cli.py tests/unit/test_documentation_contracts.py -q` — 62 passed, 1 warning
- `PATH=/opt/homebrew/bin:$PATH npm run test -- --run src/components/leader/__tests__/LeaderConsole.test.tsx` — 14 passed
- `PATH=/opt/homebrew/bin:$PATH npm run build` — passed; existing Vite chunk-size warning only
- `PATH=/opt/homebrew/bin:$PATH node frontend/playwright-smoke-atc.mjs` — 13/13 baseline checks passed

## Evidence
- Playwright report: `/Users/mcole_studio/AI_Stack/agents/skunkworks/workspace/screenshots/playwright-atc-2026-07-10T17-05-44-563Z/report.json`
- Screenshots: dashboard, create-project modal, usage, context in the same report directory
