### PR TITLE
Treat stale Leader default prompts as healthy work

### DIFF
--- a/docs/leader_kickoff_recovery_plan.md
+++ b/docs/leader_kickoff_recovery_plan.md
@@ -306,6 +306,7 @@ Tower should not enter normal low-frequency monitoring until the Leader reaches 
 - `atc leader health --summary` prints the normalized Leader state, task/dispatch truth, recommended action, and the exact recovery/health command operators should run next.
 - Project UI Leader health guidance displays the same normalized Leader state and recommended command so a blocked/unverified startup does not appear as only `0 tasks`.
 - Provider-specific prompt text/key handling remains inside runtime provider adapters/classifiers; API/CLI/UI surfaces consume only neutral health fields and redacted diagnostics.
+- A `default_prompt_visible` observation is suppressed as stale when canonical Leader work already exists (for example, task graph creation), so health does not report a running Leader as blocked merely because the provider returned to its default prompt after doing work.
 
 ### Work
 

--- a/src/atc/runtime/health.py
+++ b/src/atc/runtime/health.py
@@ -156,11 +156,11 @@ def _leader_kickoff_health_state(
         return "failed"
     if not has_payload:
         return "starting"
+    if task_total > 0 or first_actionable_step_observed_at:
+        return "working"
     if not (leader_reported_active and goal_accepted):
         return "kickoff_unverified"
-    if task_total <= 0 and not first_actionable_step_observed_at:
-        return "task_graph_empty"
-    return "working"
+    return "task_graph_empty"
 
 
 def _ace_assignment_acceptance_state(
@@ -495,6 +495,22 @@ async def leader_health(
     kickoff_trace_id = (
         kickoff_payload.get("trace_id") if isinstance(kickoff_payload, dict) else None
     )
+    stale_default_prompt_blocker = bool(
+        blocker == BlockerReason.DEFAULT_PROMPT_VISIBLE.value
+        and runtime_state in {RuntimeState.READY.value, RuntimeState.ACTIVE.value}
+        and (task_graph_created_at or leader_reported_active or goal_accepted)
+    )
+    effective_blocker = None if stale_default_prompt_blocker else blocker
+    kickoff_blocker_reason = effective_blocker
+    if stale_default_prompt_blocker:
+        diagnostics = {
+            **diagnostics,
+            "suppressed_blocker_reason": blocker,
+            "suppressed_blocker_basis": "canonical_leader_work_observed",
+        }
+    kickoff_acceptance_observed = bool(
+        (leader_reported_active and goal_accepted) or task_graph_created_at
+    )
     pending_prompt_text = _pending_prompt_text_from_diagnostics(diagnostics)
     pending_payload_matches = _pending_prompt_matches_payload(
         pending_prompt_text,
@@ -504,7 +520,7 @@ async def leader_health(
         "kickoff_payload_persisted": bool(kickoff_payload),
         "kickoff_state": _leader_kickoff_health_state(
             runtime_state=runtime_state,
-            blocker=blocker,
+            blocker=effective_blocker,
             has_payload=bool(kickoff_payload),
             leader_reported_active=leader_reported_active,
             goal_accepted=goal_accepted,
@@ -512,7 +528,7 @@ async def leader_health(
             first_actionable_step_observed_at=first_actionable_step_observed_at,
         ),
         "startup_handshake_state": "blocked"
-        if blocker
+        if effective_blocker
         else (
             "ready"
             if runtime_state in {RuntimeState.READY.value, RuntimeState.ACTIVE.value}
@@ -522,23 +538,26 @@ async def leader_health(
             "leader_reported_active"
             if leader_reported_active and goal_accepted and first_actionable_step_observed_at
             else (
-                "goal_accepted"
-                if leader_reported_active and goal_accepted
-                else ("submitted_pending_acceptance" if kickoff_payload else "not_submitted")
+                "task_graph_created"
+                if task_graph_created_at
+                else (
+                    "goal_accepted"
+                    if leader_reported_active and goal_accepted
+                    else ("submitted_pending_acceptance" if kickoff_payload else "not_submitted")
+                )
             )
         ),
         "kickoff_verified": bool(
-            not blocker
+            not effective_blocker
             and runtime_state in {RuntimeState.READY.value, RuntimeState.ACTIVE.value}
-            and leader_reported_active
-            and goal_accepted
+            and kickoff_acceptance_observed
             and first_actionable_step_observed_at
         ),
         "goal_accepted": goal_accepted,
         "leader_reported_active": leader_reported_active,
         "leader_active_reported_at": leader_active_reported_at,
         "delivery_trace_id": kickoff_trace_id,
-        "kickoff_blocker_reason": blocker,
+        "kickoff_blocker_reason": kickoff_blocker_reason,
         "first_actionable_step_observed_at": first_actionable_step_observed_at,
         "task_graph_created_at": task_graph_created_at,
         "original_goal_available": bool(
@@ -564,7 +583,7 @@ async def leader_health(
         "blocked": sum(1 for a in project_assignments if a.blocker_reason),
         "unverified": sum(1 for a in project_assignments if not a.dispatch_verified),
     }
-    current_blocker = blocker or next(
+    current_blocker = effective_blocker or next(
         (a.blocker_reason for a in project_assignments if a.blocker_reason), None
     )
     delivery_state = _delivery_state_for_runtime(runtime_state, has_payload=bool(kickoff_payload))
@@ -588,7 +607,7 @@ async def leader_health(
         provider=getattr(session, "provider", None),
         runtime_state=runtime_state,
         delivery_state=delivery_state,
-        blocker_reason=blocker,
+        blocker_reason=effective_blocker,
         last_activity_at=latest_activity,
         task_graph_state=task_summary,
         kickoff_state=kickoff_state,

--- a/tests/unit/test_runtime_health.py
+++ b/tests/unit/test_runtime_health.py
@@ -261,6 +261,64 @@ async def test_leader_health_unverified_startup_checks_trust_before_progress_nud
 
 
 @pytest.mark.asyncio
+async def test_leader_health_suppresses_stale_default_prompt_after_task_graph_exists(db) -> None:
+    project = await create_project(db, "leader-default-prompt-stale")
+    leader = await create_leader(db, project.id, goal="Create tasks")
+    session = await create_session(
+        db,
+        project.id,
+        "manager",
+        "leader-stale-default-prompt",
+        status="working",
+        provider="codex",
+    )
+    await db.execute(
+        "UPDATE sessions SET tmux_pane = ?, tmux_session = ? WHERE id = ?",
+        ("%23", "atc", session.id),
+    )
+    await db.execute(
+        "UPDATE leaders SET session_id = ?, context = ? WHERE id = ?",
+        (
+            session.id,
+            json.dumps({"leader_kickoff_payload": {"message": "go"}}),
+            leader.id,
+        ),
+    )
+    await create_task_graph(db, project.id, "Task one")
+    await create_task_graph(db, project.id, "Task two")
+    await db.commit()
+
+    health = await leader_health(
+        db,
+        project.id,
+        runtime_service=FakeRuntimeService(
+            RuntimeInspection(
+                session_id=session.id,
+                provider_name="codex",
+                alive=True,
+                readiness=ReadinessState.READY,
+                summary="Ready at default prompt after producing work",
+                details={"blocker_reason": "default_prompt_visible"},
+            )
+        ),
+    )
+
+    assert health.runtime_state == "ready"
+    assert health.blocker_reason is None
+    assert health.current_blocker is None
+    assert health.leader_state == "working"
+    assert health.kickoff_state["kickoff_state"] == "working"
+    assert health.kickoff_state["goal_acceptance_state"] == "task_graph_created"
+    assert health.kickoff_state["kickoff_verified"] is True
+    assert health.provider_diagnostics["suppressed_blocker_reason"] == "default_prompt_visible"
+    assert health.provider_diagnostics["suppressed_blocker_basis"] == (
+        "canonical_leader_work_observed"
+    )
+    assert health.operator_guidance["severity"] == "ok"
+    assert health.operator_guidance["recommended_action"] == "none"
+
+
+@pytest.mark.asyncio
 async def test_ace_health_treats_startup_trust_as_expected_pre_instruction_branch(db) -> None:
     project = await create_project(db, "ace-trust-startup")
     task = await create_task_graph(db, project.id, "Task one")


### PR DESCRIPTION
## Summary
- suppress stale `default_prompt_visible` Leader blockers once canonical Leader work is visible (task graph/goal acceptance evidence)
- treat task graph creation as kickoff acceptance evidence so a running Leader is not reported as blocked just because the provider is back at its default prompt
- add regression coverage and document the health contract while preserving provider separation

## Validation
- `./.venv/bin/python -m ruff check src/atc/runtime/health.py tests/unit/test_runtime_health.py`
- `PYTHONPATH=src ./.venv/bin/python -m pytest tests/unit/test_runtime_health.py -q` → 23 passed, 1 warning
- `PYTHONPATH=src ./.venv/bin/python -m pytest tests/unit/test_runtime_health.py tests/unit/test_leader_kickoff.py tests/unit/test_cli.py tests/unit/test_documentation_contracts.py -q` → 69 passed, 1 warning
- `git diff --check`
- `PATH=/opt/homebrew/bin:$PATH npm run build` → passed; existing Vite chunk-size warning only
- Playwright ATC baseline smoke → 13/13 checks passed, report `/Users/mcole_studio/AI_Stack/agents/skunkworks/workspace/screenshots/playwright-atc-2026-07-10T17-57-51-739Z/report.json`

## Architecture notes
- Provider adapters still own prompt classification.
- Shared health code only reconciles provider-neutral blocker observations with canonical ATC evidence.
- No Tower/Leader/API layer parses provider-specific prompt text.