### PR TITLE
Converge Phase 9 runtime truth docs

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -62,6 +62,8 @@ Important fields:
 - `operator_guidance`: user-facing summary with severity, recommended action, command, and details.
 - `provider_diagnostics`: redacted nested provider details for debugging only; orchestration must not branch on provider-specific prompt strings.
 
+`POST /api/projects/{id}/leader/report-active` is the canonical Leader-owned proof point that the goal was accepted. A Leader should call it before normal task/Ace supervision so Tower can distinguish accepted work from a session row or submitted prompt. The request records provider-neutral acceptance evidence such as `goal_accepted`, `message`, and later task-graph timestamps; it does not encode provider prompt text.
+
 `POST /api/projects/{id}/leader/recover` plans or applies inspect-first recovery. Use dry-run before mutation. A typical operator flow is:
 
 ```bash
@@ -69,7 +71,14 @@ atc leader health --project-id <project-id> --summary
 atc leader recover --project-id <project-id> --dry-run
 ```
 
-Recovery apply policies must remain explicit; pressing Enter or resending a persisted kickoff is not success until health/kickoff verification changes.
+Recovery apply policies must remain explicit; pressing Enter or resending a persisted kickoff is not success until health/kickoff verification changes. Recovery outcomes are audited through provider-neutral `runtime_recovery_audit` events; exact prompt strings, key sequences, and provider TUI mechanics remain inside provider adapters/classifiers.
+
+Leader health consumers must use the contract in this section rather than optimistic shortcuts:
+
+- `session_id`, `status`, `delivery_state=sent/submitted`, or a visible pane is not execution proof.
+- `kickoff_verified=true` requires Leader acceptance plus first actionable work, usually task graph creation.
+- `blocker_reason` values are stable product-facing codes; raw provider prompt text belongs only in redacted diagnostics.
+- `operator_guidance.command`/`recommended_command` are the safe operator/CLI entrypoints for recovery.
 
 ## Tasks / Task Graphs
 

--- a/docs/CODEBASE_MAP.md
+++ b/docs/CODEBASE_MAP.md
@@ -57,7 +57,7 @@ Current/future paths:
 
 See:
 - `docs/runtime_truth_recovery_plan.md` — provider-neutral runtime truth, delivery verification, health, and recovery model
-- `docs/leader_kickoff_recovery_plan.md` — follow-up phased plan for proving Leader goal acceptance, startup prompt recovery, task graph ergonomics, and managed-agent local API capability setup
+- `docs/leader_kickoff_recovery_plan.md` — phased contract for proving Leader goal acceptance, startup prompt recovery, task graph ergonomics, managed-agent local API capability setup, and role/API documentation convergence
 - `docs/provider_runtime_refactor_plan.md`
 - `docs/provider_cli_wrapper_spec.md`
 - `docs/RUNTIME_PROVIDER_GUARDRAILS.md`

--- a/docs/START_HERE.md
+++ b/docs/START_HERE.md
@@ -87,7 +87,7 @@ These docs exist to:
 - `docs/runtime_truth_recovery_plan.md`
   - provider-neutral runtime truth, delivery verification, health, and recovery model
 - `docs/leader_kickoff_recovery_plan.md`
-  - planned follow-up phases for Leader kickoff verification, startup prompt recovery, task graph ergonomics, and local ATC API capability setup
+  - phased Leader kickoff verification/recovery contract; includes Phase 9 API and role-documentation convergence requirements
 - `docs/runtime_orchestration_phase0_baseline.md`
   - Phase 0 validation evidence, current delivery/session path map, test inventory, and Playwright baseline gate
 - `docs/agents/README.md`

--- a/docs/agents/ACE.md
+++ b/docs/agents/ACE.md
@@ -61,7 +61,13 @@ atc ace report-artifact --project-id <project-id> --ace-id <ace-id> --path /abso
 
 This creates Ace-side evidence that the assignment was accepted. Without `assignment_accepted=true`, Leader should treat delivered prompts as `awaiting_ace_active_report` rather than verified active work.
 
-If blocked by auth, trust, permissions, missing tools, or an unclear prompt, Ace should report the provider-neutral blocker upward. Leader owns recovery decisions and should use ATC health/recovery surfaces rather than asking the Ace to improvise provider-specific prompt handling.
+When producing work artifacts, Ace should route evidence through the canonical artifact path instead of leaving Leader to search sibling worktrees or terminal scrollback:
+
+```bash
+atc ace report-artifact --project-id <project-id> --ace-id <ace-id> --path /absolute/output --kind worktree
+```
+
+If blocked by auth, trust, permissions, missing tools, or an unclear prompt, Ace should report the provider-neutral blocker upward. Leader owns recovery decisions and should use ATC health/recovery surfaces rather than asking the Ace to improvise provider-specific prompt handling. Ace reports should name stable blocker categories such as `runtime_trust_required`, `runtime_permission_required`, or `prompt_not_submitted` when available, not raw provider prompt wording.
 
 ## Must not do
 

--- a/docs/agents/LEADER.md
+++ b/docs/agents/LEADER.md
@@ -92,7 +92,15 @@ POST /api/projects/{project_id}/leader/report-complete
 
 This hook is the canonical way Tower learns the project is done after handoff.
 
-Leader may inspect the local ATC API helper/capability files generated into the managed workspace for approved local API access. The local ATC API helper is restricted to the configured localhost base URL and allowlisted paths; external network or secret-bearing approval decisions remain outside Leader control.
+Leader may inspect the local ATC API helper/capability files generated into the managed workspace for approved local API access. The local ATC API helper is restricted to the configured localhost base URL and allowlisted paths such as `/openapi.json`, `/api/projects`, task graph routes, Leader health/recovery, and Ace health/reporting routes; external network or secret-bearing approval decisions remain outside Leader control.
+
+Leader's runtime truth contract is:
+
+- call `atc leader report-active --project-id <project-id> --message "accepted goal"` or `POST /api/projects/{project_id}/leader/report-active` after reading and accepting the goal;
+- create or reconcile a task graph before claiming first actionable progress;
+- use `atc leader bootstrap-tasks`, `atc tasks create`, and `atc tasks assign` for normal planning/assignment rather than rediscovering basic ATC APIs from OpenAPI;
+- treat `runtime_state`, `delivery_state`, `startup_readiness_state`, `assignment_acceptance_state`, `dispatch_verified`, `artifact_ready`, and `blocker_reason` as the canonical product-facing state;
+- report provider-neutral blockers upward and leave exact provider prompt handling to provider adapters/classifiers.
 
 ## Must not do
 

--- a/docs/agents/TOWER.md
+++ b/docs/agents/TOWER.md
@@ -74,6 +74,13 @@ After the Leader reports active/goal accepted and begins project work, Tower mus
 2. second identical blocker cycle: send one Leader nudge/request for Leader-owned recovery;
 3. third identical blocker cycle: escalate to the operator with choices such as wait, ask Leader to recover, stop/restart Leader, or operator-approved break-glass.
 
+Tower's normal monitoring contract is therefore:
+
+- session existence, `queued`, `submitted`, `sent`, or `202 Accepted` means only that ATC attempted startup/delivery;
+- `kickoff_verified=true`, `goal_acceptance_state=accepted_active`, and task graph/actionable-step evidence are required before Tower treats the Leader as running project work;
+- task/Ace progress after handoff is Leader-owned evidence and should be summarized from Leader health/progress, not direct Tower→Ace probing;
+- provider-specific prompt strings, trust wording, and key sequences never appear in Tower policy. Tower consumes `blocker_reason`, `runtime_state`, `delivery_state`, `operator_guidance`, and recovery audit outcomes.
+
 Tower should then wait for the event-driven completion hook:
 
 ```text

--- a/docs/leader_kickoff_recovery_plan.md
+++ b/docs/leader_kickoff_recovery_plan.md
@@ -398,6 +398,10 @@ Tower should not enter normal low-frequency monitoring until the Leader reaches 
 - Baseline UI smoke still passes, with screenshots attached to the PR when PR evidence exists.
 - Post-merge validation is rerun from `main`.
 
+### Phase 9 implementation notes
+
+Phase 9 is a contract/documentation convergence phase. It does not change runtime behavior; it makes the runtime truth contract durable across `docs/API.md`, Tower/Leader/Ace role contracts, and documentation contract tests. The docs now explicitly require Leader health/report-active/recovery consumers to treat session rows, `202 Accepted`, `queued`, `submitted`, `sent`, and visible panes as insufficient execution proof until `kickoff_verified`, Leader goal acceptance, and task graph/actionable-step evidence exist. Provider-specific prompt strings and key sequences remain provider-adapter/classifier concerns; product docs refer only to provider-neutral states, blockers, guidance, and audit events.
+
 ## Documentation requirements for every phase
 
 Every implementation PR for this plan must check and update the relevant docs before merge:

--- a/tests/unit/test_documentation_contracts.py
+++ b/tests/unit/test_documentation_contracts.py
@@ -31,6 +31,12 @@ def test_api_docs_cover_leader_health_recovery_and_task_cli_contracts() -> None:
             "provider_diagnostics",
             "atc leader health --project-id",
             "atc leader recover --project-id",
+            "POST /api/projects/{id}/leader/report-active` is the canonical "
+            "Leader-owned proof point",
+            "runtime_recovery_audit",
+            "session_id`, `status`, `delivery_state=sent/submitted`, or a visible "
+            "pane is not execution proof",
+            "kickoff_verified=true",
             "atc tasks create --project-id",
             "atc tasks assign --project-id",
             "atc leader bootstrap-tasks --project-id",
@@ -59,6 +65,10 @@ def test_role_docs_encode_runtime_truth_and_provider_boundary() -> None:
             "Leader session row is not proof",
             "provider-neutral",
             "Tower must not paste provider-specific key sequences",
+            "goal_acceptance_state=accepted_active",
+            "task/Ace progress after handoff is Leader-owned evidence",
+            "provider-specific prompt strings, trust wording, and key sequences never "
+            "appear in Tower policy",
         ],
     )
     assert_contains_all(
@@ -76,6 +86,10 @@ def test_role_docs_encode_runtime_truth_and_provider_boundary() -> None:
             "atc ace report-active --project-id",
             "atc ace report-artifact --project-id",
             "session row or assignment row exists",
+            "atc leader report-active --project-id",
+            "create or reconcile a task graph before claiming first actionable progress",
+            "provider-neutral blockers",
+            "provider adapters/classifiers",
         ],
     )
     assert_contains_all(
@@ -93,6 +107,11 @@ def test_role_docs_encode_runtime_truth_and_provider_boundary() -> None:
             "awaiting_ace_active_report",
             "Leader owns recovery decisions",
             "provider-neutral blocker",
+            "atc ace report-artifact --project-id",
+            "runtime_trust_required",
+            "runtime_permission_required",
+            "prompt_not_submitted",
+            "not raw provider prompt wording",
         ],
     )
 
@@ -107,6 +126,31 @@ def test_leader_recovery_plan_has_phase9_doc_contract_status() -> None:
             "Docs and role contracts encode the same runtime truth rules",
             "Documentation contract tests pass",
             "normal monitoring still requires kickoff/task-graph truth",
+            "Phase 9 is a contract/documentation convergence phase",
+            "does not change runtime behavior",
+            "202 Accepted",
+            "Provider-specific prompt strings and key sequences remain "
+            "provider-adapter/classifier concerns",
+        ],
+    )
+
+
+def test_entrypoints_link_phase9_runtime_truth_contract_docs() -> None:
+    start_here = read_doc("START_HERE.md")
+    codebase_map = read_doc("CODEBASE_MAP.md")
+
+    assert_contains_all(
+        start_here,
+        [
+            "docs/leader_kickoff_recovery_plan.md",
+            "Phase 9 API and role-documentation convergence requirements",
+        ],
+    )
+    assert_contains_all(
+        codebase_map,
+        [
+            "docs/leader_kickoff_recovery_plan.md",
+            "role/API documentation convergence",
         ],
     )
 


### PR DESCRIPTION
## Summary
- Converge Phase 9 Leader kickoff recovery docs across API reference, Tower/Leader/Ace role contracts, and durable entrypoints.
- Document the runtime truth contract: session rows, visible panes, `202 Accepted`, `queued`, `submitted`, and `sent` delivery states are not execution proof without Leader acceptance plus task-graph/actionable evidence.
- Strengthen documentation contract tests for Leader health/report-active/recovery fields, role boundaries, provider-neutral blockers/guidance, local ATC helper expectations, and entrypoint links.

## Validation
- `./.venv/bin/python -m ruff check tests/unit/test_documentation_contracts.py tests/e2e/test_phase8_leader_kickoff_recovery.py tests/e2e/test_phase8_scenarios.py tests/unit/test_runtime_health.py tests/unit/test_leader_kickoff.py tests/unit/test_cli.py`
- `PYTHONPATH=src ./.venv/bin/python -m pytest tests/unit/test_documentation_contracts.py tests/e2e/test_phase8_leader_kickoff_recovery.py tests/e2e/test_phase8_scenarios.py tests/unit/test_runtime_health.py tests/unit/test_leader_kickoff.py tests/unit/test_cli.py -q` — 88 passed, 1 warning
- `git diff --check`
- Markdown local-link check for touched docs — 7 files checked, links ok
- `PATH=/opt/homebrew/bin:$PATH npm run build` — passed, existing Vite chunk-size warning only
- Local API/UI readiness: `/api/health` 200, `/dashboard` 200
- `PATH=/opt/homebrew/bin:$PATH node frontend/playwright-smoke-atc.mjs` — 13/13 checks passed
- Playwright report: `/Users/mcole_studio/AI_Stack/agents/skunkworks/workspace/screenshots/playwright-atc-2026-07-11T15-34-04-797Z/report.json`

## Architecture notes
- Docs-only/runtime-contract phase; no runtime code changed.
- Provider-specific prompt strings/key sequences remain provider adapter/classifier concerns.
- Tower/Leader/Ace separation is explicit: Tower verifies Leader kickoff then relies on Leader-owned task/Ace evidence; Leader owns Ace monitoring/recovery; Ace reports acceptance and artifacts upward.
