### PR TITLE
Keep Tower helper busywork hidden

### DIFF
--- a/docs/agents/TOWER.md
+++ b/docs/agents/TOWER.md
@@ -29,6 +29,7 @@ Tower should:
 Tower is expected to:
 
 - keep the operator-facing interface simple and high-level
+- use Tower-owned hidden provider helper subagents for repetitive kickoff, health, and recovery busywork when supported, so those mechanics do not spill into the user conversation
 - create Leaders with enough context to manage their own project scope
 - verify Leader kickoff/startup readiness before handing off execution
 - after verified handoff, wait for the Leader completion hook instead of polling task progress
@@ -51,7 +52,7 @@ Tower should monitor and display these neutral fields before entering normal low
 - `blocker_reason`
 - `operator_guidance`
 
-When a Leader is blocked, Tower should surface `operator_guidance` and run inspect-first recovery paths such as `atc leader health --project-id <project-id> --summary` and `atc leader recover --project-id <project-id> --dry-run`. Tower must not paste provider-specific key sequences or branch on raw provider prompt text; provider adapters/classifiers own those details and expose only provider-neutral blockers and recovery recommendations.
+When a Leader is blocked, Tower should surface `operator_guidance` and run inspect-first recovery paths such as `atc leader health --project-id <project-id> --summary` and `atc leader recover --project-id <project-id> --dry-run`. Tower may delegate that repetitive health/recovery busywork to a Tower-owned hidden provider helper subagent, with durable audit records and only aggregate status/escalations shown to the operator. Tower must not paste provider-specific key sequences or branch on raw provider prompt text; provider adapters/classifiers own those details and expose only provider-neutral blockers and recovery recommendations.
 
 Tower must treat a managed Leader folder trust/startup prompt as a hard expected branch immediately after `atc leader start`, not as a surprise discovered after progress remains zero. The required post-start order is:
 

--- a/docs/leader_kickoff_recovery_plan.md
+++ b/docs/leader_kickoff_recovery_plan.md
@@ -268,7 +268,8 @@ Tower should not enter normal low-frequency monitoring until the Leader reaches 
 - The capability declares `external_network_allowed: false`, a local host allowlist, bounded methods, and ATC/OpenAPI path prefixes only.
 - `.atc/local_api.sh` validates method/path against the capability file before issuing a request; disallowed paths fail locally without network access.
 - Provider-neutral AGENTS/CLAUDE instructions tell managed agents to use the scoped helper or `atc` CLI for local API inspection and explicitly state that external network access is not authorized.
-- Provider adapters remain responsible for any provider-specific approval or trust mechanics; orchestration/deploy code only emits neutral capability metadata, helper files, and instructions.
+- Tower kickoff/health/recovery busywork may be delegated to Tower-owned hidden provider helper subagents so the user-facing assistant sees only aggregate status, completion, and escalation requests.
+- Provider adapters remain responsible for any provider-specific approval, trust, or helper-subagent mechanics; orchestration/deploy code only emits neutral capability metadata, helper files, instructions, and provider-helper requests.
 
 ### Work
 

--- a/docs/provider_subagent_contract.md
+++ b/docs/provider_subagent_contract.md
@@ -50,6 +50,20 @@ Backend settings endpoints:
 Visibility is display-only. Changing it must not start, stop, cancel, or alter
 helper execution.
 
+## Hidden Tower busywork
+
+Tower may use provider-native helper subagents for repetitive kickoff, health,
+and recovery supervision so the user-facing assistant can stay in conversation
+instead of manually running Tower internals in chat. Those helper runs are still
+Tower-owned work: they inherit Tower's role boundary, use canonical ATC APIs/CLI
+for state mutation, and write durable audit rows/events.
+
+Tower kickoff/recovery helper requests must use hidden visibility. The normal UI
+may show only Tower's aggregate state, completion status, or an escalation that
+needs operator approval. Provider-specific mechanics, such as Codex `/subagent`
+syntax, remain inside provider modules; shared ATC code uses provider-neutral
+purposes such as `tower_kickoff_supervision` and `tower_recovery_supervision`.
+
 ## Provider-neutral request shape
 
 The shared contract is `atc.providers.helpers.ProviderHelperRequest`:

--- a/src/atc/providers/helpers.py
+++ b/src/atc/providers/helpers.py
@@ -29,6 +29,29 @@ class ProviderHelperParentRole(StrEnum):
     ACE = "ace"
 
 
+class ProviderHelperPurpose(StrEnum):
+    """Provider-neutral helper purposes that product layers may request.
+
+    These values describe why a parent ATC role wants provider-native helper
+    work. They intentionally do not describe how a provider launches or drives
+    the helper; provider modules translate the purpose into mechanics such as
+    Codex /subagent usage.
+    """
+
+    TOWER_KICKOFF_SUPERVISION = "tower_kickoff_supervision"
+    TOWER_RECOVERY_SUPERVISION = "tower_recovery_supervision"
+    PROJECT_STATUS_CHECK = "project_status_check"
+    TASK_EXECUTION_ASSIST = "task_execution_assist"
+
+
+TOWER_BUSYWORK_HELPER_PURPOSES = frozenset(
+    {
+        ProviderHelperPurpose.TOWER_KICKOFF_SUPERVISION,
+        ProviderHelperPurpose.TOWER_RECOVERY_SUPERVISION,
+    }
+)
+
+
 class ProviderHelperRunStatus(StrEnum):
     """Lifecycle status for a provider helper run audit record."""
 
@@ -92,6 +115,15 @@ class ProviderHelperRequest:
             raise ValueError("purpose is required")
         if not self.prompt.strip():
             raise ValueError("prompt is required")
+        purpose = self.purpose.strip()
+        if (
+            self.parent_role is ProviderHelperParentRole.TOWER
+            and purpose in TOWER_BUSYWORK_HELPER_PURPOSES
+            and self.visibility is not ProviderHelperVisibility.HIDDEN
+        ):
+            raise ValueError(
+                "tower kickoff/recovery helper busywork must use hidden visibility"
+            )
 
 
 @dataclass(frozen=True)

--- a/tests/unit/test_documentation_contracts.py
+++ b/tests/unit/test_documentation_contracts.py
@@ -109,3 +109,28 @@ def test_leader_recovery_plan_has_phase9_doc_contract_status() -> None:
             "normal monitoring still requires kickoff/task-graph truth",
         ],
     )
+
+
+def test_provider_subagent_contract_keeps_tower_busywork_hidden() -> None:
+    contract = read_doc("provider_subagent_contract.md")
+    tower = read_doc("agents/TOWER.md")
+
+    assert_contains_all(
+        contract,
+        [
+            "Hidden Tower busywork",
+            "Tower kickoff/recovery helper requests must use hidden visibility",
+            "Codex `/subagent`",
+            "tower_kickoff_supervision",
+            "tower_recovery_supervision",
+            "Provider-specific mechanics",
+        ],
+    )
+    assert_contains_all(
+        tower,
+        [
+            "Tower-owned hidden provider helper subagents",
+            "busywork",
+            "aggregate status/escalations",
+        ],
+    )

--- a/tests/unit/test_provider_helpers.py
+++ b/tests/unit/test_provider_helpers.py
@@ -5,6 +5,7 @@ import pytest
 from atc.providers.helpers import (
     ProviderHelperEventType,
     ProviderHelperParentRole,
+    ProviderHelperPurpose,
     ProviderHelperRequest,
     ProviderHelperResult,
     ProviderHelperRunStatus,
@@ -62,6 +63,31 @@ def test_provider_helper_result_normalizes_status() -> None:
 
     assert result.status is ProviderHelperRunStatus.COMPLETED
     assert result.summary == "done"
+
+
+def test_tower_kickoff_busywork_helpers_must_stay_hidden() -> None:
+    request = ProviderHelperRequest(
+        provider="codex",
+        parent_session_id="tower-session-1",
+        parent_role=ProviderHelperParentRole.TOWER,
+        purpose=ProviderHelperPurpose.TOWER_KICKOFF_SUPERVISION,
+        prompt="Use provider-native helper mechanics to verify Leader kickoff.",
+    )
+
+    assert request.visibility is ProviderHelperVisibility.HIDDEN
+
+    with pytest.raises(
+        ValueError,
+        match="tower kickoff/recovery helper busywork must use hidden visibility",
+    ):
+        ProviderHelperRequest(
+            provider="codex",
+            parent_session_id="tower-session-1",
+            parent_role="tower",
+            purpose=ProviderHelperPurpose.TOWER_RECOVERY_SUPERVISION,
+            prompt="Inspect recovery state.",
+            visibility="summary",
+        )
 
 
 def test_known_event_types_are_provider_neutral() -> None:


### PR DESCRIPTION
## Summary
- correct the Tower/provider-helper contract so Tower kickoff, health, and recovery busywork may be delegated to hidden provider-native helper subagents
- add provider-neutral helper purposes for Tower kickoff/recovery supervision without exposing Codex-specific mechanics in shared orchestration code
- require Tower kickoff/recovery helper busywork to remain hidden while retaining durable auditability
- update Tower/provider subagent docs and doc contract tests so the user-facing assistant sees aggregate status/escalations, not manual Tower internals

## Validation
- `./.venv/bin/python -m ruff check src/atc/providers/helpers.py tests/unit/test_provider_helpers.py tests/unit/test_documentation_contracts.py`
- `PYTHONPATH=src ./.venv/bin/python -m pytest tests/unit/test_provider_helpers.py tests/unit/test_documentation_contracts.py -q` — 12 passed, 1 warning
- `PYTHONPATH=src ./.venv/bin/python -m pytest tests/unit/test_provider_helpers.py tests/unit/test_provider_helper_state.py tests/unit/test_provider_helper_settings.py tests/unit/test_documentation_contracts.py tests/unit/test_runtime_health.py tests/unit/test_leader_kickoff.py -q` — 43 passed, 1 warning
- `PATH=/opt/homebrew/bin:$PATH npm run build` — passed; existing Vite chunk-size warning only
- `PATH=/opt/homebrew/bin:$PATH node frontend/playwright-smoke-atc.mjs` — 13/13 checks passed

## Playwright evidence
- Report: `/Users/mcole_studio/AI_Stack/agents/skunkworks/workspace/screenshots/playwright-atc-2026-07-10T17-29-05-009Z/report.json`
- Screenshots: `01-dashboard-initial.png`, `05-create-project-modal.png`, `08-usage.png`, `12-context.png`

## Architecture note
Provider separation is preserved: shared ATC code defines neutral helper purposes and visibility requirements only. Provider adapters/modules still own provider-native mechanics such as Codex `/subagent` usage, prompt syntax, and helper execution details.