### PR TITLE
Fix usage token summary and tooltip readability

### DIFF
--- a/frontend/src/context/AppContext.tsx
+++ b/frontend/src/context/AppContext.tsx
@@ -310,6 +310,13 @@ export function AppProvider({ children }: AppProviderProps) {
       const failureLogs = await api.get<FailureLog[]>("/failure-logs?limit=200");
       dispatch({ type: "SET_FAILURE_LOGS", payload: failureLogs });
 
+      // Fetch aggregate usage totals used by dashboard/usage summary cards.
+      // Daily chart data is fetched by UsagePage, but the top-line counters must
+      // come from the canonical aggregate endpoint so they do not remain at the
+      // initial zero state while the chart already has token rows.
+      const usage = await api.get<UsageSummary>("/usage/summary");
+      dispatch({ type: "SET_USAGE", payload: usage });
+
       // Fetch tower status for panel state
       const towerStatus = await api.get<{
         state: string;

--- a/frontend/src/pages/UsagePage.tsx
+++ b/frontend/src/pages/UsagePage.tsx
@@ -58,6 +58,25 @@ const PERIOD_LABELS: Record<Period, string> = {
   "90d": "90d",
 };
 
+const CHART_TOOLTIP_STYLE = {
+  backgroundColor: "#0d1117",
+  border: "1px solid var(--color-border)",
+  borderRadius: "8px",
+  boxShadow: "0 12px 32px rgba(0, 0, 0, 0.45)",
+  color: "var(--color-text-primary)",
+  fontSize: "12px",
+  opacity: 1,
+};
+
+const CHART_TOOLTIP_LABEL_STYLE = {
+  color: "var(--color-text-primary)",
+  fontWeight: 600,
+};
+
+const CHART_TOOLTIP_ITEM_STYLE = {
+  color: "var(--color-text-primary)",
+};
+
 // ---------------------------------------------------------------------------
 // Period selector
 // ---------------------------------------------------------------------------
@@ -89,7 +108,7 @@ function PeriodSelector({
 // ---------------------------------------------------------------------------
 
 export default function UsagePage() {
-  const { state } = useAppContext();
+  const { state, dispatch } = useAppContext();
   const { usage, projects, budgets } = state;
 
   const [period, setPeriod] = useState<Period>("7d");
@@ -101,6 +120,9 @@ export default function UsagePage() {
   // Resource data
   const [resourceData, setResourceData] = useState<ResourceDataPoint[]>([]);
   const [resourceLoaded, setResourceLoaded] = useState(false);
+
+  // Aggregate usage summary
+  const [usageSummaryLoaded, setUsageSummaryLoaded] = useState(false);
 
   // Codex sync status
   const [codexStatus, setCodexStatus] = useState<CodexSyncStatus | null>(null);
@@ -125,6 +147,18 @@ export default function UsagePage() {
       setResourceLoaded(true);
     } catch {
       setResourceData([]);
+    }
+  }
+
+  async function fetchUsageSummary() {
+    try {
+      const summary = await api.get<typeof usage>("/usage/summary");
+      dispatch({ type: "SET_USAGE", payload: summary });
+    } catch {
+      // Keep the existing summary if the aggregate endpoint is temporarily
+      // unavailable. The chart endpoint is independent and may still render.
+    } finally {
+      setUsageSummaryLoaded(true);
     }
   }
 
@@ -154,7 +188,9 @@ export default function UsagePage() {
         `Inserted ${result.inserted_events} token event${suffix}.`,
       );
       setTokenLoaded(false);
+      setUsageSummaryLoaded(false);
       await fetchCodexStatus();
+      await fetchUsageSummary();
     } catch {
       setCodexSyncMessage("Codex sync failed. Check backend logs.");
       await fetchCodexStatus();
@@ -165,6 +201,7 @@ export default function UsagePage() {
 
   if (!tokenLoaded) void fetchTokens(period);
   if (!resourceLoaded) void fetchResources();
+  if (!usageSummaryLoaded) void fetchUsageSummary();
   if (!codexStatusLoaded) void fetchCodexStatus();
 
   function handlePeriodChange(p: Period) {
@@ -254,12 +291,9 @@ export default function UsagePage() {
                   }
                 />
                 <Tooltip
-                  contentStyle={{
-                    background: "var(--color-surface)",
-                    border: "1px solid var(--color-border)",
-                    borderRadius: "6px",
-                    fontSize: "11px",
-                  }}
+                  contentStyle={CHART_TOOLTIP_STYLE}
+                  labelStyle={CHART_TOOLTIP_LABEL_STYLE}
+                  itemStyle={CHART_TOOLTIP_ITEM_STYLE}
                 />
                 <Legend wrapperStyle={{ fontSize: "10px" }} />
                 {models.map((model) => (
@@ -330,12 +364,9 @@ export default function UsagePage() {
                   }
                 />
                 <Tooltip
-                  contentStyle={{
-                    background: "var(--color-surface)",
-                    border: "1px solid var(--color-border)",
-                    borderRadius: "6px",
-                    fontSize: "11px",
-                  }}
+                  contentStyle={CHART_TOOLTIP_STYLE}
+                  labelStyle={CHART_TOOLTIP_LABEL_STYLE}
+                  itemStyle={CHART_TOOLTIP_ITEM_STYLE}
                   labelFormatter={fmtTime}
                 />
                 <Legend

--- a/frontend/src/pages/__tests__/UsagePage.test.tsx
+++ b/frontend/src/pages/__tests__/UsagePage.test.tsx
@@ -4,9 +4,18 @@ import UsagePage from "../UsagePage";
 import { renderWithProviders } from "../../test/helpers";
 
 beforeEach(() => {
-  vi.spyOn(globalThis, "fetch").mockResolvedValue(
-    new Response(JSON.stringify([]), { status: 200 }),
-  );
+  vi.spyOn(globalThis, "fetch").mockImplementation((input) => {
+    const url = String(input);
+    if (url.includes("/usage/summary")) {
+      return Promise.resolve(
+        new Response(
+          JSON.stringify({ today_tokens: 0, month_tokens: 0 }),
+          { status: 200 },
+        ),
+      );
+    }
+    return Promise.resolve(new Response(JSON.stringify([]), { status: 200 }));
+  });
 });
 
 describe("UsagePage", () => {
@@ -28,6 +37,29 @@ describe("UsagePage", () => {
   it("shows token usage card", () => {
     renderWithProviders(<UsagePage />);
     expect(screen.getByText("Token Usage")).toBeInTheDocument();
+  });
+
+  it("loads token summary counters from the aggregate usage endpoint", async () => {
+    vi.spyOn(globalThis, "fetch").mockImplementation((input) => {
+      const url = String(input);
+      if (url.includes("/usage/summary")) {
+        return Promise.resolve(
+          new Response(
+            JSON.stringify({ today_tokens: 999, month_tokens: 123456 }),
+            { status: 200 },
+          ),
+        );
+      }
+      if (url.includes("/usage/tokens")) {
+        return Promise.resolve(new Response(JSON.stringify([]), { status: 200 }));
+      }
+      return Promise.resolve(new Response(JSON.stringify([]), { status: 200 }));
+    });
+
+    renderWithProviders(<UsagePage />);
+
+    expect(await screen.findByText("999")).toBeInTheDocument();
+    expect(await screen.findByText("123k")).toBeInTheDocument();
   });
 
   it("shows budget utilization section", () => {


### PR DESCRIPTION
## Summary
- Load aggregate `/api/usage/summary` data into shared app state so Usage/Dashboard token summary cards update instead of staying at the zero initial state while chart rows are present.
- Refresh the aggregate summary after manual Codex token sync so counters and charts update together.
- Make Recharts tooltip panels opaque/dark with explicit text color and shadow so hover data is readable on the Usage page.
- Add frontend coverage proving UsagePage renders non-zero summary counters returned by the aggregate endpoint.

## Validation
- `./.venv/bin/python -m ruff check src/atc/api/routers/usage.py` — passed.
- `cd frontend && PATH=/opt/homebrew/bin:$PATH npm run test -- UsagePage.test.tsx AppContext.test.tsx` — passed: 13 tests.
- `cd frontend && PATH=/opt/homebrew/bin:$PATH npm run build` — passed; existing Vite large chunk warning only.
- Custom Playwright usage smoke with mocked token data — passed; verified Usage counters `175k` / `405k` and tooltip computed styles `backgroundColor=rgb(13, 17, 23)`, `opacity=1`, dark shadow.
- `PATH=/opt/homebrew/bin:$PATH node frontend/playwright-smoke-atc.mjs` — passed: 13/13 checks.
- `git diff --check` — passed.

## Evidence
- Usage counter/tooltip smoke screenshots:
  - `/Users/mcole_studio/AI_Stack/agents/skunkworks/workspace/screenshots/usage-fix-smoke-2026-07-13T19-16/usage-summary-fixed.png`
  - `/Users/mcole_studio/AI_Stack/agents/skunkworks/workspace/screenshots/usage-fix-smoke-2026-07-13T19-16/usage-tooltip-opaque.png`
- Baseline Playwright report: `/Users/mcole_studio/AI_Stack/agents/skunkworks/workspace/screenshots/playwright-atc-2026-07-13T02-19-07-286Z/report.json`
